### PR TITLE
#53 Decouple PageCursor Assembly Thread Initiation to Avoid Race Conditions

### DIFF
--- a/core/src/main/java/dev/hardwood/reader/ColumnReader.java
+++ b/core/src/main/java/dev/hardwood/reader/ColumnReader.java
@@ -123,7 +123,7 @@ public class ColumnReader implements AutoCloseable {
             assemblyBuffer = new ColumnAssemblyBuffer(column, batchSize);
         }
 
-        PageCursor pageCursor = new PageCursor(
+        PageCursor pageCursor = PageCursor.create(
                 pageInfos, context, fileManager, projectedColumnIndex, fileName, assemblyBuffer);
         this.iterator = new ColumnValueIterator(pageCursor, column, flat);
     }

--- a/core/src/main/java/dev/hardwood/reader/MultiFileRowReader.java
+++ b/core/src/main/java/dev/hardwood/reader/MultiFileRowReader.java
@@ -99,7 +99,7 @@ public class MultiFileRowReader extends AbstractRowReader {
                 assemblyBuffer = new ColumnAssemblyBuffer(columnSchema, adaptiveBatchSize);
             }
 
-            PageCursor pageCursor = new PageCursor(
+            PageCursor pageCursor = PageCursor.create(
                     initResult.firstFileState().pageInfosByColumn().get(i), context, fileManager, i, firstFileName,
                     assemblyBuffer);
             iterators[i] = new ColumnValueIterator(pageCursor, columnSchema, flatSchema);

--- a/core/src/main/java/dev/hardwood/reader/SingleFileRowReader.java
+++ b/core/src/main/java/dev/hardwood/reader/SingleFileRowReader.java
@@ -138,7 +138,7 @@ final class SingleFileRowReader extends AbstractRowReader {
                 assemblyBuffer = new ColumnAssemblyBuffer(columnSchema, adaptiveBatchSize);
             }
 
-            PageCursor pageCursor = new PageCursor(pageInfosByColumn.get(i), context, fileName, assemblyBuffer);
+            PageCursor pageCursor = PageCursor.create(pageInfosByColumn.get(i), context, fileName, assemblyBuffer);
             iterators[i] = new ColumnValueIterator(pageCursor, columnSchema, flatSchema);
         }
 

--- a/core/src/test/java/dev/hardwood/internal/reader/ColumnAssemblyBufferTest.java
+++ b/core/src/test/java/dev/hardwood/internal/reader/ColumnAssemblyBufferTest.java
@@ -10,7 +10,6 @@ package dev.hardwood.internal.reader;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
 
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
 
@@ -26,42 +25,34 @@ public class ColumnAssemblyBufferTest {
     private static final int BATCH_SIZE = 4;
 
     /**
-     * Tests that exceptions in the assembly thread are propagated to the consumer.
-     * Uses a PageCursor subclass that throws an error after returning two pages.
+     * Tests that exceptions in the producer thread are propagated to the consumer.
      */
     @Test
     @Timeout(value = 5, unit = TimeUnit.SECONDS)
-    void testAssemblyThreadExceptionPropagatedToConsumer() throws Exception {
+    void testProducerExceptionPropagatedToConsumer() {
         ColumnSchema column = new ColumnSchema(
                 "test_col", PhysicalType.INT32, RepetitionType.REQUIRED,
                 null, 0, 0, 0, null);
 
         ColumnAssemblyBuffer buffer = new ColumnAssemblyBuffer(column, BATCH_SIZE);
 
-        // 3 pages: the cursor will return 2 successfully, then throw on the 3rd
         Page page1 = new Page.IntPage(new int[]{1, 2, 3, 4}, null, null, 0, 4);
         Page page2 = new Page.IntPage(new int[]{5, 6, 7}, null, null, 0, 3);
         Page page3 = new Page.IntPage(new int[]{8, 9, 10}, null, null, 0, 3);
 
-        try (HardwoodContextImpl context = HardwoodContextImpl.create()) {
-            ErrorInducingPageCursor cursor = new ErrorInducingPageCursor(
-                    List.of(page1, page2, page3),
-                    context,
-                    buffer,
-                    2  // throw after returning 2 pages
-            );
+        // Produce a series of pages (triggering an explicit failure after page 2)
+        producePagesWithError(buffer, List.of(page1, page2, page3), 2);
 
-            // First batch should be available (page 1 filled it)
-            TypedColumnData batch1 = buffer.awaitNextBatch();
-            assertThat(batch1).as("First batch should be available").isNotNull();
-            assertThat(batch1.recordCount()).isEqualTo(4);
+        // First batch should be available (page 1 filled it)
+        TypedColumnData batch1 = buffer.awaitNextBatch();
+        assertThat(batch1).as("First batch should be available").isNotNull();
+        assertThat(batch1.recordCount()).isEqualTo(4);
 
-            // Second call throws error: page 2's partial batch wasn't published,
-            // queue is empty, so checkError() throws the producer's error
-            assertThatThrownBy(buffer::awaitNextBatch)
-                    .isInstanceOf(RuntimeException.class)
-                    .hasMessageContaining("Simulated error on page 3");
-        }
+        // Second call throws error: page 2's partial batch wasn't published,
+        // queue is empty, so checkError() throws the producer's error
+        assertThatThrownBy(buffer::awaitNextBatch)
+                .isInstanceOf(RuntimeException.class)
+                .hasMessageContaining("Simulated error on page 3");
     }
 
     /**
@@ -69,7 +60,7 @@ public class ColumnAssemblyBufferTest {
      */
     @Test
     @Timeout(value = 5, unit = TimeUnit.SECONDS)
-    void testNormalOperationAllPagesProcessed() throws Exception {
+    void testNormalOperationAllPagesProcessed() {
         ColumnSchema column = new ColumnSchema(
                 "test_col", PhysicalType.INT32, RepetitionType.REQUIRED,
                 null, 0, 0, 0, null);
@@ -80,134 +71,41 @@ public class ColumnAssemblyBufferTest {
         Page page2 = new Page.IntPage(new int[]{5, 6, 7}, null, null, 0, 3);
         Page page3 = new Page.IntPage(new int[]{8, 9, 10}, null, null, 0, 3);
 
-        try (HardwoodContextImpl context = HardwoodContextImpl.create()) {
-            // Create a PageCursor that processes all pages successfully
-            ErrorInducingPageCursor cursor = new ErrorInducingPageCursor(
-                    List.of(page1, page2, page3),
-                    context,
-                    buffer,
-                    -1  // no error
-            );
+        producePages(buffer, List.of(page1, page2, page3));
 
-            // Consume all batches
-            int totalRows = 0;
-            while (true) {
-                TypedColumnData batch = buffer.awaitNextBatch();
-                if (batch == null) {
-                    break;
+        // Consume all batches
+        int totalRows = 0;
+        while (true) {
+            TypedColumnData batch = buffer.awaitNextBatch();
+            if (batch == null) {
+                break;
+            }
+            totalRows += batch.recordCount();
+        }
+
+        // All 10 rows should be received
+        assertThat(totalRows).isEqualTo(10);
+    }
+
+    private static void producePages(ColumnAssemblyBuffer buffer, List<Page> pages) {
+        Thread.startVirtualThread(() -> {
+            for (Page page : pages) {
+                buffer.appendPage(page);
+            }
+            buffer.finish();
+        });
+    }
+
+    private static void producePagesWithError(ColumnAssemblyBuffer buffer, List<Page> pages, int errorAfterPage) {
+        Thread.startVirtualThread(() -> {
+            for (int i = 0; i < pages.size(); i++) {
+                if (i >= errorAfterPage) {
+                    buffer.signalError(new RuntimeException("Simulated error on page " + (i + 1)));
+                    return;
                 }
-                totalRows += batch.recordCount();
+                buffer.appendPage(pages.get(i));
             }
-
-            // All 10 rows should be received
-            assertThat(totalRows).isEqualTo(10);
-        }
-    }
-
-    /**
-     * Sample test that attempts to reproduce (<a href="https://github.com/hardwood-hq/hardwood/issues/53">#53</a>)
-     * that appears to be a race condition during
-     */
-    @Test
-    @Timeout(value = 5, unit = TimeUnit.SECONDS)
-    void testAssemblyThreadRaceCondition() throws Exception {
-        ColumnSchema column = new ColumnSchema(
-                "test_col", PhysicalType.INT32, RepetitionType.REQUIRED,
-                null, 0, 0, 0, null);
-
-        ColumnAssemblyBuffer buffer = new ColumnAssemblyBuffer(column, BATCH_SIZE);
-
-        Page page1 = new Page.IntPage(new int[]{1, 2, 3, 4}, null, null, 0, 4);
-        Page page2 = new Page.IntPage(new int[]{5, 6, 7}, null, null, 0, 3);
-
-        try (HardwoodContextImpl context = HardwoodContextImpl.create()) {
-            new SlowInitPageCursor(List.of(page1, page2), context, buffer);
-
-            TypedColumnData batch1 = buffer.awaitNextBatch();
-            assertThat(batch1).as("First batch should be available").isNotNull();
-            assertThat(batch1.recordCount()).isEqualTo(4);
-
-            TypedColumnData batch2 = buffer.awaitNextBatch();
-            assertThat(batch2).as("Second batch should be available").isNotNull();
-            assertThat(batch2.recordCount()).isEqualTo(3);
-
-            assertThat(buffer.awaitNextBatch()).isNull();
-        }
-    }
-
-    /**
-     * A PageCursor subclass that simulates intentionally slow assembly thread initialization
-     * to attempt to demonstrate possible race conditions
-     */
-    private static class SlowInitPageCursor extends PageCursor {
-
-        private final List<Page> pages;
-        private int currentPage = 0;
-
-        SlowInitPageCursor(List<Page> pages, HardwoodContextImpl context,
-                           ColumnAssemblyBuffer assemblyBuffer) {
-            super(List.of(), context, null, assemblyBuffer);
-            // Take a bit before initializing the assembly thread
-            try { Thread.sleep(100); } catch (InterruptedException e) { Thread.currentThread().interrupt(); }
-            this.pages = pages;
-        }
-
-        @Override
-        public boolean hasNext() {
-            return currentPage < pages.size();
-        }
-
-        @Override
-        public Page nextPage() {
-            if (currentPage >= pages.size()) {
-                return null;
-            }
-            return pages.get(currentPage++);
-        }
-    }
-
-    /**
-     * A PageCursor subclass that returns pre-defined pages and optionally
-     * throws an error after a specified number of pages.
-     */
-    private static class ErrorInducingPageCursor extends PageCursor {
-
-        private final List<Page> pages;
-        private final int errorAfterPage;  // -1 means no error
-        private int currentPage = 0;
-
-        /**
-         * Guards against access before complete initialization by the assembly thread started
-         * in the parent constructor.
-         */
-        private final boolean initialized;
-
-        ErrorInducingPageCursor(List<Page> pages, HardwoodContextImpl context,
-                                ColumnAssemblyBuffer assemblyBuffer, int errorAfterPage) {
-            // Pass empty pageInfos - we override nextPage() and hasNext()
-            super(List.of(), context, null, assemblyBuffer);
-            this.pages = pages;
-            this.errorAfterPage = errorAfterPage;
-            this.initialized = true;
-        }
-
-        @Override
-        public boolean hasNext() {
-            return initialized && currentPage < pages.size();
-        }
-
-        @Override
-        public Page nextPage() {
-            if (currentPage >= pages.size()) {
-                return null;
-            }
-
-            // Check if we should throw an error
-            if (errorAfterPage >= 0 && currentPage >= errorAfterPage) {
-                throw new RuntimeException("Simulated error on page " + (currentPage + 1));
-            }
-
-            return pages.get(currentPage++);
-        }
+            buffer.finish();
+        });
     }
 }


### PR DESCRIPTION
### Description
This pull request addresses #53 which details a potential race-condition that would intermittently arise, specifically during CI builds. The underlying issue itself was the result of the `PageCursor` constructor starting the assembly thread _before_ the construction was complete. 

### Key Changes
- Added two new static `PageCursor.create()` factory methods (single-file, multi-file) which are now responsible for construction of the instance _and_ subsequent thread initialization.
- Updated existing test cases within the `ColumnAssemblyBufferTest` class to no longer use a static, subclassed instance in favor of a simpler message buffer to handle the processing.
  - Removed some of the previously `@Disabled` test cases that were updated within #51 prior to this fix.

### Verification
To reproduce the initial issue a new `ColumnAssemblyBufferTest.testAssemblyThreadRaceCondition` test was temporarily introduced ([fe4e0b8](https://github.com/hardwood-hq/hardwood/pull/55/commits/fe4e0b8e361069b4ac45124b2a54bfcc33d49e84)) in conjunction with an intentionally slow `PageCursor` to simulate the race-condition successfully:

<img width="699" height="98" alt="Screenshot 2026-02-24 at 1 58 00 PM" src="https://github.com/user-attachments/assets/86e8de36-591a-419c-9503-075a646ce4aa" />

After verifying the test failed as expected, the previously mentioned `PageCursor.create()` factory methods were introduced to verify the fix and all previously disabled tests were passing as expected:

<img width="631" height="73" alt="image" src="https://github.com/user-attachments/assets/09c9c884-e15c-43e0-b99b-53454e71a0b7" />

#### Regression Verification
There appears to be no noticeable regressions in terms of performance as it relates to these changes and the project successfully builds:

```
====================================================================================================
PERFORMANCE TEST RESULTS
====================================================================================================

Environment:
  CPU cores:       14
  Java version:    25.0.2
  OS:              Mac OS X aarch64

Data:
  Files processed: 119
  Total rows:      651,209,003
  Total size:      9,241.1 MB
  Runs per contender: 5

Performance (all runs):
  Contender                          Time (s)     Records/sec   Records/sec/core       MB/sec
  -----------------------------------------------------------------------------------------------
  Hardwood (multifile) [1]               2.28     285,994,292         20,428,164       4058.5
  Hardwood (multifile) [2]               2.39     272,130,799         19,437,914       3861.7
  Hardwood (multifile) [3]               2.14     304,303,272         21,735,948       4318.3
  Hardwood (multifile) [4]               2.13     305,588,458         21,827,747       4336.5
  Hardwood (multifile) [5]               2.14     304,587,934         21,756,281       4322.3
  Hardwood (multifile) [AVG]             2.22     293,999,550         20,999,968       4172.1
                                   min: 2.13s, max: 2.39s, spread: 0.26s
```

