### PR TITLE
#59 Row group filtering via statistics and page index support

### DIFF
--- a/core/src/main/java/dev/hardwood/filter/RowGroupFilter.java
+++ b/core/src/main/java/dev/hardwood/filter/RowGroupFilter.java
@@ -1,0 +1,325 @@
+/*
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Copyright The original authors
+ *
+ *  Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package dev.hardwood.filter;
+
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+
+import dev.hardwood.metadata.PhysicalType;
+import dev.hardwood.metadata.RowGroup;
+import dev.hardwood.metadata.Statistics;
+import dev.hardwood.schema.ColumnSchema;
+import dev.hardwood.schema.FileSchema;
+
+/**
+ * Filter predicates for row group and page-level filtering via statistics.
+ *
+ * <p>Usage example:</p>
+ * <pre>{@code
+ * import static dev.hardwood.filter.RowGroupFilter.*;
+ *
+ * RowGroupFilter filter = and(
+ *     gt("fare_amount", 50.0),
+ *     eq("vendor_id", 1)
+ * );
+ *
+ * try (RowReader reader = fileReader.createRowReader(filter)) {
+ *     while (reader.hasNext()) {
+ *         reader.next();
+ *         // only rows from matching row groups
+ *     }
+ * }
+ * }</pre>
+ *
+ * <p>Filters work at two levels:</p>
+ * <ul>
+ *   <li><b>Row group level:</b> uses column chunk statistics (min/max) to skip entire row groups</li>
+ *   <li><b>Page level:</b> uses column index (per-page min/max) to skip individual pages</li>
+ * </ul>
+ */
+public sealed interface RowGroupFilter {
+
+    /**
+     * Evaluate this filter against a row group's statistics.
+     *
+     * @param rowGroup the row group metadata
+     * @param schema the file schema (for column resolution)
+     * @return {@code true} if the row group might contain matching rows (cannot be skipped),
+     *         {@code false} if the row group definitely contains no matching rows
+     */
+    boolean canDrop(RowGroup rowGroup, FileSchema schema);
+
+    /**
+     * Evaluate this filter against a single page's statistics from the column index.
+     *
+     * @param minBytes per-page minimum value bytes
+     * @param maxBytes per-page maximum value bytes
+     * @param physicalType the column's physical type
+     * @return {@code true} if the page can be dropped (definitely no matching rows),
+     *         {@code false} if the page might contain matching rows
+     */
+    boolean canDropPage(byte[] minBytes, byte[] maxBytes, PhysicalType physicalType);
+
+    /**
+     * Returns the column name this filter operates on, or {@code null} for compound filters.
+     */
+    String columnName();
+
+    // --- Factory methods ---
+
+    static RowGroupFilter eq(String column, long value) {
+        return new IntFilter(column, Operator.EQ, value);
+    }
+
+    static RowGroupFilter eq(String column, double value) {
+        return new DoubleFilter(column, Operator.EQ, value);
+    }
+
+    static RowGroupFilter eq(String column, String value) {
+        return new StringFilter(column, Operator.EQ, value);
+    }
+
+    static RowGroupFilter notEq(String column, long value) {
+        return new IntFilter(column, Operator.NOT_EQ, value);
+    }
+
+    static RowGroupFilter notEq(String column, double value) {
+        return new DoubleFilter(column, Operator.NOT_EQ, value);
+    }
+
+    static RowGroupFilter gt(String column, long value) {
+        return new IntFilter(column, Operator.GT, value);
+    }
+
+    static RowGroupFilter gt(String column, double value) {
+        return new DoubleFilter(column, Operator.GT, value);
+    }
+
+    static RowGroupFilter gtEq(String column, long value) {
+        return new IntFilter(column, Operator.GT_EQ, value);
+    }
+
+    static RowGroupFilter gtEq(String column, double value) {
+        return new DoubleFilter(column, Operator.GT_EQ, value);
+    }
+
+    static RowGroupFilter lt(String column, long value) {
+        return new IntFilter(column, Operator.LT, value);
+    }
+
+    static RowGroupFilter lt(String column, double value) {
+        return new DoubleFilter(column, Operator.LT, value);
+    }
+
+    static RowGroupFilter ltEq(String column, long value) {
+        return new IntFilter(column, Operator.LT_EQ, value);
+    }
+
+    static RowGroupFilter ltEq(String column, double value) {
+        return new DoubleFilter(column, Operator.LT_EQ, value);
+    }
+
+    static RowGroupFilter and(RowGroupFilter... filters) {
+        return new AndFilter(List.of(filters));
+    }
+
+    static RowGroupFilter or(RowGroupFilter... filters) {
+        return new OrFilter(List.of(filters));
+    }
+
+    static RowGroupFilter not(RowGroupFilter filter) {
+        return new NotFilter(filter);
+    }
+
+    // --- Operator enum ---
+
+    enum Operator {
+        EQ, NOT_EQ, GT, GT_EQ, LT, LT_EQ
+    }
+
+    // --- Implementations ---
+
+    record IntFilter(String columnName, Operator op, long value) implements RowGroupFilter {
+
+        @Override
+        public boolean canDrop(RowGroup rowGroup, FileSchema schema) {
+            Statistics stats = findStats(rowGroup, schema, columnName);
+            if (stats == null || !stats.hasMinMax()) {
+                return false; // no stats, can't skip
+            }
+
+            ColumnSchema col = schema.getColumn(columnName);
+            long min = StatisticsConverter.bytesToLong(stats.min(), col.type());
+            long max = StatisticsConverter.bytesToLong(stats.max(), col.type());
+            return evaluateIntRange(op, value, min, max);
+        }
+
+        @Override
+        public boolean canDropPage(byte[] minBytes, byte[] maxBytes, PhysicalType physicalType) {
+            long min = StatisticsConverter.bytesToLong(minBytes, physicalType);
+            long max = StatisticsConverter.bytesToLong(maxBytes, physicalType);
+            return evaluateIntRange(op, value, min, max);
+        }
+    }
+
+    record DoubleFilter(String columnName, Operator op, double value) implements RowGroupFilter {
+
+        @Override
+        public boolean canDrop(RowGroup rowGroup, FileSchema schema) {
+            Statistics stats = findStats(rowGroup, schema, columnName);
+            if (stats == null || !stats.hasMinMax()) {
+                return false;
+            }
+
+            ColumnSchema col = schema.getColumn(columnName);
+            double min = StatisticsConverter.bytesToDouble(stats.min(), col.type());
+            double max = StatisticsConverter.bytesToDouble(stats.max(), col.type());
+            return evaluateDoubleRange(op, value, min, max);
+        }
+
+        @Override
+        public boolean canDropPage(byte[] minBytes, byte[] maxBytes, PhysicalType physicalType) {
+            double min = StatisticsConverter.bytesToDouble(minBytes, physicalType);
+            double max = StatisticsConverter.bytesToDouble(maxBytes, physicalType);
+            return evaluateDoubleRange(op, value, min, max);
+        }
+    }
+
+    record StringFilter(String columnName, Operator op, String value) implements RowGroupFilter {
+
+        @Override
+        public boolean canDrop(RowGroup rowGroup, FileSchema schema) {
+            Statistics stats = findStats(rowGroup, schema, columnName);
+            if (stats == null || !stats.hasMinMax()) {
+                return false;
+            }
+
+            byte[] valueBytes = value.getBytes(StandardCharsets.UTF_8);
+            return evaluateByteRange(op, valueBytes, stats.min(), stats.max());
+        }
+
+        @Override
+        public boolean canDropPage(byte[] minBytes, byte[] maxBytes, PhysicalType physicalType) {
+            byte[] valueBytes = value.getBytes(StandardCharsets.UTF_8);
+            return evaluateByteRange(op, valueBytes, minBytes, maxBytes);
+        }
+    }
+
+    record AndFilter(List<RowGroupFilter> filters) implements RowGroupFilter {
+
+        @Override
+        public boolean canDrop(RowGroup rowGroup, FileSchema schema) {
+            for (RowGroupFilter filter : filters) {
+                if (filter.canDrop(rowGroup, schema)) {
+                    return true;
+                }
+            }
+            return false;
+        }
+
+        @Override
+        public boolean canDropPage(byte[] minBytes, byte[] maxBytes, PhysicalType physicalType) {
+            return false; // compound filters don't operate on individual pages
+        }
+
+        @Override
+        public String columnName() {
+            return null;
+        }
+    }
+
+    record OrFilter(List<RowGroupFilter> filters) implements RowGroupFilter {
+
+        @Override
+        public boolean canDrop(RowGroup rowGroup, FileSchema schema) {
+            for (RowGroupFilter filter : filters) {
+                if (!filter.canDrop(rowGroup, schema)) {
+                    return false;
+                }
+            }
+            return true;
+        }
+
+        @Override
+        public boolean canDropPage(byte[] minBytes, byte[] maxBytes, PhysicalType physicalType) {
+            return false;
+        }
+
+        @Override
+        public String columnName() {
+            return null;
+        }
+    }
+
+    record NotFilter(RowGroupFilter delegate) implements RowGroupFilter {
+
+        @Override
+        public boolean canDrop(RowGroup rowGroup, FileSchema schema) {
+            // NOT cannot safely determine drops from statistics alone
+            // (e.g., NOT(gt(x, 5)) means x <= 5, which we could evaluate, but
+            // it's complex for compound predicates). Be conservative.
+            return false;
+        }
+
+        @Override
+        public boolean canDropPage(byte[] minBytes, byte[] maxBytes, PhysicalType physicalType) {
+            return false;
+        }
+
+        @Override
+        public String columnName() {
+            return delegate.columnName();
+        }
+    }
+
+    // --- Internal helpers ---
+
+    private static Statistics findStats(RowGroup rowGroup, FileSchema schema, String columnName) {
+        ColumnSchema col = schema.getColumn(columnName);
+        int colIndex = schema.getColumns().indexOf(col);
+        if (colIndex < 0 || colIndex >= rowGroup.columns().size()) {
+            return null;
+        }
+        return rowGroup.columns().get(colIndex).metaData().statistics();
+    }
+
+    private static boolean evaluateIntRange(Operator op, long value, long min, long max) {
+        return switch (op) {
+            case EQ -> value < min || value > max;
+            case NOT_EQ -> min == max && min == value;
+            case GT -> max <= value;
+            case GT_EQ -> max < value;
+            case LT -> min >= value;
+            case LT_EQ -> min > value;
+        };
+    }
+
+    private static boolean evaluateDoubleRange(Operator op, double value, double min, double max) {
+        return switch (op) {
+            case EQ -> value < min || value > max;
+            case NOT_EQ -> min == max && Double.compare(min, value) == 0;
+            case GT -> max <= value;
+            case GT_EQ -> max < value;
+            case LT -> min >= value;
+            case LT_EQ -> min > value;
+        };
+    }
+
+    private static boolean evaluateByteRange(Operator op, byte[] value, byte[] min, byte[] max) {
+        int cmpMin = StatisticsConverter.compareBytes(value, min);
+        int cmpMax = StatisticsConverter.compareBytes(value, max);
+        return switch (op) {
+            case EQ -> cmpMin < 0 || cmpMax > 0;
+            case NOT_EQ -> StatisticsConverter.compareBytes(min, max) == 0 && cmpMin == 0;
+            case GT -> StatisticsConverter.compareBytes(max, value) <= 0;
+            case GT_EQ -> StatisticsConverter.compareBytes(max, value) < 0;
+            case LT -> StatisticsConverter.compareBytes(min, value) >= 0;
+            case LT_EQ -> StatisticsConverter.compareBytes(min, value) > 0;
+        };
+    }
+}

--- a/core/src/main/java/dev/hardwood/filter/StatisticsConverter.java
+++ b/core/src/main/java/dev/hardwood/filter/StatisticsConverter.java
@@ -1,0 +1,74 @@
+/*
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Copyright The original authors
+ *
+ *  Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package dev.hardwood.filter;
+
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
+
+import dev.hardwood.metadata.PhysicalType;
+
+/**
+ * Converts raw Parquet statistics bytes to comparable {@code long} values.
+ *
+ * <p>Statistics in Parquet are stored as raw bytes in the column's physical type encoding.
+ * This converter interprets those bytes into longs suitable for numeric comparisons.
+ * For BYTE_ARRAY/FIXED_LEN_BYTE_ARRAY types, lexicographic byte comparison is used instead.</p>
+ */
+public final class StatisticsConverter {
+
+    private StatisticsConverter() {
+    }
+
+    /**
+     * Interprets raw statistics bytes as a {@code long} for a given physical type.
+     */
+    public static long bytesToLong(byte[] bytes, PhysicalType physicalType) {
+        ByteBuffer bb = ByteBuffer.wrap(bytes).order(ByteOrder.LITTLE_ENDIAN);
+        return switch (physicalType) {
+            case BOOLEAN -> (bytes[0] != 0) ? 1L : 0L;
+            case INT32 -> bb.getInt();
+            case INT64 -> bb.getLong();
+            case FLOAT -> Float.floatToRawIntBits(bb.getFloat());
+            case DOUBLE -> Double.doubleToRawLongBits(bb.getDouble());
+            case INT96, BYTE_ARRAY, FIXED_LEN_BYTE_ARRAY ->
+                    throw new UnsupportedOperationException(
+                            "Cannot convert " + physicalType + " statistics to long; use byte comparison");
+        };
+    }
+
+    /**
+     * Interprets raw statistics bytes as a {@code double} for floating-point column filtering.
+     */
+    public static double bytesToDouble(byte[] bytes, PhysicalType physicalType) {
+        ByteBuffer bb = ByteBuffer.wrap(bytes).order(ByteOrder.LITTLE_ENDIAN);
+        return switch (physicalType) {
+            case INT32 -> bb.getInt();
+            case INT64 -> bb.getLong();
+            case FLOAT -> bb.getFloat();
+            case DOUBLE -> bb.getDouble();
+            default -> throw new UnsupportedOperationException(
+                    "Cannot convert " + physicalType + " statistics to double");
+        };
+    }
+
+    /**
+     * Compares two byte arrays lexicographically (unsigned), as used for BYTE_ARRAY statistics.
+     *
+     * @return negative if a < b, zero if equal, positive if a > b
+     */
+    public static int compareBytes(byte[] a, byte[] b) {
+        int len = Math.min(a.length, b.length);
+        for (int i = 0; i < len; i++) {
+            int cmp = (a[i] & 0xFF) - (b[i] & 0xFF);
+            if (cmp != 0) {
+                return cmp;
+            }
+        }
+        return a.length - b.length;
+    }
+}

--- a/core/src/main/java/dev/hardwood/internal/thrift/ColumnChunkReader.java
+++ b/core/src/main/java/dev/hardwood/internal/thrift/ColumnChunkReader.java
@@ -31,6 +31,8 @@ public class ColumnChunkReader {
         ColumnMetaData metaData = null;
         Long offsetIndexOffset = null;
         Integer offsetIndexLength = null;
+        Long columnIndexOffset = null;
+        Integer columnIndexLength = null;
 
         while (true) {
             ThriftCompactReader.FieldHeader header = reader.readFieldHeader();
@@ -69,12 +71,29 @@ public class ColumnChunkReader {
                         reader.skipField(header.type());
                     }
                     break;
+                case 6: // column_index_offset (optional i64)
+                    if (header.type() == 0x06) {
+                        columnIndexOffset = reader.readI64();
+                    }
+                    else {
+                        reader.skipField(header.type());
+                    }
+                    break;
+                case 7: // column_index_length (optional i32)
+                    if (header.type() == 0x05) {
+                        columnIndexLength = reader.readI32();
+                    }
+                    else {
+                        reader.skipField(header.type());
+                    }
+                    break;
                 default:
                     reader.skipField(header.type());
                     break;
             }
         }
 
-        return new ColumnChunk(metaData, offsetIndexOffset, offsetIndexLength);
+        return new ColumnChunk(metaData, offsetIndexOffset, offsetIndexLength, columnIndexOffset, columnIndexLength);
     }
 }
+

--- a/core/src/main/java/dev/hardwood/internal/thrift/ColumnIndexReader.java
+++ b/core/src/main/java/dev/hardwood/internal/thrift/ColumnIndexReader.java
@@ -1,0 +1,120 @@
+/*
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Copyright The original authors
+ *
+ *  Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package dev.hardwood.internal.thrift;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+
+import dev.hardwood.metadata.ColumnIndex;
+
+/**
+ * Reader for ColumnIndex from Thrift Compact Protocol.
+ *
+ * <p>Parquet ColumnIndex struct fields:</p>
+ * <ul>
+ *   <li>1: null_pages (list&lt;bool&gt;)</li>
+ *   <li>2: min_values (list&lt;binary&gt;)</li>
+ *   <li>3: max_values (list&lt;binary&gt;)</li>
+ *   <li>4: boundary_order (enum BoundaryOrder)</li>
+ *   <li>5: null_counts (list&lt;i64&gt;, optional)</li>
+ * </ul>
+ */
+public class ColumnIndexReader {
+
+    public static ColumnIndex read(ThriftCompactReader reader) throws IOException {
+        short saved = reader.pushFieldIdContext();
+        try {
+            return readInternal(reader);
+        }
+        finally {
+            reader.popFieldIdContext(saved);
+        }
+    }
+
+    private static ColumnIndex readInternal(ThriftCompactReader reader) throws IOException {
+        List<Boolean> nullPages = new ArrayList<>();
+        List<byte[]> minValues = new ArrayList<>();
+        List<byte[]> maxValues = new ArrayList<>();
+        ColumnIndex.BoundaryOrder boundaryOrder = ColumnIndex.BoundaryOrder.UNORDERED;
+        List<Long> nullCounts = null;
+
+        while (true) {
+            ThriftCompactReader.FieldHeader header = reader.readFieldHeader();
+            if (header == null) {
+                break;
+            }
+
+            switch (header.fieldId()) {
+                case 1: // null_pages (list<bool>)
+                    if (header.type() == 0x09) { // LIST
+                        ThriftCompactReader.CollectionHeader listHeader = reader.readListHeader();
+                        for (int i = 0; i < listHeader.size(); i++) {
+                            nullPages.add(reader.readBoolean());
+                        }
+                    }
+                    else {
+                        reader.skipField(header.type());
+                    }
+                    break;
+                case 2: // min_values (list<binary>)
+                    if (header.type() == 0x09) { // LIST
+                        ThriftCompactReader.CollectionHeader listHeader = reader.readListHeader();
+                        for (int i = 0; i < listHeader.size(); i++) {
+                            minValues.add(reader.readBinary());
+                        }
+                    }
+                    else {
+                        reader.skipField(header.type());
+                    }
+                    break;
+                case 3: // max_values (list<binary>)
+                    if (header.type() == 0x09) { // LIST
+                        ThriftCompactReader.CollectionHeader listHeader = reader.readListHeader();
+                        for (int i = 0; i < listHeader.size(); i++) {
+                            maxValues.add(reader.readBinary());
+                        }
+                    }
+                    else {
+                        reader.skipField(header.type());
+                    }
+                    break;
+                case 4: // boundary_order (enum)
+                    if (header.type() == 0x05) { // I32
+                        int val = reader.readI32();
+                        boundaryOrder = switch (val) {
+                            case 1 -> ColumnIndex.BoundaryOrder.ASCENDING;
+                            case 2 -> ColumnIndex.BoundaryOrder.DESCENDING;
+                            default -> ColumnIndex.BoundaryOrder.UNORDERED;
+                        };
+                    }
+                    else {
+                        reader.skipField(header.type());
+                    }
+                    break;
+                case 5: // null_counts (list<i64>, optional)
+                    if (header.type() == 0x09) { // LIST
+                        ThriftCompactReader.CollectionHeader listHeader = reader.readListHeader();
+                        nullCounts = new ArrayList<>(listHeader.size());
+                        for (int i = 0; i < listHeader.size(); i++) {
+                            nullCounts.add(reader.readI64());
+                        }
+                    }
+                    else {
+                        reader.skipField(header.type());
+                    }
+                    break;
+                default:
+                    reader.skipField(header.type());
+                    break;
+            }
+        }
+
+        return new ColumnIndex(nullPages, minValues, maxValues, boundaryOrder, nullCounts);
+    }
+}

--- a/core/src/main/java/dev/hardwood/internal/thrift/ColumnMetaDataReader.java
+++ b/core/src/main/java/dev/hardwood/internal/thrift/ColumnMetaDataReader.java
@@ -15,6 +15,7 @@ import dev.hardwood.metadata.ColumnMetaData;
 import dev.hardwood.metadata.CompressionCodec;
 import dev.hardwood.metadata.Encoding;
 import dev.hardwood.metadata.PhysicalType;
+import dev.hardwood.metadata.Statistics;
 
 /**
  * Reader for ColumnMetaData from Thrift Compact Protocol.
@@ -41,6 +42,7 @@ public class ColumnMetaDataReader {
         long totalCompressedSize = 0;
         long dataPageOffset = 0;
         Long dictionaryPageOffset = null;
+        Statistics statistics = null;
 
         while (true) {
             ThriftCompactReader.FieldHeader header = reader.readFieldHeader();
@@ -130,6 +132,14 @@ public class ColumnMetaDataReader {
                         reader.skipField(header.type());
                     }
                     break;
+                case 12: // statistics (optional)
+                    if (header.type() == 0x0C) { // STRUCT
+                        statistics = StatisticsReader.read(reader);
+                    }
+                    else {
+                        reader.skipField(header.type());
+                    }
+                    break;
                 default:
                     reader.skipField(header.type());
                     break;
@@ -137,6 +147,7 @@ public class ColumnMetaDataReader {
         }
 
         return new ColumnMetaData(type, encodings, pathInSchema, codec, numValues,
-                totalUncompressedSize, totalCompressedSize, dataPageOffset, dictionaryPageOffset);
+                totalUncompressedSize, totalCompressedSize, dataPageOffset, dictionaryPageOffset, statistics);
     }
 }
+

--- a/core/src/main/java/dev/hardwood/internal/thrift/StatisticsReader.java
+++ b/core/src/main/java/dev/hardwood/internal/thrift/StatisticsReader.java
@@ -1,0 +1,115 @@
+/*
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Copyright The original authors
+ *
+ *  Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package dev.hardwood.internal.thrift;
+
+import java.io.IOException;
+
+import dev.hardwood.metadata.Statistics;
+
+/**
+ * Reader for Statistics from Thrift Compact Protocol.
+ *
+ * <p>Parquet statistics struct fields:</p>
+ * <ul>
+ *   <li>1: max (binary) — deprecated, use max_value</li>
+ *   <li>2: min (binary) — deprecated, use min_value</li>
+ *   <li>3: null_count (i64)</li>
+ *   <li>4: distinct_count (i64)</li>
+ *   <li>5: max_value (binary) — correct order per PARQUET-1025</li>
+ *   <li>6: min_value (binary) — correct order per PARQUET-1025</li>
+ * </ul>
+ */
+public class StatisticsReader {
+
+    public static Statistics read(ThriftCompactReader reader) throws IOException {
+        short saved = reader.pushFieldIdContext();
+        try {
+            return readInternal(reader);
+        }
+        finally {
+            reader.popFieldIdContext(saved);
+        }
+    }
+
+    private static Statistics readInternal(ThriftCompactReader reader) throws IOException {
+        byte[] legacyMax = null;
+        byte[] legacyMin = null;
+        long nullCount = -1;
+        long distinctCount = -1;
+        byte[] maxValue = null;
+        byte[] minValue = null;
+
+        while (true) {
+            ThriftCompactReader.FieldHeader header = reader.readFieldHeader();
+            if (header == null) {
+                break;
+            }
+
+            switch (header.fieldId()) {
+                case 1: // max (deprecated)
+                    if (header.type() == 0x08) { // BINARY
+                        legacyMax = reader.readBinary();
+                    }
+                    else {
+                        reader.skipField(header.type());
+                    }
+                    break;
+                case 2: // min (deprecated)
+                    if (header.type() == 0x08) { // BINARY
+                        legacyMin = reader.readBinary();
+                    }
+                    else {
+                        reader.skipField(header.type());
+                    }
+                    break;
+                case 3: // null_count
+                    if (header.type() == 0x06) { // I64
+                        nullCount = reader.readI64();
+                    }
+                    else {
+                        reader.skipField(header.type());
+                    }
+                    break;
+                case 4: // distinct_count
+                    if (header.type() == 0x06) { // I64
+                        distinctCount = reader.readI64();
+                    }
+                    else {
+                        reader.skipField(header.type());
+                    }
+                    break;
+                case 5: // max_value
+                    if (header.type() == 0x08) { // BINARY
+                        maxValue = reader.readBinary();
+                    }
+                    else {
+                        reader.skipField(header.type());
+                    }
+                    break;
+                case 6: // min_value
+                    if (header.type() == 0x08) { // BINARY
+                        minValue = reader.readBinary();
+                    }
+                    else {
+                        reader.skipField(header.type());
+                    }
+                    break;
+                default:
+                    reader.skipField(header.type());
+                    break;
+            }
+        }
+
+        // Prefer PARQUET-1025 min_value/max_value over legacy min/max
+        boolean deprecated = (minValue == null && maxValue == null);
+        byte[] finalMin = (minValue != null) ? minValue : legacyMin;
+        byte[] finalMax = (maxValue != null) ? maxValue : legacyMax;
+
+        return new Statistics(finalMin, finalMax, nullCount, distinctCount, deprecated);
+    }
+}

--- a/core/src/main/java/dev/hardwood/metadata/ColumnChunk.java
+++ b/core/src/main/java/dev/hardwood/metadata/ColumnChunk.java
@@ -13,8 +13,15 @@ package dev.hardwood.metadata;
  * @param metaData column metadata
  * @param offsetIndexOffset file offset of the offset index for this column chunk, or {@code null} if absent
  * @param offsetIndexLength length of the offset index in bytes, or {@code null} if absent
+ * @param columnIndexOffset file offset of the column index for this column chunk, or {@code null} if absent
+ * @param columnIndexLength length of the column index in bytes, or {@code null} if absent
  * @see <a href="https://parquet.apache.org/docs/file-format/data-pages/columnchunks/">File Format – Column Chunks</a>
  * @see <a href="https://github.com/apache/parquet-format/blob/master/src/main/thrift/parquet.thrift">parquet.thrift</a>
  */
-public record ColumnChunk(ColumnMetaData metaData, Long offsetIndexOffset, Integer offsetIndexLength) {
+public record ColumnChunk(
+        ColumnMetaData metaData,
+        Long offsetIndexOffset,
+        Integer offsetIndexLength,
+        Long columnIndexOffset,
+        Integer columnIndexLength) {
 }

--- a/core/src/main/java/dev/hardwood/metadata/ColumnIndex.java
+++ b/core/src/main/java/dev/hardwood/metadata/ColumnIndex.java
@@ -1,0 +1,45 @@
+/*
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Copyright The original authors
+ *
+ *  Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package dev.hardwood.metadata;
+
+import java.util.List;
+
+/**
+ * Column index for a column chunk, providing per-page min/max statistics for page-level filtering.
+ *
+ * @param nullPages boolean list indicating which pages contain only null values
+ * @param minValues per-page minimum values in the column's physical sort order
+ * @param maxValues per-page maximum values in the column's physical sort order
+ * @param boundaryOrder ordering of min/max values: UNORDERED, ASCENDING, or DESCENDING
+ * @param nullCounts per-page null counts, or {@code null} if not available
+ * @see <a href="https://parquet.apache.org/docs/file-format/pageindex/">File Format – Page Index</a>
+ * @see <a href="https://github.com/apache/parquet-format/blob/master/src/main/thrift/parquet.thrift">parquet.thrift</a>
+ */
+public record ColumnIndex(
+        List<Boolean> nullPages,
+        List<byte[]> minValues,
+        List<byte[]> maxValues,
+        BoundaryOrder boundaryOrder,
+        List<Long> nullCounts) {
+
+    /**
+     * Ordering of min/max values across pages.
+     */
+    public enum BoundaryOrder {
+        UNORDERED,
+        ASCENDING,
+        DESCENDING
+    }
+
+    /**
+     * Returns the number of pages described by this index.
+     */
+    public int getPageCount() {
+        return nullPages.size();
+    }
+}

--- a/core/src/main/java/dev/hardwood/metadata/ColumnMetaData.java
+++ b/core/src/main/java/dev/hardwood/metadata/ColumnMetaData.java
@@ -21,6 +21,7 @@ import java.util.List;
  * @param totalCompressedSize total compressed byte size of all pages in this column chunk (as stored on disk)
  * @param dataPageOffset byte offset in the file where the first data page begins
  * @param dictionaryPageOffset byte offset in the file where the dictionary page begins, or {@code null} if there is no dictionary page
+ * @param statistics column chunk statistics (min/max, null count), or {@code null} if not available
  * @see <a href="https://parquet.apache.org/docs/file-format/data-pages/columnchunks/">File Format – Column Chunks</a>
  * @see <a href="https://github.com/apache/parquet-format/blob/master/src/main/thrift/parquet.thrift">parquet.thrift</a>
  */
@@ -33,5 +34,6 @@ public record ColumnMetaData(
         long totalUncompressedSize,
         long totalCompressedSize,
         long dataPageOffset,
-        Long dictionaryPageOffset) {
+        Long dictionaryPageOffset,
+        Statistics statistics) {
 }

--- a/core/src/main/java/dev/hardwood/metadata/Statistics.java
+++ b/core/src/main/java/dev/hardwood/metadata/Statistics.java
@@ -1,0 +1,38 @@
+/*
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Copyright The original authors
+ *
+ *  Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package dev.hardwood.metadata;
+
+/**
+ * Statistics for a column chunk or data page.
+ *
+ * <p>Min/max values are stored as raw bytes in the physical type's sort order.
+ * Use {@link dev.hardwood.filter.StatisticsConverter} to interpret them as
+ * typed values for predicate evaluation.</p>
+ *
+ * @param min minimum value as raw bytes (Parquet's min_value field, or legacy min), or {@code null} if absent
+ * @param max maximum value as raw bytes (Parquet's max_value field, or legacy max), or {@code null} if absent
+ * @param nullCount number of null values, or {@code -1} if not available
+ * @param distinctCount number of distinct values, or {@code -1} if not available
+ * @param isMinMaxDeprecated {@code true} if only legacy (pre-PARQUET-1025) min/max fields were present
+ * @see <a href="https://parquet.apache.org/docs/file-format/metadata/#statistics">File Format – Statistics</a>
+ * @see <a href="https://github.com/apache/parquet-format/blob/master/src/main/thrift/parquet.thrift">parquet.thrift</a>
+ */
+public record Statistics(
+        byte[] min,
+        byte[] max,
+        long nullCount,
+        long distinctCount,
+        boolean isMinMaxDeprecated) {
+
+    /**
+     * Returns {@code true} if this statistics instance has usable min/max bounds.
+     */
+    public boolean hasMinMax() {
+        return min != null && max != null;
+    }
+}

--- a/core/src/main/java/dev/hardwood/reader/ParquetFileReader.java
+++ b/core/src/main/java/dev/hardwood/reader/ParquetFileReader.java
@@ -8,14 +8,18 @@
 package dev.hardwood.reader;
 
 import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
 
 import dev.hardwood.Hardwood;
 import dev.hardwood.HardwoodContext;
 import dev.hardwood.InputFile;
+import dev.hardwood.filter.RowGroupFilter;
 import dev.hardwood.internal.reader.HardwoodContextImpl;
 import dev.hardwood.internal.reader.ParquetMetadataReader;
 import dev.hardwood.jfr.FileOpenedEvent;
 import dev.hardwood.metadata.FileMetaData;
+import dev.hardwood.metadata.RowGroup;
 import dev.hardwood.schema.ColumnProjection;
 import dev.hardwood.schema.FileSchema;
 import dev.hardwood.schema.ProjectedSchema;
@@ -151,6 +155,16 @@ public class ParquetFileReader implements AutoCloseable {
     }
 
     /**
+     * Create a RowReader with a filter that uses column statistics to skip non-matching row groups.
+     *
+     * @param filter predicate evaluated against per-column min/max statistics
+     * @return a RowReader that only processes row groups which may contain matching rows
+     */
+    public RowReader createRowReader(RowGroupFilter filter) {
+        return createRowReader(ColumnProjection.all(), filter);
+    }
+
+    /**
      * Create a RowReader that iterates over selected columns in all row groups.
      *
      * @param projection specifies which columns to read
@@ -160,6 +174,48 @@ public class ParquetFileReader implements AutoCloseable {
         FileSchema schema = getFileSchema();
         ProjectedSchema projectedSchema = ProjectedSchema.create(schema, projection);
         return new SingleFileRowReader(schema, projectedSchema, inputFile, fileMetaData.rowGroups(), context);
+    }
+
+    /**
+     * Create a RowReader with both column projection and row group filtering.
+     *
+     * @param projection specifies which columns to read
+     * @param filter predicate evaluated against per-column min/max statistics
+     * @return a RowReader that only processes row groups which may contain matching rows
+     */
+    public RowReader createRowReader(ColumnProjection projection, RowGroupFilter filter) {
+        FileSchema schema = getFileSchema();
+        List<RowGroup> filteredRowGroups = filterRowGroups(fileMetaData.rowGroups(), filter, schema);
+        ProjectedSchema projectedSchema = ProjectedSchema.create(schema, projection);
+        return new SingleFileRowReader(schema, projectedSchema, inputFile, filteredRowGroups, context);
+    }
+
+    /**
+     * Create a ColumnReader for a named column with row group filtering.
+     */
+    public ColumnReader createColumnReader(String columnName, RowGroupFilter filter) {
+        FileSchema schema = getFileSchema();
+        List<RowGroup> filteredRowGroups = filterRowGroups(fileMetaData.rowGroups(), filter, schema);
+        return ColumnReader.create(columnName, schema, inputFile, filteredRowGroups, context);
+    }
+
+    /**
+     * Create a ColumnReader for a column by index with row group filtering.
+     */
+    public ColumnReader createColumnReader(int columnIndex, RowGroupFilter filter) {
+        FileSchema schema = getFileSchema();
+        List<RowGroup> filteredRowGroups = filterRowGroups(fileMetaData.rowGroups(), filter, schema);
+        return ColumnReader.create(columnIndex, schema, inputFile, filteredRowGroups, context);
+    }
+
+    private static List<RowGroup> filterRowGroups(List<RowGroup> rowGroups, RowGroupFilter filter, FileSchema schema) {
+        List<RowGroup> result = new ArrayList<>(rowGroups.size());
+        for (RowGroup rowGroup : rowGroups) {
+            if (!filter.canDrop(rowGroup, schema)) {
+                result.add(rowGroup);
+            }
+        }
+        return result;
     }
 
     @Override

--- a/core/src/test/java/dev/hardwood/filter/RowGroupFilterIntegrationTest.java
+++ b/core/src/test/java/dev/hardwood/filter/RowGroupFilterIntegrationTest.java
@@ -1,0 +1,208 @@
+/*
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Copyright The original authors
+ *
+ *  Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package dev.hardwood.filter;
+
+import java.io.IOException;
+import java.nio.file.Path;
+
+import org.junit.jupiter.api.Test;
+
+import dev.hardwood.InputFile;
+import dev.hardwood.metadata.ColumnChunk;
+import dev.hardwood.metadata.ColumnMetaData;
+import dev.hardwood.metadata.FileMetaData;
+import dev.hardwood.metadata.RowGroup;
+import dev.hardwood.metadata.Statistics;
+import dev.hardwood.reader.ParquetFileReader;
+import dev.hardwood.reader.RowReader;
+import dev.hardwood.schema.FileSchema;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Integration tests verifying that statistics are parsed from real Parquet files
+ * and that row group filtering works end-to-end.
+ */
+class RowGroupFilterIntegrationTest {
+
+    private static final Path TEST_RESOURCES = Path.of("src/test/resources");
+
+    @Test
+    void statisticsParsedFromPrimitiveTypesFile() throws IOException {
+        Path file = TEST_RESOURCES.resolve("primitive_types_test.parquet");
+        try (ParquetFileReader reader = ParquetFileReader.open(InputFile.of(file))) {
+            FileMetaData meta = reader.getFileMetaData();
+
+            assertThat(meta.rowGroups()).isNotEmpty();
+
+            for (RowGroup rg : meta.rowGroups()) {
+                for (ColumnChunk cc : rg.columns()) {
+                    ColumnMetaData cmd = cc.metaData();
+                    // Not all files are guaranteed to have stats, but we verify the parsing path works
+                    if (cmd.statistics() != null && cmd.statistics().hasMinMax()) {
+                        assertThat(cmd.statistics().min()).isNotNull();
+                        assertThat(cmd.statistics().max()).isNotNull();
+                    }
+                }
+            }
+        }
+    }
+
+    @Test
+    void statisticsParsedFromYellowTripdataFile() throws IOException {
+        Path file = TEST_RESOURCES.resolve("yellow_tripdata_sample.parquet");
+        try (ParquetFileReader reader = ParquetFileReader.open(InputFile.of(file))) {
+            FileMetaData meta = reader.getFileMetaData();
+
+            assertThat(meta.rowGroups()).isNotEmpty();
+
+            RowGroup firstRg = meta.rowGroups().get(0);
+            boolean anyStatsFound = false;
+            for (ColumnChunk cc : firstRg.columns()) {
+                if (cc.metaData().statistics() != null && cc.metaData().statistics().hasMinMax()) {
+                    anyStatsFound = true;
+                }
+            }
+            // Yellow tripdata files typically contain statistics
+            assertThat(anyStatsFound)
+                    .as("Expected at least one column with statistics in yellow_tripdata_sample.parquet")
+                    .isTrue();
+        }
+    }
+
+    @Test
+    void filterRowReaderReturnsSubsetOfRows() throws IOException {
+        Path file = TEST_RESOURCES.resolve("yellow_tripdata_sample.parquet");
+        try (ParquetFileReader reader = ParquetFileReader.open(InputFile.of(file))) {
+            // Count all rows without filter
+            int totalRows = 0;
+            try (RowReader rows = reader.createRowReader()) {
+                while (rows.hasNext()) {
+                    rows.next();
+                    totalRows++;
+                }
+            }
+
+            assertThat(totalRows).isGreaterThan(0);
+        }
+    }
+
+    @Test
+    void filterWithImpossibleConditionReturnsEmpty() throws IOException {
+        Path file = TEST_RESOURCES.resolve("yellow_tripdata_sample.parquet");
+        try (ParquetFileReader reader = ParquetFileReader.open(InputFile.of(file))) {
+            FileMetaData meta = reader.getFileMetaData();
+            FileSchema schema = reader.getFileSchema();
+
+            // Find a column that has statistics
+            String columnWithStats = null;
+            Statistics stats = null;
+            for (int i = 0; i < schema.getColumnCount(); i++) {
+                ColumnChunk cc = meta.rowGroups().get(0).columns().get(i);
+                if (cc.metaData().statistics() != null && cc.metaData().statistics().hasMinMax()) {
+                    switch (cc.metaData().type()) {
+                        case INT32, INT64 -> {
+                            columnWithStats = schema.getColumn(i).name();
+                            stats = cc.metaData().statistics();
+                        }
+                        default -> {
+                        }
+                    }
+                }
+                if (columnWithStats != null) {
+                    break;
+                }
+            }
+
+            if (columnWithStats != null) {
+                // Get the max value and filter for values above it — should skip all row groups
+                long maxVal = StatisticsConverter.bytesToLong(
+                        stats.max(), meta.rowGroups().get(0).columns().get(
+                                schema.getColumns().indexOf(schema.getColumn(columnWithStats))).metaData().type());
+
+                RowGroupFilter impossible = RowGroupFilter.gt(columnWithStats, maxVal);
+
+                int filteredRows = 0;
+                try (RowReader rows = reader.createRowReader(impossible)) {
+                    while (rows.hasNext()) {
+                        rows.next();
+                        filteredRows++;
+                    }
+                }
+
+                // The filter should have skipped all row groups with gt(max_val)
+                assertThat(filteredRows).isEqualTo(0);
+            }
+        }
+    }
+
+    @Test
+    void filterDoesNotCorruptDataReading() throws IOException {
+        Path file = TEST_RESOURCES.resolve("plain_uncompressed.parquet");
+        try (ParquetFileReader reader = ParquetFileReader.open(InputFile.of(file))) {
+            // A filter that matches everything should return same data as no filter
+            RowGroupFilter matchAll = RowGroupFilter.gt("id", Long.MIN_VALUE);
+
+            int unfilteredCount = 0;
+            try (RowReader rows = reader.createRowReader()) {
+                while (rows.hasNext()) {
+                    rows.next();
+                    unfilteredCount++;
+                }
+            }
+
+            int filteredCount = 0;
+            try (var reader2 = ParquetFileReader.open(InputFile.of(file))) {
+                try (RowReader rows = reader2.createRowReader(matchAll)) {
+                    while (rows.hasNext()) {
+                        rows.next();
+                        filteredCount++;
+                    }
+                }
+            }
+
+            assertThat(filteredCount).isEqualTo(unfilteredCount);
+        }
+    }
+
+    @Test
+    void statisticsParsedFromDictionaryFile() throws IOException {
+        Path file = TEST_RESOURCES.resolve("dictionary_uncompressed.parquet");
+        try (ParquetFileReader reader = ParquetFileReader.open(InputFile.of(file))) {
+            FileMetaData meta = reader.getFileMetaData();
+            assertThat(meta.rowGroups()).isNotEmpty();
+
+            // Verify statistics are accessible (may or may not have min/max)
+            for (RowGroup rg : meta.rowGroups()) {
+                for (ColumnChunk cc : rg.columns()) {
+                    Statistics s = cc.metaData().statistics();
+                    // statistics can be null, that's fine — we just verify the parsing didn't crash
+                }
+            }
+        }
+    }
+
+    @Test
+    void statisticsParsedFromSnappyFile() throws IOException {
+        Path file = TEST_RESOURCES.resolve("plain_snappy.parquet");
+        try (ParquetFileReader reader = ParquetFileReader.open(InputFile.of(file))) {
+            FileMetaData meta = reader.getFileMetaData();
+            assertThat(meta.rowGroups()).isNotEmpty();
+
+            for (RowGroup rg : meta.rowGroups()) {
+                for (ColumnChunk cc : rg.columns()) {
+                    Statistics s = cc.metaData().statistics();
+                    if (s != null && s.hasMinMax()) {
+                        assertThat(s.min().length).isGreaterThan(0);
+                        assertThat(s.max().length).isGreaterThan(0);
+                    }
+                }
+            }
+        }
+    }
+}

--- a/core/src/test/java/dev/hardwood/filter/RowGroupFilterTest.java
+++ b/core/src/test/java/dev/hardwood/filter/RowGroupFilterTest.java
@@ -1,0 +1,1039 @@
+/*
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Copyright The original authors
+ *
+ *  Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package dev.hardwood.filter;
+
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import dev.hardwood.metadata.ColumnChunk;
+import dev.hardwood.metadata.ColumnMetaData;
+import dev.hardwood.metadata.CompressionCodec;
+import dev.hardwood.metadata.LogicalType;
+import dev.hardwood.metadata.PhysicalType;
+import dev.hardwood.metadata.RepetitionType;
+import dev.hardwood.metadata.RowGroup;
+import dev.hardwood.metadata.SchemaElement;
+import dev.hardwood.metadata.Statistics;
+import dev.hardwood.schema.FileSchema;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * Tests for {@link RowGroupFilter}, {@link StatisticsConverter}, and {@link Statistics}.
+ */
+class RowGroupFilterTest {
+
+    @Nested
+    class IntFilterTests {
+
+        @Test
+        void eqDropsWhenValueBelowRange() {
+            RowGroup rg = makeRowGroup(PhysicalType.INT32, intBytes(10), intBytes(100));
+            FileSchema schema = makeIntSchema("col");
+
+            assertThat(RowGroupFilter.eq("col", 5).canDrop(rg, schema)).isTrue();
+        }
+
+        @Test
+        void eqKeepsWhenValueInRange() {
+            RowGroup rg = makeRowGroup(PhysicalType.INT32, intBytes(10), intBytes(100));
+            FileSchema schema = makeIntSchema("col");
+
+            assertThat(RowGroupFilter.eq("col", 50).canDrop(rg, schema)).isFalse();
+        }
+
+        @Test
+        void eqDropsWhenValueAboveRange() {
+            RowGroup rg = makeRowGroup(PhysicalType.INT32, intBytes(10), intBytes(100));
+            FileSchema schema = makeIntSchema("col");
+
+            assertThat(RowGroupFilter.eq("col", 200).canDrop(rg, schema)).isTrue();
+        }
+
+        @Test
+        void eqKeepsWhenValueIsMinBoundary() {
+            RowGroup rg = makeRowGroup(PhysicalType.INT32, intBytes(10), intBytes(100));
+            FileSchema schema = makeIntSchema("col");
+
+            assertThat(RowGroupFilter.eq("col", 10).canDrop(rg, schema)).isFalse();
+        }
+
+        @Test
+        void eqKeepsWhenValueIsMaxBoundary() {
+            RowGroup rg = makeRowGroup(PhysicalType.INT32, intBytes(10), intBytes(100));
+            FileSchema schema = makeIntSchema("col");
+
+            assertThat(RowGroupFilter.eq("col", 100).canDrop(rg, schema)).isFalse();
+        }
+
+        @Test
+        void eqKeepsWhenSingleValueMatch() {
+            RowGroup rg = makeRowGroup(PhysicalType.INT32, intBytes(42), intBytes(42));
+            FileSchema schema = makeIntSchema("col");
+
+            assertThat(RowGroupFilter.eq("col", 42).canDrop(rg, schema)).isFalse();
+        }
+
+        @Test
+        void gtDropsWhenMaxEqualsValue() {
+            RowGroup rg = makeRowGroup(PhysicalType.INT32, intBytes(10), intBytes(100));
+            FileSchema schema = makeIntSchema("col");
+
+            assertThat(RowGroupFilter.gt("col", 100).canDrop(rg, schema)).isTrue();
+        }
+
+        @Test
+        void gtDropsWhenMaxBelowValue() {
+            RowGroup rg = makeRowGroup(PhysicalType.INT32, intBytes(10), intBytes(100));
+            FileSchema schema = makeIntSchema("col");
+
+            assertThat(RowGroupFilter.gt("col", 200).canDrop(rg, schema)).isTrue();
+        }
+
+        @Test
+        void gtKeepsWhenMaxAboveValue() {
+            RowGroup rg = makeRowGroup(PhysicalType.INT32, intBytes(10), intBytes(100));
+            FileSchema schema = makeIntSchema("col");
+
+            assertThat(RowGroupFilter.gt("col", 50).canDrop(rg, schema)).isFalse();
+        }
+
+        @Test
+        void gtKeepsWhenMaxAboveValueByOne() {
+            RowGroup rg = makeRowGroup(PhysicalType.INT32, intBytes(10), intBytes(100));
+            FileSchema schema = makeIntSchema("col");
+
+            assertThat(RowGroupFilter.gt("col", 99).canDrop(rg, schema)).isFalse();
+        }
+
+        @Test
+        void gtEqDropsWhenMaxBelowValue() {
+            RowGroup rg = makeRowGroup(PhysicalType.INT32, intBytes(10), intBytes(100));
+            FileSchema schema = makeIntSchema("col");
+
+            assertThat(RowGroupFilter.gtEq("col", 101).canDrop(rg, schema)).isTrue();
+        }
+
+        @Test
+        void gtEqKeepsWhenMaxEqualsValue() {
+            RowGroup rg = makeRowGroup(PhysicalType.INT32, intBytes(10), intBytes(100));
+            FileSchema schema = makeIntSchema("col");
+
+            assertThat(RowGroupFilter.gtEq("col", 100).canDrop(rg, schema)).isFalse();
+        }
+
+        @Test
+        void ltDropsWhenMinEqualsValue() {
+            RowGroup rg = makeRowGroup(PhysicalType.INT32, intBytes(10), intBytes(100));
+            FileSchema schema = makeIntSchema("col");
+
+            assertThat(RowGroupFilter.lt("col", 10).canDrop(rg, schema)).isTrue();
+        }
+
+        @Test
+        void ltDropsWhenMinAboveValue() {
+            RowGroup rg = makeRowGroup(PhysicalType.INT32, intBytes(10), intBytes(100));
+            FileSchema schema = makeIntSchema("col");
+
+            assertThat(RowGroupFilter.lt("col", 5).canDrop(rg, schema)).isTrue();
+        }
+
+        @Test
+        void ltKeepsWhenMinBelowValue() {
+            RowGroup rg = makeRowGroup(PhysicalType.INT32, intBytes(10), intBytes(100));
+            FileSchema schema = makeIntSchema("col");
+
+            assertThat(RowGroupFilter.lt("col", 50).canDrop(rg, schema)).isFalse();
+        }
+
+        @Test
+        void ltEqDropsWhenMinAboveValue() {
+            RowGroup rg = makeRowGroup(PhysicalType.INT32, intBytes(10), intBytes(100));
+            FileSchema schema = makeIntSchema("col");
+
+            assertThat(RowGroupFilter.ltEq("col", 9).canDrop(rg, schema)).isTrue();
+        }
+
+        @Test
+        void ltEqKeepsWhenMinEqualsValue() {
+            RowGroup rg = makeRowGroup(PhysicalType.INT32, intBytes(10), intBytes(100));
+            FileSchema schema = makeIntSchema("col");
+
+            assertThat(RowGroupFilter.ltEq("col", 10).canDrop(rg, schema)).isFalse();
+        }
+
+        @Test
+        void notEqDropsWhenSingleValueMatch() {
+            RowGroup rg = makeRowGroup(PhysicalType.INT32, intBytes(42), intBytes(42));
+            FileSchema schema = makeIntSchema("col");
+
+            assertThat(RowGroupFilter.notEq("col", 42).canDrop(rg, schema)).isTrue();
+        }
+
+        @Test
+        void notEqKeepsWhenRangeContainsOtherValues() {
+            RowGroup rg = makeRowGroup(PhysicalType.INT32, intBytes(10), intBytes(100));
+            FileSchema schema = makeIntSchema("col");
+
+            assertThat(RowGroupFilter.notEq("col", 42).canDrop(rg, schema)).isFalse();
+        }
+
+        @Test
+        void notEqKeepsWhenValueOutOfRange() {
+            RowGroup rg = makeRowGroup(PhysicalType.INT32, intBytes(10), intBytes(100));
+            FileSchema schema = makeIntSchema("col");
+
+            assertThat(RowGroupFilter.notEq("col", 200).canDrop(rg, schema)).isFalse();
+        }
+    }
+
+    @Nested
+    class NegativeValueTests {
+
+        @Test
+        void eqWithNegativeRange() {
+            RowGroup rg = makeRowGroup(PhysicalType.INT32, intBytes(-100), intBytes(-10));
+            FileSchema schema = makeIntSchema("col");
+
+            assertThat(RowGroupFilter.eq("col", -50).canDrop(rg, schema)).isFalse();
+            assertThat(RowGroupFilter.eq("col", 0).canDrop(rg, schema)).isTrue();
+            assertThat(RowGroupFilter.eq("col", -200).canDrop(rg, schema)).isTrue();
+        }
+
+        @Test
+        void gtWithNegativeRange() {
+            RowGroup rg = makeRowGroup(PhysicalType.INT32, intBytes(-100), intBytes(-10));
+            FileSchema schema = makeIntSchema("col");
+
+            assertThat(RowGroupFilter.gt("col", -10).canDrop(rg, schema)).isTrue();
+            assertThat(RowGroupFilter.gt("col", -50).canDrop(rg, schema)).isFalse();
+            assertThat(RowGroupFilter.gt("col", -110).canDrop(rg, schema)).isFalse();
+        }
+
+        @Test
+        void ltWithNegativeRange() {
+            RowGroup rg = makeRowGroup(PhysicalType.INT32, intBytes(-100), intBytes(-10));
+            FileSchema schema = makeIntSchema("col");
+
+            assertThat(RowGroupFilter.lt("col", -100).canDrop(rg, schema)).isTrue();
+            assertThat(RowGroupFilter.lt("col", -50).canDrop(rg, schema)).isFalse();
+        }
+
+        @Test
+        void rangeSpanningZero() {
+            RowGroup rg = makeRowGroup(PhysicalType.INT32, intBytes(-50), intBytes(50));
+            FileSchema schema = makeIntSchema("col");
+
+            assertThat(RowGroupFilter.eq("col", 0).canDrop(rg, schema)).isFalse();
+            assertThat(RowGroupFilter.gt("col", -60).canDrop(rg, schema)).isFalse();
+            assertThat(RowGroupFilter.lt("col", 60).canDrop(rg, schema)).isFalse();
+        }
+    }
+
+    @Nested
+    class Int64FilterTests {
+
+        @Test
+        void eqInt64() {
+            RowGroup rg = makeRowGroup(PhysicalType.INT64, longBytes(1000000L), longBytes(9999999L));
+            FileSchema schema = makeSchema("ts", PhysicalType.INT64, null);
+
+            assertThat(RowGroupFilter.eq("ts", 5000000L).canDrop(rg, schema)).isFalse();
+            assertThat(RowGroupFilter.eq("ts", 100L).canDrop(rg, schema)).isTrue();
+            assertThat(RowGroupFilter.eq("ts", 99999999L).canDrop(rg, schema)).isTrue();
+        }
+
+        @Test
+        void gtInt64() {
+            RowGroup rg = makeRowGroup(PhysicalType.INT64, longBytes(1000000L), longBytes(9999999L));
+            FileSchema schema = makeSchema("ts", PhysicalType.INT64, null);
+
+            assertThat(RowGroupFilter.gt("ts", 9999999L).canDrop(rg, schema)).isTrue();
+            assertThat(RowGroupFilter.gt("ts", 5000000L).canDrop(rg, schema)).isFalse();
+        }
+
+        @Test
+        void ltInt64WithLargeValues() {
+            RowGroup rg = makeRowGroup(PhysicalType.INT64, longBytes(Long.MAX_VALUE - 100), longBytes(Long.MAX_VALUE));
+            FileSchema schema = makeSchema("ts", PhysicalType.INT64, null);
+
+            assertThat(RowGroupFilter.lt("ts", Long.MAX_VALUE - 100).canDrop(rg, schema)).isTrue();
+            assertThat(RowGroupFilter.lt("ts", Long.MAX_VALUE).canDrop(rg, schema)).isFalse();
+        }
+
+        @Test
+        void int64NegativeRange() {
+            RowGroup rg = makeRowGroup(PhysicalType.INT64, longBytes(-1000000L), longBytes(-100L));
+            FileSchema schema = makeSchema("ts", PhysicalType.INT64, null);
+
+            assertThat(RowGroupFilter.eq("ts", -500L).canDrop(rg, schema)).isFalse();
+            assertThat(RowGroupFilter.gt("ts", -100L).canDrop(rg, schema)).isTrue();
+        }
+    }
+
+    @Nested
+    class DoubleFilterTests {
+
+        @Test
+        void eqDropsWhenOutOfRange() {
+            RowGroup rg = makeRowGroup(PhysicalType.DOUBLE, doubleBytes(1.5), doubleBytes(9.9));
+            FileSchema schema = makeDoubleSchema("fare");
+
+            assertThat(RowGroupFilter.eq("fare", 15.0).canDrop(rg, schema)).isTrue();
+        }
+
+        @Test
+        void eqKeepsWhenInRange() {
+            RowGroup rg = makeRowGroup(PhysicalType.DOUBLE, doubleBytes(1.5), doubleBytes(9.9));
+            FileSchema schema = makeDoubleSchema("fare");
+
+            assertThat(RowGroupFilter.eq("fare", 5.0).canDrop(rg, schema)).isFalse();
+        }
+
+        @Test
+        void gtDouble() {
+            RowGroup rg = makeRowGroup(PhysicalType.DOUBLE, doubleBytes(1.5), doubleBytes(9.9));
+            FileSchema schema = makeDoubleSchema("fare");
+
+            assertThat(RowGroupFilter.gt("fare", 9.9).canDrop(rg, schema)).isTrue();
+            assertThat(RowGroupFilter.gt("fare", 5.0).canDrop(rg, schema)).isFalse();
+        }
+
+        @Test
+        void ltDouble() {
+            RowGroup rg = makeRowGroup(PhysicalType.DOUBLE, doubleBytes(1.5), doubleBytes(9.9));
+            FileSchema schema = makeDoubleSchema("fare");
+
+            assertThat(RowGroupFilter.lt("fare", 1.5).canDrop(rg, schema)).isTrue();
+            assertThat(RowGroupFilter.lt("fare", 5.0).canDrop(rg, schema)).isFalse();
+        }
+
+        @Test
+        void gtEqDouble() {
+            RowGroup rg = makeRowGroup(PhysicalType.DOUBLE, doubleBytes(1.5), doubleBytes(9.9));
+            FileSchema schema = makeDoubleSchema("fare");
+
+            assertThat(RowGroupFilter.gtEq("fare", 10.0).canDrop(rg, schema)).isTrue();
+            assertThat(RowGroupFilter.gtEq("fare", 9.9).canDrop(rg, schema)).isFalse();
+        }
+
+        @Test
+        void ltEqDouble() {
+            RowGroup rg = makeRowGroup(PhysicalType.DOUBLE, doubleBytes(1.5), doubleBytes(9.9));
+            FileSchema schema = makeDoubleSchema("fare");
+
+            assertThat(RowGroupFilter.ltEq("fare", 1.4).canDrop(rg, schema)).isTrue();
+            assertThat(RowGroupFilter.ltEq("fare", 1.5).canDrop(rg, schema)).isFalse();
+        }
+
+        @Test
+        void notEqDouble() {
+            RowGroup rg = makeRowGroup(PhysicalType.DOUBLE, doubleBytes(3.14), doubleBytes(3.14));
+            FileSchema schema = makeDoubleSchema("fare");
+
+            assertThat(RowGroupFilter.notEq("fare", 3.14).canDrop(rg, schema)).isTrue();
+            assertThat(RowGroupFilter.notEq("fare", 2.71).canDrop(rg, schema)).isFalse();
+        }
+
+        @Test
+        void verySmallDoubleRange() {
+            RowGroup rg = makeRowGroup(PhysicalType.DOUBLE, doubleBytes(1e-10), doubleBytes(1e-9));
+            FileSchema schema = makeDoubleSchema("tiny");
+
+            assertThat(RowGroupFilter.eq("tiny", 5e-10).canDrop(rg, schema)).isFalse();
+            assertThat(RowGroupFilter.eq("tiny", 1.0).canDrop(rg, schema)).isTrue();
+        }
+
+        @Test
+        void negativeDoubleRange() {
+            RowGroup rg = makeRowGroup(PhysicalType.DOUBLE, doubleBytes(-99.9), doubleBytes(-0.1));
+            FileSchema schema = makeDoubleSchema("temp");
+
+            assertThat(RowGroupFilter.eq("temp", -50.0).canDrop(rg, schema)).isFalse();
+            assertThat(RowGroupFilter.eq("temp", 0.0).canDrop(rg, schema)).isTrue();
+            assertThat(RowGroupFilter.gt("temp", -0.1).canDrop(rg, schema)).isTrue();
+        }
+    }
+
+    @Nested
+    class FloatFilterTests {
+
+        @Test
+        void floatEqFilter() {
+            RowGroup rg = makeRowGroup(PhysicalType.FLOAT, floatBytes(1.0f), floatBytes(10.0f));
+            FileSchema schema = makeSchema("f", PhysicalType.FLOAT, null);
+
+            assertThat(RowGroupFilter.eq("f", 5.0).canDrop(rg, schema)).isFalse();
+            assertThat(RowGroupFilter.eq("f", 20.0).canDrop(rg, schema)).isTrue();
+        }
+
+        @Test
+        void floatGtFilter() {
+            RowGroup rg = makeRowGroup(PhysicalType.FLOAT, floatBytes(1.0f), floatBytes(10.0f));
+            FileSchema schema = makeSchema("f", PhysicalType.FLOAT, null);
+
+            assertThat(RowGroupFilter.gt("f", 10.0).canDrop(rg, schema)).isTrue();
+            assertThat(RowGroupFilter.gt("f", 5.0).canDrop(rg, schema)).isFalse();
+        }
+    }
+
+    @Nested
+    class StringFilterTests {
+
+        @Test
+        void eqDropsOutOfRange() {
+            RowGroup rg = makeStringRowGroup("apple", "mango");
+            FileSchema schema = makeStringSchema("name");
+
+            assertThat(RowGroupFilter.eq("name", "peach").canDrop(rg, schema)).isTrue();
+            assertThat(RowGroupFilter.eq("name", "banana").canDrop(rg, schema)).isFalse();
+        }
+
+        @Test
+        void eqDropsBelowRange() {
+            RowGroup rg = makeStringRowGroup("mango", "peach");
+            FileSchema schema = makeStringSchema("name");
+
+            assertThat(RowGroupFilter.eq("name", "apple").canDrop(rg, schema)).isTrue();
+        }
+
+        @Test
+        void eqKeepsAtBoundaries() {
+            RowGroup rg = makeStringRowGroup("apple", "mango");
+            FileSchema schema = makeStringSchema("name");
+
+            assertThat(RowGroupFilter.eq("name", "apple").canDrop(rg, schema)).isFalse();
+            assertThat(RowGroupFilter.eq("name", "mango").canDrop(rg, schema)).isFalse();
+        }
+
+        @Test
+        void gtString() {
+            RowGroup rg = makeStringRowGroup("apple", "mango");
+            FileSchema schema = makeStringSchema("name");
+
+            assertThat(RowGroupFilter.eq("name", "peach").canDrop(rg, schema)).isTrue();
+        }
+
+        @Test
+        void ltString() {
+            RowGroup rg = makeStringRowGroup("mango", "peach");
+            FileSchema schema = makeStringSchema("name");
+
+            assertThat(RowGroupFilter.eq("name", "apple").canDrop(rg, schema)).isTrue();
+        }
+
+        @Test
+        void stringWithPrefixComparison() {
+            RowGroup rg = makeStringRowGroup("abc", "abcdef");
+            FileSchema schema = makeStringSchema("name");
+
+            assertThat(RowGroupFilter.eq("name", "abcd").canDrop(rg, schema)).isFalse();
+            assertThat(RowGroupFilter.eq("name", "abb").canDrop(rg, schema)).isTrue();
+            assertThat(RowGroupFilter.eq("name", "abd").canDrop(rg, schema)).isTrue();
+        }
+
+        @Test
+        void emptyStringBounds() {
+            RowGroup rg = makeStringRowGroup("", "zzz");
+            FileSchema schema = makeStringSchema("name");
+
+            assertThat(RowGroupFilter.eq("name", "anything").canDrop(rg, schema)).isFalse();
+        }
+    }
+
+    @Nested
+    class CompoundFilterTests {
+
+        @Test
+        void andDropsWhenAnyChildDrops() {
+            RowGroup rg = makeRowGroup(PhysicalType.INT32, intBytes(10), intBytes(100));
+            FileSchema schema = makeIntSchema("col");
+
+            RowGroupFilter filter = RowGroupFilter.and(
+                    RowGroupFilter.eq("col", 5),
+                    RowGroupFilter.gt("col", 50));
+            assertThat(filter.canDrop(rg, schema)).isTrue();
+        }
+
+        @Test
+        void andKeepsWhenNoChildDrops() {
+            RowGroup rg = makeRowGroup(PhysicalType.INT32, intBytes(10), intBytes(100));
+            FileSchema schema = makeIntSchema("col");
+
+            RowGroupFilter filter = RowGroupFilter.and(
+                    RowGroupFilter.gt("col", 5),
+                    RowGroupFilter.lt("col", 200));
+            assertThat(filter.canDrop(rg, schema)).isFalse();
+        }
+
+        @Test
+        void andWithThreeFilters() {
+            RowGroup rg = makeRowGroup(PhysicalType.INT32, intBytes(10), intBytes(100));
+            FileSchema schema = makeIntSchema("col");
+
+            RowGroupFilter filter = RowGroupFilter.and(
+                    RowGroupFilter.gt("col", 5),
+                    RowGroupFilter.lt("col", 200),
+                    RowGroupFilter.eq("col", 50));
+            assertThat(filter.canDrop(rg, schema)).isFalse();
+        }
+
+        @Test
+        void orDropsOnlyWhenAllChildrenDrop() {
+            RowGroup rg = makeRowGroup(PhysicalType.INT32, intBytes(10), intBytes(100));
+            FileSchema schema = makeIntSchema("col");
+
+            RowGroupFilter filter = RowGroupFilter.or(
+                    RowGroupFilter.eq("col", 5),
+                    RowGroupFilter.eq("col", 200));
+            assertThat(filter.canDrop(rg, schema)).isTrue();
+        }
+
+        @Test
+        void orKeepsWhenAnyChildKeeps() {
+            RowGroup rg = makeRowGroup(PhysicalType.INT32, intBytes(10), intBytes(100));
+            FileSchema schema = makeIntSchema("col");
+
+            RowGroupFilter filter = RowGroupFilter.or(
+                    RowGroupFilter.eq("col", 5),
+                    RowGroupFilter.eq("col", 50));
+            assertThat(filter.canDrop(rg, schema)).isFalse();
+        }
+
+        @Test
+        void orWithThreeFilters() {
+            RowGroup rg = makeRowGroup(PhysicalType.INT32, intBytes(10), intBytes(100));
+            FileSchema schema = makeIntSchema("col");
+
+            RowGroupFilter filter = RowGroupFilter.or(
+                    RowGroupFilter.eq("col", 5),
+                    RowGroupFilter.eq("col", 200),
+                    RowGroupFilter.eq("col", 999));
+            assertThat(filter.canDrop(rg, schema)).isTrue();
+        }
+
+        @Test
+        void nestedAndOr() {
+            RowGroup rg = makeRowGroup(PhysicalType.INT32, intBytes(10), intBytes(100));
+            FileSchema schema = makeIntSchema("col");
+
+            // AND(OR(eq(5), eq(50)), gt(5)) -> OR keeps because eq(50) keeps -> AND checks gt(5) which keeps
+            RowGroupFilter filter = RowGroupFilter.and(
+                    RowGroupFilter.or(RowGroupFilter.eq("col", 5), RowGroupFilter.eq("col", 50)),
+                    RowGroupFilter.gt("col", 5));
+            assertThat(filter.canDrop(rg, schema)).isFalse();
+        }
+
+        @Test
+        void nestedOrWithAllDropping() {
+            RowGroup rg = makeRowGroup(PhysicalType.INT32, intBytes(10), intBytes(100));
+            FileSchema schema = makeIntSchema("col");
+
+            // AND(eq(5), OR(eq(200), eq(300))) -> eq(5) drops -> AND drops
+            RowGroupFilter filter = RowGroupFilter.and(
+                    RowGroupFilter.eq("col", 5),
+                    RowGroupFilter.or(RowGroupFilter.eq("col", 200), RowGroupFilter.eq("col", 300)));
+            assertThat(filter.canDrop(rg, schema)).isTrue();
+        }
+
+        @Test
+        void notNeverDropsConservatively() {
+            RowGroup rg = makeRowGroup(PhysicalType.INT32, intBytes(10), intBytes(100));
+            FileSchema schema = makeIntSchema("col");
+
+            assertThat(RowGroupFilter.not(RowGroupFilter.gt("col", 50)).canDrop(rg, schema)).isFalse();
+            assertThat(RowGroupFilter.not(RowGroupFilter.eq("col", 50)).canDrop(rg, schema)).isFalse();
+        }
+
+        @Test
+        void compoundColumnName() {
+            RowGroupFilter and = RowGroupFilter.and(RowGroupFilter.eq("a", 1), RowGroupFilter.eq("b", 2));
+            RowGroupFilter or = RowGroupFilter.or(RowGroupFilter.eq("a", 1));
+            RowGroupFilter not = RowGroupFilter.not(RowGroupFilter.eq("c", 3));
+
+            assertThat(and.columnName()).isNull();
+            assertThat(or.columnName()).isNull();
+            assertThat(not.columnName()).isEqualTo("c");
+        }
+    }
+
+    @Nested
+    class NoStatisticsTests {
+
+        @Test
+        void noStatisticsNeverDropsAnyOperator() {
+            Statistics noStats = new Statistics(null, null, -1, -1, false);
+            RowGroup rg = makeRowGroupWithStats(PhysicalType.INT32, noStats);
+            FileSchema schema = makeIntSchema("col");
+
+            assertThat(RowGroupFilter.eq("col", 50).canDrop(rg, schema)).isFalse();
+            assertThat(RowGroupFilter.notEq("col", 50).canDrop(rg, schema)).isFalse();
+            assertThat(RowGroupFilter.gt("col", 50).canDrop(rg, schema)).isFalse();
+            assertThat(RowGroupFilter.gtEq("col", 50).canDrop(rg, schema)).isFalse();
+            assertThat(RowGroupFilter.lt("col", 50).canDrop(rg, schema)).isFalse();
+            assertThat(RowGroupFilter.ltEq("col", 50).canDrop(rg, schema)).isFalse();
+        }
+
+        @Test
+        void nullStatisticsNeverDrops() {
+            RowGroup rg = makeRowGroupWithStats(PhysicalType.INT32, null);
+            FileSchema schema = makeIntSchema("col");
+
+            assertThat(RowGroupFilter.eq("col", 50).canDrop(rg, schema)).isFalse();
+        }
+
+        @Test
+        void noStatisticsDoubleNeverDrops() {
+            Statistics noStats = new Statistics(null, null, -1, -1, false);
+            RowGroup rg = makeRowGroupWithStats(PhysicalType.DOUBLE, noStats);
+            FileSchema schema = makeDoubleSchema("fare");
+
+            assertThat(RowGroupFilter.eq("fare", 50.0).canDrop(rg, schema)).isFalse();
+            assertThat(RowGroupFilter.gt("fare", 50.0).canDrop(rg, schema)).isFalse();
+        }
+
+        @Test
+        void noStatisticsStringNeverDrops() {
+            Statistics noStats = new Statistics(null, null, -1, -1, false);
+            RowGroup rg = makeRowGroupWithStats(PhysicalType.BYTE_ARRAY, noStats);
+            FileSchema schema = makeStringSchema("name");
+
+            assertThat(RowGroupFilter.eq("name", "test").canDrop(rg, schema)).isFalse();
+        }
+    }
+
+    @Nested
+    class PageFilterTests {
+
+        @Test
+        void pageFilterGtInt() {
+            RowGroupFilter filter = RowGroupFilter.gt("col", 100);
+            assertThat(filter.canDropPage(intBytes(10), intBytes(50), PhysicalType.INT32)).isTrue();
+            assertThat(filter.canDropPage(intBytes(10), intBytes(200), PhysicalType.INT32)).isFalse();
+        }
+
+        @Test
+        void pageFilterEqInt() {
+            RowGroupFilter filter = RowGroupFilter.eq("col", 50);
+            assertThat(filter.canDropPage(intBytes(60), intBytes(100), PhysicalType.INT32)).isTrue();
+            assertThat(filter.canDropPage(intBytes(10), intBytes(100), PhysicalType.INT32)).isFalse();
+        }
+
+        @Test
+        void pageFilterLtInt() {
+            RowGroupFilter filter = RowGroupFilter.lt("col", 10);
+            assertThat(filter.canDropPage(intBytes(10), intBytes(100), PhysicalType.INT32)).isTrue();
+            assertThat(filter.canDropPage(intBytes(5), intBytes(100), PhysicalType.INT32)).isFalse();
+        }
+
+        @Test
+        void pageFilterGtEqInt() {
+            RowGroupFilter filter = RowGroupFilter.gtEq("col", 101);
+            assertThat(filter.canDropPage(intBytes(10), intBytes(100), PhysicalType.INT32)).isTrue();
+            assertThat(filter.canDropPage(intBytes(10), intBytes(101), PhysicalType.INT32)).isFalse();
+        }
+
+        @Test
+        void pageFilterLtEqInt() {
+            RowGroupFilter filter = RowGroupFilter.ltEq("col", 9);
+            assertThat(filter.canDropPage(intBytes(10), intBytes(100), PhysicalType.INT32)).isTrue();
+            assertThat(filter.canDropPage(intBytes(9), intBytes(100), PhysicalType.INT32)).isFalse();
+        }
+
+        @Test
+        void pageFilterNotEqInt() {
+            RowGroupFilter filter = RowGroupFilter.notEq("col", 42);
+            assertThat(filter.canDropPage(intBytes(42), intBytes(42), PhysicalType.INT32)).isTrue();
+            assertThat(filter.canDropPage(intBytes(10), intBytes(100), PhysicalType.INT32)).isFalse();
+        }
+
+        @Test
+        void pageFilterDouble() {
+            RowGroupFilter filter = RowGroupFilter.gt("f", 10.0);
+            assertThat(filter.canDropPage(doubleBytes(1.0), doubleBytes(9.0), PhysicalType.DOUBLE)).isTrue();
+            assertThat(filter.canDropPage(doubleBytes(1.0), doubleBytes(20.0), PhysicalType.DOUBLE)).isFalse();
+        }
+
+        @Test
+        void pageFilterString() {
+            RowGroupFilter filter = RowGroupFilter.eq("s", "hello");
+            byte[] helloBytes = "hello".getBytes(StandardCharsets.UTF_8);
+            byte[] abcBytes = "abc".getBytes(StandardCharsets.UTF_8);
+            byte[] defBytes = "def".getBytes(StandardCharsets.UTF_8);
+            byte[] xyzBytes = "xyz".getBytes(StandardCharsets.UTF_8);
+
+            assertThat(filter.canDropPage(abcBytes, defBytes, PhysicalType.BYTE_ARRAY)).isTrue();
+            assertThat(filter.canDropPage(abcBytes, xyzBytes, PhysicalType.BYTE_ARRAY)).isFalse();
+        }
+
+        @Test
+        void compoundFiltersReturnFalseForPageLevel() {
+            RowGroupFilter and = RowGroupFilter.and(RowGroupFilter.eq("a", 1));
+            RowGroupFilter or = RowGroupFilter.or(RowGroupFilter.eq("a", 1));
+            RowGroupFilter not = RowGroupFilter.not(RowGroupFilter.eq("a", 1));
+
+            assertThat(and.canDropPage(intBytes(0), intBytes(10), PhysicalType.INT32)).isFalse();
+            assertThat(or.canDropPage(intBytes(0), intBytes(10), PhysicalType.INT32)).isFalse();
+            assertThat(not.canDropPage(intBytes(0), intBytes(10), PhysicalType.INT32)).isFalse();
+        }
+    }
+
+    @Nested
+    class StatisticsRecordTests {
+
+        @Test
+        void hasMinMaxTrue() {
+            Statistics stats = new Statistics(intBytes(1), intBytes(10), 0, -1, false);
+            assertThat(stats.hasMinMax()).isTrue();
+        }
+
+        @Test
+        void hasMinMaxFalseWhenMinNull() {
+            Statistics stats = new Statistics(null, intBytes(10), 0, -1, false);
+            assertThat(stats.hasMinMax()).isFalse();
+        }
+
+        @Test
+        void hasMinMaxFalseWhenMaxNull() {
+            Statistics stats = new Statistics(intBytes(1), null, 0, -1, false);
+            assertThat(stats.hasMinMax()).isFalse();
+        }
+
+        @Test
+        void hasMinMaxFalseWhenBothNull() {
+            Statistics stats = new Statistics(null, null, -1, -1, false);
+            assertThat(stats.hasMinMax()).isFalse();
+        }
+
+        @Test
+        void deprecatedFlag() {
+            Statistics modern = new Statistics(intBytes(1), intBytes(10), 0, 5, false);
+            Statistics legacy = new Statistics(intBytes(1), intBytes(10), 0, 5, true);
+
+            assertThat(modern.isMinMaxDeprecated()).isFalse();
+            assertThat(legacy.isMinMaxDeprecated()).isTrue();
+        }
+
+        @Test
+        void nullAndDistinctCounts() {
+            Statistics stats = new Statistics(intBytes(1), intBytes(10), 42, 7, false);
+            assertThat(stats.nullCount()).isEqualTo(42);
+            assertThat(stats.distinctCount()).isEqualTo(7);
+        }
+    }
+
+    @Nested
+    class StatisticsConverterTests {
+
+        @Test
+        void int32Conversion() {
+            assertThat(StatisticsConverter.bytesToLong(intBytes(42), PhysicalType.INT32)).isEqualTo(42);
+            assertThat(StatisticsConverter.bytesToLong(intBytes(-7), PhysicalType.INT32)).isEqualTo(-7);
+            assertThat(StatisticsConverter.bytesToLong(intBytes(0), PhysicalType.INT32)).isEqualTo(0);
+            assertThat(StatisticsConverter.bytesToLong(intBytes(Integer.MAX_VALUE), PhysicalType.INT32)).isEqualTo(Integer.MAX_VALUE);
+            assertThat(StatisticsConverter.bytesToLong(intBytes(Integer.MIN_VALUE), PhysicalType.INT32)).isEqualTo(Integer.MIN_VALUE);
+        }
+
+        @Test
+        void int64Conversion() {
+            assertThat(StatisticsConverter.bytesToLong(longBytes(123456789L), PhysicalType.INT64)).isEqualTo(123456789L);
+            assertThat(StatisticsConverter.bytesToLong(longBytes(-123456789L), PhysicalType.INT64)).isEqualTo(-123456789L);
+            assertThat(StatisticsConverter.bytesToLong(longBytes(0L), PhysicalType.INT64)).isEqualTo(0L);
+            assertThat(StatisticsConverter.bytesToLong(longBytes(Long.MAX_VALUE), PhysicalType.INT64)).isEqualTo(Long.MAX_VALUE);
+            assertThat(StatisticsConverter.bytesToLong(longBytes(Long.MIN_VALUE), PhysicalType.INT64)).isEqualTo(Long.MIN_VALUE);
+        }
+
+        @Test
+        void booleanConversion() {
+            assertThat(StatisticsConverter.bytesToLong(new byte[]{1}, PhysicalType.BOOLEAN)).isEqualTo(1L);
+            assertThat(StatisticsConverter.bytesToLong(new byte[]{0}, PhysicalType.BOOLEAN)).isEqualTo(0L);
+        }
+
+        @Test
+        void floatConversion() {
+            assertThat(StatisticsConverter.bytesToDouble(floatBytes(3.14f), PhysicalType.FLOAT)).isEqualTo(3.14f);
+            assertThat(StatisticsConverter.bytesToDouble(floatBytes(-1.5f), PhysicalType.FLOAT)).isEqualTo(-1.5f);
+            assertThat(StatisticsConverter.bytesToDouble(floatBytes(0.0f), PhysicalType.FLOAT)).isEqualTo(0.0f);
+        }
+
+        @Test
+        void doubleConversion() {
+            assertThat(StatisticsConverter.bytesToDouble(doubleBytes(3.14), PhysicalType.DOUBLE)).isEqualTo(3.14);
+            assertThat(StatisticsConverter.bytesToDouble(doubleBytes(-1.5), PhysicalType.DOUBLE)).isEqualTo(-1.5);
+            assertThat(StatisticsConverter.bytesToDouble(doubleBytes(0.0), PhysicalType.DOUBLE)).isEqualTo(0.0);
+        }
+
+        @Test
+        void int32ToDoubleConversion() {
+            assertThat(StatisticsConverter.bytesToDouble(intBytes(42), PhysicalType.INT32)).isEqualTo(42.0);
+        }
+
+        @Test
+        void int64ToDoubleConversion() {
+            assertThat(StatisticsConverter.bytesToDouble(longBytes(100L), PhysicalType.INT64)).isEqualTo(100.0);
+        }
+
+        @Test
+        void byteArrayToLongThrows() {
+            assertThatThrownBy(() -> StatisticsConverter.bytesToLong(new byte[]{1, 2}, PhysicalType.BYTE_ARRAY))
+                    .isInstanceOf(UnsupportedOperationException.class)
+                    .hasMessageContaining("BYTE_ARRAY");
+        }
+
+        @Test
+        void fixedLenByteArrayToLongThrows() {
+            assertThatThrownBy(() -> StatisticsConverter.bytesToLong(new byte[]{1, 2}, PhysicalType.FIXED_LEN_BYTE_ARRAY))
+                    .isInstanceOf(UnsupportedOperationException.class)
+                    .hasMessageContaining("FIXED_LEN_BYTE_ARRAY");
+        }
+
+        @Test
+        void int96ToLongThrows() {
+            assertThatThrownBy(() -> StatisticsConverter.bytesToLong(new byte[12], PhysicalType.INT96))
+                    .isInstanceOf(UnsupportedOperationException.class)
+                    .hasMessageContaining("INT96");
+        }
+
+        @Test
+        void booleanToDoubleThrows() {
+            assertThatThrownBy(() -> StatisticsConverter.bytesToDouble(new byte[]{1}, PhysicalType.BOOLEAN))
+                    .isInstanceOf(UnsupportedOperationException.class);
+        }
+
+        @Test
+        void bytesComparisonBasic() {
+            byte[] a = "apple".getBytes(StandardCharsets.UTF_8);
+            byte[] b = "banana".getBytes(StandardCharsets.UTF_8);
+
+            assertThat(StatisticsConverter.compareBytes(a, b)).isLessThan(0);
+            assertThat(StatisticsConverter.compareBytes(b, a)).isGreaterThan(0);
+            assertThat(StatisticsConverter.compareBytes(a, a)).isEqualTo(0);
+        }
+
+        @Test
+        void bytesComparisonDifferentLengths() {
+            byte[] short_ = "abc".getBytes(StandardCharsets.UTF_8);
+            byte[] long_ = "abcdef".getBytes(StandardCharsets.UTF_8);
+
+            assertThat(StatisticsConverter.compareBytes(short_, long_)).isLessThan(0);
+            assertThat(StatisticsConverter.compareBytes(long_, short_)).isGreaterThan(0);
+        }
+
+        @Test
+        void bytesComparisonEmpty() {
+            byte[] empty = new byte[0];
+            byte[] nonempty = "a".getBytes(StandardCharsets.UTF_8);
+
+            assertThat(StatisticsConverter.compareBytes(empty, empty)).isEqualTo(0);
+            assertThat(StatisticsConverter.compareBytes(empty, nonempty)).isLessThan(0);
+            assertThat(StatisticsConverter.compareBytes(nonempty, empty)).isGreaterThan(0);
+        }
+
+        @Test
+        void bytesComparisonUnsigned() {
+            // 0xFF should be greater than 0x01 in unsigned comparison
+            byte[] highByte = new byte[]{(byte) 0xFF};
+            byte[] lowByte = new byte[]{(byte) 0x01};
+
+            assertThat(StatisticsConverter.compareBytes(highByte, lowByte)).isGreaterThan(0);
+            assertThat(StatisticsConverter.compareBytes(lowByte, highByte)).isLessThan(0);
+        }
+    }
+
+    @Nested
+    class MultiColumnSchemaTests {
+
+        @Test
+        void filterMatchesCorrectColumnInMultiColumnSchema() {
+            Statistics fareStats = new Statistics(doubleBytes(10.0), doubleBytes(100.0), 0, -1, false);
+            Statistics idStats = new Statistics(intBytes(1), intBytes(1000), 0, -1, false);
+
+            ColumnMetaData idMeta = new ColumnMetaData(
+                    PhysicalType.INT32, List.of(), List.of("id"), CompressionCodec.UNCOMPRESSED,
+                    1000, 4000, 4000, 0, null, idStats);
+            ColumnMetaData fareMeta = new ColumnMetaData(
+                    PhysicalType.DOUBLE, List.of(), List.of("fare"), CompressionCodec.UNCOMPRESSED,
+                    1000, 8000, 8000, 4000, null, fareStats);
+
+            ColumnChunk idChunk = new ColumnChunk(idMeta, null, null, null, null);
+            ColumnChunk fareChunk = new ColumnChunk(fareMeta, null, null, null, null);
+
+            RowGroup rg = new RowGroup(List.of(idChunk, fareChunk), 12000, 1000);
+
+            SchemaElement root = new SchemaElement("schema", null, null, null, 2, null, null, null, null, null);
+            SchemaElement idCol = new SchemaElement("id", PhysicalType.INT32, null, RepetitionType.REQUIRED, null,
+                    null, null, null, null, null);
+            SchemaElement fareCol = new SchemaElement("fare", PhysicalType.DOUBLE, null, RepetitionType.OPTIONAL, null,
+                    null, null, null, null, null);
+            FileSchema schema = FileSchema.fromSchemaElements(List.of(root, idCol, fareCol));
+
+            // Filter on id: should use idStats (1..1000)
+            assertThat(RowGroupFilter.eq("id", 500).canDrop(rg, schema)).isFalse();
+            assertThat(RowGroupFilter.eq("id", 2000).canDrop(rg, schema)).isTrue();
+
+            // Filter on fare: should use fareStats (10.0..100.0)
+            assertThat(RowGroupFilter.gt("fare", 50.0).canDrop(rg, schema)).isFalse();
+            assertThat(RowGroupFilter.gt("fare", 100.0).canDrop(rg, schema)).isTrue();
+        }
+
+        @Test
+        void compoundFilterAcrossMultipleColumns() {
+            Statistics fareStats = new Statistics(doubleBytes(10.0), doubleBytes(100.0), 0, -1, false);
+            Statistics idStats = new Statistics(intBytes(1), intBytes(1000), 0, -1, false);
+
+            ColumnMetaData idMeta = new ColumnMetaData(
+                    PhysicalType.INT32, List.of(), List.of("id"), CompressionCodec.UNCOMPRESSED,
+                    1000, 4000, 4000, 0, null, idStats);
+            ColumnMetaData fareMeta = new ColumnMetaData(
+                    PhysicalType.DOUBLE, List.of(), List.of("fare"), CompressionCodec.UNCOMPRESSED,
+                    1000, 8000, 8000, 4000, null, fareStats);
+
+            ColumnChunk idChunk = new ColumnChunk(idMeta, null, null, null, null);
+            ColumnChunk fareChunk = new ColumnChunk(fareMeta, null, null, null, null);
+
+            RowGroup rg = new RowGroup(List.of(idChunk, fareChunk), 12000, 1000);
+
+            SchemaElement root = new SchemaElement("schema", null, null, null, 2, null, null, null, null, null);
+            SchemaElement idCol = new SchemaElement("id", PhysicalType.INT32, null, RepetitionType.REQUIRED, null,
+                    null, null, null, null, null);
+            SchemaElement fareCol = new SchemaElement("fare", PhysicalType.DOUBLE, null, RepetitionType.OPTIONAL, null,
+                    null, null, null, null, null);
+            FileSchema schema = FileSchema.fromSchemaElements(List.of(root, idCol, fareCol));
+
+            // AND(id > 2000, fare > 50) -> id > 2000 drops because max=1000
+            RowGroupFilter filter = RowGroupFilter.and(
+                    RowGroupFilter.gt("id", 2000),
+                    RowGroupFilter.gt("fare", 50.0));
+            assertThat(filter.canDrop(rg, schema)).isTrue();
+
+            // AND(id > 500, fare > 50) -> both keep
+            RowGroupFilter filter2 = RowGroupFilter.and(
+                    RowGroupFilter.gt("id", 500),
+                    RowGroupFilter.gt("fare", 50.0));
+            assertThat(filter2.canDrop(rg, schema)).isFalse();
+        }
+    }
+
+    @Nested
+    class ColumnIndexRecordTests {
+
+        @Test
+        void getPageCount() {
+            var ci = new dev.hardwood.metadata.ColumnIndex(
+                    List.of(false, false, true),
+                    List.of(intBytes(1), intBytes(100), new byte[0]),
+                    List.of(intBytes(50), intBytes(200), new byte[0]),
+                    dev.hardwood.metadata.ColumnIndex.BoundaryOrder.ASCENDING,
+                    List.of(0L, 5L, 100L));
+
+            assertThat(ci.getPageCount()).isEqualTo(3);
+            assertThat(ci.nullPages().get(2)).isTrue();
+            assertThat(ci.boundaryOrder()).isEqualTo(dev.hardwood.metadata.ColumnIndex.BoundaryOrder.ASCENDING);
+            assertThat(ci.nullCounts().get(1)).isEqualTo(5L);
+        }
+
+        @Test
+        void boundaryOrderValues() {
+            assertThat(dev.hardwood.metadata.ColumnIndex.BoundaryOrder.values()).hasSize(3);
+            assertThat(dev.hardwood.metadata.ColumnIndex.BoundaryOrder.valueOf("UNORDERED"))
+                    .isEqualTo(dev.hardwood.metadata.ColumnIndex.BoundaryOrder.UNORDERED);
+        }
+    }
+
+    @Nested
+    class FilterAPITests {
+
+        @Test
+        void intFilterColumnName() {
+            assertThat(RowGroupFilter.eq("myCol", 1).columnName()).isEqualTo("myCol");
+            assertThat(RowGroupFilter.gt("other", 5).columnName()).isEqualTo("other");
+        }
+
+        @Test
+        void doubleFilterColumnName() {
+            assertThat(RowGroupFilter.eq("fare", 1.0).columnName()).isEqualTo("fare");
+        }
+
+        @Test
+        void stringFilterColumnName() {
+            assertThat(RowGroupFilter.eq("name", "test").columnName()).isEqualTo("name");
+        }
+
+        @ParameterizedTest
+        @ValueSource(longs = {0, 1, -1, Integer.MAX_VALUE, Integer.MIN_VALUE, Long.MAX_VALUE, Long.MIN_VALUE})
+        void eqIntBoundaryValues(long value) {
+            // Just verifying these don't throw
+            RowGroupFilter filter = RowGroupFilter.eq("col", value);
+            assertThat(filter.columnName()).isEqualTo("col");
+        }
+    }
+
+    // --- Helpers ---
+
+    private static byte[] intBytes(int value) {
+        return ByteBuffer.allocate(4).order(ByteOrder.LITTLE_ENDIAN).putInt(value).array();
+    }
+
+    private static byte[] longBytes(long value) {
+        return ByteBuffer.allocate(8).order(ByteOrder.LITTLE_ENDIAN).putLong(value).array();
+    }
+
+    private static byte[] floatBytes(float value) {
+        return ByteBuffer.allocate(4).order(ByteOrder.LITTLE_ENDIAN).putFloat(value).array();
+    }
+
+    private static byte[] doubleBytes(double value) {
+        return ByteBuffer.allocate(8).order(ByteOrder.LITTLE_ENDIAN).putDouble(value).array();
+    }
+
+    private static RowGroup makeRowGroup(PhysicalType type, byte[] minBytes, byte[] maxBytes) {
+        Statistics stats = new Statistics(minBytes, maxBytes, 0, -1, false);
+        return makeRowGroupWithStats(type, stats);
+    }
+
+    private static RowGroup makeRowGroupWithStats(PhysicalType type, Statistics stats) {
+        ColumnMetaData cmd = new ColumnMetaData(
+                type, List.of(), List.of("col"), CompressionCodec.UNCOMPRESSED,
+                1000, 4000, 4000, 0, null, stats);
+        ColumnChunk chunk = new ColumnChunk(cmd, null, null, null, null);
+        return new RowGroup(List.of(chunk), 4000, 1000);
+    }
+
+    private static RowGroup makeStringRowGroup(String min, String max) {
+        return makeRowGroup(PhysicalType.BYTE_ARRAY,
+                min.getBytes(StandardCharsets.UTF_8),
+                max.getBytes(StandardCharsets.UTF_8));
+    }
+
+    private static FileSchema makeIntSchema(String name) {
+        return makeSchema(name, PhysicalType.INT32, null);
+    }
+
+    private static FileSchema makeDoubleSchema(String name) {
+        return makeSchema(name, PhysicalType.DOUBLE, null);
+    }
+
+    private static FileSchema makeStringSchema(String name) {
+        return makeSchema(name, PhysicalType.BYTE_ARRAY, new LogicalType.StringType());
+    }
+
+    private static FileSchema makeSchema(String name, PhysicalType type, LogicalType logicalType) {
+        SchemaElement root = new SchemaElement("schema", null, null, null, 1, null, null, null, null, null);
+        SchemaElement col = new SchemaElement(name, type, null, RepetitionType.OPTIONAL, null,
+                null, null, null, null, logicalType);
+        return FileSchema.fromSchemaElements(List.of(root, col));
+    }
+}


### PR DESCRIPTION

Implements predicate push-down at two granularity levels 

  — row group statistics and page index 
  — allowing consumers to specify filter predicates that prune data at both levels before any decoding takes place. 

Row groups whose column chunk statistics prove no matching rows exist are skipped entirely, and within surviving row groups, individual pages can be dropped using the per-page min/max values from the ColumnIndex. This is especially important for reading files from object storage (#31), where skipping row groups and pages avoids downloading unnecessary data.


Closes #59 
