### PR TITLE
#10: Address Missing Hadoop 3.4.3 Dependency Issue

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -37,7 +37,8 @@
   </modules>
 
   <properties>
-    <!-- Update to 3.4.3 when available in Maven Central -->
+    <!-- Hadoop 3.4.3+ required for Java 24+ (HADOOP-19212: Subject.getSubject() removed) -->
+    <!-- TODO: Update to 3.4.3 when available in Maven Central -->
     <hadoop.version>3.4.4-SNAPSHOT</hadoop.version>
     <java.version>21</java.version>
     <java.version.build>25</java.version.build>
@@ -48,7 +49,7 @@
   </properties>
 
   <!-- Apache snapshots repo for Hadoop 3.4.4-SNAPSHOT (HADOOP-19212 fix for Java 24+) -->
-  <!-- Remove once 3.4.3+ is in Central -->
+  <!-- TODO: Remove once 3.4.3+ is in Central -->
   <repositories>
     <repository>
       <id>apache-hadoop-snapshots</id>
@@ -135,7 +136,6 @@
         <artifactId>parquet-avro</artifactId>
         <version>1.16.0</version>
       </dependency>
-        <!-- Hadoop 3.4.3+ required for Java 24+ (HADOOP-19212: Subject.getSubject() removed) -->
       <dependency>
         <groupId>org.apache.hadoop</groupId>
         <artifactId>hadoop-common</artifactId>


### PR DESCRIPTION
### Description

This pull request addresses the issue detailed in #10 which caused the `parquet-testing-runner` to fail to properly build due to a missing Hadoop 3.4.3 dependency that was dropped from its original staging repository.

### Fix and Verification
The fix temporarily introduces a newer 3.4.4 version of the same dependency available within an existing SNAPSHOT repository to address the build issues. It also introduces some minor quality-of-life improvements such as consolidating the referenced Hadoop version in a new `hadoop.version` variable to support future upgrades.

After introducing the change, the previously failing build was able to pull down the dependency and compile successfully as seen below using the 3.4.4 release:

<img width="1136" height="512" alt="image" src="https://github.com/user-attachments/assets/d13f0bc1-909c-47c5-baea-356dd5885500" />

### Future Improvement

As part of this effort, #12 was created as a placeholder issue to remove this workaround when the official version is available.