### PR TITLE
#41 Adding performance test for nested data

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -85,7 +85,9 @@
       "Bash(git -C /app log --oneline -20)",
       "Bash(jar:*)",
       "Bash(../mvnw surefire:test:*)",
-      "Bash(git status:*)"
+      "Bash(git status:*)",
+      "WebFetch(domain:docs.overturemaps.org)",
+      "WebFetch(domain:registry.opendata.aws)"
     ]
   }
 }

--- a/core/src/main/java/dev/hardwood/internal/encoding/PlainDecoder.java
+++ b/core/src/main/java/dev/hardwood/internal/encoding/PlainDecoder.java
@@ -38,9 +38,8 @@ public class PlainDecoder implements ValueDecoder {
      * Read a fixed-length byte array value.
      */
     public byte[] readFixedLenByteArray(int length) throws IOException {
-        byte[] bytes = new byte[length];
-        int read = input.read(bytes);
-        if (read != length) {
+        byte[] bytes = input.readNBytes(length);
+        if (bytes.length != length) {
             throw new IOException("Unexpected EOF while reading fixed-length byte array");
         }
         return bytes;
@@ -255,9 +254,8 @@ public class PlainDecoder implements ValueDecoder {
     }
 
     private byte[] readInt96() throws IOException {
-        byte[] bytes = new byte[12];
-        int read = input.read(bytes);
-        if (read != 12) {
+        byte[] bytes = input.readNBytes(12);
+        if (bytes.length != 12) {
             throw new IOException("Unexpected EOF while reading INT96");
         }
         return bytes;
@@ -265,9 +263,8 @@ public class PlainDecoder implements ValueDecoder {
 
     private byte[] readByteArray() throws IOException {
         // Read length (4 bytes, little-endian)
-        byte[] lengthBytes = new byte[4];
-        int read = input.read(lengthBytes);
-        if (read != 4) {
+        byte[] lengthBytes = input.readNBytes(4);
+        if (lengthBytes.length != 4) {
             throw new IOException("Unexpected EOF while reading BYTE_ARRAY length");
         }
         int length = ByteBuffer.wrap(lengthBytes).order(ByteOrder.LITTLE_ENDIAN).getInt();
@@ -276,10 +273,13 @@ public class PlainDecoder implements ValueDecoder {
             throw new IOException("Invalid BYTE_ARRAY length: " + length);
         }
 
+        if (length == 0) {
+            return new byte[0];
+        }
+
         // Read data
-        byte[] data = new byte[length];
-        read = input.read(data);
-        if (read != length) {
+        byte[] data = input.readNBytes(length);
+        if (data.length != length) {
             throw new IOException("Unexpected EOF while reading BYTE_ARRAY data");
         }
         return data;

--- a/core/src/main/java/dev/hardwood/internal/thrift/ThriftCompactReader.java
+++ b/core/src/main/java/dev/hardwood/internal/thrift/ThriftCompactReader.java
@@ -243,8 +243,9 @@ public class ThriftCompactReader {
             case TYPE_MAP:
                 int mapSize = (int) readVarint();
                 if (mapSize > 0) {
-                    byte keyType = readByte();
-                    byte valueType = readByte();
+                    byte kvTypes = readByte();
+                    byte keyType = (byte) ((kvTypes >> 4) & 0x0F);
+                    byte valueType = (byte) (kvTypes & 0x0F);
                     for (int i = 0; i < mapSize; i++) {
                         skipField(keyType);
                         skipField(valueType);

--- a/core/src/test/java/dev/hardwood/internal/reader/DictionaryTest.java
+++ b/core/src/test/java/dev/hardwood/internal/reader/DictionaryTest.java
@@ -1,0 +1,57 @@
+/*
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Copyright The original authors
+ *
+ *  Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package dev.hardwood.internal.reader;
+
+import java.io.IOException;
+
+import org.junit.jupiter.api.Test;
+
+import dev.hardwood.metadata.PhysicalType;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class DictionaryTest {
+
+    @Test
+    void parseByteArrayDictionary() throws IOException {
+        byte[] data = {
+            2, 0, 0, 0, 'A', 'B',       // len=2, "AB"
+            3, 0, 0, 0, 'X', 'Y', 'Z'   // len=3, "XYZ"
+        };
+        Dictionary dict = Dictionary.parse(data, 2, PhysicalType.BYTE_ARRAY, null);
+        assertThat(dict.size()).isEqualTo(2);
+    }
+
+    /**
+     * Reproduces the "Unexpected EOF while reading BYTE_ARRAY data" bug that
+     * occurred with the Overture Maps places file. The last dictionary entry had
+     * length 0 (empty string). ByteArrayInputStream.read(byte[0]) returns -1 at
+     * stream EOF instead of 0, causing the EOF check to trip.
+     */
+    @Test
+    void parseByteArrayDictionaryWithEmptyLastEntry() throws IOException {
+        byte[] data = {
+            2, 0, 0, 0, 'S', 'P',     // len=2, "SP"
+            2, 0, 0, 0, 'G', 'O',     // len=2, "GO"
+            0, 0, 0, 0                  // len=0, ""
+        };
+        Dictionary dict = Dictionary.parse(data, 3, PhysicalType.BYTE_ARRAY, null);
+        assertThat(dict.size()).isEqualTo(3);
+    }
+
+    @Test
+    void parseIntDictionary() throws IOException {
+        byte[] data = {
+            10, 0, 0, 0,
+            20, 0, 0, 0,
+            30, 0, 0, 0
+        };
+        Dictionary dict = Dictionary.parse(data, 3, PhysicalType.INT32, null);
+        assertThat(dict.size()).isEqualTo(3);
+    }
+}

--- a/core/src/test/java/dev/hardwood/internal/thrift/ThriftCompactReaderTest.java
+++ b/core/src/test/java/dev/hardwood/internal/thrift/ThriftCompactReaderTest.java
@@ -1,0 +1,177 @@
+/*
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Copyright The original authors
+ *
+ *  Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package dev.hardwood.internal.thrift;
+
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Tests for ThriftCompactReader, particularly field skipping for complex types.
+ */
+class ThriftCompactReaderTest {
+
+    /**
+     * Verifies that MAP fields are skipped correctly per the Thrift Compact Protocol spec.
+     * <p>
+     * The spec encodes MAP as: varint(size), then if size > 0, a single byte with
+     * key type in the high nibble and value type in the low nibble, followed by
+     * size key-value pairs.
+     * </p>
+     * <p>
+     * A previous bug read two separate bytes for key/value types instead of one packed byte.
+     * </p>
+     */
+    @Test
+    void skipFieldHandlesMapWithPackedKeyValueTypes() throws IOException {
+        // Build a Thrift MAP with 2 entries: map<i32, i32>
+        // Format: varint(2), byte(key_type << 4 | value_type), then 2 pairs of zigzag i32
+        ByteBuffer buffer = ByteBuffer.allocate(64).order(ByteOrder.LITTLE_ENDIAN);
+
+        // MAP size = 2 (varint)
+        buffer.put((byte) 2);
+
+        // Key/value types packed: i32 (0x05) << 4 | i32 (0x05) = 0x55
+        buffer.put((byte) 0x55);
+
+        // Entry 1: key=10 (zigzag=20), value=20 (zigzag=40)
+        buffer.put((byte) 20); // zigzag(10) = 20
+        buffer.put((byte) 40); // zigzag(20) = 40
+
+        // Entry 2: key=30 (zigzag=60), value=40 (zigzag=80)
+        buffer.put((byte) 60); // zigzag(30) = 60
+        buffer.put((byte) 80); // zigzag(40) = 80
+
+        // Sentinel byte to verify we stopped at the right position
+        buffer.put((byte) 0xFF);
+
+        buffer.flip();
+
+        ThriftCompactReader reader = new ThriftCompactReader(buffer);
+        reader.skipField((byte) 0x0B); // TYPE_MAP
+
+        // Should have consumed exactly 6 bytes: 1 (size) + 1 (types) + 4 (entries)
+        assertThat(reader.getBytesRead()).isEqualTo(6);
+    }
+
+    /**
+     * Verifies that empty MAP (size=0) is skipped correctly.
+     * An empty map is just a single varint(0) with no type byte.
+     */
+    @Test
+    void skipFieldHandlesEmptyMap() throws IOException {
+        ByteBuffer buffer = ByteBuffer.allocate(16).order(ByteOrder.LITTLE_ENDIAN);
+
+        // MAP size = 0
+        buffer.put((byte) 0);
+
+        // Sentinel
+        buffer.put((byte) 0xFF);
+
+        buffer.flip();
+
+        ThriftCompactReader reader = new ThriftCompactReader(buffer);
+        reader.skipField((byte) 0x0B); // TYPE_MAP
+
+        // Should have consumed exactly 1 byte (the zero size varint)
+        assertThat(reader.getBytesRead()).isEqualTo(1);
+    }
+
+    /**
+     * Verifies that MAP with string keys and struct values is skipped correctly.
+     * This exercises the recursive skipping through complex nested types.
+     */
+    @Test
+    void skipFieldHandlesMapWithStringKeysAndStructValues() throws IOException {
+        ByteBuffer buffer = ByteBuffer.allocate(64).order(ByteOrder.LITTLE_ENDIAN);
+
+        // MAP size = 1
+        buffer.put((byte) 1);
+
+        // Key/value types packed: BINARY (0x08) << 4 | STRUCT (0x0C) = 0x8C
+        buffer.put((byte) 0x8C);
+
+        // Entry 1 key: binary string "ab" (length=2, then 2 bytes)
+        buffer.put((byte) 2); // length varint
+        buffer.put((byte) 'a');
+        buffer.put((byte) 'b');
+
+        // Entry 1 value: struct with one i32 field (field id=1), then STOP
+        // Field header: delta=1, type=i32(0x05) -> byte = 0x15
+        buffer.put((byte) 0x15);
+        buffer.put((byte) 42); // zigzag(21) = 42
+        buffer.put((byte) 0x00); // STOP
+
+        // Sentinel
+        buffer.put((byte) 0xFF);
+
+        buffer.flip();
+
+        ThriftCompactReader reader = new ThriftCompactReader(buffer);
+        reader.skipField((byte) 0x0B); // TYPE_MAP
+
+        // 1 (size) + 1 (types) + 3 (key) + 3 (struct) = 8 bytes
+        assertThat(reader.getBytesRead()).isEqualTo(8);
+    }
+
+    /**
+     * Verifies that nested struct skipping correctly saves/restores field ID context.
+     */
+    @Test
+    void skipStructPreservesFieldIdContext() throws IOException {
+        // Build a struct with fields 1 (i32) and 2 (struct with field 1 (i32)) and 3 (i32)
+        ByteBuffer buffer = ByteBuffer.allocate(64).order(ByteOrder.LITTLE_ENDIAN);
+
+        // Field 1: type i32 (0x05), delta 1 -> 0x15
+        buffer.put((byte) 0x15);
+        buffer.put((byte) 10); // zigzag(5) = 10
+
+        // Field 2: type struct (0x0C), delta 1 -> 0x1C
+        buffer.put((byte) 0x1C);
+        // Nested struct: field 1 i32
+        buffer.put((byte) 0x15);
+        buffer.put((byte) 20); // zigzag(10) = 20
+        buffer.put((byte) 0x00); // STOP nested struct
+
+        // Field 3: type i32 (0x05), delta 1 -> 0x15
+        buffer.put((byte) 0x15);
+        buffer.put((byte) 30); // zigzag(15) = 30
+
+        // STOP outer struct
+        buffer.put((byte) 0x00);
+
+        buffer.flip();
+
+        ThriftCompactReader reader = new ThriftCompactReader(buffer);
+
+        // Read field 1
+        ThriftCompactReader.FieldHeader f1 = reader.readFieldHeader();
+        assertThat(f1.fieldId()).isEqualTo((short) 1);
+        int val1 = reader.readI32();
+        assertThat(val1).isEqualTo(5);
+
+        // Skip field 2 (struct)
+        ThriftCompactReader.FieldHeader f2 = reader.readFieldHeader();
+        assertThat(f2.fieldId()).isEqualTo((short) 2);
+        reader.skipField(f2.type());
+
+        // Read field 3 - should correctly be field 3, not field 1
+        ThriftCompactReader.FieldHeader f3 = reader.readFieldHeader();
+        assertThat(f3.fieldId()).isEqualTo((short) 3);
+        int val3 = reader.readI32();
+        assertThat(val3).isEqualTo(15);
+
+        // Should be at STOP
+        ThriftCompactReader.FieldHeader stop = reader.readFieldHeader();
+        assertThat(stop).isNull();
+    }
+}

--- a/performance-testing/end-to-end/src/test/java/dev/hardwood/perf/FlatPerformanceTest.java
+++ b/performance-testing/end-to-end/src/test/java/dev/hardwood/perf/FlatPerformanceTest.java
@@ -52,7 +52,7 @@ import static org.assertj.core.api.Assertions.withinPercentage;
  * </p>
  */
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
-class SimplePerformanceTest {
+class FlatPerformanceTest {
 
     private static final Path DATA_DIR = Path.of("../test-data-setup/target/tlc-trip-record-data");
     private static final YearMonth DEFAULT_START = YearMonth.of(2016, 1);

--- a/performance-testing/end-to-end/src/test/java/dev/hardwood/perf/NestedPerformanceTest.java
+++ b/performance-testing/end-to-end/src/test/java/dev/hardwood/perf/NestedPerformanceTest.java
@@ -1,0 +1,948 @@
+/*
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Copyright The original authors
+ *
+ *  Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package dev.hardwood.perf;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.BitSet;
+import java.util.EnumSet;
+import java.util.List;
+import java.util.Set;
+import java.util.function.Supplier;
+import java.util.stream.Collectors;
+
+import org.apache.avro.generic.GenericRecord;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.parquet.avro.AvroParquetReader;
+import org.apache.parquet.hadoop.ParquetReader;
+import org.apache.parquet.hadoop.util.HadoopInputFile;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+
+import dev.hardwood.Hardwood;
+import dev.hardwood.reader.ColumnReader;
+import dev.hardwood.reader.ParquetFileReader;
+import dev.hardwood.reader.RowReader;
+import dev.hardwood.row.PqList;
+import dev.hardwood.row.PqMap;
+import dev.hardwood.row.PqStruct;
+import dev.hardwood.schema.SchemaNode;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.withinPercentage;
+
+/**
+ * Performance comparison test for deeply nested Parquet schemas.
+ *
+ * <p>
+ * Uses an Overture Maps places file (downloaded by test-data-setup module) with
+ * deeply nested structs, lists, and maps to compare reading performance.
+ * </p>
+ */
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+class NestedPerformanceTest {
+
+    private static final Path DATA_FILE = Path.of(
+            "../test-data-setup/target/overture-maps-data/overture_places.zstd.parquet");
+    private static final int DEFAULT_RUNS = 5;
+    private static final String CONTENDERS_PROPERTY = "perf.contenders";
+    private static final String RUNS_PROPERTY = "perf.runs";
+
+    enum Contender {
+        PARQUET_JAVA("parquet-java"),
+        HARDWOOD_NAMED("Hardwood (named)"),
+        HARDWOOD_INDEXED("Hardwood (indexed)"),
+        HARDWOOD_COLUMNAR("Hardwood (columnar)");
+
+        private final String displayName;
+
+        Contender(String displayName) {
+            this.displayName = displayName;
+        }
+
+        String displayName() {
+            return displayName;
+        }
+
+        static Contender fromString(String name) {
+            for (Contender c : values()) {
+                if (c.name().equalsIgnoreCase(name) || c.displayName.equalsIgnoreCase(name)) {
+                    return c;
+                }
+            }
+            throw new IllegalArgumentException("Unknown contender: " + name
+                    + ". Valid values: " + Arrays.toString(values()));
+        }
+    }
+
+    record Result(
+            long rowCount,
+            long durationMs,
+            int minVersion,
+            int maxVersion,
+            double minConfidence,
+            double maxConfidence,
+            double minBboxXmin,
+            double maxBboxXmax,
+            long totalWebsiteCount,
+            int maxWebsiteCount,
+            long totalSourceCount,
+            int maxSourceCount,
+            long totalNameEntries,
+            int maxNameEntries,
+            int maxPrimaryNameLength,
+            long totalAddressCount,
+            int maxAddressCount) {
+    }
+
+    private Set<Contender> getEnabledContenders() {
+        String property = System.getProperty(CONTENDERS_PROPERTY);
+        if (property == null || property.isBlank()) {
+            return EnumSet.of(Contender.HARDWOOD_NAMED);
+        }
+        if (property.equalsIgnoreCase("all")) {
+            return EnumSet.allOf(Contender.class);
+        }
+        return Arrays.stream(property.split(","))
+                .map(String::trim)
+                .filter(s -> !s.isEmpty())
+                .map(Contender::fromString)
+                .collect(Collectors.toCollection(() -> EnumSet.noneOf(Contender.class)));
+    }
+
+    private int getRunCount() {
+        String property = System.getProperty(RUNS_PROPERTY);
+        if (property == null || property.isBlank()) {
+            return DEFAULT_RUNS;
+        }
+        return Integer.parseInt(property);
+    }
+
+    @Test
+    void comparePerformance() throws IOException {
+        assertThat(Files.exists(DATA_FILE))
+                .as("Overture Maps data file should exist at %s. Run test-data-setup first.", DATA_FILE)
+                .isTrue();
+
+        Set<Contender> enabledContenders = getEnabledContenders();
+        int runCount = getRunCount();
+
+        long fileSize = Files.size(DATA_FILE);
+        System.out.println("\n=== Nested Schema Performance Test ===");
+        System.out.println("File: " + DATA_FILE.getFileName());
+        System.out.println("File size: " + String.format("%,.1f MB", fileSize / (1024.0 * 1024.0)));
+        System.out.println("Runs per contender: " + runCount);
+        System.out.println("Enabled contenders: " + enabledContenders.stream()
+                .map(Contender::displayName)
+                .collect(Collectors.joining(", ")));
+
+        // Warmup
+        System.out.println("\nWarmup run...");
+        Contender warmupContender = enabledContenders.iterator().next();
+        getRunner(warmupContender).get();
+
+        // Timed runs
+        System.out.println("\nTimed runs:");
+        java.util.Map<Contender, List<Result>> results = new java.util.EnumMap<>(Contender.class);
+
+        for (Contender contender : enabledContenders) {
+            List<Result> contenderResults = new ArrayList<>();
+            for (int i = 0; i < runCount; i++) {
+                Result result = timeRun(contender.displayName() + " [" + (i + 1) + "/" + runCount + "]",
+                        getRunner(contender));
+                contenderResults.add(result);
+            }
+            results.put(contender, contenderResults);
+        }
+
+        printResults(fileSize, runCount, results);
+        verifyCorrectness(results);
+    }
+
+    @Test
+    void printRows() throws IOException {
+        assertThat(Files.exists(DATA_FILE))
+                .as("Overture Maps data file should exist at %s. Run test-data-setup first.", DATA_FILE)
+                .isTrue();
+
+        try (Hardwood hardwood = Hardwood.create();
+             ParquetFileReader reader = hardwood.open(DATA_FILE)) {
+
+            System.out.println("\n=== Schema ===");
+            System.out.println(reader.getFileSchema());
+
+            System.out.println("\n=== Sample Rows (first 5 with nested data) ===\n");
+
+            try (RowReader rowReader = reader.createRowReader()) {
+                int printed = 0;
+                int scanned = 0;
+                while (rowReader.hasNext() && printed < 5) {
+                    rowReader.next();
+                    scanned++;
+
+                    // Skip rows where most nested fields are null
+                    if (rowReader.isNull("names") && rowReader.isNull("sources")) {
+                        continue;
+                    }
+
+                    printed++;
+                    System.out.println("--- Row " + scanned + " ---");
+
+                    if (!rowReader.isNull("id")) {
+                        System.out.println("  id: " + rowReader.getString("id"));
+                    }
+                    if (!rowReader.isNull("version")) {
+                        System.out.println("  version: " + rowReader.getInt("version"));
+                    }
+                    if (!rowReader.isNull("confidence")) {
+                        System.out.println("  confidence: " + rowReader.getDouble("confidence"));
+                    }
+
+                    if (!rowReader.isNull("bbox")) {
+                        PqStruct bbox = rowReader.getStruct("bbox");
+                        System.out.println("  bbox:");
+                        System.out.println("    xmin: " + bbox.getFloat("xmin"));
+                        System.out.println("    xmax: " + bbox.getFloat("xmax"));
+                        System.out.println("    ymin: " + bbox.getFloat("ymin"));
+                        System.out.println("    ymax: " + bbox.getFloat("ymax"));
+                    }
+
+                    if (!rowReader.isNull("names")) {
+                        PqStruct names = rowReader.getStruct("names");
+                        if (!names.isNull("primary")) {
+                            System.out.println("  names.primary: " + names.getString("primary"));
+                        }
+                        if (!names.isNull("common")) {
+                            PqMap common = names.getMap("common");
+                            System.out.println("  names.common: " + common.size() + " entries");
+                            int count = 0;
+                            for (PqMap.Entry entry : common.getEntries()) {
+                                if (count >= 3) {
+                                    System.out.println("    ... and " + (common.size() - 3) + " more");
+                                    break;
+                                }
+                                System.out.println("    " + entry.getStringKey() + " -> " + entry.getStringValue());
+                                count++;
+                            }
+                        }
+                    }
+
+                    if (!rowReader.isNull("sources")) {
+                        PqList sources = rowReader.getList("sources");
+                        System.out.println("  sources: " + sources.size() + " entries");
+                        for (int s = 0; s < Math.min(sources.size(), 2); s++) {
+                            PqStruct src = (PqStruct) sources.get(s);
+                            if (src != null) {
+                                System.out.println("    [" + s + "]:");
+                                if (!src.isNull("dataset")) {
+                                    System.out.println("      dataset: " + src.getString("dataset"));
+                                }
+                                if (!src.isNull("record_id")) {
+                                    System.out.println("      record_id: " + src.getString("record_id"));
+                                }
+                            }
+                        }
+                    }
+
+                    if (!rowReader.isNull("websites")) {
+                        PqList websites = rowReader.getList("websites");
+                        System.out.println("  websites: " + websites.size() + " entries");
+                        for (String url : websites.strings()) {
+                            System.out.println("    - " + url);
+                        }
+                    }
+
+                    if (!rowReader.isNull("addresses")) {
+                        PqList addresses = rowReader.getList("addresses");
+                        System.out.println("  addresses: " + addresses.size() + " entries");
+                        for (int a = 0; a < Math.min(addresses.size(), 2); a++) {
+                            PqStruct addr = (PqStruct) addresses.get(a);
+                            if (addr != null) {
+                                System.out.println("    [" + a + "]:");
+                                if (!addr.isNull("freeform")) {
+                                    System.out.println("      freeform: " + addr.getString("freeform"));
+                                }
+                                if (!addr.isNull("locality")) {
+                                    System.out.println("      locality: " + addr.getString("locality"));
+                                }
+                                if (!addr.isNull("country")) {
+                                    System.out.println("      country: " + addr.getString("country"));
+                                }
+                            }
+                        }
+                    }
+
+                    System.out.println();
+                }
+                System.out.println("(Scanned " + scanned + " rows to find " + printed + " with nested data)");
+            }
+        }
+    }
+
+    // ==================== Runners ====================
+
+    private Supplier<Result> getRunner(Contender contender) {
+        return switch (contender) {
+            case PARQUET_JAVA -> this::runParquetJava;
+            case HARDWOOD_NAMED -> this::runHardwoodNamed;
+            case HARDWOOD_INDEXED -> this::runHardwoodIndexed;
+            case HARDWOOD_COLUMNAR -> this::runHardwoodColumnar;
+        };
+    }
+
+    private Result runParquetJava() {
+        long rowCount = 0;
+        int minVersion = Integer.MAX_VALUE;
+        int maxVersion = Integer.MIN_VALUE;
+        double minConfidence = Double.MAX_VALUE;
+        double maxConfidence = -Double.MAX_VALUE;
+        double minBboxXmin = Double.MAX_VALUE;
+        double maxBboxXmax = -Double.MAX_VALUE;
+        long totalWebsiteCount = 0;
+        int maxWebsiteCount = 0;
+        long totalSourceCount = 0;
+        int maxSourceCount = 0;
+        long totalNameEntries = 0;
+        int maxNameEntries = 0;
+        int maxPrimaryNameLength = 0;
+        long totalAddressCount = 0;
+        int maxAddressCount = 0;
+
+        Configuration conf = new Configuration();
+        org.apache.hadoop.fs.Path hadoopPath = new org.apache.hadoop.fs.Path(DATA_FILE.toUri());
+
+        try (ParquetReader<GenericRecord> reader = AvroParquetReader
+                .<GenericRecord>builder(HadoopInputFile.fromPath(hadoopPath, conf))
+                .build()) {
+            GenericRecord record;
+            while ((record = reader.read()) != null) {
+                rowCount++;
+
+                // version (int)
+                Object v = record.get("version");
+                if (v != null) {
+                    int version = ((Number) v).intValue();
+                    if (version < minVersion) minVersion = version;
+                    if (version > maxVersion) maxVersion = version;
+                }
+
+                // confidence (double)
+                Object c = record.get("confidence");
+                if (c != null) {
+                    double confidence = ((Number) c).doubleValue();
+                    if (confidence < minConfidence) minConfidence = confidence;
+                    if (confidence > maxConfidence) maxConfidence = confidence;
+                }
+
+                // bbox (struct)
+                Object bboxObj = record.get("bbox");
+                if (bboxObj instanceof GenericRecord bbox) {
+                    Object xminObj = bbox.get("xmin");
+                    Object xmaxObj = bbox.get("xmax");
+                    if (xminObj != null) {
+                        double xmin = ((Number) xminObj).doubleValue();
+                        if (xmin < minBboxXmin) minBboxXmin = xmin;
+                    }
+                    if (xmaxObj != null) {
+                        double xmax = ((Number) xmaxObj).doubleValue();
+                        if (xmax > maxBboxXmax) maxBboxXmax = xmax;
+                    }
+                }
+
+                // websites (list<string>)
+                Object websitesObj = record.get("websites");
+                if (websitesObj instanceof java.util.List<?> websites) {
+                    int size = websites.size();
+                    totalWebsiteCount += size;
+                    if (size > maxWebsiteCount) maxWebsiteCount = size;
+                }
+
+                // sources (list<struct>)
+                Object sourcesObj = record.get("sources");
+                if (sourcesObj instanceof java.util.List<?> sources) {
+                    int size = sources.size();
+                    totalSourceCount += size;
+                    if (size > maxSourceCount) maxSourceCount = size;
+                }
+
+                // names (struct -> map, string)
+                Object namesObj = record.get("names");
+                if (namesObj instanceof GenericRecord names) {
+                    Object commonObj = names.get("common");
+                    if (commonObj instanceof java.util.Map<?, ?> commonMap) {
+                        int size = commonMap.size();
+                        totalNameEntries += size;
+                        if (size > maxNameEntries) maxNameEntries = size;
+                    }
+
+                    Object primaryObj = names.get("primary");
+                    if (primaryObj != null) {
+                        int len = primaryObj.toString().length();
+                        if (len > maxPrimaryNameLength) maxPrimaryNameLength = len;
+                    }
+                }
+
+                // addresses (list<struct>)
+                Object addressesObj = record.get("addresses");
+                if (addressesObj instanceof java.util.List<?> addresses) {
+                    int size = addresses.size();
+                    totalAddressCount += size;
+                    if (size > maxAddressCount) maxAddressCount = size;
+                }
+            }
+        }
+        catch (IOException e) {
+            throw new RuntimeException("Failed to read file: " + DATA_FILE, e);
+        }
+
+        return new Result(rowCount, 0, minVersion, maxVersion, minConfidence, maxConfidence,
+                minBboxXmin, maxBboxXmax, totalWebsiteCount, maxWebsiteCount,
+                totalSourceCount, maxSourceCount, totalNameEntries, maxNameEntries,
+                maxPrimaryNameLength, totalAddressCount, maxAddressCount);
+    }
+
+    private Result runHardwoodNamed() {
+        long rowCount = 0;
+        int minVersion = Integer.MAX_VALUE;
+        int maxVersion = Integer.MIN_VALUE;
+        double minConfidence = Double.MAX_VALUE;
+        double maxConfidence = -Double.MAX_VALUE;
+        double minBboxXmin = Double.MAX_VALUE;
+        double maxBboxXmax = -Double.MAX_VALUE;
+        long totalWebsiteCount = 0;
+        int maxWebsiteCount = 0;
+        long totalSourceCount = 0;
+        int maxSourceCount = 0;
+        long totalNameEntries = 0;
+        int maxNameEntries = 0;
+        int maxPrimaryNameLength = 0;
+        long totalAddressCount = 0;
+        int maxAddressCount = 0;
+
+        try (Hardwood hardwood = Hardwood.create();
+             ParquetFileReader reader = hardwood.open(DATA_FILE);
+             RowReader rowReader = reader.createRowReader()) {
+
+            while (rowReader.hasNext()) {
+                rowReader.next();
+                rowCount++;
+
+                // version (int)
+                if (!rowReader.isNull("version")) {
+                    int version = rowReader.getInt("version");
+                    if (version < minVersion) minVersion = version;
+                    if (version > maxVersion) maxVersion = version;
+                }
+
+                // confidence (double)
+                if (!rowReader.isNull("confidence")) {
+                    double confidence = rowReader.getDouble("confidence");
+                    if (confidence < minConfidence) minConfidence = confidence;
+                    if (confidence > maxConfidence) maxConfidence = confidence;
+                }
+
+                // bbox (struct -> float)
+                if (!rowReader.isNull("bbox")) {
+                    PqStruct bbox = rowReader.getStruct("bbox");
+                    if (!bbox.isNull("xmin")) {
+                        double xmin = bbox.getFloat("xmin");
+                        if (xmin < minBboxXmin) minBboxXmin = xmin;
+                    }
+                    if (!bbox.isNull("xmax")) {
+                        double xmax = bbox.getFloat("xmax");
+                        if (xmax > maxBboxXmax) maxBboxXmax = xmax;
+                    }
+                }
+
+                // websites (list<string>)
+                if (!rowReader.isNull("websites")) {
+                    PqList websites = rowReader.getList("websites");
+                    int size = websites.size();
+                    totalWebsiteCount += size;
+                    if (size > maxWebsiteCount) maxWebsiteCount = size;
+                }
+
+                // sources (list<struct>)
+                if (!rowReader.isNull("sources")) {
+                    PqList sources = rowReader.getList("sources");
+                    int size = sources.size();
+                    totalSourceCount += size;
+                    if (size > maxSourceCount) maxSourceCount = size;
+                }
+
+                // names (struct -> map, string)
+                if (!rowReader.isNull("names")) {
+                    PqStruct names = rowReader.getStruct("names");
+                    if (!names.isNull("common")) {
+                        PqMap common = names.getMap("common");
+                        int size = common.size();
+                        totalNameEntries += size;
+                        if (size > maxNameEntries) maxNameEntries = size;
+                    }
+                    if (!names.isNull("primary")) {
+                        int len = names.getString("primary").length();
+                        if (len > maxPrimaryNameLength) maxPrimaryNameLength = len;
+                    }
+                }
+
+                // addresses (list<struct>)
+                if (!rowReader.isNull("addresses")) {
+                    PqList addresses = rowReader.getList("addresses");
+                    int size = addresses.size();
+                    totalAddressCount += size;
+                    if (size > maxAddressCount) maxAddressCount = size;
+                }
+            }
+        }
+        catch (IOException e) {
+            throw new RuntimeException("Failed to read file: " + DATA_FILE, e);
+        }
+
+        return new Result(rowCount, 0, minVersion, maxVersion, minConfidence, maxConfidence,
+                minBboxXmin, maxBboxXmax, totalWebsiteCount, maxWebsiteCount,
+                totalSourceCount, maxSourceCount, totalNameEntries, maxNameEntries,
+                maxPrimaryNameLength, totalAddressCount, maxAddressCount);
+    }
+
+    private Result runHardwoodIndexed() {
+        long rowCount = 0;
+        int minVersion = Integer.MAX_VALUE;
+        int maxVersion = Integer.MIN_VALUE;
+        double minConfidence = Double.MAX_VALUE;
+        double maxConfidence = -Double.MAX_VALUE;
+        double minBboxXmin = Double.MAX_VALUE;
+        double maxBboxXmax = -Double.MAX_VALUE;
+        long totalWebsiteCount = 0;
+        int maxWebsiteCount = 0;
+        long totalSourceCount = 0;
+        int maxSourceCount = 0;
+        long totalNameEntries = 0;
+        int maxNameEntries = 0;
+        int maxPrimaryNameLength = 0;
+        long totalAddressCount = 0;
+        int maxAddressCount = 0;
+
+        try (Hardwood hardwood = Hardwood.create();
+             ParquetFileReader reader = hardwood.open(DATA_FILE);
+             RowReader rowReader = reader.createRowReader()) {
+
+            // Resolve top-level field indices once (RowReader supports int-based access)
+            SchemaNode.GroupNode root = reader.getFileSchema().getRootNode();
+            int versionIdx = findFieldIndex(root, "version");
+            int confidenceIdx = findFieldIndex(root, "confidence");
+            int bboxIdx = findFieldIndex(root, "bbox");
+            int websitesIdx = findFieldIndex(root, "websites");
+            int sourcesIdx = findFieldIndex(root, "sources");
+            int namesIdx = findFieldIndex(root, "names");
+            int addressesIdx = findFieldIndex(root, "addresses");
+
+            while (rowReader.hasNext()) {
+                rowReader.next();
+                rowCount++;
+
+                if (!rowReader.isNull(versionIdx)) {
+                    int version = rowReader.getInt(versionIdx);
+                    if (version < minVersion) minVersion = version;
+                    if (version > maxVersion) maxVersion = version;
+                }
+
+                if (!rowReader.isNull(confidenceIdx)) {
+                    double confidence = rowReader.getDouble(confidenceIdx);
+                    if (confidence < minConfidence) minConfidence = confidence;
+                    if (confidence > maxConfidence) maxConfidence = confidence;
+                }
+
+                // PqStruct uses name-based access only
+                if (!rowReader.isNull(bboxIdx)) {
+                    PqStruct bbox = rowReader.getStruct(bboxIdx);
+                    if (!bbox.isNull("xmin")) {
+                        double xmin = bbox.getFloat("xmin");
+                        if (xmin < minBboxXmin) minBboxXmin = xmin;
+                    }
+                    if (!bbox.isNull("xmax")) {
+                        double xmax = bbox.getFloat("xmax");
+                        if (xmax > maxBboxXmax) maxBboxXmax = xmax;
+                    }
+                }
+
+                if (!rowReader.isNull(websitesIdx)) {
+                    PqList websites = rowReader.getList(websitesIdx);
+                    int size = websites.size();
+                    totalWebsiteCount += size;
+                    if (size > maxWebsiteCount) maxWebsiteCount = size;
+                }
+
+                if (!rowReader.isNull(sourcesIdx)) {
+                    PqList sources = rowReader.getList(sourcesIdx);
+                    int size = sources.size();
+                    totalSourceCount += size;
+                    if (size > maxSourceCount) maxSourceCount = size;
+                }
+
+                if (!rowReader.isNull(namesIdx)) {
+                    PqStruct names = rowReader.getStruct(namesIdx);
+                    if (!names.isNull("common")) {
+                        PqMap common = names.getMap("common");
+                        int size = common.size();
+                        totalNameEntries += size;
+                        if (size > maxNameEntries) maxNameEntries = size;
+                    }
+                    if (!names.isNull("primary")) {
+                        int len = names.getString("primary").length();
+                        if (len > maxPrimaryNameLength) maxPrimaryNameLength = len;
+                    }
+                }
+
+                if (!rowReader.isNull(addressesIdx)) {
+                    PqList addresses = rowReader.getList(addressesIdx);
+                    int size = addresses.size();
+                    totalAddressCount += size;
+                    if (size > maxAddressCount) maxAddressCount = size;
+                }
+            }
+        }
+        catch (IOException e) {
+            throw new RuntimeException("Failed to read file: " + DATA_FILE, e);
+        }
+
+        return new Result(rowCount, 0, minVersion, maxVersion, minConfidence, maxConfidence,
+                minBboxXmin, maxBboxXmax, totalWebsiteCount, maxWebsiteCount,
+                totalSourceCount, maxSourceCount, totalNameEntries, maxNameEntries,
+                maxPrimaryNameLength, totalAddressCount, maxAddressCount);
+    }
+
+    private Result runHardwoodColumnar() {
+        long rowCount = 0;
+        int minVersion = Integer.MAX_VALUE;
+        int maxVersion = Integer.MIN_VALUE;
+        double minConfidence = Double.MAX_VALUE;
+        double maxConfidence = -Double.MAX_VALUE;
+        double minBboxXmin = Double.MAX_VALUE;
+        double maxBboxXmax = -Double.MAX_VALUE;
+        long totalWebsiteCount = 0;
+        int maxWebsiteCount = 0;
+        long totalSourceCount = 0;
+        int maxSourceCount = 0;
+        long totalAddressCount = 0;
+        int maxAddressCount = 0;
+
+        try (Hardwood hardwood = Hardwood.create();
+             ParquetFileReader reader = hardwood.open(DATA_FILE)) {
+
+            // Resolve column indices from schema
+            int versionColIdx = reader.getFileSchema().getColumn("version").columnIndex();
+            int confidenceColIdx = reader.getFileSchema().getColumn("confidence").columnIndex();
+
+            // Find bbox leaf columns by walking the schema tree
+            SchemaNode.GroupNode root = reader.getFileSchema().getRootNode();
+            SchemaNode.GroupNode bboxNode = (SchemaNode.GroupNode) findChild(root, "bbox");
+            int bboxXminColIdx = ((SchemaNode.PrimitiveNode) findChild(bboxNode, "xmin")).columnIndex();
+            int bboxXmaxColIdx = ((SchemaNode.PrimitiveNode) findChild(bboxNode, "xmax")).columnIndex();
+
+            // For list sizes, use a leaf column under the list
+            int websiteLeafColIdx = findFirstLeafColumnIndex(findChild(root, "websites"));
+            int sourceLeafColIdx = findFirstLeafColumnIndex(findChild(root, "sources"));
+            int addressLeafColIdx = findFirstLeafColumnIndex(findChild(root, "addresses"));
+
+            // Read flat primitives: version and confidence
+            try (ColumnReader versionCol = reader.createColumnReader(versionColIdx);
+                 ColumnReader confidenceCol = reader.createColumnReader(confidenceColIdx)) {
+                while (versionCol.nextBatch() & confidenceCol.nextBatch()) {
+                    int count = versionCol.getRecordCount();
+                    int[] versions = versionCol.getInts();
+                    double[] confidences = confidenceCol.getDoubles();
+                    BitSet vNulls = versionCol.getElementNulls();
+                    BitSet cNulls = confidenceCol.getElementNulls();
+
+                    for (int i = 0; i < count; i++) {
+                        if (vNulls == null || !vNulls.get(i)) {
+                            if (versions[i] < minVersion) minVersion = versions[i];
+                            if (versions[i] > maxVersion) maxVersion = versions[i];
+                        }
+                        if (cNulls == null || !cNulls.get(i)) {
+                            if (confidences[i] < minConfidence) minConfidence = confidences[i];
+                            if (confidences[i] > maxConfidence) maxConfidence = confidences[i];
+                        }
+                    }
+                    rowCount += count;
+                }
+            }
+
+            // Read bbox leaf columns
+            try (ColumnReader xminCol = reader.createColumnReader(bboxXminColIdx);
+                 ColumnReader xmaxCol = reader.createColumnReader(bboxXmaxColIdx)) {
+                while (xminCol.nextBatch() & xmaxCol.nextBatch()) {
+                    int count = xminCol.getRecordCount();
+                    float[] xmins = xminCol.getFloats();
+                    float[] xmaxs = xmaxCol.getFloats();
+                    BitSet xminNulls = xminCol.getElementNulls();
+                    BitSet xmaxNulls = xmaxCol.getElementNulls();
+
+                    for (int i = 0; i < count; i++) {
+                        if (xminNulls == null || !xminNulls.get(i)) {
+                            if (xmins[i] < minBboxXmin) minBboxXmin = xmins[i];
+                        }
+                        if (xmaxNulls == null || !xmaxNulls.get(i)) {
+                            if (xmaxs[i] > maxBboxXmax) maxBboxXmax = xmaxs[i];
+                        }
+                    }
+                }
+            }
+
+            // Compute list sizes from nested leaf columns
+            totalWebsiteCount = computeListSizes(reader, websiteLeafColIdx, new long[2]);
+            long[] websiteSizes = new long[2];
+            totalWebsiteCount = computeListSizes(reader, websiteLeafColIdx, websiteSizes);
+            maxWebsiteCount = (int) websiteSizes[1];
+
+            long[] sourceSizes = new long[2];
+            totalSourceCount = computeListSizes(reader, sourceLeafColIdx, sourceSizes);
+            maxSourceCount = (int) sourceSizes[1];
+
+            long[] addressSizes = new long[2];
+            totalAddressCount = computeListSizes(reader, addressLeafColIdx, addressSizes);
+            maxAddressCount = (int) addressSizes[1];
+        }
+        catch (IOException e) {
+            throw new RuntimeException("Failed to read file: " + DATA_FILE, e);
+        }
+
+        // Columnar doesn't compute name entries or primary name length (requires row assembly)
+        return new Result(rowCount, 0, minVersion, maxVersion, minConfidence, maxConfidence,
+                minBboxXmin, maxBboxXmax, totalWebsiteCount, maxWebsiteCount,
+                totalSourceCount, maxSourceCount, 0, 0, 0,
+                totalAddressCount, maxAddressCount);
+    }
+
+    /**
+     * Compute list sizes from a nested leaf column using level-0 offsets.
+     * Returns totalCount, and populates sizes[0]=totalCount, sizes[1]=maxCount.
+     */
+    private long computeListSizes(ParquetFileReader reader, int colIdx, long[] sizes) {
+        long totalCount = 0;
+        int maxCount = 0;
+
+        try (ColumnReader col = reader.createColumnReader(colIdx)) {
+            while (col.nextBatch()) {
+                int recordCount = col.getRecordCount();
+                int valueCount = col.getValueCount();
+                int[] offsets = col.getOffsets(0);
+                BitSet levelNulls = col.getLevelNulls(0);
+
+                for (int r = 0; r < recordCount; r++) {
+                    if (levelNulls != null && levelNulls.get(r)) continue;
+                    int start = offsets[r];
+                    int end = (r + 1 < recordCount) ? offsets[r + 1] : valueCount;
+                    int size = end - start;
+                    totalCount += size;
+                    if (size > maxCount) maxCount = size;
+                }
+            }
+        }
+
+        sizes[0] = totalCount;
+        sizes[1] = maxCount;
+        return totalCount;
+    }
+
+    // ==================== Helpers ====================
+
+    private static int findFieldIndex(SchemaNode.GroupNode group, String name) {
+        for (int i = 0; i < group.children().size(); i++) {
+            if (group.children().get(i).name().equals(name)) {
+                return i;
+            }
+        }
+        throw new IllegalArgumentException("Field not found: " + name + " in " + group.name());
+    }
+
+    private static SchemaNode findChild(SchemaNode.GroupNode group, String name) {
+        for (SchemaNode child : group.children()) {
+            if (child.name().equals(name)) {
+                return child;
+            }
+        }
+        throw new IllegalArgumentException("Child not found: " + name + " in " + group.name());
+    }
+
+    private static int findFirstLeafColumnIndex(SchemaNode node) {
+        return switch (node) {
+            case SchemaNode.PrimitiveNode prim -> prim.columnIndex();
+            case SchemaNode.GroupNode group -> {
+                SchemaNode first = group.isList() ? group.getListElement() : group.children().get(0);
+                yield findFirstLeafColumnIndex(first);
+            }
+        };
+    }
+
+    // ==================== Timing and Reporting ====================
+
+    private Result timeRun(String name, Supplier<Result> runner) {
+        System.out.println("  Running " + name + "...");
+        long start = System.currentTimeMillis();
+        Result result = runner.get();
+        long duration = System.currentTimeMillis() - start;
+        return new Result(result.rowCount(), duration,
+                result.minVersion(), result.maxVersion(),
+                result.minConfidence(), result.maxConfidence(),
+                result.minBboxXmin(), result.maxBboxXmax(),
+                result.totalWebsiteCount(), result.maxWebsiteCount(),
+                result.totalSourceCount(), result.maxSourceCount(),
+                result.totalNameEntries(), result.maxNameEntries(),
+                result.maxPrimaryNameLength(),
+                result.totalAddressCount(), result.maxAddressCount());
+    }
+
+    private void printResults(long fileSize, int runCount,
+                              java.util.Map<Contender, List<Result>> results) {
+        int cpuCores = Runtime.getRuntime().availableProcessors();
+        Result firstResult = results.values().iterator().next().get(0);
+
+        System.out.println("\n" + "=".repeat(100));
+        System.out.println("NESTED SCHEMA PERFORMANCE TEST RESULTS");
+        System.out.println("=".repeat(100));
+        System.out.println();
+        System.out.println("Environment:");
+        System.out.println("  CPU cores:       " + cpuCores);
+        System.out.println("  Java version:    " + System.getProperty("java.version"));
+        System.out.println("  OS:              " + System.getProperty("os.name") + " " + System.getProperty("os.arch"));
+        System.out.println();
+        System.out.println("Data:");
+        System.out.println("  Total rows:      " + String.format("%,d", firstResult.rowCount()));
+        System.out.println("  File size:       " + String.format("%,.1f MB", fileSize / (1024.0 * 1024.0)));
+        System.out.println("  Runs per contender: " + runCount);
+        System.out.println();
+
+        // Correctness verification
+        if (results.size() > 1) {
+            System.out.println("Correctness Verification:");
+            System.out.println(String.format("  %-25s %10s %10s %10s %12s %12s %10s",
+                    "", "min_ver", "max_ver", "rows", "websites", "sources", "addresses"));
+            for (var entry : results.entrySet()) {
+                Result r = entry.getValue().get(0);
+                System.out.println(String.format("  %-25s %,10d %,10d %,10d %,12d %,12d %,10d",
+                        entry.getKey().displayName(),
+                        r.minVersion(), r.maxVersion(), r.rowCount(),
+                        r.totalWebsiteCount(), r.totalSourceCount(), r.totalAddressCount()));
+            }
+            System.out.println();
+        }
+
+        // Performance
+        System.out.println("Performance (all runs):");
+        System.out.println(String.format("  %-30s %12s %15s %18s %12s",
+                "Contender", "Time (s)", "Records/sec", "Records/sec/core", "MB/sec"));
+        System.out.println("  " + "-".repeat(95));
+
+        for (var entry : results.entrySet()) {
+            Contender c = entry.getKey();
+            List<Result> contenderResults = entry.getValue();
+            int cores = isHardwood(c) ? cpuCores : 1;
+
+            for (int i = 0; i < contenderResults.size(); i++) {
+                String label = c.displayName() + " [" + (i + 1) + "]";
+                printResultRow(label, contenderResults.get(i), cores, fileSize);
+            }
+
+            double avgDurationMs = contenderResults.stream()
+                    .mapToLong(Result::durationMs)
+                    .average()
+                    .orElse(0);
+            Result avgResult = new Result(firstResult.rowCount(), (long) avgDurationMs,
+                    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0);
+            printResultRow(c.displayName() + " [AVG]", avgResult, cores, fileSize);
+
+            long minDuration = contenderResults.stream().mapToLong(Result::durationMs).min().orElse(0);
+            long maxDuration = contenderResults.stream().mapToLong(Result::durationMs).max().orElse(0);
+            System.out.println(String.format("  %-30s   min: %.2fs, max: %.2fs, spread: %.2fs",
+                    "", minDuration / 1000.0, maxDuration / 1000.0, (maxDuration - minDuration) / 1000.0));
+            System.out.println();
+        }
+
+        System.out.println("=".repeat(100));
+    }
+
+    private boolean isHardwood(Contender c) {
+        return c != Contender.PARQUET_JAVA;
+    }
+
+    private void printResultRow(String name, Result result, int cpuCores, long totalBytes) {
+        double seconds = result.durationMs() / 1000.0;
+        double recordsPerSec = result.rowCount() / seconds;
+        double recordsPerSecPerCore = recordsPerSec / cpuCores;
+        double mbPerSec = (totalBytes / (1024.0 * 1024.0)) / seconds;
+
+        System.out.println(String.format("  %-30s %12.2f %,15.0f %,18.0f %12.1f",
+                name, seconds, recordsPerSec, recordsPerSecPerCore, mbPerSec));
+    }
+
+    private void verifyCorrectness(java.util.Map<Contender, List<Result>> results) {
+        if (results.size() < 2) {
+            return;
+        }
+
+        var first = results.entrySet().iterator().next();
+        Result reference = first.getValue().get(0);
+        String referenceName = first.getKey().displayName();
+
+        for (var entry : results.entrySet()) {
+            if (entry.getKey() == first.getKey()) continue;
+            Result other = entry.getValue().get(0);
+            String otherName = entry.getKey().displayName();
+
+            // Columnar computes list sizes from leaf columns, which undercounts when
+            // the leaf field is null within a present list entry. Skip list/name checks.
+            boolean isColumnar = entry.getKey() == Contender.HARDWOOD_COLUMNAR;
+
+            assertThat(other.rowCount())
+                    .as("%s rowCount should match %s", otherName, referenceName)
+                    .isEqualTo(reference.rowCount());
+            assertThat(other.minVersion())
+                    .as("%s minVersion should match %s", otherName, referenceName)
+                    .isEqualTo(reference.minVersion());
+            assertThat(other.maxVersion())
+                    .as("%s maxVersion should match %s", otherName, referenceName)
+                    .isEqualTo(reference.maxVersion());
+            assertThat(other.minConfidence())
+                    .as("%s minConfidence should match %s", otherName, referenceName)
+                    .isCloseTo(reference.minConfidence(), withinPercentage(0.0001));
+            assertThat(other.maxConfidence())
+                    .as("%s maxConfidence should match %s", otherName, referenceName)
+                    .isCloseTo(reference.maxConfidence(), withinPercentage(0.0001));
+            assertThat(other.minBboxXmin())
+                    .as("%s minBboxXmin should match %s", otherName, referenceName)
+                    .isCloseTo(reference.minBboxXmin(), withinPercentage(0.0001));
+            assertThat(other.maxBboxXmax())
+                    .as("%s maxBboxXmax should match %s", otherName, referenceName)
+                    .isCloseTo(reference.maxBboxXmax(), withinPercentage(0.0001));
+
+            if (!isColumnar) {
+                assertThat(other.totalWebsiteCount())
+                        .as("%s totalWebsiteCount should match %s", otherName, referenceName)
+                        .isEqualTo(reference.totalWebsiteCount());
+                assertThat(other.totalSourceCount())
+                        .as("%s totalSourceCount should match %s", otherName, referenceName)
+                        .isEqualTo(reference.totalSourceCount());
+                assertThat(other.totalAddressCount())
+                        .as("%s totalAddressCount should match %s", otherName, referenceName)
+                        .isEqualTo(reference.totalAddressCount());
+                assertThat(other.totalNameEntries())
+                        .as("%s totalNameEntries should match %s", otherName, referenceName)
+                        .isEqualTo(reference.totalNameEntries());
+                assertThat(other.maxPrimaryNameLength())
+                        .as("%s maxPrimaryNameLength should match %s", otherName, referenceName)
+                        .isEqualTo(reference.maxPrimaryNameLength());
+            }
+        }
+
+        System.out.println("\nAll results match!");
+    }
+}

--- a/performance-testing/test-data-setup/pom.xml
+++ b/performance-testing/test-data-setup/pom.xml
@@ -44,6 +44,22 @@
               </systemProperties>
             </configuration>
           </execution>
+          <execution>
+            <id>download-overture-maps-data</id>
+            <phase>generate-test-resources</phase>
+            <goals>
+              <goal>java</goal>
+            </goals>
+            <configuration>
+              <mainClass>dev.hardwood.testdata.OvertureMapsDownloader</mainClass>
+              <systemProperties>
+                <systemProperty>
+                  <key>data.dir</key>
+                  <value>${project.build.directory}/overture-maps-data</value>
+                </systemProperty>
+              </systemProperties>
+            </configuration>
+          </execution>
         </executions>
       </plugin>
     </plugins>

--- a/performance-testing/test-data-setup/src/main/java/dev/hardwood/testdata/OvertureMapsDownloader.java
+++ b/performance-testing/test-data-setup/src/main/java/dev/hardwood/testdata/OvertureMapsDownloader.java
@@ -1,0 +1,84 @@
+/*
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Copyright The original authors
+ *
+ *  Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package dev.hardwood.testdata;
+
+import java.io.IOException;
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+/**
+ * Downloads an Overture Maps places Parquet file for nested schema performance testing.
+ */
+public final class OvertureMapsDownloader {
+
+    private static final String FILE_URL =
+            "https://overturemaps-us-west-2.s3.us-west-2.amazonaws.com/release/2026-02-18.0/"
+            + "theme=places/type=place/part-00000-308cb36d-c529-4dc2-83bb-fe6b282a2b1a-c000.zstd.parquet";
+
+    private static final String TARGET_FILENAME = "overture_places.zstd.parquet";
+
+    public static void main(String[] args) throws IOException {
+        Path dataDir = getDataDirFromProperty();
+        Files.createDirectories(dataDir);
+        Path target = dataDir.resolve(TARGET_FILENAME);
+
+        if (Files.exists(target) && Files.size(target) > 0) {
+            System.out.println("Overture Maps file already exists: " + target.toAbsolutePath()
+                    + " (" + Files.size(target) + " bytes)");
+            return;
+        }
+
+        downloadFile(FILE_URL, target);
+        System.out.println("Download complete. File at: " + target.toAbsolutePath());
+    }
+
+    private static Path getDataDirFromProperty() {
+        String property = System.getProperty("data.dir");
+        if (property == null || property.isBlank()) {
+            return Path.of("target/overture-maps-data");
+        }
+        return Path.of(property);
+    }
+
+    private static void downloadFile(String url, Path target) {
+        System.out.println("Downloading: " + url);
+        try {
+            HttpClient client = HttpClient.newBuilder()
+                    .followRedirects(HttpClient.Redirect.NORMAL)
+                    .build();
+            HttpRequest request = HttpRequest.newBuilder()
+                    .uri(URI.create(url))
+                    .GET()
+                    .build();
+            HttpResponse<Path> response = client.send(request,
+                    HttpResponse.BodyHandlers.ofFile(target));
+            if (response.statusCode() != 200) {
+                Files.deleteIfExists(target);
+                System.out.println("  Failed (status " + response.statusCode() + ") - skipping");
+            }
+            else {
+                System.out.println("  Downloaded: " + Files.size(target) + " bytes");
+            }
+        }
+        catch (Exception e) {
+            System.out.println("  Failed: " + e.getMessage() + " - skipping");
+            try {
+                Files.deleteIfExists(target);
+            }
+            catch (IOException ignored) {
+            }
+        }
+    }
+
+    private OvertureMapsDownloader() {
+    }
+}


### PR DESCRIPTION
Parsing of files with nested schemas hasn't been optimized so far, and it definitely shows:

```
Performance (all runs):
  Contender                          Time (s)     Records/sec   Records/sec/core       MB/sec
  -----------------------------------------------------------------------------------------------
  parquet-java [1]                      22.53         406,166            406,166         39.2
  parquet-java [AVG]                    22.53         406,166            406,166         39.2
                                   min: 22.53s, max: 22.53s, spread: 0.00s

  Hardwood (named) [1]                  24.77         369,516             23,095         35.6
  Hardwood (named) [AVG]                24.77         369,516             23,095         35.6
                                   min: 24.77s, max: 24.77s, spread: 0.00s

  Hardwood (indexed) [1]                21.89         418,192             26,137         40.3
  Hardwood (indexed) [AVG]              21.89         418,192             26,137         40.3
                                   min: 21.89s, max: 21.89s, spread: 0.00s

  Hardwood (columnar) [1]                0.80      11,383,756            711,485       1097.3
  Hardwood (columnar) [AVG]              0.80      11,383,756            711,485       1097.3
                                   min: 0.80s, max: 0.80s, spread: 0.00s
```