### PR TITLE
#12 Updated Hadoop to 3.4.3

### DIFF
--- a/parquet-testing-runner/pom.xml
+++ b/parquet-testing-runner/pom.xml
@@ -22,21 +22,6 @@
   <name>Hardwood Parquet Testing Runner</name>
   <description>Comparison tests between Hardwood and parquet-java reference implementation</description>
 
-  <!-- Apache snapshots repo for Hadoop 3.4.4-SNAPSHOT (HADOOP-19212 fix for Java 24+) -->
-  <!-- TODO: Remove once 3.4.3+ is in Central -->
-  <repositories>
-    <repository>
-      <id>apache-hadoop-snapshots</id>
-      <url>https://repository.apache.org/content/repositories/snapshots/</url>
-      <releases>
-        <enabled>false</enabled>
-      </releases>
-      <snapshots>
-        <enabled>true</enabled>
-      </snapshots>
-    </repository>
-  </repositories>
-
   <dependencyManagement>
     <dependencies>
       <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -52,9 +52,7 @@
   </modules>
 
   <properties>
-    <!-- Hadoop 3.4.3+ required for Java 24+ (HADOOP-19212: Subject.getSubject() removed) -->
-    <!-- TODO: Update to 3.4.3 when available in Maven Central -->
-    <hadoop.version>3.4.4-SNAPSHOT</hadoop.version>
+    <hadoop.version>3.4.3</hadoop.version>
     <java.version>21</java.version>
     <java.version.build>25</java.version.build>
     <maven.compiler.parameters>true</maven.compiler.parameters>


### PR DESCRIPTION
### Description

This pull request addresses #12 which updates the Hadoop dependency to the official 3.4.3 release (from the previous temporary 3.4.4 snapshot workaround detailed in #10).

### Key Changes
- Updates the `hadoop.version` to the official 3.4.3 release (from the previous `3.4.4-SNAPSHOT` version that was used due to the previous staging version being unexpectedly removed).
  - Removed the `apache-hadoop-snapshots` repository as there are no dependencies which rely on snapshot versions within the project.
  
### Verification
After introducing the updated version, the project built successfully as expected:

```
[INFO] Reactor Summary for Hardwood Parent 1.0.0-SNAPSHOT:
[INFO] 
[INFO] Hardwood Parent .................................... SUCCESS [  0.204 s]
[INFO] Hardwood BOM ....................................... SUCCESS [  0.008 s]
[INFO] Hardwood Test BOM .................................. SUCCESS [  0.007 s]
[INFO] Hardwood Core ...................................... SUCCESS [ 13.007 s]
[INFO] Hardwood Parquet-Java Compatibility ................ SUCCESS [  0.501 s]
[INFO] Hardwood Integration Tests ......................... SUCCESS [  0.540 s]
[INFO] Hardwood Parquet Testing Runner .................... SUCCESS [  7.764 s]
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  22.082 s
[INFO] Finished at: 2026-02-26T21:19:39-06:00
[INFO] ------------------------------------------------------------------------
```
