### PR TITLE
hardwood#34 Columnar API

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,7 +2,7 @@
 
 To run Maven, always run ./mvnw (Maven wrapper).
 Run ./mvnw verify to build the project.
-When doing changes in hardwood-core, install that module before running the performance tests.
+When doing changes in hardwood-core, install that module before running the performance tests or any other module.
 When running Maven commands, always apply a timeout of 180 seconds to detect deadlocks early on.
 Enable -Pperformance-test to run performance tests.
 

--- a/core/src/main/java/dev/hardwood/HardwoodContext.java
+++ b/core/src/main/java/dev/hardwood/HardwoodContext.java
@@ -5,7 +5,7 @@
  *
  *  Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
  */
-package dev.hardwood.reader;
+package dev.hardwood;
 
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
@@ -16,6 +16,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 import dev.hardwood.internal.compression.DecompressorFactory;
 import dev.hardwood.internal.compression.libdeflate.LibdeflateLoader;
 import dev.hardwood.internal.compression.libdeflate.LibdeflatePool;
+import dev.hardwood.reader.ParquetFileReader;
 
 /**
  * Context object that manages shared resources for Parquet file reading.

--- a/core/src/main/java/dev/hardwood/internal/reader/PageCursor.java
+++ b/core/src/main/java/dev/hardwood/internal/reader/PageCursor.java
@@ -14,7 +14,7 @@ import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Executor;
 
-import dev.hardwood.reader.HardwoodContext;
+import dev.hardwood.HardwoodContext;
 
 /**
  * Cursor over a column's pages with async prefetching.

--- a/core/src/main/java/dev/hardwood/internal/reader/PageScanner.java
+++ b/core/src/main/java/dev/hardwood/internal/reader/PageScanner.java
@@ -12,6 +12,7 @@ import java.nio.MappedByteBuffer;
 import java.util.ArrayList;
 import java.util.List;
 
+import dev.hardwood.HardwoodContext;
 import dev.hardwood.internal.compression.Decompressor;
 import dev.hardwood.internal.thrift.PageHeaderReader;
 import dev.hardwood.internal.thrift.ThriftCompactReader;
@@ -19,7 +20,6 @@ import dev.hardwood.metadata.ColumnChunk;
 import dev.hardwood.metadata.ColumnMetaData;
 import dev.hardwood.metadata.CompressionCodec;
 import dev.hardwood.metadata.PageHeader;
-import dev.hardwood.reader.HardwoodContext;
 import dev.hardwood.schema.ColumnSchema;
 
 /**

--- a/core/src/main/java/dev/hardwood/reader/MultiFileColumnReaders.java
+++ b/core/src/main/java/dev/hardwood/reader/MultiFileColumnReaders.java
@@ -1,0 +1,113 @@
+/*
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Copyright The original authors
+ *
+ *  Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package dev.hardwood.reader;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+import dev.hardwood.HardwoodContext;
+import dev.hardwood.internal.reader.FileManager;
+import dev.hardwood.schema.ColumnSchema;
+import dev.hardwood.schema.FileSchema;
+import dev.hardwood.schema.ProjectedSchema;
+
+/**
+ * Holds multiple {@link ColumnReader} instances backed by a shared {@link FileManager}
+ * for cross-file prefetching across multiple Parquet files.
+ *
+ * <p>Usage:</p>
+ * <pre>{@code
+ * try (Hardwood hardwood = Hardwood.create();
+ *      MultiFileParquetReader parquet = hardwood.openAll(files);
+ *      MultiFileColumnReaders columns = parquet.createColumnReaders(
+ *          ColumnProjection.columns("passenger_count", "trip_distance", "fare_amount"))) {
+ *
+ *     ColumnReader col0 = columns.getColumnReader("passenger_count");
+ *     ColumnReader col1 = columns.getColumnReader("trip_distance");
+ *     ColumnReader col2 = columns.getColumnReader("fare_amount");
+ *
+ *     while (col0.nextBatch() & col1.nextBatch() & col2.nextBatch()) {
+ *         int count = col0.getRecordCount();
+ *         double[] v0 = col0.getDoubles();
+ *         // ...
+ *     }
+ * }
+ * }</pre>
+ */
+public class MultiFileColumnReaders implements AutoCloseable {
+
+    private final Map<String, ColumnReader> readersByName;
+    private final ColumnReader[] readersByIndex;
+
+    MultiFileColumnReaders(HardwoodContext context, FileManager fileManager,
+                           FileManager.InitResult initResult) {
+        FileSchema schema = initResult.schema();
+        ProjectedSchema projectedSchema = initResult.projectedSchema();
+        String firstFileName = initResult.firstFileState().path().getFileName().toString();
+
+        int projectedColumnCount = projectedSchema.getProjectedColumnCount();
+        this.readersByName = new LinkedHashMap<>(projectedColumnCount);
+        this.readersByIndex = new ColumnReader[projectedColumnCount];
+
+        for (int i = 0; i < projectedColumnCount; i++) {
+            int originalIndex = projectedSchema.toOriginalIndex(i);
+            ColumnSchema columnSchema = schema.getColumn(originalIndex);
+
+            ColumnReader reader = new ColumnReader(
+                    columnSchema,
+                    initResult.firstFileState().pageInfosByColumn().get(i),
+                    context,
+                    ColumnReader.DEFAULT_BATCH_SIZE,
+                    fileManager,
+                    i,
+                    firstFileName);
+
+            readersByName.put(columnSchema.name(), reader);
+            readersByIndex[i] = reader;
+        }
+    }
+
+    /**
+     * Get the number of projected columns.
+     */
+    public int getColumnCount() {
+        return readersByIndex.length;
+    }
+
+    /**
+     * Get the ColumnReader for a named column.
+     *
+     * @param columnName the column name (must have been requested in the projection)
+     * @return the ColumnReader for the column
+     * @throws IllegalArgumentException if the column was not requested
+     */
+    public ColumnReader getColumnReader(String columnName) {
+        ColumnReader reader = readersByName.get(columnName);
+        if (reader == null) {
+            throw new IllegalArgumentException("Column '" + columnName + "' was not requested");
+        }
+        return reader;
+    }
+
+    /**
+     * Get the ColumnReader by index within the requested columns.
+     *
+     * @param index index within the requested column names (0-based)
+     * @return the ColumnReader at the given index
+     */
+    public ColumnReader getColumnReader(int index) {
+        return readersByIndex[index];
+    }
+
+    @Override
+    public void close() {
+        for (ColumnReader reader : readersByIndex) {
+            reader.close();
+        }
+    }
+}

--- a/core/src/main/java/dev/hardwood/reader/MultiFileParquetReader.java
+++ b/core/src/main/java/dev/hardwood/reader/MultiFileParquetReader.java
@@ -1,0 +1,98 @@
+/*
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Copyright The original authors
+ *
+ *  Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package dev.hardwood.reader;
+
+import java.io.IOException;
+import java.nio.file.Path;
+import java.util.List;
+
+import dev.hardwood.HardwoodContext;
+import dev.hardwood.internal.reader.FileManager;
+import dev.hardwood.schema.FileSchema;
+
+/**
+ * Entry point for reading multiple Parquet files with cross-file prefetching.
+ * <p>
+ * This is the multi-file equivalent of {@link ParquetFileReader}. It opens the
+ * first file, reads the schema, and lets you choose between row-oriented or
+ * column-oriented access with a specific column projection.
+ * </p>
+ *
+ * <p>Usage:</p>
+ * <pre>{@code
+ * try (Hardwood hardwood = Hardwood.create();
+ *      MultiFileParquetReader reader = hardwood.openAll(files)) {
+ *
+ *     FileSchema schema = reader.getFileSchema();
+ *
+ *     // Row-oriented access:
+ *     try (MultiFileRowReader rows = reader.createRowReader(
+ *             ColumnProjection.columns("col1", "col2"))) { ... }
+ *
+ *     // Column-oriented access:
+ *     try (MultiFileColumnReaders columns = reader.createColumnReaders(
+ *             ColumnProjection.columns("col1", "col2"))) { ... }
+ * }
+ * }</pre>
+ */
+public class MultiFileParquetReader implements AutoCloseable {
+
+    private final List<Path> files;
+    private final HardwoodContext context;
+    private final FileManager fileManager;
+    private final FileSchema schema;
+
+    public MultiFileParquetReader(List<Path> files, HardwoodContext context) throws IOException {
+        if (files.isEmpty()) {
+            throw new IllegalArgumentException("At least one file must be provided");
+        }
+        this.files = files;
+        this.context = context;
+        this.fileManager = new FileManager(files, context);
+        this.schema = fileManager.openFirst();
+    }
+
+    /**
+     * Get the file schema (common across all files).
+     */
+    public FileSchema getFileSchema() {
+        return schema;
+    }
+
+    /**
+     * Create a row reader that iterates over all rows in all files.
+     */
+    public MultiFileRowReader createRowReader() {
+        return createRowReader(ColumnProjection.all());
+    }
+
+    /**
+     * Create a row reader that iterates over selected columns in all files.
+     *
+     * @param projection specifies which columns to read
+     */
+    public MultiFileRowReader createRowReader(ColumnProjection projection) {
+        FileManager.InitResult initResult = fileManager.initialize(projection);
+        return new MultiFileRowReader(files, context, fileManager, initResult);
+    }
+
+    /**
+     * Create column readers for batch-oriented access to the requested columns.
+     *
+     * @param projection specifies which columns to read
+     */
+    public MultiFileColumnReaders createColumnReaders(ColumnProjection projection) {
+        FileManager.InitResult initResult = fileManager.initialize(projection);
+        return new MultiFileColumnReaders(context, fileManager, initResult);
+    }
+
+    @Override
+    public void close() {
+        fileManager.close();
+    }
+}

--- a/core/src/main/java/dev/hardwood/reader/ParquetFileReader.java
+++ b/core/src/main/java/dev/hardwood/reader/ParquetFileReader.java
@@ -13,11 +13,11 @@ import java.nio.channels.FileChannel;
 import java.nio.file.Path;
 import java.nio.file.StandardOpenOption;
 
+import dev.hardwood.Hardwood;
+import dev.hardwood.HardwoodContext;
 import dev.hardwood.internal.reader.FileMappingEvent;
 import dev.hardwood.internal.reader.ParquetMetadataReader;
-import dev.hardwood.metadata.ColumnChunk;
 import dev.hardwood.metadata.FileMetaData;
-import dev.hardwood.schema.ColumnSchema;
 import dev.hardwood.schema.FileSchema;
 import dev.hardwood.schema.ProjectedSchema;
 
@@ -66,7 +66,7 @@ public class ParquetFileReader implements AutoCloseable {
      * Open a Parquet file with a shared context.
      * The context is NOT closed when this reader is closed.
      */
-    static ParquetFileReader open(Path path, HardwoodContext context) throws IOException {
+    public static ParquetFileReader open(Path path, HardwoodContext context) throws IOException {
         return open(path, context, false);
     }
 
@@ -113,8 +113,20 @@ public class ParquetFileReader implements AutoCloseable {
         return FileSchema.fromSchemaElements(fileMetaData.schema());
     }
 
-    public ColumnReader getColumnReader(ColumnSchema idColumn, ColumnChunk idColumnChunk) throws IOException {
-        return new ColumnReader(path, idColumn, idColumnChunk, context);
+    /**
+     * Create a ColumnReader for a named column, spanning all row groups.
+     */
+    public ColumnReader createColumnReader(String columnName) {
+        FileSchema schema = getFileSchema();
+        return ColumnReader.create(columnName, schema, fileMapping, fileMetaData.rowGroups(), context);
+    }
+
+    /**
+     * Create a ColumnReader for a column by index, spanning all row groups.
+     */
+    public ColumnReader createColumnReader(int columnIndex) {
+        FileSchema schema = getFileSchema();
+        return ColumnReader.create(columnIndex, schema, fileMapping, fileMetaData.rowGroups(), context);
     }
 
     /**

--- a/core/src/main/java/dev/hardwood/reader/SingleFileRowReader.java
+++ b/core/src/main/java/dev/hardwood/reader/SingleFileRowReader.java
@@ -15,6 +15,7 @@ import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ForkJoinPool;
 
+import dev.hardwood.HardwoodContext;
 import dev.hardwood.internal.reader.BatchDataView;
 import dev.hardwood.internal.reader.ColumnAssemblyBuffer;
 import dev.hardwood.internal.reader.ColumnValueIterator;

--- a/core/src/test/java/dev/hardwood/MultiFileColumnReadersTest.java
+++ b/core/src/test/java/dev/hardwood/MultiFileColumnReadersTest.java
@@ -1,0 +1,359 @@
+/*
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Copyright The original authors
+ *
+ *  Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package dev.hardwood;
+
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.BitSet;
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+
+import dev.hardwood.reader.ColumnProjection;
+import dev.hardwood.reader.ColumnReader;
+import dev.hardwood.reader.MultiFileColumnReaders;
+import dev.hardwood.reader.MultiFileParquetReader;
+import dev.hardwood.reader.ParquetFileReader;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * Tests for {@link MultiFileColumnReaders} and cross-file column-oriented prefetching.
+ */
+class MultiFileColumnReadersTest {
+
+    @Test
+    void testReadSingleFile() throws Exception {
+        Path filePath = Paths.get("src/test/resources/plain_uncompressed.parquet");
+
+        try (Hardwood hardwood = Hardwood.create();
+             MultiFileParquetReader parquet = hardwood.openAll(List.of(filePath));
+             MultiFileColumnReaders columns = parquet.createColumnReaders(ColumnProjection.columns("id", "value"))) {
+
+            ColumnReader idReader = columns.getColumnReader("id");
+            ColumnReader valueReader = columns.getColumnReader("value");
+
+            assertThat(idReader.nextBatch() & valueReader.nextBatch()).isTrue();
+            assertThat(idReader.getRecordCount()).isEqualTo(3);
+            assertThat(valueReader.getRecordCount()).isEqualTo(3);
+
+            long[] ids = idReader.getLongs();
+            assertThat(ids[0]).isEqualTo(1L);
+            assertThat(ids[1]).isEqualTo(2L);
+            assertThat(ids[2]).isEqualTo(3L);
+
+            long[] values = valueReader.getLongs();
+            assertThat(values[0]).isEqualTo(100L);
+            assertThat(values[1]).isEqualTo(200L);
+            assertThat(values[2]).isEqualTo(300L);
+
+            assertThat(idReader.nextBatch() & valueReader.nextBatch()).isFalse();
+        }
+    }
+
+    @Test
+    void testReadMultipleIdenticalFiles() throws Exception {
+        Path filePath = Paths.get("src/test/resources/plain_uncompressed.parquet");
+        List<Path> files = List.of(filePath, filePath, filePath);
+
+        long idSum = 0;
+        long valueSum = 0;
+        long rowCount = 0;
+
+        try (Hardwood hardwood = Hardwood.create();
+             MultiFileParquetReader parquet = hardwood.openAll(files);
+             MultiFileColumnReaders columns = parquet.createColumnReaders(ColumnProjection.columns("id", "value"))) {
+
+            ColumnReader idReader = columns.getColumnReader("id");
+            ColumnReader valueReader = columns.getColumnReader("value");
+
+            while (idReader.nextBatch() & valueReader.nextBatch()) {
+                int count = idReader.getRecordCount();
+                long[] ids = idReader.getLongs();
+                long[] values = valueReader.getLongs();
+
+                for (int i = 0; i < count; i++) {
+                    idSum += ids[i];
+                    valueSum += values[i];
+                }
+                rowCount += count;
+            }
+        }
+
+        // 3 rows x 3 files = 9 rows
+        assertThat(rowCount).isEqualTo(9);
+        // id sum = (1+2+3) * 3 = 18
+        assertThat(idSum).isEqualTo(18L);
+        // value sum = (100+200+300) * 3 = 1800
+        assertThat(valueSum).isEqualTo(1800L);
+    }
+
+    @Test
+    void testGetColumnReaderByIndex() throws Exception {
+        Path filePath = Paths.get("src/test/resources/plain_uncompressed.parquet");
+
+        try (Hardwood hardwood = Hardwood.create();
+             MultiFileParquetReader parquet = hardwood.openAll(List.of(filePath));
+             MultiFileColumnReaders columns = parquet.createColumnReaders(ColumnProjection.columns("id", "value"))) {
+
+            assertThat(columns.getColumnReader(0).getColumnSchema().name()).isEqualTo("id");
+            assertThat(columns.getColumnReader(1).getColumnSchema().name()).isEqualTo("value");
+        }
+    }
+
+    @Test
+    void testUnknownColumnNameThrows() throws Exception {
+        Path filePath = Paths.get("src/test/resources/plain_uncompressed.parquet");
+
+        try (Hardwood hardwood = Hardwood.create();
+             MultiFileParquetReader parquet = hardwood.openAll(List.of(filePath));
+             MultiFileColumnReaders columns = parquet.createColumnReaders(ColumnProjection.columns("id"))) {
+
+            assertThatThrownBy(() -> columns.getColumnReader("nonexistent"))
+                    .isInstanceOf(IllegalArgumentException.class)
+                    .hasMessageContaining("nonexistent");
+        }
+    }
+
+    @Test
+    void testReadFileWithNulls() throws Exception {
+        Path filePath = Paths.get("src/test/resources/plain_uncompressed_with_nulls.parquet");
+        List<Path> files = List.of(filePath);
+
+        try (Hardwood hardwood = Hardwood.create();
+             MultiFileParquetReader parquet = hardwood.openAll(files);
+             MultiFileColumnReaders columns = parquet.createColumnReaders(ColumnProjection.columns("id", "name"))) {
+
+            ColumnReader idReader = columns.getColumnReader("id");
+            ColumnReader nameReader = columns.getColumnReader("name");
+
+            assertThat(idReader.nextBatch() & nameReader.nextBatch()).isTrue();
+
+            // id column — required, no nulls
+            assertThat(idReader.getRecordCount()).isEqualTo(3);
+            assertThat(idReader.getElementNulls()).isNull();
+
+            // name column — optional, row 1 is null
+            assertThat(nameReader.getRecordCount()).isEqualTo(3);
+            BitSet nulls = nameReader.getElementNulls();
+            assertThat(nulls).isNotNull();
+            assertThat(nulls.get(0)).isFalse();
+            assertThat(nulls.get(1)).isTrue();
+            assertThat(nulls.get(2)).isFalse();
+
+            String[] names = nameReader.getStrings();
+            assertThat(names[0]).isEqualTo("alice");
+            assertThat(names[1]).isNull();
+            assertThat(names[2]).isEqualTo("charlie");
+
+            assertThat(idReader.nextBatch() & nameReader.nextBatch()).isFalse();
+        }
+    }
+
+    @Test
+    void testMultipleFilesPreservesDataIntegrity() throws Exception {
+        Path filePath = Paths.get("src/test/resources/plain_uncompressed.parquet");
+        List<Path> files = List.of(filePath, filePath);
+
+        try (Hardwood hardwood = Hardwood.create();
+             MultiFileParquetReader parquet = hardwood.openAll(files);
+             MultiFileColumnReaders columns = parquet.createColumnReaders(ColumnProjection.columns("id", "value"))) {
+
+            ColumnReader idReader = columns.getColumnReader("id");
+            ColumnReader valueReader = columns.getColumnReader("value");
+
+            long runningSum = 0;
+            int rowCount = 0;
+
+            while (idReader.nextBatch() & valueReader.nextBatch()) {
+                int count = idReader.getRecordCount();
+                long[] ids = idReader.getLongs();
+                long[] values = valueReader.getLongs();
+
+                for (int i = 0; i < count; i++) {
+                    // Verify the relationship holds (value = id * 100 in this test file)
+                    assertThat(values[i]).isEqualTo(ids[i] * 100);
+                    runningSum += values[i];
+                }
+                rowCount += count;
+            }
+
+            assertThat(rowCount).isEqualTo(6);
+            // Sum should be (100 + 200 + 300) * 2 = 1200
+            assertThat(runningSum).isEqualTo(1200L);
+        }
+    }
+
+    @Test
+    void testRowCountMatchesSingleFileReading() throws Exception {
+        Path filePath = Paths.get("src/test/resources/plain_uncompressed.parquet");
+        List<Path> files = List.of(filePath, filePath);
+
+        // Count rows using MultiFileColumnReaders
+        long multiFileCount = 0;
+        try (Hardwood hardwood = Hardwood.create();
+             MultiFileParquetReader parquet = hardwood.openAll(files);
+             MultiFileColumnReaders columns = parquet.createColumnReaders(ColumnProjection.columns("id"))) {
+            ColumnReader reader = columns.getColumnReader("id");
+            while (reader.nextBatch()) {
+                multiFileCount += reader.getRecordCount();
+            }
+        }
+
+        // Count rows using individual single-file ColumnReaders
+        long singleFileCount = 0;
+        try (Hardwood hardwood = Hardwood.create()) {
+            for (Path file : files) {
+                try (ParquetFileReader fileReader = hardwood.open(file);
+                     ColumnReader reader = fileReader.createColumnReader("id")) {
+                    while (reader.nextBatch()) {
+                        singleFileCount += reader.getRecordCount();
+                    }
+                }
+            }
+        }
+
+        assertThat(multiFileCount).isEqualTo(singleFileCount);
+    }
+
+    @Test
+    void testMultipleTypedColumns() throws Exception {
+        Path filePath = Paths.get("src/test/resources/primitive_types_test.parquet");
+        List<Path> files = List.of(filePath, filePath);
+
+        try (Hardwood hardwood = Hardwood.create();
+             MultiFileParquetReader parquet = hardwood.openAll(files);
+             MultiFileColumnReaders columns = parquet.createColumnReaders(
+                     ColumnProjection.columns("int_col", "long_col", "float_col", "double_col", "bool_col", "string_col"))) {
+
+            ColumnReader intReader = columns.getColumnReader("int_col");
+            ColumnReader longReader = columns.getColumnReader("long_col");
+            ColumnReader floatReader = columns.getColumnReader("float_col");
+            ColumnReader doubleReader = columns.getColumnReader("double_col");
+            ColumnReader boolReader = columns.getColumnReader("bool_col");
+            ColumnReader stringReader = columns.getColumnReader("string_col");
+
+            long intSum = 0;
+            long longSum = 0;
+            double floatSum = 0;
+            double doubleSum = 0;
+            int trueCount = 0;
+            int rowCount = 0;
+
+            while (intReader.nextBatch() & longReader.nextBatch()
+                    & floatReader.nextBatch() & doubleReader.nextBatch()
+                    & boolReader.nextBatch() & stringReader.nextBatch()) {
+
+                int count = intReader.getRecordCount();
+                int[] ints = intReader.getInts();
+                long[] longs = longReader.getLongs();
+                float[] floats = floatReader.getFloats();
+                double[] doubles = doubleReader.getDoubles();
+                boolean[] bools = boolReader.getBooleans();
+
+                for (int i = 0; i < count; i++) {
+                    intSum += ints[i];
+                    longSum += longs[i];
+                    floatSum += floats[i];
+                    doubleSum += doubles[i];
+                    if (bools[i]) trueCount++;
+                }
+                rowCount += count;
+            }
+
+            // 3 rows x 2 files = 6 rows
+            assertThat(rowCount).isEqualTo(6);
+            // int_col: (1+2+3) * 2 = 12
+            assertThat(intSum).isEqualTo(12);
+            // long_col: (100+200+300) * 2 = 1200
+            assertThat(longSum).isEqualTo(1200L);
+            // float_col: (1.5+2.5+3.5) * 2 = 15.0
+            assertThat(floatSum).isCloseTo(15.0, org.assertj.core.data.Offset.offset(0.01));
+            // double_col: (10.5+20.5+30.5) * 2 = 123.0
+            assertThat(doubleSum).isCloseTo(123.0, org.assertj.core.data.Offset.offset(0.001));
+            // bool_col: (true, false, true) * 2 = 4 trues
+            assertThat(trueCount).isEqualTo(4);
+        }
+    }
+
+    @Test
+    void testNullsAcrossFileBoundary() throws Exception {
+        Path filePath = Paths.get("src/test/resources/plain_uncompressed_with_nulls.parquet");
+        List<Path> files = List.of(filePath, filePath);
+
+        int nullCount = 0;
+        int rowCount = 0;
+
+        try (Hardwood hardwood = Hardwood.create();
+             MultiFileParquetReader parquet = hardwood.openAll(files);
+             MultiFileColumnReaders columns = parquet.createColumnReaders(ColumnProjection.columns("name"))) {
+
+            ColumnReader nameReader = columns.getColumnReader("name");
+
+            while (nameReader.nextBatch()) {
+                int count = nameReader.getRecordCount();
+                BitSet nulls = nameReader.getElementNulls();
+
+                for (int i = 0; i < count; i++) {
+                    if (nulls != null && nulls.get(i)) {
+                        nullCount++;
+                    }
+                }
+                rowCount += count;
+            }
+        }
+
+        // 3 rows x 2 files = 6 rows, 1 null per file = 2 nulls
+        assertThat(rowCount).isEqualTo(6);
+        assertThat(nullCount).isEqualTo(2);
+    }
+
+    @Test
+    void testSingleColumnSubset() throws Exception {
+        Path filePath = Paths.get("src/test/resources/plain_uncompressed.parquet");
+        List<Path> files = List.of(filePath, filePath, filePath);
+
+        long idSum = 0;
+        long rowCount = 0;
+
+        try (Hardwood hardwood = Hardwood.create();
+             MultiFileParquetReader parquet = hardwood.openAll(files);
+             MultiFileColumnReaders columns = parquet.createColumnReaders(ColumnProjection.columns("id"))) {
+
+            ColumnReader idReader = columns.getColumnReader("id");
+
+            while (idReader.nextBatch()) {
+                int count = idReader.getRecordCount();
+                long[] ids = idReader.getLongs();
+                for (int i = 0; i < count; i++) {
+                    idSum += ids[i];
+                }
+                rowCount += count;
+            }
+        }
+
+        // 3 rows x 3 files = 9 rows
+        assertThat(rowCount).isEqualTo(9);
+        // (1+2+3) * 3 = 18
+        assertThat(idSum).isEqualTo(18L);
+    }
+
+    @Test
+    void testNestingDepthIsFlat() throws Exception {
+        Path filePath = Paths.get("src/test/resources/plain_uncompressed.parquet");
+
+        try (Hardwood hardwood = Hardwood.create();
+             MultiFileParquetReader parquet = hardwood.openAll(List.of(filePath));
+             MultiFileColumnReaders columns = parquet.createColumnReaders(ColumnProjection.columns("id"))) {
+
+            ColumnReader reader = columns.getColumnReader("id");
+            assertThat(reader.getNestingDepth()).isEqualTo(0);
+        }
+    }
+}

--- a/core/src/test/java/dev/hardwood/MultiFileRowReaderTest.java
+++ b/core/src/test/java/dev/hardwood/MultiFileRowReaderTest.java
@@ -15,7 +15,7 @@ import java.util.List;
 import org.junit.jupiter.api.Test;
 
 import dev.hardwood.reader.ColumnProjection;
-import dev.hardwood.reader.Hardwood;
+import dev.hardwood.reader.MultiFileParquetReader;
 import dev.hardwood.reader.MultiFileRowReader;
 import dev.hardwood.reader.ParquetFileReader;
 import dev.hardwood.reader.RowReader;
@@ -35,7 +35,8 @@ class MultiFileRowReaderTest {
         List<Path> files = List.of(filePath);
 
         try (Hardwood hardwood = Hardwood.create();
-             MultiFileRowReader reader = hardwood.openAll(files)) {
+             MultiFileParquetReader parquet = hardwood.openAll(files);
+             MultiFileRowReader reader = parquet.createRowReader()) {
 
             List<Long> ids = new ArrayList<>();
             List<Long> values = new ArrayList<>();
@@ -58,7 +59,8 @@ class MultiFileRowReaderTest {
         List<Path> files = List.of(filePath, filePath, filePath);
 
         try (Hardwood hardwood = Hardwood.create();
-             MultiFileRowReader reader = hardwood.openAll(files)) {
+             MultiFileParquetReader parquet = hardwood.openAll(files);
+             MultiFileRowReader reader = parquet.createRowReader()) {
 
             List<Long> ids = new ArrayList<>();
             List<Long> values = new ArrayList<>();
@@ -85,7 +87,8 @@ class MultiFileRowReaderTest {
         List<Path> files = List.of(filePath, filePath);
 
         try (Hardwood hardwood = Hardwood.create();
-             MultiFileRowReader reader = hardwood.openAll(files, ColumnProjection.columns("id"))) {
+             MultiFileParquetReader parquet = hardwood.openAll(files);
+             MultiFileRowReader reader = parquet.createRowReader(ColumnProjection.columns("id"))) {
 
             List<Long> ids = new ArrayList<>();
 
@@ -106,7 +109,8 @@ class MultiFileRowReaderTest {
         List<Path> files = List.of(filePath);
 
         try (Hardwood hardwood = Hardwood.create();
-             MultiFileRowReader reader = hardwood.openAll(files)) {
+             MultiFileParquetReader parquet = hardwood.openAll(files);
+             MultiFileRowReader reader = parquet.createRowReader()) {
 
             assertThat(reader.getFieldCount()).isEqualTo(2);
             assertThat(reader.getFieldName(0)).isEqualTo("id");
@@ -120,7 +124,8 @@ class MultiFileRowReaderTest {
         List<Path> files = List.of(filePath);
 
         try (Hardwood hardwood = Hardwood.create();
-             MultiFileRowReader reader = hardwood.openAll(files, ColumnProjection.columns("value"))) {
+             MultiFileParquetReader parquet = hardwood.openAll(files);
+             MultiFileRowReader reader = parquet.createRowReader(ColumnProjection.columns("value"))) {
 
             assertThat(reader.getFieldCount()).isEqualTo(1);
             assertThat(reader.getFieldName(0)).isEqualTo("value");
@@ -133,7 +138,8 @@ class MultiFileRowReaderTest {
         List<Path> files = List.of(filePath);
 
         try (Hardwood hardwood = Hardwood.create();
-             MultiFileRowReader reader = hardwood.openAll(files)) {
+             MultiFileParquetReader parquet = hardwood.openAll(files);
+             MultiFileRowReader reader = parquet.createRowReader()) {
 
             reader.hasNext();
             reader.next();
@@ -161,7 +167,8 @@ class MultiFileRowReaderTest {
         // Count rows using MultiFileRowReader
         long multiFileCount = 0;
         try (Hardwood hardwood = Hardwood.create();
-             MultiFileRowReader reader = hardwood.openAll(files)) {
+             MultiFileParquetReader parquet = hardwood.openAll(files);
+             MultiFileRowReader reader = parquet.createRowReader()) {
             while (reader.hasNext()) {
                 reader.next();
                 multiFileCount++;
@@ -191,7 +198,8 @@ class MultiFileRowReaderTest {
         List<Path> files = List.of(filePathWithNulls);
 
         try (Hardwood hardwood = Hardwood.create();
-             MultiFileRowReader reader = hardwood.openAll(files)) {
+             MultiFileParquetReader parquet = hardwood.openAll(files);
+             MultiFileRowReader reader = parquet.createRowReader()) {
 
             int rowCount = 0;
             int nullCount = 0;
@@ -218,7 +226,8 @@ class MultiFileRowReaderTest {
         List<Path> files = List.of(filePath, filePath);
 
         try (Hardwood hardwood = Hardwood.create();
-             MultiFileRowReader reader = hardwood.openAll(files)) {
+             MultiFileParquetReader parquet = hardwood.openAll(files);
+             MultiFileRowReader reader = parquet.createRowReader()) {
 
             long runningSum = 0;
             int rowCount = 0;
@@ -247,7 +256,8 @@ class MultiFileRowReaderTest {
         List<Path> files = List.of(wideFile, wideFile);
 
         try (Hardwood hardwood = Hardwood.create();
-             MultiFileRowReader reader = hardwood.openAll(files)) {
+             MultiFileParquetReader parquet = hardwood.openAll(files);
+             MultiFileRowReader reader = parquet.createRowReader()) {
 
             int rowCount = 0;
             while (reader.hasNext()) {
@@ -270,7 +280,8 @@ class MultiFileRowReaderTest {
         List<Path> files = List.of(filePath, filePath, filePath);
 
         try (Hardwood hardwood = Hardwood.create();
-             MultiFileRowReader reader = hardwood.openAll(files, ColumnProjection.columns("id"))) {
+             MultiFileParquetReader parquet = hardwood.openAll(files);
+             MultiFileRowReader reader = parquet.createRowReader(ColumnProjection.columns("id"))) {
 
             List<Long> ids = new ArrayList<>();
             while (reader.hasNext()) {
@@ -291,7 +302,8 @@ class MultiFileRowReaderTest {
         List<Path> files = List.of(nestedStructFile);
 
         try (Hardwood hardwood = Hardwood.create();
-             MultiFileRowReader reader = hardwood.openAll(files)) {
+             MultiFileParquetReader parquet = hardwood.openAll(files);
+             MultiFileRowReader reader = parquet.createRowReader()) {
 
             // Row 0: id=1, address={street="123 Main St", city="New York", zip=10001}
             assertThat(reader.hasNext()).isTrue();
@@ -331,7 +343,8 @@ class MultiFileRowReaderTest {
         List<Path> files = List.of(nestedStructFile, nestedStructFile);
 
         try (Hardwood hardwood = Hardwood.create();
-             MultiFileRowReader reader = hardwood.openAll(files)) {
+             MultiFileParquetReader parquet = hardwood.openAll(files);
+             MultiFileRowReader reader = parquet.createRowReader()) {
 
             List<Integer> ids = new ArrayList<>();
             List<String> cities = new ArrayList<>();
@@ -368,7 +381,8 @@ class MultiFileRowReaderTest {
         List<Path> files = List.of(nestedStructFile, nestedStructFile);
 
         try (Hardwood hardwood = Hardwood.create();
-             MultiFileRowReader reader = hardwood.openAll(files, ColumnProjection.columns("address"))) {
+             MultiFileParquetReader parquet = hardwood.openAll(files);
+             MultiFileRowReader reader = parquet.createRowReader(ColumnProjection.columns("address"))) {
 
             assertThat(reader.getFieldCount()).isEqualTo(1);
             assertThat(reader.getFieldName(0)).isEqualTo("address");
@@ -403,7 +417,8 @@ class MultiFileRowReaderTest {
         // Count rows using MultiFileRowReader
         long multiFileCount = 0;
         try (Hardwood hardwood = Hardwood.create();
-             MultiFileRowReader reader = hardwood.openAll(files)) {
+             MultiFileParquetReader parquet = hardwood.openAll(files);
+             MultiFileRowReader reader = parquet.createRowReader()) {
             while (reader.hasNext()) {
                 reader.next();
                 multiFileCount++;

--- a/core/src/test/java/dev/hardwood/internal/reader/ColumnAssemblyBufferTest.java
+++ b/core/src/test/java/dev/hardwood/internal/reader/ColumnAssemblyBufferTest.java
@@ -13,9 +13,9 @@ import java.util.concurrent.TimeUnit;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
 
+import dev.hardwood.HardwoodContext;
 import dev.hardwood.metadata.PhysicalType;
 import dev.hardwood.metadata.RepetitionType;
-import dev.hardwood.reader.HardwoodContext;
 import dev.hardwood.schema.ColumnSchema;
 
 import static org.assertj.core.api.Assertions.assertThat;

--- a/core/src/test/java/dev/hardwood/internal/reader/PageCursorTest.java
+++ b/core/src/test/java/dev/hardwood/internal/reader/PageCursorTest.java
@@ -17,9 +17,9 @@ import java.util.List;
 
 import org.junit.jupiter.api.Test;
 
+import dev.hardwood.HardwoodContext;
 import dev.hardwood.metadata.FileMetaData;
 import dev.hardwood.metadata.RowGroup;
-import dev.hardwood.reader.HardwoodContext;
 import dev.hardwood.reader.ParquetFileReader;
 import dev.hardwood.schema.ColumnSchema;
 import dev.hardwood.schema.FileSchema;

--- a/designs/COLUMN_READER_BATCH_API.md
+++ b/designs/COLUMN_READER_BATCH_API.md
@@ -1,0 +1,166 @@
+# Design: ColumnReader Batch API with Multi-Level Offsets
+
+## Context
+
+Benchmarking showed that per-row `hasNext()/next()/getDouble()` access is the primary consumer bottleneck — 2.5x slower than direct array iteration. Replacing per-row access with vectorized `for (int i = 0; i < count; i++)` loops over batch arrays gives a **2x speedup** (330M → 600M rec/s) with the same pipeline.
+
+The old `ColumnReader` exposed values one at a time (`readNext()` → `Object`). It was reworked to expose batch-oriented typed arrays with multi-level offsets for nested/repeated columns, matching the Arrow-style offset pattern.
+
+## API
+
+### Full API surface
+
+```java
+public class ColumnReader implements AutoCloseable {
+    // Batch iteration
+    boolean nextBatch();
+    int getRecordCount();        // rows in current batch
+    int getValueCount();         // total leaf values in current batch
+
+    // Typed value arrays (flattened for repeated columns)
+    int[] getInts();
+    long[] getLongs();
+    float[] getFloats();
+    double[] getDoubles();
+    boolean[] getBooleans();
+    byte[][] getBinaries();
+    String[] getStrings();       // convenience: converts byte arrays to UTF-8
+
+    // Null handling — per-level bitmaps
+    BitSet getElementNulls();           // leaf value nulls (null if no nulls possible)
+    BitSet getLevelNulls(int level);    // group-level nulls at offset level k
+
+    // Offsets for repeated columns
+    int getNestingDepth();              // 0 for flat, maxRepetitionLevel for nested
+    int[] getOffsets(int level);        // offset array for given level (0-indexed)
+
+    // Metadata
+    ColumnSchema getColumnSchema();
+
+    void close();
+}
+```
+
+### Consumer code by column type
+
+**Flat column** (required or optional):
+```java
+try (ColumnReader reader = fileReader.createColumnReader("fare_amount")) {
+    while (reader.nextBatch()) {
+        int count = reader.getRecordCount();    // == getValueCount() for flat
+        double[] values = reader.getDoubles();
+        BitSet nulls = reader.getElementNulls(); // null if column is required
+
+        for (int i = 0; i < count; i++) {
+            if (nulls == null || !nulls.get(i)) sum += values[i];
+        }
+    }
+}
+```
+
+**Simple list** (`list<double>`, nestingDepth=1):
+```java
+try (ColumnReader reader = fileReader.createColumnReader("fare_components")) {
+    while (reader.nextBatch()) {
+        int recordCount = reader.getRecordCount();
+        int valueCount = reader.getValueCount();
+        double[] values = reader.getDoubles();
+        int[] offsets = reader.getOffsets(0);         // record → value position
+        BitSet recordNulls = reader.getLevelNulls(0); // null list records
+        BitSet elementNulls = reader.getElementNulls(); // null elements within lists
+
+        for (int r = 0; r < recordCount; r++) {
+            if (recordNulls != null && recordNulls.get(r)) continue;
+            int start = offsets[r];
+            int end = (r + 1 < recordCount) ? offsets[r + 1] : valueCount;
+            for (int i = start; i < end; i++) {
+                if (elementNulls == null || !elementNulls.get(i)) sum += values[i];
+            }
+        }
+    }
+}
+```
+
+**Nested list** (`list<list<double>>`, nestingDepth=2):
+```java
+int[] outerOff = reader.getOffsets(0);  // record → inner list index
+int[] innerOff = reader.getOffsets(1);  // inner list → value position
+BitSet recordNulls = reader.getLevelNulls(0);    // null records
+BitSet innerListNulls = reader.getLevelNulls(1); // null inner lists
+
+for (int r = 0; r < recordCount; r++) {
+    if (recordNulls != null && recordNulls.get(r)) continue;
+    int listStart = outerOff[r];
+    int listEnd = (r + 1 < recordCount) ? outerOff[r + 1] : innerListCount;
+    for (int j = listStart; j < listEnd; j++) {
+        if (innerListNulls != null && innerListNulls.get(j)) continue;
+        int valStart = innerOff[j];
+        int valEnd = innerOff[j + 1];
+        // process values[valStart..valEnd)
+    }
+}
+```
+
+### Offset model
+
+`maxRepetitionLevel` determines offset array count:
+- **Flat** (maxRep=0): no offsets, `getRecordCount() == getValueCount()`
+- **Simple list** (maxRep=1): 1 offset array
+- **Nested list/map** (maxRep=N): N offset arrays, chained
+
+Level k boundary: positions where `repLevel[i] <= k`.
+
+### Null model
+
+- `getElementNulls()`: BitSet over leaf values. For flat columns this doubles as record-level nulls (since records = values). Null if all elements are required.
+- `getLevelNulls(int level)`: BitSet over items at offset level k. Null if that schema level is required. Only valid for `0 <= level < getNestingDepth()`.
+- Computed from definition levels during batch assembly. Each schema nesting level has a known def level threshold; values below that threshold at a group boundary indicate null.
+
+## Implementation
+
+### ColumnReader internals
+
+Changed from per-column-chunk to per-file (spanning all row groups). Reuses existing infrastructure:
+
+- **Page scanning**: Same pattern as `SingleFileRowReader.initialize()` — scans pages for one column across all row groups using `PageScanner`, in parallel via `CompletableFuture` on `context.executor()`.
+- **Flat columns**: Uses `ColumnAssemblyBuffer` + `PageCursor` with eager assembly virtual thread. `nextBatch()` calls `assemblyBuffer.awaitNextBatch()` returning `FlatColumnData`.
+- **Nested columns**: Uses `ColumnValueIterator.readBatch(batchSize)` returning `NestedColumnData` with values + rep/def levels + recordOffsets.
+
+### Multi-level offset computation
+
+Static method `computeMultiLevelOffsets()` on `ColumnReader`. Given `int[] repLevels`, `int valueCount`, `int recordCount`, `int maxRepLevel`, computes `int[][] offsets`. Simple list (maxRep=1) has a fast path; general case does a two-pass approach (count items, then fill offsets).
+
+### Per-level null bitmap computation
+
+Private method `computeNullBitmaps()` on `ColumnReader`. Computes element-level nulls from definition levels (values where `defLevel < maxDefLevel`), and per-nesting-level nulls using a def-level threshold derived from the schema: `defThreshold = maxDefLevel - maxRepLevel + k + 1`.
+
+### Factory methods on ParquetFileReader
+
+```java
+public ColumnReader createColumnReader(String columnName)
+public ColumnReader createColumnReader(int columnIndex)
+```
+
+Both scan pages across all row groups in parallel, then create a `ColumnReader` with the collected `PageInfo` list.
+
+## Key files
+
+| File | Role |
+|------|------|
+| `core/.../reader/ColumnReader.java` | Batch API, offset/null computation, factory methods |
+| `core/.../reader/ParquetFileReader.java` | `createColumnReader()` factory methods |
+| `core/.../internal/reader/ColumnAssemblyBuffer.java` | Flat column batch assembly |
+| `core/.../internal/reader/ColumnValueIterator.java` | Nested column batch assembly |
+| `core/.../internal/reader/PageCursor.java` | Page iteration (single and multi-file) |
+| `core/.../internal/reader/FlatColumnData.java` | Typed batch data for flat columns |
+| `core/.../internal/reader/NestedColumnData.java` | Typed batch data for nested columns |
+
+## Tests
+
+- **`ParquetReaderTest`**: Tests batch API for flat required columns (`getLongs()`), optional columns with nulls (`getBinaries()` + `getElementNulls()`), compressed columns (Snappy), and column-by-index access.
+- **`ParquetTestingRepoTest`**: Reads every column of every test file via the batch API, verifying `getRecordCount()` totals.
+- **`ParquetComparisonTest`**: Validates batch API results against Apache parquet-java reference reads for all test files.
+
+## Performance
+
+`HARDWOOD_COLUMN_READER` contender in `SimplePerformanceTest` uses three column readers (`passenger_count`, `trip_distance`, `fare_amount`) with the batch loop pattern. Approaches ~600M rec/s for flat columns, matching the vectorized baseline.

--- a/designs/MULTI_FILE_COLUMN_READER.md
+++ b/designs/MULTI_FILE_COLUMN_READER.md
@@ -1,0 +1,131 @@
+# Design: Multi-File ColumnReader
+
+## Context
+
+The single-file `ColumnReader` scans pages across all row groups within one file but cannot span multiple files. The row-based path already has `MultiFileRowReader` which uses `FileManager` + `PageCursor` cross-file prefetching to stream across files. The multi-file column reader provides the equivalent for the columnar API.
+
+## API
+
+### Architecture
+
+The multi-file column reader follows the same two-step pattern as the row reader:
+
+```
+Hardwood.openAll(files)
+  → MultiFileParquetReader        (reads schema, defers page scanning)
+      → createColumnReaders(ColumnProjection)
+          → MultiFileColumnReaders (shared FileManager, cross-file prefetching)
+              → getColumnReader(name/index)
+                  → ColumnReader   (batch-oriented API)
+```
+
+### MultiFileParquetReader (intermediate)
+
+```java
+public class MultiFileParquetReader implements AutoCloseable {
+    FileSchema getFileSchema();
+    MultiFileRowReader createRowReader();
+    MultiFileRowReader createRowReader(ColumnProjection projection);
+    MultiFileColumnReaders createColumnReaders(ColumnProjection projection);
+}
+```
+
+`MultiFileParquetReader` reads the schema eagerly from the first file via `FileManager.openFirst()`, but defers page scanning until a reader is created. This lets consumers inspect `getFileSchema()` before deciding which columns to project.
+
+### MultiFileColumnReaders
+
+```java
+public class MultiFileColumnReaders implements AutoCloseable {
+    int getColumnCount();
+    ColumnReader getColumnReader(String columnName);
+    ColumnReader getColumnReader(int index);   // index within the requested columns
+    void close();
+}
+```
+
+### Usage
+
+```java
+try (Hardwood hardwood = Hardwood.create();
+     MultiFileParquetReader parquet = hardwood.openAll(files);
+     MultiFileColumnReaders columns = parquet.createColumnReaders(
+         ColumnProjection.columns("passenger_count", "trip_distance", "fare_amount"))) {
+
+    ColumnReader col0 = columns.getColumnReader("passenger_count");
+    ColumnReader col1 = columns.getColumnReader("trip_distance");
+    ColumnReader col2 = columns.getColumnReader("fare_amount");
+
+    while (col0.nextBatch() & col1.nextBatch() & col2.nextBatch()) {
+        int count = col0.getRecordCount();
+        double[] v0 = col0.getDoubles();
+        double[] v1 = col1.getDoubles();
+        double[] v2 = col2.getDoubles();
+        for (int i = 0; i < count; i++) {
+            passengerCount += (long) v0[i];
+            tripDistance += v1[i];
+            fareAmount += v2[i];
+        }
+    }
+}
+```
+
+A varargs overload is also available:
+```java
+MultiFileParquetReader parquet = hardwood.openAll(
+    Path.of("data_01.parquet"), Path.of("data_02.parquet"));
+```
+
+## Implementation
+
+### MultiFileParquetReader
+
+- Constructor takes `List<Path> files` and `HardwoodContext context`
+- Creates a `FileManager` and calls `openFirst()` to read the schema from the first file
+- `createColumnReaders(ColumnProjection)` calls `fileManager.initialize(projection)` to scan pages, then passes the `FileManager` and `InitResult` to the `MultiFileColumnReaders` constructor
+- Owns the `FileManager` lifecycle — closes it on `close()`
+
+### MultiFileColumnReaders
+
+- Constructor receives `HardwoodContext`, `FileManager`, and `FileManager.InitResult`
+- For each projected column, creates a `ColumnReader` using the multi-file constructor with the `FileManager` for cross-file prefetching
+- Stores readers in both a `LinkedHashMap<String, ColumnReader>` (by name) and a `ColumnReader[]` (by index)
+- Does **not** close the `FileManager` — that's owned by the parent `MultiFileParquetReader`
+
+### ColumnReader multi-file constructor
+
+Package-private constructor that accepts an additional `FileManager`, `projectedColumnIndex`, and `fileName`:
+
+```java
+ColumnReader(ColumnSchema column, List<PageInfo> pageInfos, HardwoodContext context,
+             int batchSize, FileManager fileManager, int projectedColumnIndex, String fileName)
+```
+
+The `PageCursor` is created with the `FileManager` for cross-file prefetching — the same pattern used by `MultiFileRowReader`.
+
+### FileManager two-phase initialization
+
+`FileManager` was split into two phases to support the `MultiFileParquetReader` intermediate:
+
+1. `openFirst()` — maps and reads metadata from the first file, returns `FileSchema`
+2. `initialize(ColumnProjection)` — scans pages for projected columns across all files, triggers prefetch
+
+This split allows `MultiFileParquetReader` to expose the schema before committing to a column projection.
+
+## Key files
+
+| File | Role |
+|------|------|
+| `core/.../reader/MultiFileColumnReaders.java` | Holds multiple ColumnReaders with shared FileManager |
+| `core/.../reader/MultiFileParquetReader.java` | Intermediate factory: schema access + reader creation |
+| `core/.../reader/ColumnReader.java` | Multi-file constructor delegates to PageCursor with FileManager |
+| `core/.../Hardwood.java` | `openAll(List<Path>)` and `openAll(Path, Path...)` entry points |
+| `core/.../internal/reader/FileManager.java` | Two-phase init: `openFirst()` + `initialize(projection)` |
+
+## Tests
+
+- **`MultiFileColumnReadersTest`** (11 tests): Covers single-file, multi-file, column-by-index, unknown column errors, nulls, data integrity across file boundaries, multiple typed columns (int, long, float, double, boolean, string), single-column projection, and nesting depth metadata.
+- **`SimplePerformanceTest`**: `HARDWOOD_COLUMN_READER_MULTIFILE` contender exercises the full multi-file column reader path with cross-file prefetching.
+
+## Performance
+
+`HARDWOOD_COLUMN_READER_MULTIFILE` eliminates file-boundary latency compared to `HARDWOOD_COLUMN_READER` (which reopens a `ParquetFileReader` per file). Cross-file prefetching ensures pages from file N+1 are ready when file N is exhausted.

--- a/performance-testing/end-to-end/src/test/java/dev/hardwood/perf/FileMappingJfrTest.java
+++ b/performance-testing/end-to-end/src/test/java/dev/hardwood/perf/FileMappingJfrTest.java
@@ -17,7 +17,8 @@ import org.moditect.jfrunit.EnableEvent;
 import org.moditect.jfrunit.JfrEventTest;
 import org.moditect.jfrunit.JfrEvents;
 
-import dev.hardwood.reader.Hardwood;
+import dev.hardwood.Hardwood;
+import dev.hardwood.reader.MultiFileParquetReader;
 import dev.hardwood.reader.MultiFileRowReader;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -60,7 +61,8 @@ public class FileMappingJfrTest {
 
         // Use MultiFileRowReader with all columns (no projection)
         try (Hardwood hardwood = Hardwood.create();
-                MultiFileRowReader rowReader = hardwood.openAll(files2025)) {
+                MultiFileParquetReader parquet = hardwood.openAll(files2025);
+                MultiFileRowReader rowReader = parquet.createRowReader()) {
 
             while (rowReader.hasNext()) {
                 rowReader.next();

--- a/performance-testing/micro-benchmarks/src/main/java/dev/hardwood/benchmarks/PageHandlingBenchmark.java
+++ b/performance-testing/micro-benchmarks/src/main/java/dev/hardwood/benchmarks/PageHandlingBenchmark.java
@@ -30,6 +30,7 @@ import org.openjdk.jmh.annotations.TearDown;
 import org.openjdk.jmh.annotations.Warmup;
 import org.openjdk.jmh.infra.Blackhole;
 
+import dev.hardwood.HardwoodContext;
 import dev.hardwood.internal.compression.Decompressor;
 import dev.hardwood.internal.reader.Page;
 import dev.hardwood.internal.reader.PageInfo;
@@ -41,7 +42,6 @@ import dev.hardwood.metadata.ColumnChunk;
 import dev.hardwood.metadata.ColumnMetaData;
 import dev.hardwood.metadata.PageHeader;
 import dev.hardwood.metadata.RowGroup;
-import dev.hardwood.reader.HardwoodContext;
 import dev.hardwood.reader.ParquetFileReader;
 import dev.hardwood.schema.ColumnSchema;
 import dev.hardwood.schema.FileSchema;

--- a/performance-testing/micro-benchmarks/src/main/java/dev/hardwood/benchmarks/PipelineBenchmark.java
+++ b/performance-testing/micro-benchmarks/src/main/java/dev/hardwood/benchmarks/PipelineBenchmark.java
@@ -30,6 +30,7 @@ import org.openjdk.jmh.annotations.TearDown;
 import org.openjdk.jmh.annotations.Warmup;
 import org.openjdk.jmh.infra.Blackhole;
 
+import dev.hardwood.HardwoodContext;
 import dev.hardwood.internal.reader.PageInfo;
 import dev.hardwood.internal.reader.PageScanner;
 import dev.hardwood.internal.reader.TypedColumnData;
@@ -37,7 +38,6 @@ import dev.hardwood.metadata.ColumnChunk;
 import dev.hardwood.metadata.ColumnMetaData;
 import dev.hardwood.metadata.LogicalType;
 import dev.hardwood.metadata.RowGroup;
-import dev.hardwood.reader.HardwoodContext;
 import dev.hardwood.reader.ParquetFileReader;
 import dev.hardwood.schema.ColumnSchema;
 import dev.hardwood.schema.FileSchema;


### PR DESCRIPTION
This provides a columnar API via `ColumnReader`, allowing to access values in a batched fashion, which yields substantial performance improvements, as it gets rid of the record-level iteration in the consumer.

```
Performance (all runs):
  Contender                          Time (s)     Records/sec   Records/sec/core       MB/sec
  -----------------------------------------------------------------------------------------------
  Hardwood (multifile) [1]               2.64     246,390,088         15,399,381       3496.4
  Hardwood (multifile) [2]               2.73     238,975,781         14,935,986       3391.2
  Hardwood (multifile) [3]               2.79     233,743,361         14,608,960       3317.0
  Hardwood (multifile) [AVG]             2.72     239,591,245         14,974,453       3400.0
                                   min: 2.64s, max: 2.79s, spread: 0.14s

  Hardwood (column reader) [1]           1.69     386,244,960         24,140,310       5481.1
  Hardwood (column reader) [2]           1.46     446,033,564         27,877,098       6329.5
  Hardwood (column reader) [3]           1.47     443,300,887         27,706,305       6290.7
  Hardwood (column reader) [AVG]         1.54     423,412,876         26,463,305       6008.5
                                   min: 1.46s, max: 1.69s, spread: 0.23s

  Hardwood (column reader multifile) [1]         1.41     463,164,298         28,947,769       6572.6
  Hardwood (column reader multifile) [2]         1.26     517,654,215         32,353,388       7345.9
  Hardwood (column reader multifile) [3]         1.24     524,322,869         32,770,179       7440.5
  Hardwood (column reader multifile) [AVG]         1.30     500,160,525         31,260,033       7097.6
                                   min: 1.24s, max: 1.41s, spread: 0.16s
```

The existing `ColumnReader` has been reworked substantially, now not exposing single values any more, but batches. Also it avoids any boxing.

I also restructured the public entrypoint API (`Hardwood`) and reader APIs for consistency: `Hardwood` lets you now chose between single file and multi file support, from the returned `(MultiFile)ParquetFileReader` you can obtain schema data and row or column readers as needed.

@rionmonster, in case you wanted to take a look at this (no pressure), the README changes probably are a good starting point, then the performance test. I haven't super carefully vetted the actual impl of `ColumnReader` as written by Claude, it looks ok though, the API makes sense, tests pass, and it's fast(er), which was good enough for me at this point. We may surely do further iterations on the implementation.