### PR TITLE
#224 Lazy row-group initialization

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -108,7 +108,8 @@
       "Bash(gh release:*)",
       "Bash(head -5 /workspace/_designs/*.md)",
       "Bash(gh search:*)",
-      "Bash(git bisect:*)"
+      "Bash(git bisect:*)",
+      "Bash(gh repo:*)"
     ]
   }
 }

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -100,6 +100,7 @@ jobs:
       - name: 'Check out repository'
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6 — https://github.com/actions/checkout/releases/tag/v6
         with:
+          ref: v${{ inputs.release-version }}
           submodules: 'true'
 
       - name: 'Add Developer Command Prompt for Microsoft Visual C++'

--- a/_designs/LAZY_ROW_GROUP_INITIALIZATION.md
+++ b/_designs/LAZY_ROW_GROUP_INITIALIZATION.md
@@ -1,0 +1,241 @@
+# Lazy Row-Group Initialization
+
+**Status: Implemented (Phases 1-3)**
+
+## Problem
+
+`SingleFileRowReader.initialize()` eagerly fetches column chunk data for **all** row groups before returning the first row. For local files this is invisible (zero-copy slices off a memory-mapped buffer), but for S3 and other remote backends each row group triggers `readRange()` calls that perform HTTP GETs, downloading the full column data for every row group upfront.
+
+This means `print -n 10` on a multi-row-group S3 file downloads the entire file before printing a single row, even though the first row group alone contains far more than 10 rows.
+
+The same pattern exists in `FileManager.scanAllProjectedColumns()` (the multi-file path) and in `ColumnReader.create()` (the columnar API).
+
+### What is and isn't eager
+
+The reader pipeline has two phases with different eagerness characteristics:
+
+1. **Fetching and page scanning** (in `initialize()`) — **eager, no back-pressure.** For each row group, `initialize()` fetches index buffers (`RowGroupIndexBuffers.fetch()`), fetches all column chunk data (`inputFile.readRange()`), and scans page headers (`PageScanner.scanPages()`), creating `PageInfo` objects that hold `ByteBuffer` slices of the raw compressed data. This happens for ALL row groups before the first row is returned.
+
+2. **Page decoding and batch assembly** (in `PageCursor` / `ColumnAssemblyBuffer`) — **lazy, with back-pressure.** `PageCursor` decodes pages via an adaptive prefetch queue capped at 4–8 futures. `ColumnAssemblyBuffer` publishes assembled batches via an `ArrayBlockingQueue` with capacity 2 — the assembly thread blocks when the consumer hasn't consumed previous batches. This pipeline is well-bounded and works correctly.
+
+The back-pressure in phase 2 was always the intended design. The problem is that phase 1 has no equivalent gating: it downloads all raw column chunk data upfront. Before the `InputFile` abstraction was introduced (#98), `SingleFileRowReader` operated on a `MappedByteBuffer` directly, so phase 1 was just pointer arithmetic — no actual I/O. When S3 support was added, `readRange()` became a real HTTP GET, but the eager loop structure was preserved unchanged, turning phase 1 into a full-file download.
+
+## Phase 1: Lazy row-group fetching (implemented)
+
+Row-group fetching is now demand-driven: `initialize()` scans only the first row group, and `PageCursor` lazily fetches subsequent row groups when the assembly thread exhausts the current one.
+
+### How back-pressure gates row-group fetching
+
+Row groups are **not** proactively prefetched in `fillPrefetchQueue()` — unlike pages (which are small and decoded async), row groups involve full I/O on remote backends. Instead, row groups are fetched on demand via `tryLoadNextRowGroupBlocking()` when the assembly thread runs out of pages in the current row group.
+
+The `ColumnAssemblyBuffer` back-pressure chain naturally limits how far ahead the assembly thread gets:
+
+1. `readyBatches` queue (capacity 2) blocks the assembly thread on `put()` when full
+2. `arrayPool` (initially 3 arrays, 1 taken by constructor) blocks on `take()` when empty
+3. Combined, the assembly thread can produce at most **3 batches** before blocking — 2 in the queue + 1 being filled when the pool runs dry
+
+With batch size determined by `computeOptimalBatchSize()` (targets 6 MB of L2 cache across all projected columns), the number of row groups fetched before back-pressure engages depends on the ratio of rows-per-row-group to batch size. For typical production files with large row groups (50K–1M+ rows), the first row group alone fills multiple batches, and the assembly thread never reaches the second row group before blocking.
+
+### Concurrency
+
+`SingleFileRowReader.getPagesForRowGroup()` is called by multiple assembly threads concurrently (one per column). Shared per-row-group state (index buffers, column chunk data) is cached and access is `synchronized` to prevent data races. The cache is keyed by row group index — when any column requests a new row group, the shared data is fetched once and reused by all columns.
+
+`FileManager.scanRowGroupForColumn()` uses the same pattern with a `synchronized` block on the per-file `PerFileRowGroupContext`.
+
+### What was implemented
+
+- **`RowGroupPageSource`** — functional interface for lazy row-group page fetching
+- **`PageCursor`** — added `tryLoadNextRowGroupBlocking()`, `hasMoreRowGroups()`, `fetchRowGroupPages()` that work with both `RowGroupPageSource` (single-file) and `FileManager` (multi-file). Row-group state resets on file boundary crossings.
+- **`SingleFileRowReader`** — `initialize()` scans only the first row group; `getPagesForRowGroup()` extracted with synchronized per-row-group caching
+- **`FileManager`** — `scanFirstRowGroup()` replaces `scanAllProjectedColumns()`; `PerFileRowGroupContext` stores per-file state for lazy access; `getRowGroupPages()` / `getRowGroupCount()` methods for `PageCursor`
+- **`ColumnReader`** — `create()` scans only the first row group; `scanRowGroup()` extracted as `RowGroupPageSource`
+- **`TestParquetGenerator`** — pure Java Parquet file generator (Thrift compact protocol writer) for generating test files on the fly, avoiding large committed binaries
+- **`S3SelectiveReadJfrTest`** — 4 new tests: partial read for RowReader and ColumnReader (assert fewer RowGroupScanned events), full read correctness, and incremental scanning verification
+
+## Phase 2: Lazy page fetching within a row group
+
+Phase 1 fetches one row group at a time instead of all at once, but still fetches the **entire** row group's column chunk data upfront via `readRange()`. For production Parquet files where a single row group is 128 MB+ (the Spark/Hive default), `print -n 10` still downloads the full row group to decode just the first page.
+
+### Where Phase 2 matters most
+
+Phase 1 is sufficient when row groups are small relative to the data needed. Phase 2 matters when:
+
+- **Row groups are large** (128 MB+, typical in Spark/Hive output) and the consumer only needs a few pages
+- **The file has few row groups** (often just 1-2 for files written with default settings), so Phase 1's row-group skipping provides no benefit
+- **S3 or remote backends**, where each `readRange()` is an HTTP GET with real latency and bandwidth cost
+
+For local files (mmap), Phase 2 has no benefit — `readRange()` is a zero-copy slice regardless of size.
+
+### Making page scanning incremental
+
+`PageScanner.scanPagesSequential()` already reads page headers one at a time in a `while` loop. Each page header declares `compressedPageSize`, which gives the offset of the next page. The scanner discovers page boundaries as it goes — there is no need to have the full column chunk in memory to find the next page. Today it collects all `PageInfo` objects into a list and returns them; instead, it can yield them incrementally.
+
+This means lazy page fetching works **without an OffsetIndex**. The sequential scan itself provides the page boundaries on demand. When an OffsetIndex is available, it enables additional optimizations (skipping directly to specific pages, knowing row counts per page for smarter read-ahead sizing), but it is not a prerequisite.
+
+### Integration with Phase 1's RowGroupPageSource
+
+In Phase 1, `RowGroupPageSource.getPages()` fetches the full column chunk data and scans all pages for a row group, returning the complete `List<PageInfo>`. In Phase 2, this changes: the source returns a lazy `PageScanner` iterator instead of a materialized list, and `PageCursor` pulls pages from it on demand.
+
+The key change is in how `PageCursor` obtains pages. Today, `tryLoadNextRowGroupBlocking()` calls `fetchRowGroupPages()` which returns a `List<PageInfo>` and appends them all to `pageInfos`. In Phase 2, instead of appending a pre-scanned list, `PageCursor` holds a reference to the `PageScanner` iterator and pulls pages from it in `fillPrefetchQueue()`:
+
+```
+fillPrefetchQueue():
+    while prefetchQueue.size < targetPrefetchDepth:
+        if no more pages in pageInfos and scanner has more:
+            PageInfo page = scanner.nextPage()   // may trigger readRange() for next window
+            pageInfos.add(page)
+        if nextPageIndex >= pageInfos.size:
+            break
+        // ... existing prefetch logic
+```
+
+This naturally integrates with the existing back-pressure: `fillPrefetchQueue()` is called from `nextPage()`, which is called by the assembly thread, which is gated by `ColumnAssemblyBuffer`. Pages are only pulled from the scanner when the assembly thread needs them.
+
+### Incremental fetch model
+
+Instead of fetching the full column chunk via a single `readRange()`, fetch a sliding window of raw bytes and advance it as the page scanner progresses:
+
+1. Fetch an initial window of the column chunk (e.g. the first 256 KB, or a configurable size)
+2. `PageScanner` reads page headers sequentially from this window, yielding `PageInfo` objects one at a time
+3. `PageCursor` consumes them via its prefetch queue, applying back-pressure — the scanner only advances when the cursor needs more pages
+4. When the scanner reaches the end of the fetched window, it fetches the next window via another `readRange()` call
+5. Previous windows become unreachable once all their pages have been decoded
+
+The window size can adapt based on page sizes observed so far: if pages are large, use larger windows to amortize `readRange()` overhead; if pages are small, smaller windows suffice.
+
+### PageScanner as an iterator
+
+Transform `PageScanner` from a batch method (`List<PageInfo> scanPages()`) into an iterator-like interface:
+
+```java
+boolean hasNextPage()
+PageInfo nextPage()
+```
+
+The existing `scanPages()` method can remain as a convenience that drains the iterator into a list, preserving compatibility with code paths that don't need lazy fetching (e.g. local files where the full chunk is already memory-mapped).
+
+### OffsetIndex as an accelerator
+
+When an OffsetIndex is available, additional optimizations become possible:
+
+- **Skip to specific pages.** The `OffsetIndex` provides exact file offsets per page, enabling direct seeks instead of sequential header scanning. This is useful when combining lazy fetching with page-level filter pushdown: only the matching pages need to be fetched.
+- **Row-count-aware read-ahead.** The `OffsetIndex` includes `firstRowIndex` per page, enabling the read-ahead window to be sized in terms of rows rather than bytes.
+- **Existing `PageRange`/`PageRangeData` infrastructure.** The selective I/O path already used for filter pushdown can be reused for demand-driven page fetching when an OffsetIndex is present.
+
+### Scope
+
+- Transform `PageScanner` into an incremental iterator with windowed fetching
+- Modify `PageCursor` to pull pages from the scanner on demand instead of consuming a pre-populated list
+- Update `RowGroupPageSource` (and `FileManager.scanRowGroupForColumn()`, `SingleFileRowReader.getPagesForRowGroup()`, `ColumnReader.scanRowGroup()`) to return a lazy scanner rather than a materialized page list
+- Add OffsetIndex-based optimizations as an enhancement on top of the sequential path
+- Adapt read-ahead window size based on observed page sizes
+
+## Phase 3: Row limit in the reader API
+
+Phases 1 and 2 make fetching lazy — the reader only pulls data when the consumer asks for it. But the reader still doesn't know *when to stop*. Today, the row limit lives in the CLI layer (`PrintCommand.prepareSampling()` applies `.limit(rowLimit)` on a stream), so the reader has no opportunity to act on it. The reader continues fetching, scanning, and decoding until the consumer stops calling `hasNext()`, at which point in-flight prefetch work is wasted.
+
+Passing a `maxRows` parameter into the reader enables three optimizations that phases 1 and 2 cannot achieve on their own. This phase applies to `RowReader` only — `ColumnReader` exposes batch-level arrays rather than individual rows, so a row limit is not meaningful for its API. `ColumnReader` benefits from phases 1 and 2 (lazy row-group and page fetching) but not from phase 3.
+
+### Why Phase 3 matters even with back-pressure
+
+Phase 1 demonstrated that back-pressure from `ColumnAssemblyBuffer` limits how far ahead the assembly thread gets: it can produce at most 3 batches before blocking. However, each batch can hold tens or hundreds of thousands of rows (e.g. ~98K rows for 8 INT64 columns). For `print -n 10`, the reader still fetches and decodes enough data for ~300K rows before back-pressure engages — orders of magnitude more than needed.
+
+With `maxRows`, the reader can:
+- Skip row groups entirely based on metadata row counts (no I/O at all)
+- Stop the assembly thread immediately after enough rows are emitted (no wasted decode work)
+- Cancel in-flight prefetch futures (no wasted I/O)
+
+### Row-group skipping
+
+With `maxRows` known upfront and row-group row counts available from metadata, the reader can compute exactly which row groups are needed. For `maxRows = 10` on a file where the first row group has 100K rows, the reader knows at initialization time that only one row group will ever be needed — it never even registers the remaining row groups with `RowGroupPageSource`.
+
+### Early termination of prefetch and assembly
+
+When `AbstractRowReader` has emitted `maxRows` rows, it can set `exhausted = true` immediately instead of waiting for iterators to drain. More importantly, it can signal `PageCursor` to stop — cancelling in-flight prefetch futures and terminating the assembly thread. Without `maxRows`, the reader doesn't know the consumer is done until `close()` is called, by which time background threads may have decoded pages that will never be consumed.
+
+### Interaction with record-level filtering
+
+When a record-level filter is active, `maxRows` is an upper bound on *output* rows, not *input* rows. The reader must continue scanning until either `maxRows` matching rows have been emitted or all data is exhausted. The row limit is checked after filter evaluation, in `hasNextMatch()`, not before.
+
+### API surface
+
+Add a `maxRows` parameter to the `createRowReader` overloads:
+
+```java
+RowReader createRowReader(long maxRows)
+RowReader createRowReader(ColumnProjection projection, long maxRows)
+RowReader createRowReader(FilterPredicate filter, long maxRows)
+RowReader createRowReader(ColumnProjection projection, FilterPredicate filter, long maxRows)
+```
+
+`maxRows <= 0` means unlimited (the current behavior). The parameter is propagated to `AbstractRowReader`, which counts emitted rows and stops iteration when the limit is reached.
+
+For the CLI, `PrintCommand` passes its parsed `-n` value directly to `createRowReader()` instead of applying it as a stream operation.
+
+### Scope
+
+- Add `maxRows` field to `AbstractRowReader`, check in `hasNext()`
+- Add `createRowReader` overloads to `ParquetFileReader` and multi-file readers
+- Signal `PageCursor` to stop on early termination (cancel prefetch futures, finish assembly buffer)
+- Update `PrintCommand` to pass the row limit to the reader
+- Update usage documentation
+
+## Test plan
+
+### Phase 1 tests (implemented)
+
+Test data is generated on the fly by `TestParquetGenerator` (pure Java, Thrift compact protocol), producing a file with 20 row groups × 50K rows × 8 INT64 columns (1M rows). This avoids committing a large binary to git.
+
+**`partialReadDoesNotScanAllRowGroups`** — reads 10 rows via `RowReader`, asserts ≤50 `RowGroupScanned` events (out of 160 for a full read). Prints per-column breakdown for diagnostics. Actual results show ~33 events with back-pressure limiting to ~3–6 row groups per column.
+
+**`columnReaderPartialReadDoesNotScanAllRowGroups`** — reads one batch via `ColumnReader`, asserts ≤15 `RowGroupScanned` events (out of 20 for a full read).
+
+**`lazyInitScansRowGroupsIncrementally`** — full read via `RowReader`, asserts all 160 events, confirming lazy scanning produces correct results across all row groups.
+
+**`fullReadReturnsAllRows`** — reads all 1M rows, asserts correct count and last value.
+
+### Phase 2 tests
+
+**S3 JFR test: `partialRowGroupReadTransfersProportionalBytes`** — use a single-row-group file with many pages (larger than 64 KB). Read a small number of rows and assert that bytes transferred are proportional to the rows read, not the full row group size.
+
+### Phase 3 tests
+
+**Unit test: `maxRowsLimitsOutput`** — read with `maxRows = 10` from a file with 10K+ rows and assert exactly 10 rows are returned.
+
+**Unit test: `maxRowsWithFilterLimitsMatchingRows`** — combine `maxRows` with a `FilterPredicate` and assert that the limit applies to matching (output) rows, not scanned (input) rows.
+
+**S3 JFR test: `maxRowsStopsEarly`** — read with `maxRows = 10` from a large multi-row-group S3 file and assert that bytes transferred are comparable to the phase 1/2 lazy tests — confirming that the reader doesn't fetch beyond what is needed and that prefetch work is cancelled.
+
+### Existing tests
+
+All existing reader tests (flat, nested, filtered, projected, multi-file, S3) must continue to pass, validating that lazy row-group, page-level, and row-limit transitions produce identical results.
+
+## Files to modify
+
+### Phase 1 (implemented)
+
+- `core/src/main/java/dev/hardwood/internal/reader/RowGroupPageSource.java` — new functional interface
+- `core/src/main/java/dev/hardwood/internal/reader/PageCursor.java` — row-group boundary tracking, `tryLoadNextRowGroupBlocking()`, `hasMoreRowGroups()`, `fetchRowGroupPages()`; row-group state reset on file boundary crossings
+- `core/src/main/java/dev/hardwood/reader/SingleFileRowReader.java` — `initialize()` scans first row group only; `getPagesForRowGroup()` with synchronized caching
+- `core/src/main/java/dev/hardwood/internal/reader/FileManager.java` — `scanFirstRowGroup()`, `PerFileRowGroupContext`, `getRowGroupPages()`, `getRowGroupCount()`, `scanRowGroupForColumn()`
+- `core/src/main/java/dev/hardwood/reader/ColumnReader.java` — `create()` scans first row group only; `scanRowGroup()` as `RowGroupPageSource`
+- `s3/src/test/java/dev/hardwood/s3/TestParquetGenerator.java` — pure Java Parquet file generator
+- `s3/src/test/java/dev/hardwood/s3/S3SelectiveReadJfrTest.java` — 4 new tests
+
+### Phase 2
+
+- `core/src/main/java/dev/hardwood/internal/reader/PageScanner.java` — transform from batch (`scanPages()`) to iterator (`hasNextPage()`/`nextPage()`) with windowed fetching
+- `core/src/main/java/dev/hardwood/internal/reader/PageCursor.java` — pull pages from scanner on demand in `fillPrefetchQueue()`
+- `core/src/main/java/dev/hardwood/reader/SingleFileRowReader.java` — `getPagesForRowGroup()` returns lazy scanner
+- `core/src/main/java/dev/hardwood/internal/reader/FileManager.java` — `scanRowGroupForColumn()` returns lazy scanner
+- `core/src/main/java/dev/hardwood/reader/ColumnReader.java` — `scanRowGroup()` returns lazy scanner
+- `s3/src/test/java/dev/hardwood/s3/S3SelectiveReadJfrTest.java` — add intra-row-group lazy fetch test
+
+### Phase 3
+
+- `core/src/main/java/dev/hardwood/reader/AbstractRowReader.java` — add `maxRows` field, check in `hasNext()`, signal early termination
+- `core/src/main/java/dev/hardwood/reader/ParquetFileReader.java` — add `createRowReader` overloads with `maxRows`
+- `core/src/main/java/dev/hardwood/reader/SingleFileRowReader.java` — propagate `maxRows`, use for row-group skipping
+- `core/src/main/java/dev/hardwood/internal/reader/PageCursor.java` — support cancellation of in-flight prefetch futures
+- `cli/src/main/java/dev/hardwood/cli/command/PrintCommand.java` — pass `-n` to `createRowReader()` instead of stream `.limit()`
+- `docs/content/usage.md` — document `maxRows` parameter

--- a/cli/src/main/java/dev/hardwood/cli/command/InspectDictionaryCommand.java
+++ b/cli/src/main/java/dev/hardwood/cli/command/InspectDictionaryCommand.java
@@ -20,6 +20,7 @@ import dev.hardwood.internal.reader.HardwoodContextImpl;
 import dev.hardwood.internal.reader.PageInfo;
 import dev.hardwood.internal.reader.PageScanner;
 import dev.hardwood.internal.reader.RowGroupIndexBuffers;
+import dev.hardwood.internal.reader.RowRanges;
 import dev.hardwood.metadata.ColumnChunk;
 import dev.hardwood.metadata.FileMetaData;
 import dev.hardwood.metadata.RowGroup;
@@ -109,7 +110,7 @@ public class InspectDictionaryCommand implements Callable<Integer> {
 
             PageScanner scanner = new PageScanner(columnSchema, chunk, context,
                     chunkData, chunkStart, indexBuffers.forColumn(columnSchema.columnIndex()),
-                    rgIdx, fileMixin.file);
+                    rgIdx, fileMixin.file, RowRanges.ALL, 0);
             List<PageInfo> pages = scanner.scanPages();
 
             Dictionary dictionary = pages.isEmpty() ? null : pages.get(0).dictionary();

--- a/cli/src/main/java/dev/hardwood/cli/command/PrintCommand.java
+++ b/cli/src/main/java/dev/hardwood/cli/command/PrintCommand.java
@@ -84,7 +84,11 @@ public class PrintCommand implements Callable<Integer> {
 
         try (ParquetFileReader reader = ParquetFileReader.open(inputFile)) {
             FileSchema fileSchema = reader.getFileSchema();
-            try (RowReader rowReader = reader.createRowReader(projection)) {
+            // Pass positive row limits to the reader so it can stop fetching early.
+            // Negative limits (tail) and no limit require reading all rows.
+            try (RowReader rowReader = rowLimit > 0
+                    ? reader.createRowReader(projection, rowLimit)
+                    : reader.createRowReader(projection)) {
                 String[] headers = RowTable.topLevelFieldNames(fileSchema, projection);
                 List<SchemaNode> fields = projectedFields(fileSchema, projection);
                 AtomicLong rowIndex = addRowIndex ? new AtomicLong() : null;

--- a/core/src/main/java/dev/hardwood/internal/reader/FileManager.java
+++ b/core/src/main/java/dev/hardwood/internal/reader/FileManager.java
@@ -53,6 +53,9 @@ public class FileManager {
     // Thread-safe storage for file states and loading futures
     private final ConcurrentHashMap<Integer, CompletableFuture<FileState>> fileFutures = new ConcurrentHashMap<>();
 
+    // Per-file row-group context for lazy row-group fetching
+    private final ConcurrentHashMap<Integer, PerFileRowGroupContext> rowGroupContexts = new ConcurrentHashMap<>();
+
     // Set after first file is opened
     private volatile ProjectedSchema projectedSchema;
     private volatile FileSchema referenceSchema;
@@ -110,8 +113,8 @@ public class FileManager {
 
         InputFile first = inputFiles.get(0);
 
-        // Scan pages for the first file
-        List<List<PageInfo>> pageInfosByColumn = scanAllProjectedColumns(first,
+        // Scan first row group of the first file (subsequent row groups fetched lazily)
+        List<List<PageInfo>> pageInfosByColumn = scanFirstRowGroup(0, first,
                 firstOpenedFile);
 
         FileState firstFileState = new FileState(
@@ -234,8 +237,8 @@ public class FileManager {
         // Validate schema compatibility
         validateSchemaCompatibility(inputFile, openedFile.schema);
 
-        // Scan pages for all projected columns
-        List<List<PageInfo>> pageInfosByColumn = scanAllProjectedColumns(inputFile, openedFile);
+        // Scan first row group (subsequent row groups fetched lazily by PageCursor)
+        List<List<PageInfo>> pageInfosByColumn = scanFirstRowGroup(fileIndex, inputFile, openedFile);
 
         LOG.log(System.Logger.Level.DEBUG, "Loaded file {0}: {1}", fileIndex, inputFile.name());
 
@@ -327,12 +330,14 @@ public class FileManager {
         }
     }
 
-    /// Scans pages for all projected columns.
+    /// Scans pages for the first row group of all projected columns and stores
+    /// per-file context for lazy row-group fetching of subsequent row groups.
     ///
+    /// @param fileIndex the file index (for storing row-group context)
     /// @param inputFile the input file
     /// @param openedFile the opened file with metadata and schema
-    /// @return list of page info lists, one per projected column
-    private List<List<PageInfo>> scanAllProjectedColumns(InputFile inputFile, OpenedFile openedFile) {
+    /// @return list of page info lists (first row group only), one per projected column
+    private List<List<PageInfo>> scanFirstRowGroup(int fileIndex, InputFile inputFile, OpenedFile openedFile) {
         int projectedColumnCount = projectedSchema.getProjectedColumnCount();
         List<RowGroup> rowGroups = filterRowGroups(openedFile.metaData.rowGroups(), inputFile.name());
 
@@ -346,128 +351,28 @@ public class FileManager {
             columnIndices[projectedIndex] = columnSchemas[projectedIndex].columnIndex();
         }
 
-        String fileName = inputFile.name();
+        // Store context for lazy row-group fetching
+        PerFileRowGroupContext ctx = new PerFileRowGroupContext(
+                inputFile, rowGroups, columnIndices, columnSchemas, filterPredicate, context);
+        rowGroupContexts.put(fileIndex, ctx);
 
-        // Scan each projected column in parallel, coalescing chunk reads per row group
-        @SuppressWarnings("unchecked")
-        CompletableFuture<List<PageInfo>>[] scanFutures = new CompletableFuture[projectedColumnCount];
-        for (int i = 0; i < projectedColumnCount; i++) {
-            scanFutures[i] = CompletableFuture.completedFuture(new ArrayList<>());
+        // Scan only the first row group
+        List<List<PageInfo>> result = new ArrayList<>(projectedColumnCount);
+        if (rowGroups.isEmpty()) {
+            for (int i = 0; i < projectedColumnCount; i++) {
+                result.add(List.of());
+            }
+            return result;
         }
 
-        for (int rowGroupIndex = 0; rowGroupIndex < rowGroups.size(); rowGroupIndex++) {
-            final int rgIdx = rowGroupIndex;
-            RowGroup rowGroup = rowGroups.get(rgIdx);
-
-            // Pre-fetch indexes and coalesced column chunk data
-            RowGroupIndexBuffers indexBuffers;
+        for (int projectedIndex = 0; projectedIndex < projectedColumnCount; projectedIndex++) {
+            PageScanner scanner = createScannerForColumn(ctx, 0, projectedIndex);
             try {
-                indexBuffers = RowGroupIndexBuffers.fetch(inputFile, rowGroup);
+                result.add(scanner.scanPages());
             }
             catch (IOException e) {
-                throw new UncheckedIOException("Failed to fetch index buffers for row group " + rgIdx, e);
+                throw new UncheckedIOException("Failed to scan pages for column " + projectedIndex, e);
             }
-
-            // Compute matching row ranges for page-level Column Index filtering
-            RowRanges matchingRows = RowRanges.ALL;
-            if (filterPredicate != null) {
-                matchingRows = PageFilterEvaluator.computeMatchingRows(
-                        filterPredicate, rowGroup, indexBuffers);
-            }
-
-            // Try page-range I/O for each column when filtering is active.
-            // Columns that don't benefit fall back to full chunk fetching.
-            final RowRanges rowRanges = matchingRows;
-            PageRangeData[] pageRangeDataPerColumn = new PageRangeData[projectedColumnCount];
-
-            if (!matchingRows.isAll()) {
-                for (int projectedIndex = 0; projectedIndex < projectedColumnCount; projectedIndex++) {
-                    int columnIndex = columnIndices[projectedIndex];
-                    ColumnIndexBuffers colBuffers = indexBuffers.forColumn(columnIndex);
-                    if (colBuffers != null && colBuffers.offsetIndex() != null) {
-                        try {
-                            OffsetIndex offsetIndex = OffsetIndexReader.read(
-                                    new ThriftCompactReader(colBuffers.offsetIndex()));
-                            ColumnChunk columnChunk = rowGroup.columns().get(columnIndex);
-                            List<PageRange> pageRanges = PageRange.forColumn(
-                                    offsetIndex, matchingRows, columnChunk, rowGroup.numRows(), ChunkRange.MAX_GAP_BYTES);
-                            if (!pageRanges.isEmpty()) {
-                                pageRangeDataPerColumn[projectedIndex] = PageRangeData.fetch(inputFile, pageRanges);
-                            }
-                        }
-                        catch (IOException e) {
-                            throw new UncheckedIOException("Failed to fetch page ranges for row group " + rgIdx, e);
-                        }
-                    }
-                }
-            }
-
-            // Fetch full chunks for columns not using page-range I/O
-            List<ChunkRange> chunkRanges = null;
-            ByteBuffer[] rangeBuffers = null;
-            for (int projectedIndex = 0; projectedIndex < projectedColumnCount; projectedIndex++) {
-                if (pageRangeDataPerColumn[projectedIndex] == null) {
-                    // At least one column needs full chunk data — fetch all chunks once
-                    chunkRanges = ChunkRange.coalesce(
-                            rowGroup.columns(), columnIndices, ChunkRange.MAX_GAP_BYTES);
-                    rangeBuffers = new ByteBuffer[chunkRanges.size()];
-                    try {
-                        for (int r = 0; r < chunkRanges.size(); r++) {
-                            ChunkRange range = chunkRanges.get(r);
-                            rangeBuffers[r] = inputFile.readRange(range.offset(), range.length());
-                        }
-                    }
-                    catch (IOException e) {
-                        throw new UncheckedIOException("Failed to fetch column chunk data for row group " + rgIdx, e);
-                    }
-                    break;
-                }
-            }
-
-            for (int projectedIndex = 0; projectedIndex < projectedColumnCount; projectedIndex++) {
-                final int columnIndex = columnIndices[projectedIndex];
-                final ColumnSchema columnSchema = columnSchemas[projectedIndex];
-                final ColumnChunk columnChunk = rowGroup.columns().get(columnIndex);
-                final PageRangeData colPageRangeData = pageRangeDataPerColumn[projectedIndex];
-
-                final PageScanner scanner;
-                if (colPageRangeData != null) {
-                    scanner = new PageScanner(columnSchema, columnChunk, context,
-                            colPageRangeData, indexBuffers.forColumn(columnIndex),
-                            rgIdx, fileName, rowRanges);
-                }
-                else {
-                    final ByteBuffer colChunkData = sliceColumnChunk(chunkRanges, rangeBuffers, columnChunk);
-                    final long colChunkOffset = chunkStartOffset(columnChunk);
-                    scanner = new PageScanner(columnSchema, columnChunk, context,
-                            colChunkData, colChunkOffset, indexBuffers.forColumn(columnIndex),
-                            rgIdx, fileName, rowRanges);
-                }
-
-                final CompletableFuture<List<PageInfo>> previousFuture = scanFutures[projectedIndex];
-                scanFutures[projectedIndex] = previousFuture.thenCombineAsync(
-                        CompletableFuture.supplyAsync(() -> {
-                            try {
-                                return scanner.scanPages();
-                            }
-                            catch (IOException e) {
-                                throw new UncheckedIOException(
-                                        "Failed to scan pages for column " + columnSchema.name(), e);
-                            }
-                        }, context.executor()),
-                        (existing, newPages) -> {
-                            existing.addAll(newPages);
-                            return existing;
-                        }, context.executor());
-            }
-        }
-
-        // Wait for all scans to complete
-        CompletableFuture.allOf(scanFutures).join();
-
-        List<List<PageInfo>> result = new ArrayList<>(projectedColumnCount);
-        for (int i = 0; i < projectedColumnCount; i++) {
-            result.add(scanFutures[i].join());
         }
 
         return result;
@@ -491,6 +396,147 @@ public class FileManager {
         event.commit();
 
         return filtered;
+    }
+
+    /// Returns the number of row groups for the given file.
+    /// The file must have been loaded already.
+    ///
+    /// @param fileIndex the file index
+    /// @return the number of row groups, or 0 if file not ready
+    public int getRowGroupCount(int fileIndex) {
+        PerFileRowGroupContext ctx = rowGroupContexts.get(fileIndex);
+        return ctx != null ? ctx.rowGroups.size() : 0;
+    }
+
+    /// Creates a [PageScanner] for a specific row group and column within a file.
+    /// Used by [PageCursor] for lazy row-group fetching in multi-file mode.
+    ///
+    /// @param fileIndex the file index
+    /// @param rowGroupIndex the row group index within the file
+    /// @param projectedColumnIndex the projected column index
+    /// @return a PageScanner, or null if out of bounds
+    public PageScanner getRowGroupScanner(int fileIndex, int rowGroupIndex, int projectedColumnIndex) {
+        PerFileRowGroupContext ctx = rowGroupContexts.get(fileIndex);
+        if (ctx == null || rowGroupIndex >= ctx.rowGroups.size()) {
+            return null;
+        }
+        return createScannerForColumn(ctx, rowGroupIndex, projectedColumnIndex);
+    }
+
+    /// Context for lazy row-group fetching within a single file.
+    private static class PerFileRowGroupContext {
+        final InputFile inputFile;
+        final List<RowGroup> rowGroups;
+        final int[] columnIndices;
+        final ColumnSchema[] columnSchemas;
+        final ResolvedPredicate filterPredicate;
+        final HardwoodContextImpl context;
+
+        // Cached per-row-group shared metadata
+        int cachedRowGroupIndex = -1;
+        RowGroupIndexBuffers cachedIndexBuffers;
+        RowRanges cachedMatchingRows;
+        PageRangeData[] cachedPageRangeData;
+
+        PerFileRowGroupContext(InputFile inputFile, List<RowGroup> rowGroups,
+                               int[] columnIndices, ColumnSchema[] columnSchemas,
+                               ResolvedPredicate filterPredicate, HardwoodContextImpl context) {
+            this.inputFile = inputFile;
+            this.rowGroups = rowGroups;
+            this.columnIndices = columnIndices;
+            this.columnSchemas = columnSchemas;
+            this.filterPredicate = filterPredicate;
+            this.context = context;
+        }
+    }
+
+    /// Creates a PageScanner for a single column in a single row group, caching shared metadata.
+    private PageScanner createScannerForColumn(PerFileRowGroupContext ctx,
+                                                int rowGroupIndex, int projectedColumnIndex) {
+        synchronized (ctx) {
+            if (ctx.cachedRowGroupIndex != rowGroupIndex) {
+                ctx.cachedRowGroupIndex = rowGroupIndex;
+                RowGroup rowGroup = ctx.rowGroups.get(rowGroupIndex);
+                int projectedColumnCount = ctx.columnIndices.length;
+
+                try {
+                    ctx.cachedIndexBuffers = RowGroupIndexBuffers.fetch(ctx.inputFile, rowGroup);
+                }
+                catch (IOException e) {
+                    throw new UncheckedIOException("Failed to fetch index buffers for row group " + rowGroupIndex, e);
+                }
+
+                ctx.cachedMatchingRows = RowRanges.ALL;
+                if (ctx.filterPredicate != null) {
+                    ctx.cachedMatchingRows = PageFilterEvaluator.computeMatchingRows(
+                            ctx.filterPredicate, rowGroup, ctx.cachedIndexBuffers);
+                }
+
+                ctx.cachedPageRangeData = new PageRangeData[projectedColumnCount];
+                if (!ctx.cachedMatchingRows.isAll()) {
+                    for (int projIdx = 0; projIdx < projectedColumnCount; projIdx++) {
+                        int columnIndex = ctx.columnIndices[projIdx];
+                        ColumnIndexBuffers colBuffers = ctx.cachedIndexBuffers.forColumn(columnIndex);
+                        if (colBuffers != null && colBuffers.offsetIndex() != null) {
+                            try {
+                                OffsetIndex offsetIndex = OffsetIndexReader.read(
+                                        new ThriftCompactReader(colBuffers.offsetIndex()));
+                                ColumnChunk columnChunk = rowGroup.columns().get(columnIndex);
+                                List<PageRange> pageRanges = PageRange.forColumn(
+                                        offsetIndex, ctx.cachedMatchingRows, columnChunk,
+                                        rowGroup.numRows(), ChunkRange.MAX_GAP_BYTES);
+                                if (!pageRanges.isEmpty()) {
+                                    ctx.cachedPageRangeData[projIdx] = PageRangeData.fetch(ctx.inputFile, pageRanges);
+                                }
+                            }
+                            catch (IOException e) {
+                                throw new UncheckedIOException(
+                                        "Failed to fetch page ranges for row group " + rowGroupIndex, e);
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
+        // Create a PageScanner for this specific column (outside the synchronized block)
+        RowGroup rowGroup = ctx.rowGroups.get(rowGroupIndex);
+        int columnIndex = ctx.columnIndices[projectedColumnIndex];
+        ColumnSchema columnSchema = ctx.columnSchemas[projectedColumnIndex];
+        ColumnChunk columnChunk = rowGroup.columns().get(columnIndex);
+
+        if (ctx.cachedPageRangeData[projectedColumnIndex] != null) {
+            // Page-range path: data already fetched selectively, use batch scanner
+            return new PageScanner(columnSchema, columnChunk, ctx.context,
+                    ctx.cachedPageRangeData[projectedColumnIndex],
+                    ctx.cachedIndexBuffers.forColumn(columnIndex),
+                    rowGroupIndex, ctx.inputFile.name(), ctx.cachedMatchingRows, 0);
+        }
+
+        // Determine the column chunk's file offset and length
+        long colChunkOffset = chunkStartOffset(columnChunk);
+        int colChunkLength = Math.toIntExact(columnChunk.metaData().totalCompressedSize());
+
+        // OffsetIndex path (no filter): fetch the full chunk for direct page lookup
+        if (columnChunk.offsetIndexOffset() != null) {
+            try {
+                ByteBuffer colChunkData = ctx.inputFile.readRange(colChunkOffset, colChunkLength);
+                return new PageScanner(columnSchema, columnChunk, ctx.context,
+                        colChunkData, colChunkOffset,
+                        ctx.cachedIndexBuffers.forColumn(columnIndex),
+                        rowGroupIndex, ctx.inputFile.name(), ctx.cachedMatchingRows, 0);
+            }
+            catch (IOException e) {
+                throw new UncheckedIOException("Failed to fetch column chunk data for row group " + rowGroupIndex, e);
+            }
+        }
+
+        // Sequential path (no OffsetIndex): use WindowedChunkReader for lazy fetching
+        WindowedChunkReader chunkReader = new WindowedChunkReader(
+                ctx.inputFile, colChunkOffset, colChunkLength);
+        return new PageScanner(columnSchema, columnChunk, ctx.context,
+                chunkReader, ctx.cachedIndexBuffers.forColumn(columnIndex),
+                rowGroupIndex, ctx.inputFile.name(), ctx.cachedMatchingRows, 0);
     }
 
     /// Waits for any in-flight prefetch to finish, then closes all opened files.
@@ -543,5 +589,4 @@ public class FileManager {
                 ? dictOffset
                 : columnChunk.metaData().dataPageOffset();
     }
-
 }

--- a/core/src/main/java/dev/hardwood/internal/reader/PageCursor.java
+++ b/core/src/main/java/dev/hardwood/internal/reader/PageCursor.java
@@ -7,6 +7,8 @@
  */
 package dev.hardwood.internal.reader;
 
+import java.io.IOException;
+import java.io.UncheckedIOException;
 import java.util.ArrayDeque;
 import java.util.ArrayList;
 import java.util.Deque;
@@ -48,6 +50,11 @@ public class PageCursor {
     private PageReader pageReader;
     private int nextPageIndex = 0;
 
+    // Row-group support (single-file lazy row-group fetching)
+    private final RowGroupPageSource rowGroupSource;
+    private int currentRowGroupIndex = 0;
+    private final int totalRowGroups;
+
     // Multi-file support
     private final FileManager fileManager;
     private int currentFileIndex = 0;
@@ -61,11 +68,38 @@ public class PageCursor {
     // Eager assembly support (optional)
     private final ColumnAssemblyBuffer assemblyBuffer;
 
+    // Active page scanner for the current row group (yields pages incrementally)
+    private PageScanner activeScanner;
+
     /// Creates a PageCursor for single-file reading with optional eager assembly.
     /// Starts the assembly thread before returning if an assembly buffer is provided.
     public static PageCursor create(List<PageInfo> pageInfos, HardwoodContextImpl context,
                                     String fileName, ColumnAssemblyBuffer assemblyBuffer) {
-        PageCursor cursor = new PageCursor(pageInfos, context, null, -1, fileName, assemblyBuffer);
+        PageCursor cursor = new PageCursor(null, pageInfos, context, null, -1, fileName, assemblyBuffer,
+                null, 0, 1);
+        cursor.startAssemblyThread();
+        return cursor;
+    }
+
+    /// Creates a PageCursor for single-file reading with lazy row-group and page fetching.
+    /// The initial scanner yields pages incrementally from the first row group.
+    /// Subsequent row groups are fetched on demand via the `rowGroupSource`.
+    ///
+    /// @param initialScanner scanner for the first row group
+    /// @param context hardwood context with executor
+    /// @param projectedColumnIndex the projected column index for row-group page requests
+    /// @param fileName the file name for logging
+    /// @param assemblyBuffer optional buffer for eager batch assembly
+    /// @param rowGroupSource callback for fetching scanners for subsequent row groups
+    /// @param firstRowGroupIndex the index of the first row group (after statistics-based filtering)
+    /// @param totalRowGroups total number of row groups available
+    public static PageCursor create(PageScanner initialScanner, HardwoodContextImpl context,
+                                    int projectedColumnIndex, String fileName,
+                                    ColumnAssemblyBuffer assemblyBuffer,
+                                    RowGroupPageSource rowGroupSource,
+                                    int firstRowGroupIndex, int totalRowGroups) {
+        PageCursor cursor = new PageCursor(initialScanner, List.of(), context, null, projectedColumnIndex,
+                fileName, assemblyBuffer, rowGroupSource, firstRowGroupIndex, totalRowGroups);
         cursor.startAssemblyThread();
         return cursor;
     }
@@ -75,21 +109,24 @@ public class PageCursor {
     public static PageCursor create(List<PageInfo> pageInfos, HardwoodContextImpl context,
                                     FileManager fileManager, int projectedColumnIndex, String initialFileName,
                                     ColumnAssemblyBuffer assemblyBuffer) {
-        PageCursor cursor = new PageCursor(pageInfos, context, fileManager, projectedColumnIndex,
-                initialFileName, assemblyBuffer);
+        PageCursor cursor = new PageCursor(null, pageInfos, context, fileManager, projectedColumnIndex,
+                initialFileName, assemblyBuffer, null, 0, 1);
         cursor.startAssemblyThread();
         return cursor;
     }
 
     /// Creates a PageCursor for single-file reading without eager assembly.
     public PageCursor(List<PageInfo> pageInfos, HardwoodContextImpl context) {
-        this(pageInfos, context, null, -1, null, null);
+        this(null, pageInfos, context, null, -1, null, null, null, 0, 1);
     }
 
-    private PageCursor(List<PageInfo> pageInfos, HardwoodContextImpl context,
+    private PageCursor(PageScanner initialScanner, List<PageInfo> pageInfos,
+               HardwoodContextImpl context,
                FileManager fileManager, int projectedColumnIndex, String initialFileName,
-               ColumnAssemblyBuffer assemblyBuffer) {
+               ColumnAssemblyBuffer assemblyBuffer,
+               RowGroupPageSource rowGroupSource, int firstRowGroupIndex, int totalRowGroups) {
         this.pageInfos = new ArrayList<>(pageInfos);
+        this.activeScanner = initialScanner;
         this.context = context;
         this.executor = context.executor();
         this.fileManager = fileManager;
@@ -97,18 +134,29 @@ public class PageCursor {
         this.initialFileName = initialFileName;
         this.currentFileEndIndex = pageInfos.size();
         this.assemblyBuffer = assemblyBuffer;
+        this.rowGroupSource = rowGroupSource;
+        this.currentRowGroupIndex = firstRowGroupIndex;
+        this.totalRowGroups = totalRowGroups;
 
-        if (pageInfos.isEmpty()) {
-            this.columnName = "unknown";
-            this.pageReader = null;
+        // Initialize PageReader and column name from the scanner or first page
+        if (initialScanner != null) {
+            this.columnName = initialScanner.columnSchema().name();
+            this.pageReader = new PageReader(
+                    initialScanner.columnMetaData(),
+                    initialScanner.columnSchema(),
+                    context.decompressorFactory());
         }
-        else {
+        else if (!pageInfos.isEmpty()) {
             PageInfo first = pageInfos.get(0);
             this.columnName = first.columnSchema().name();
             this.pageReader = new PageReader(
                     first.columnMetaData(),
                     first.columnSchema(),
                     context.decompressorFactory());
+        }
+        else {
+            this.columnName = "unknown";
+            this.pageReader = null;
         }
 
         // Start prefetching immediately
@@ -154,7 +202,22 @@ public class PageCursor {
         if (!prefetchQueue.isEmpty() || nextPageIndex < pageInfos.size()) {
             return true;
         }
-        // Queue empty and current pages exhausted - check if there are more files
+        // Check if the active scanner has more pages
+        if (activeScanner != null) {
+            try {
+                if (activeScanner.hasNextPage()) {
+                    return true;
+                }
+            }
+            catch (IOException e) {
+                throw new UncheckedIOException(e);
+            }
+            activeScanner = null;
+        }
+        // Queue empty and current pages exhausted - check for more row groups or files
+        if (hasMoreRowGroups()) {
+            return true;
+        }
         return fileManager != null && fileManager.hasFile(currentFileIndex + 1);
     }
 
@@ -164,8 +227,8 @@ public class PageCursor {
     public Page nextPage() {
         if (prefetchQueue.isEmpty()) {
             if (nextPageIndex >= pageInfos.size()) {
-                // Current file exhausted - try to load next file (blocking if needed)
-                if (!tryLoadNextFileBlocking()) {
+                // Current data exhausted - try next row group, then next file
+                if (!tryLoadNextRowGroupBlocking() && !tryLoadNextFileBlocking()) {
                     signalExhausted();
                     return null; // Truly exhausted
                 }
@@ -229,6 +292,12 @@ public class PageCursor {
     /// loaded. This prevents one column from blocking while waiting for file loading,
     /// which would drain its prefetch queue and cause misses.
     private void fillPrefetchQueue() {
+        // Row groups are NOT proactively fetched here — unlike pages, row groups involve
+        // full I/O (readRange on remote backends). They are fetched on demand via
+        // tryLoadNextRowGroupBlocking() when the current row group is exhausted.
+        // The ColumnAssemblyBuffer's back-pressure (blocking queue capacity 2) naturally
+        // gates how fast row groups are consumed.
+
         // Proactively fetch next file if current file is running low
         // Only fetch if we haven't already fetched it (nextFileReader == null)
         int pagesRemainingInCurrentFile = currentFileEndIndex - nextPageIndex;
@@ -269,8 +338,32 @@ public class PageCursor {
             // If file not ready, we'll try again next time fillPrefetchQueue is called
         }
 
-        // Fill prefetch queue from available pages
-        while (prefetchQueue.size() < targetPrefetchDepth && nextPageIndex < pageInfos.size()) {
+        // Fill prefetch queue from available pages (pulling from active scanner on demand)
+        while (prefetchQueue.size() < targetPrefetchDepth) {
+            // Pull next page from the active scanner if the pre-populated list is exhausted
+            if (nextPageIndex >= pageInfos.size() && activeScanner != null) {
+                try {
+                    if (activeScanner.hasNextPage()) {
+                        PageInfo page = activeScanner.nextPage();
+                        if (page != null) {
+                            pageInfos.add(page);
+                        }
+                        else {
+                            activeScanner = null;
+                        }
+                    }
+                    else {
+                        activeScanner = null; // scanner exhausted
+                    }
+                }
+                catch (IOException e) {
+                    throw new UncheckedIOException(e);
+                }
+            }
+            if (nextPageIndex >= pageInfos.size()) {
+                break;
+            }
+
             // Check if we're crossing into the next file
             if (nextPageIndex >= currentFileEndIndex && nextFileReader != null) {
                 // Switch to next file's reader
@@ -278,6 +371,8 @@ public class PageCursor {
                 nextFileReader = null;
                 currentFileIndex++;
                 currentFileEndIndex = pageInfos.size(); // Update boundary for potential next file
+                // Reset row-group tracking for the new file
+                currentRowGroupIndex = 0;
                 LOG.log(System.Logger.Level.DEBUG,
                         "[{0}] Switched to new file reader for column ''{1}''",
                         fileManager.getFileName(currentFileIndex), columnName);
@@ -301,6 +396,57 @@ public class PageCursor {
     /// Returns the assembly buffer if eager assembly is enabled.
     public ColumnAssemblyBuffer getAssemblyBuffer() {
         return assemblyBuffer;
+    }
+
+    /// Tries to load pages from the next row group, blocking if necessary.
+    /// Called when we've exhausted the current row group's pages and need more.
+    ///
+    /// @return true if pages were added from the next row group, false if no more row groups
+    private boolean tryLoadNextRowGroupBlocking() {
+        if (!hasMoreRowGroups()) {
+            return false;
+        }
+
+        int nextRgIndex = currentRowGroupIndex + 1;
+        LOG.log(System.Logger.Level.DEBUG,
+                "[{0}] Blocking on row group {1} for column ''{2}''",
+                getCurrentFileName(), nextRgIndex, columnName);
+
+        PageScanner scanner = fetchRowGroupScanner(nextRgIndex);
+        if (scanner == null) {
+            return false;
+        }
+
+        activeScanner = scanner;
+        currentRowGroupIndex = nextRgIndex;
+
+        LOG.log(System.Logger.Level.DEBUG,
+                "[{0}] Obtained scanner for column ''{1}'' from row group {2}",
+                getCurrentFileName(), columnName, nextRgIndex);
+
+        return true;
+    }
+
+    /// Checks whether more row groups are available in the current file.
+    private boolean hasMoreRowGroups() {
+        if (rowGroupSource != null && currentRowGroupIndex + 1 < totalRowGroups) {
+            return true;
+        }
+        if (fileManager != null && currentRowGroupIndex + 1 < fileManager.getRowGroupCount(currentFileIndex)) {
+            return true;
+        }
+        return false;
+    }
+
+    /// Obtains a PageScanner for the given row group from the appropriate source.
+    private PageScanner fetchRowGroupScanner(int rowGroupIndex) {
+        if (rowGroupSource != null) {
+            return rowGroupSource.getScanner(rowGroupIndex, projectedColumnIndex);
+        }
+        if (fileManager != null) {
+            return fileManager.getRowGroupScanner(currentFileIndex, rowGroupIndex, projectedColumnIndex);
+        }
+        return null;
     }
 
     /// Tries to load pages from the next file, blocking if necessary.

--- a/core/src/main/java/dev/hardwood/internal/reader/PageScanner.java
+++ b/core/src/main/java/dev/hardwood/internal/reader/PageScanner.java
@@ -28,8 +28,12 @@ import dev.hardwood.schema.ColumnSchema;
 
 /// Scans page boundaries in a single column chunk and creates PageInfo objects.
 ///
-/// Reads page headers and parses dictionary pages upfront, then creates
-/// PageInfo records that can be used for on-demand page decoding.
+/// Supports two usage modes:
+///
+/// - **Batch mode**: [#scanPages()] returns all pages as a list (used when data is
+///   already pre-fetched, e.g. local files or filtered page ranges).
+/// - **Iterator mode**: [#hasNextPage()] / [#nextPage()] yield pages one at a time,
+///   backed by a [WindowedChunkReader] that fetches data from remote backends on demand.
 ///
 /// When an Offset Index is available in the file metadata, pages are located
 /// by direct lookup instead of sequentially scanning all page headers.
@@ -44,81 +48,87 @@ public class PageScanner {
     private final HardwoodContextImpl context;
     private final ByteBuffer chunkData;
     private final long chunkDataFileOffset;
+    private WindowedChunkReader windowedReader;
     private final PageRangeData pageRangeData;
     private final ColumnIndexBuffers indexBuffers;
     private final int rowGroupIndex;
     private final String fileName;
     private final RowRanges matchingRows;
 
-    /// Creates a PageScanner with pre-fetched chunk data and index buffers.
-    ///
-    /// @param columnSchema        the column schema
-    /// @param columnChunk         the column chunk metadata
-    /// @param context             the Hardwood context
-    /// @param chunkData           pre-fetched bytes for this column chunk
-    /// @param chunkDataFileOffset absolute file offset where `chunkData` starts
-    /// @param indexBuffers        pre-fetched index buffers for this column
-    /// @param rowGroupIndex       the row group index for JFR event reporting
-    /// @param fileName            the file name for error messages and JFR events
-    public PageScanner(ColumnSchema columnSchema, ColumnChunk columnChunk, HardwoodContextImpl context,
-                       ByteBuffer chunkData, long chunkDataFileOffset, ColumnIndexBuffers indexBuffers,
-                       int rowGroupIndex, String fileName) {
-        this(columnSchema, columnChunk, context, chunkData, chunkDataFileOffset,
-                indexBuffers, rowGroupIndex, fileName, RowRanges.ALL);
-    }
+    // Row limit: stop yielding pages once enough rows are covered (0 = unlimited)
+    private final long maxRows;
 
-    /// Creates a PageScanner with pre-fetched chunk data, index buffers, and optional row ranges
-    /// for page-level filtering via Column Index.
+    // Iterator state for sequential scanning
+    private int position;
+    private long valuesRead;
+    private Dictionary dictionary;
+    private boolean iteratorInitialized;
+    private boolean iteratorExhausted;
+    private int iteratorPageCount;
+    private List<PageInfo> preScannedPages; // OffsetIndex path: pre-scanned list
+    private int preScannedIndex;
+
+    /// Creates a PageScanner with pre-fetched chunk data.
     ///
-    /// @param columnSchema        the column schema
-    /// @param columnChunk         the column chunk metadata
-    /// @param context             the Hardwood context
-    /// @param chunkData           pre-fetched bytes for this column chunk
-    /// @param chunkDataFileOffset absolute file offset where `chunkData` starts
-    /// @param indexBuffers        pre-fetched index buffers for this column
-    /// @param rowGroupIndex       the row group index for JFR event reporting
-    /// @param fileName            the file name for error messages and JFR events
-    /// @param matchingRows        row ranges that might match the filter, or `RowRanges.ALL` for no filtering
+    /// @param matchingRows row ranges that might match the filter, or `RowRanges.ALL` for no filtering
+    /// @param maxRows maximum rows to yield (0 = unlimited)
     public PageScanner(ColumnSchema columnSchema, ColumnChunk columnChunk, HardwoodContextImpl context,
                        ByteBuffer chunkData, long chunkDataFileOffset, ColumnIndexBuffers indexBuffers,
-                       int rowGroupIndex, String fileName, RowRanges matchingRows) {
+                       int rowGroupIndex, String fileName, RowRanges matchingRows, long maxRows) {
         this.columnSchema = columnSchema;
         this.columnChunk = columnChunk;
         this.context = context;
         this.chunkData = chunkData;
         this.chunkDataFileOffset = chunkDataFileOffset;
+        this.windowedReader = null;
         this.pageRangeData = null;
         this.indexBuffers = indexBuffers;
         this.rowGroupIndex = rowGroupIndex;
         this.fileName = fileName;
         this.matchingRows = matchingRows;
+        this.maxRows = maxRows;
     }
 
     /// Creates a PageScanner with page-range buffers for selective I/O.
-    /// Only the matching pages (and dictionary prefix) are fetched, reducing
-    /// network I/O on remote backends.
     ///
-    /// @param columnSchema   the column schema
-    /// @param columnChunk    the column chunk metadata
-    /// @param context        the Hardwood context
-    /// @param pageRangeData  pre-fetched page-range buffers
-    /// @param indexBuffers   pre-fetched index buffers for this column
-    /// @param rowGroupIndex  the row group index for JFR event reporting
-    /// @param fileName       the file name for error messages and JFR events
-    /// @param matchingRows   row ranges that might match the filter
+    /// @param matchingRows row ranges that might match the filter
+    /// @param maxRows maximum rows to yield (0 = unlimited)
     public PageScanner(ColumnSchema columnSchema, ColumnChunk columnChunk, HardwoodContextImpl context,
                        PageRangeData pageRangeData, ColumnIndexBuffers indexBuffers,
-                       int rowGroupIndex, String fileName, RowRanges matchingRows) {
+                       int rowGroupIndex, String fileName, RowRanges matchingRows, long maxRows) {
         this.columnSchema = columnSchema;
         this.columnChunk = columnChunk;
         this.context = context;
         this.chunkData = null;
         this.chunkDataFileOffset = 0;
+        this.windowedReader = null;
         this.pageRangeData = pageRangeData;
         this.indexBuffers = indexBuffers;
         this.rowGroupIndex = rowGroupIndex;
         this.fileName = fileName;
         this.matchingRows = matchingRows;
+        this.maxRows = maxRows;
+    }
+
+    /// Creates a PageScanner with a [WindowedChunkReader] for lazy, incremental page fetching.
+    ///
+    /// @param matchingRows row ranges that might match the filter, or `RowRanges.ALL` for no filtering
+    /// @param maxRows maximum rows to yield (0 = unlimited)
+    public PageScanner(ColumnSchema columnSchema, ColumnChunk columnChunk, HardwoodContextImpl context,
+                       WindowedChunkReader windowedReader, ColumnIndexBuffers indexBuffers,
+                       int rowGroupIndex, String fileName, RowRanges matchingRows, long maxRows) {
+        this.columnSchema = columnSchema;
+        this.columnChunk = columnChunk;
+        this.context = context;
+        this.chunkData = null;
+        this.chunkDataFileOffset = 0;
+        this.windowedReader = windowedReader;
+        this.pageRangeData = null;
+        this.indexBuffers = indexBuffers;
+        this.rowGroupIndex = rowGroupIndex;
+        this.fileName = fileName;
+        this.matchingRows = matchingRows;
+        this.maxRows = maxRows;
     }
 
     /// Scan pages in this column chunk and return PageInfo objects.
@@ -131,30 +141,224 @@ public class PageScanner {
         if (columnChunk.offsetIndexOffset() != null) {
             return scanPagesFromIndex();
         }
-        return scanPagesSequential();
+        // Drain the iterator (JFR event emitted by hasNextPage() when exhausted)
+        List<PageInfo> pages = new ArrayList<>();
+        while (hasNextPage()) {
+            pages.add(nextPage());
+        }
+        return pages;
     }
 
-    /// Scan pages by sequentially reading all page headers through the column chunk.
-    ///
-    /// @return list of PageInfo objects for data pages in this chunk
-    List<PageInfo> scanPagesSequential() throws IOException {
-        RowGroupScannedEvent event = new RowGroupScannedEvent();
-        event.begin();
+    // ==================== Iterator API ====================
 
+    /// Returns the column schema for this scanner.
+    public ColumnSchema columnSchema() {
+        return columnSchema;
+    }
+
+    /// Returns the column metadata for this scanner.
+    public ColumnMetaData columnMetaData() {
+        return columnChunk.metaData();
+    }
+
+    /// Check if there are more data pages to scan.
+    /// On the first call, initializes the iterator by parsing any dictionary page
+    /// (sequential path) or pre-scanning all pages via OffsetIndex (index path).
+    ///
+    /// @return true if [#nextPage()] will return a page
+    public boolean hasNextPage() throws IOException {
+        if (iteratorExhausted) {
+            return false;
+        }
+        // Stop early if we've yielded enough rows for the consumer's limit
+        if (maxRows > 0 && valuesRead >= maxRows) {
+            iteratorExhausted = true;
+            emitRowGroupScannedEvent(iteratorPageCount);
+            return false;
+        }
+        if (!iteratorInitialized) {
+            initializeIterator();
+        }
+        // OffsetIndex path: iterate over pre-scanned list
+        if (preScannedPages != null) {
+            boolean hasMore = preScannedIndex < preScannedPages.size();
+            if (!hasMore) {
+                iteratorExhausted = true;
+            }
+            return hasMore;
+        }
+        // Sequential path: check value count and buffer position
+        ColumnMetaData metaData = columnChunk.metaData();
+        WindowedChunkReader reader = effectiveReader();
+        boolean hasMore = valuesRead < metaData.numValues() && position < reader.totalLength();
+        if (!hasMore) {
+            iteratorExhausted = true;
+            emitRowGroupScannedEvent(iteratorPageCount);
+            // Validate value count when all pages have been read
+            if (valuesRead != metaData.numValues()) {
+                throw new IOException("Value count mismatch for column '" + columnSchema.name()
+                        + "': metadata declares " + metaData.numValues()
+                        + " values but pages contain " + valuesRead);
+            }
+        }
+        return hasMore;
+    }
+
+    /// Returns the next data page. Must only be called when [#hasNextPage()] returns true.
+    ///
+    /// @return the next PageInfo
+    public PageInfo nextPage() throws IOException {
+        if (!hasNextPage()) {
+            return null;
+        }
+
+        // OffsetIndex path: return from pre-scanned list
+        if (preScannedPages != null) {
+            return preScannedPages.get(preScannedIndex++);
+        }
+
+        WindowedChunkReader reader = effectiveReader();
         ColumnMetaData metaData = columnChunk.metaData();
 
-        List<PageInfo> pageInfos = new ArrayList<>();
-        long valuesRead = 0;
-        int position = 0;
-
-        Dictionary dictionary = null;
-
-        while (valuesRead < metaData.numValues() && position < chunkData.limit()) {
-            ThriftCompactReader headerReader = new ThriftCompactReader(chunkData, position);
+        while (valuesRead < metaData.numValues() && position < reader.totalLength()) {
+            // Read page header — need enough bytes for the Thrift header (typically 20-50 bytes)
+            // Fetch a small peek first, then the full page
+            int peekSize = Math.min(256, reader.totalLength() - position);
+            ByteBuffer headerBuf = reader.slice(position, peekSize);
+            ThriftCompactReader headerReader = new ThriftCompactReader(headerBuf);
             PageHeader header = PageHeaderReader.read(headerReader);
             int headerSize = headerReader.getBytesRead();
 
-            int pageDataOffset = position + headerSize;
+            int compressedSize = header.compressedPageSize();
+            int totalPageSize = headerSize + compressedSize;
+
+            if (header.type() == PageHeader.PageType.DICTIONARY_PAGE) {
+                // Dictionary pages should have been handled in initializeIterator()
+                // but handle gracefully if encountered mid-stream
+                position += totalPageSize;
+                continue;
+            }
+
+            if (header.type() == PageHeader.PageType.DATA_PAGE ||
+                    header.type() == PageHeader.PageType.DATA_PAGE_V2) {
+                ByteBuffer pageSlice = reader.slice(position, totalPageSize);
+                PageInfo pageInfo = new PageInfo(pageSlice, columnSchema, metaData, dictionary);
+                valuesRead += getValueCount(header);
+                position += totalPageSize;
+                iteratorPageCount++;
+                return pageInfo;
+            }
+
+            // Skip unknown page types
+            position += totalPageSize;
+        }
+
+        iteratorExhausted = true;
+        return null;
+    }
+
+    /// Initializes the iterator. For the OffsetIndex path, pre-scans all pages via
+    /// `scanPagesFromIndex()`. For the sequential path, scans past any dictionary page.
+    private void initializeIterator() throws IOException {
+        iteratorInitialized = true;
+
+        // OffsetIndex path: pre-scan all pages (data is already selectively fetched)
+        if (columnChunk.offsetIndexOffset() != null && (pageRangeData != null || chunkData != null)) {
+            preScannedPages = scanPagesFromIndex();
+            preScannedIndex = 0;
+            return;
+        }
+
+        position = 0;
+        valuesRead = 0;
+        dictionary = null;
+
+        WindowedChunkReader reader = effectiveReader();
+        ColumnMetaData metaData = columnChunk.metaData();
+
+        // Scan forward past dictionary page (if present)
+        if (position < reader.totalLength()) {
+            int peekSize = Math.min(256, reader.totalLength() - position);
+            ByteBuffer headerBuf = reader.slice(position, peekSize);
+            ThriftCompactReader headerReader = new ThriftCompactReader(headerBuf);
+            PageHeader header = PageHeaderReader.read(headerReader);
+            int headerSize = headerReader.getBytesRead();
+
+            if (header.type() == PageHeader.PageType.DICTIONARY_PAGE) {
+                int pageDataOffset = position + headerSize;
+                int compressedSize = header.compressedPageSize();
+                int numValues = header.dictionaryPageHeader().numValues();
+                if (numValues < 0) {
+                    throw new IOException("Invalid dictionary page for column '" + columnSchema.name()
+                            + "': negative numValues (" + numValues + ")");
+                }
+
+                ByteBuffer compressedData = reader.slice(pageDataOffset, compressedSize);
+                if (header.crc() != null) {
+                    CrcValidator.assertCorrectCrc(header.crc(), compressedData, columnSchema.name());
+                }
+                int uncompressedSize = header.uncompressedPageSize();
+
+                dictionary = parseDictionary(compressedData, numValues, uncompressedSize,
+                        columnSchema, metaData.codec());
+
+                position += headerSize + compressedSize;
+            }
+        }
+    }
+
+    /// Returns the windowed reader. When constructed with pre-fetched `chunkData`
+    /// (no `WindowedChunkReader`), creates a wrapper that delegates to `chunkData` slices.
+    private WindowedChunkReader effectiveReader() {
+        if (windowedReader != null) {
+            return windowedReader;
+        }
+        if (chunkData != null) {
+            // Lazily wrap chunkData. No I/O — slice() is a zero-copy ByteBuffer operation.
+            windowedReader = new WindowedChunkReader(null, 0, chunkData.limit()) {
+                @Override
+                public ByteBuffer slice(int relativeOffset, int length) {
+                    return chunkData.slice(relativeOffset, length);
+                }
+            };
+            return windowedReader;
+        }
+        throw new IllegalStateException(
+                "No data source available — PageScanner requires either chunkData or a WindowedChunkReader");
+    }
+
+    /// Emits a JFR event summarizing the sequential scan.
+    private void emitRowGroupScannedEvent(int pageCount) {
+        RowGroupScannedEvent event = new RowGroupScannedEvent();
+        event.file = fileName;
+        event.rowGroupIndex = rowGroupIndex;
+        event.column = columnSchema.name();
+        event.pageCount = pageCount;
+        event.scanStrategy = RowGroupScannedEvent.STRATEGY_SEQUENTIAL;
+        event.commit();
+    }
+
+    /// Scan pages by sequentially reading all page headers through the column chunk.
+    /// This always uses the sequential path regardless of OffsetIndex availability,
+    /// making it suitable for testing both paths independently.
+    ///
+    /// @return list of PageInfo objects for data pages in this chunk
+    List<PageInfo> scanPagesSequential() throws IOException {
+        WindowedChunkReader reader = effectiveReader();
+        ColumnMetaData metaData = columnChunk.metaData();
+        long seqValuesRead = 0;
+        int seqPosition = 0;
+        Dictionary seqDictionary = null;
+
+        List<PageInfo> pages = new ArrayList<>();
+
+        while (seqValuesRead < metaData.numValues() && seqPosition < reader.totalLength()) {
+            int peekSize = Math.min(256, reader.totalLength() - seqPosition);
+            ByteBuffer headerBuf = reader.slice(seqPosition, peekSize);
+            ThriftCompactReader headerReader = new ThriftCompactReader(headerBuf);
+            PageHeader header = PageHeaderReader.read(headerReader);
+            int headerSize = headerReader.getBytesRead();
+
             int compressedSize = header.compressedPageSize();
             int totalPageSize = headerSize + compressedSize;
 
@@ -164,48 +368,32 @@ public class PageScanner {
                     throw new IOException("Invalid dictionary page for column '" + columnSchema.name()
                             + "': negative numValues (" + numValues + ")");
                 }
-
-                ByteBuffer compressedData = chunkData.slice(pageDataOffset, compressedSize);
+                int pageDataOffset = seqPosition + headerSize;
+                ByteBuffer compressedData = reader.slice(pageDataOffset, compressedSize);
                 if (header.crc() != null) {
                     CrcValidator.assertCorrectCrc(header.crc(), compressedData, columnSchema.name());
                 }
-                int uncompressedSize = header.uncompressedPageSize();
-
-                dictionary = parseDictionary(compressedData, numValues, uncompressedSize,
-                    columnSchema, metaData.codec());
+                seqDictionary = parseDictionary(compressedData, numValues,
+                        header.uncompressedPageSize(), columnSchema, metaData.codec());
             }
             else if (header.type() == PageHeader.PageType.DATA_PAGE ||
                      header.type() == PageHeader.PageType.DATA_PAGE_V2) {
-                ByteBuffer pageSlice = chunkData.slice(position, totalPageSize);
-
-                PageInfo pageInfo = new PageInfo(
-                    pageSlice,
-                    columnSchema,
-                    metaData,
-                    dictionary
-                );
-                pageInfos.add(pageInfo);
-
-                valuesRead += getValueCount(header);
+                ByteBuffer pageSlice = reader.slice(seqPosition, totalPageSize);
+                pages.add(new PageInfo(pageSlice, columnSchema, metaData, seqDictionary));
+                seqValuesRead += getValueCount(header);
             }
 
-            position += totalPageSize;
+            seqPosition += totalPageSize;
         }
 
-        if (valuesRead != metaData.numValues()) {
+        if (seqValuesRead != metaData.numValues()) {
             throw new IOException("Value count mismatch for column '" + columnSchema.name()
                     + "': metadata declares " + metaData.numValues()
-                    + " values but pages contain " + valuesRead);
+                    + " values but pages contain " + seqValuesRead);
         }
 
-        event.file = fileName;
-        event.rowGroupIndex = rowGroupIndex;
-        event.column = columnSchema.name();
-        event.pageCount = pageInfos.size();
-        event.scanStrategy = RowGroupScannedEvent.STRATEGY_SEQUENTIAL;
-        event.commit();
-
-        return pageInfos;
+        emitRowGroupScannedEvent(pages.size());
+        return pages;
     }
 
     /// Scan pages using the Offset Index for direct page location lookup.

--- a/core/src/main/java/dev/hardwood/internal/reader/RowGroupPageSource.java
+++ b/core/src/main/java/dev/hardwood/internal/reader/RowGroupPageSource.java
@@ -1,0 +1,26 @@
+/*
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Copyright The original authors
+ *
+ *  Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package dev.hardwood.internal.reader;
+
+/// Callback for lazily obtaining a [PageScanner] for the next row group within a file.
+///
+/// This is the row-group analogue of [FileManager] for cross-file transitions.
+/// [PageCursor] calls this when pages from the current row group are exhausted,
+/// obtaining a scanner that yields pages incrementally from the next row group.
+@FunctionalInterface
+public interface RowGroupPageSource {
+
+    /// Creates a [PageScanner] for the given row group and projected column.
+    /// The scanner yields pages on demand via [PageScanner#hasNextPage()] / [PageScanner#nextPage()],
+    /// enabling lazy column chunk fetching on remote backends.
+    ///
+    /// @param rowGroupIndex the row group index within the file
+    /// @param projectedColumnIndex the projected column index
+    /// @return a PageScanner for the column in that row group, or `null` if no more row groups
+    PageScanner getScanner(int rowGroupIndex, int projectedColumnIndex);
+}

--- a/core/src/main/java/dev/hardwood/internal/reader/WindowedChunkReader.java
+++ b/core/src/main/java/dev/hardwood/internal/reader/WindowedChunkReader.java
@@ -1,0 +1,105 @@
+/*
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Copyright The original authors
+ *
+ *  Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package dev.hardwood.internal.reader;
+
+import java.io.IOException;
+import java.nio.ByteBuffer;
+
+import dev.hardwood.InputFile;
+
+/// Provides windowed access to a column chunk's byte data.
+///
+/// Fetches data in windows on demand via [InputFile#readRange]. The window
+/// advances as the [PageScanner] progresses, so only the data actually needed
+/// is fetched from the network.
+///
+/// For local files backed by memory-mapped I/O, `readRange()` returns a
+/// zero-copy slice — the first window covers the full chunk with no overhead.
+///
+/// This is the bridge between [PageScanner]'s incremental iteration and the
+/// [InputFile] abstraction.
+public class WindowedChunkReader {
+
+    /// Default window size (256 KB).
+    static final int DEFAULT_WINDOW_SIZE = 256 * 1024;
+
+    private final InputFile inputFile;
+    private final long chunkOffset;
+    private final int chunkLength;
+    private final int windowSize;
+
+    // Current window state
+    private ByteBuffer window;
+    private int windowStart; // relative offset within the chunk where the window begins
+    private int windowEnd;   // relative offset within the chunk where the window ends (exclusive)
+
+    /// Creates a windowed reader for a column chunk.
+    ///
+    /// @param inputFile the file to read from
+    /// @param chunkOffset absolute file offset where the column chunk starts
+    /// @param chunkLength total size of the column chunk in bytes
+    /// @param windowSize number of bytes to fetch per window
+    public WindowedChunkReader(InputFile inputFile, long chunkOffset, int chunkLength, int windowSize) {
+        this.inputFile = inputFile;
+        this.chunkOffset = chunkOffset;
+        this.chunkLength = chunkLength;
+        this.windowSize = windowSize;
+    }
+
+    /// Creates a windowed reader with the default window size.
+    ///
+    /// @param inputFile the file to read from
+    /// @param chunkOffset absolute file offset where the column chunk starts
+    /// @param chunkLength total size of the column chunk in bytes
+    public WindowedChunkReader(InputFile inputFile, long chunkOffset, int chunkLength) {
+        this(inputFile, chunkOffset, chunkLength, DEFAULT_WINDOW_SIZE);
+    }
+
+    /// Returns a [ByteBuffer] covering bytes `[relativeOffset, relativeOffset + length)`
+    /// within the column chunk. May trigger I/O if the requested range falls outside
+    /// the current window.
+    ///
+    /// @param relativeOffset offset relative to the start of the column chunk
+    /// @param length number of bytes
+    /// @return a ByteBuffer positioned at the start of the requested range
+    /// @throws IOException if a fetch fails
+    public ByteBuffer slice(int relativeOffset, int length) throws IOException {
+        if (length > chunkLength - relativeOffset) {
+            throw new IndexOutOfBoundsException(
+                    "Requested range [" + relativeOffset + ", " + (relativeOffset + length)
+                            + ") exceeds chunk length " + chunkLength);
+        }
+
+        // Check if current window covers the requested range
+        if (window == null || relativeOffset < windowStart || relativeOffset + length > windowEnd) {
+            fetchWindow(relativeOffset, length);
+        }
+
+        int offsetInWindow = relativeOffset - windowStart;
+        return window.slice(offsetInWindow, length);
+    }
+
+    /// Total size of the column chunk in bytes.
+    public int totalLength() {
+        return chunkLength;
+    }
+
+    /// Fetches a window that covers at least `[relativeOffset, relativeOffset + minLength)`.
+    /// The window starts at `relativeOffset` and extends up to `windowSize` bytes
+    /// (or to the end of the chunk, whichever comes first).
+    private void fetchWindow(int relativeOffset, int minLength) throws IOException {
+        int fetchSize = Math.max(windowSize, minLength);
+        int available = chunkLength - relativeOffset;
+        fetchSize = Math.min(fetchSize, available);
+
+        long absoluteOffset = chunkOffset + relativeOffset;
+        window = inputFile.readRange(absoluteOffset, fetchSize);
+        windowStart = relativeOffset;
+        windowEnd = relativeOffset + fetchSize;
+    }
+}

--- a/core/src/main/java/dev/hardwood/reader/AbstractRowReader.java
+++ b/core/src/main/java/dev/hardwood/reader/AbstractRowReader.java
@@ -46,6 +46,10 @@ abstract class AbstractRowReader implements RowReader {
     protected volatile boolean closed = false;
     protected boolean initialized = false;
 
+    // Row limit: 0 = unlimited
+    protected long maxRows;
+    private long emittedRows;
+
     // Cached flat arrays for direct access (bypasses dataView virtual dispatch)
     private Object[] flatValueArrays;
     private BitSet[] flatNulls;
@@ -168,6 +172,10 @@ abstract class AbstractRowReader implements RowReader {
         if (closed || exhausted) {
             return false;
         }
+        if (maxRows > 0 && emittedRows >= maxRows) {
+            exhausted = true;
+            return false;
+        }
         if (!initialized) {
             initialize();
             if (!exhausted) {
@@ -209,6 +217,7 @@ abstract class AbstractRowReader implements RowReader {
             rowIndex++;
         }
         dataView.setRowIndex(rowIndex);
+        emittedRows++;
     }
 
     /// Row index of the next matching row, found by `hasNextMatch()` and consumed by `next()`.

--- a/core/src/main/java/dev/hardwood/reader/ColumnReader.java
+++ b/core/src/main/java/dev/hardwood/reader/ColumnReader.java
@@ -11,10 +11,8 @@ import java.io.IOException;
 import java.io.UncheckedIOException;
 import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
-import java.util.ArrayList;
 import java.util.BitSet;
 import java.util.List;
-import java.util.concurrent.CompletableFuture;
 
 import dev.hardwood.InputFile;
 import dev.hardwood.internal.predicate.PageFilterEvaluator;
@@ -34,8 +32,10 @@ import dev.hardwood.internal.reader.PageRange;
 import dev.hardwood.internal.reader.PageRangeData;
 import dev.hardwood.internal.reader.PageScanner;
 import dev.hardwood.internal.reader.RowGroupIndexBuffers;
+import dev.hardwood.internal.reader.RowGroupPageSource;
 import dev.hardwood.internal.reader.RowRanges;
 import dev.hardwood.internal.reader.TypedColumnData;
+import dev.hardwood.internal.reader.WindowedChunkReader;
 import dev.hardwood.internal.thrift.OffsetIndexReader;
 import dev.hardwood.internal.thrift.ThriftCompactReader;
 import dev.hardwood.metadata.ColumnChunk;
@@ -105,13 +105,29 @@ public class ColumnReader implements AutoCloseable {
     private BitSet elementNulls;
     private boolean nestedDataComputed;
 
-    /// Single-file constructor. Delegates to the multi-file constructor with no FileManager.
-    ColumnReader(ColumnSchema column, List<PageInfo> pageInfos, HardwoodContextImpl context,
-                 int batchSize, int[] levelNullThresholds) {
-        this(column, pageInfos, context, batchSize, levelNullThresholds, null, -1, null);
+    /// Single-file constructor with lazy row-group and page fetching.
+    ColumnReader(ColumnSchema column, PageScanner firstScanner, HardwoodContextImpl context,
+                 int batchSize, int[] levelNullThresholds,
+                 RowGroupPageSource rowGroupSource, int firstRowGroupIndex,
+                 int totalRowGroups, String fileName) {
+        this.column = column;
+        this.maxRepetitionLevel = column.maxRepetitionLevel();
+        this.batchSize = batchSize;
+        this.levelNullThresholds = levelNullThresholds;
+
+        boolean flat = maxRepetitionLevel == 0;
+
+        ColumnAssemblyBuffer assemblyBuffer = null;
+        if (flat) {
+            assemblyBuffer = new ColumnAssemblyBuffer(column, batchSize);
+        }
+
+        PageCursor pageCursor = PageCursor.create(firstScanner, context, 0,
+                fileName, assemblyBuffer, rowGroupSource, firstRowGroupIndex, totalRowGroups);
+        this.iterator = new ColumnValueIterator(pageCursor, column, flat);
     }
 
-    /// Full constructor. When `fileManager` is non-null, creates a [PageCursor]
+    /// Multi-file constructor. When `fileManager` is non-null, creates a [PageCursor]
     /// with cross-file prefetching — matching the pattern used by [MultiFileRowReader].
     ColumnReader(ColumnSchema column, List<PageInfo> pageInfos, HardwoodContextImpl context,
                  int batchSize, int[] levelNullThresholds,
@@ -401,10 +417,10 @@ public class ColumnReader implements AutoCloseable {
         return create(columnSchema, schema, inputFile, rowGroups, context, filter);
     }
 
-    /// Create a ColumnReader for a given ColumnSchema, scanning pages across all row groups.
+    /// Create a ColumnReader for a given ColumnSchema, scanning only the first row group.
+    /// Subsequent row groups are fetched lazily by `PageCursor` via `RowGroupPageSource`.
     ///
     /// @param filterPredicate resolved predicate, or `null` for no filtering.
-    @SuppressWarnings("unchecked")
     private static ColumnReader create(ColumnSchema columnSchema, FileSchema schema,
                                        InputFile inputFile, List<RowGroup> rowGroups,
                                        HardwoodContextImpl context, ResolvedPredicate filter) {
@@ -412,103 +428,98 @@ public class ColumnReader implements AutoCloseable {
         int[] projectedColumns = new int[]{ originalIndex };
         String fileName = inputFile.name();
 
-        // Scan pages for this column across all row groups in parallel
-        CompletableFuture<List<PageInfo>>[] scanFutures = new CompletableFuture[rowGroups.size()];
+        // RowGroupPageSource for lazy fetching of subsequent row groups
+        RowGroupPageSource rowGroupSource = (rgIndex, colIndex) ->
+                createScannerForRowGroup(rgIndex, columnSchema, rowGroups, inputFile, context, filter,
+                        originalIndex, fileName);
 
-        for (int rowGroupIndex = 0; rowGroupIndex < rowGroups.size(); rowGroupIndex++) {
-            final int rgIdx = rowGroupIndex;
-            RowGroup rowGroup = rowGroups.get(rgIdx);
-
-            // Pre-fetch indexes and column chunk data for this row group
-            RowGroupIndexBuffers indexBuffers;
-            try {
-                indexBuffers = RowGroupIndexBuffers.fetch(inputFile, rowGroup);
-            }
-            catch (IOException e) {
-                throw new UncheckedIOException("Failed to fetch index buffers for row group " + rgIdx, e);
-            }
-
-            // Compute matching row ranges for page-level Column Index filtering
-            RowRanges matchingRows = RowRanges.ALL;
-            if (filter != null) {
-                matchingRows = PageFilterEvaluator.computeMatchingRows(
-                        filter, rowGroup, indexBuffers);
-            }
-
-            ColumnChunk columnChunk = rowGroup.columns().get(originalIndex);
-
-            // Try page-range I/O when filtering is active
-            PageRangeData pageRangeData = null;
-            if (!matchingRows.isAll()) {
-                ColumnIndexBuffers colBuffers = indexBuffers.forColumn(originalIndex);
-                if (colBuffers != null && colBuffers.offsetIndex() != null) {
-                    try {
-                        OffsetIndex offsetIndex = OffsetIndexReader.read(
-                                new ThriftCompactReader(colBuffers.offsetIndex()));
-                        List<PageRange> pageRanges = PageRange.forColumn(
-                                offsetIndex, matchingRows, columnChunk, rowGroup.numRows(), ChunkRange.MAX_GAP_BYTES);
-                        if (!pageRanges.isEmpty()) {
-                            pageRangeData = PageRangeData.fetch(inputFile, pageRanges);
-                        }
-                    }
-                    catch (IOException e) {
-                        throw new UncheckedIOException("Failed to fetch page ranges for row group " + rgIdx, e);
-                    }
-                }
-            }
-
-            final PageScanner scanner;
-            if (pageRangeData != null) {
-                scanner = new PageScanner(columnSchema, columnChunk, context,
-                        pageRangeData, indexBuffers.forColumn(originalIndex),
-                        rgIdx, fileName, matchingRows);
-            }
-            else {
-                // Fall back to full chunk fetch
-                List<ChunkRange> chunkRanges = ChunkRange.coalesce(
-                        rowGroup.columns(), projectedColumns, ChunkRange.MAX_GAP_BYTES);
-                ByteBuffer[] rangeBuffers = new ByteBuffer[chunkRanges.size()];
-                try {
-                    for (int r = 0; r < chunkRanges.size(); r++) {
-                        ChunkRange range = chunkRanges.get(r);
-                        rangeBuffers[r] = inputFile.readRange(range.offset(), range.length());
-                    }
-                }
-                catch (IOException e) {
-                    throw new UncheckedIOException("Failed to fetch column chunk data for row group " + rgIdx, e);
-                }
-
-                ByteBuffer colChunkData = SingleFileRowReader.sliceColumnChunk(
-                        chunkRanges, rangeBuffers, columnChunk);
-                long colChunkOffset = SingleFileRowReader.chunkStartOffset(columnChunk);
-                scanner = new PageScanner(columnSchema, columnChunk, context,
-                        colChunkData, colChunkOffset, indexBuffers.forColumn(originalIndex),
-                        rgIdx, fileName, matchingRows);
-            }
-
-            scanFutures[rgIdx] = CompletableFuture.supplyAsync(() -> {
-                try {
-                    return scanner.scanPages();
-                }
-                catch (IOException e) {
-                    throw new UncheckedIOException(
-                            "Failed to scan pages for column " + columnSchema.name(), e);
-                }
-            }, context.executor());
-        }
-
-        CompletableFuture.allOf(scanFutures).join();
-
-        List<PageInfo> allPages = new ArrayList<>();
-        for (CompletableFuture<List<PageInfo>> future : scanFutures) {
-            allPages.addAll(future.join());
-        }
+        // Create scanner for the first row group
+        PageScanner firstScanner = rowGroups.isEmpty()
+                ? null
+                : createScannerForRowGroup(0, columnSchema, rowGroups, inputFile, context, filter,
+                        originalIndex, fileName);
 
         int[] thresholds = null;
         if (columnSchema.maxRepetitionLevel() > 0) {
             thresholds = NestedLevelComputer.computeLevelNullThresholds(
                     schema.getRootNode(), columnSchema.columnIndex());
         }
-        return new ColumnReader(columnSchema, allPages, context, DEFAULT_BATCH_SIZE, thresholds);
+        return new ColumnReader(columnSchema, firstScanner, context, DEFAULT_BATCH_SIZE,
+                thresholds, rowGroupSource, 0, rowGroups.size(), fileName);
+    }
+
+    /// Creates a PageScanner for a single row group.
+    private static PageScanner createScannerForRowGroup(int rowGroupIndex, ColumnSchema columnSchema,
+                                                         List<RowGroup> rowGroups, InputFile inputFile,
+                                                         HardwoodContextImpl context, ResolvedPredicate filter,
+                                                         int originalIndex, String fileName) {
+        if (rowGroupIndex >= rowGroups.size()) {
+            return null;
+        }
+
+        RowGroup rowGroup = rowGroups.get(rowGroupIndex);
+
+        RowGroupIndexBuffers indexBuffers;
+        try {
+            indexBuffers = RowGroupIndexBuffers.fetch(inputFile, rowGroup);
+        }
+        catch (IOException e) {
+            throw new UncheckedIOException("Failed to fetch index buffers for row group " + rowGroupIndex, e);
+        }
+
+        RowRanges matchingRows = RowRanges.ALL;
+        if (filter != null) {
+            matchingRows = PageFilterEvaluator.computeMatchingRows(
+                    filter, rowGroup, indexBuffers);
+        }
+
+        ColumnChunk columnChunk = rowGroup.columns().get(originalIndex);
+
+        // Try page-range I/O when filtering is active
+        if (!matchingRows.isAll()) {
+            ColumnIndexBuffers colBuffers = indexBuffers.forColumn(originalIndex);
+            if (colBuffers != null && colBuffers.offsetIndex() != null) {
+                try {
+                    OffsetIndex offsetIndex = OffsetIndexReader.read(
+                            new ThriftCompactReader(colBuffers.offsetIndex()));
+                    List<PageRange> pageRanges = PageRange.forColumn(
+                            offsetIndex, matchingRows, columnChunk, rowGroup.numRows(), ChunkRange.MAX_GAP_BYTES);
+                    if (!pageRanges.isEmpty()) {
+                        PageRangeData pageRangeData = PageRangeData.fetch(inputFile, pageRanges);
+                        return new PageScanner(columnSchema, columnChunk, context,
+                                pageRangeData, indexBuffers.forColumn(originalIndex),
+                                rowGroupIndex, fileName, matchingRows, 0);
+                    }
+                }
+                catch (IOException e) {
+                    throw new UncheckedIOException("Failed to fetch page ranges for row group " + rowGroupIndex, e);
+                }
+            }
+        }
+
+        // Determine the column chunk's file offset and length
+        long colChunkOffset = SingleFileRowReader.chunkStartOffset(columnChunk);
+        int colChunkLength = Math.toIntExact(columnChunk.metaData().totalCompressedSize());
+
+        // OffsetIndex path (no filter): fetch the full chunk for direct page lookup
+        if (columnChunk.offsetIndexOffset() != null) {
+            try {
+                ByteBuffer colChunkData = inputFile.readRange(colChunkOffset, colChunkLength);
+                return new PageScanner(columnSchema, columnChunk, context,
+                        colChunkData, colChunkOffset,
+                        indexBuffers.forColumn(originalIndex),
+                        rowGroupIndex, fileName, matchingRows, 0);
+            }
+            catch (IOException e) {
+                throw new UncheckedIOException("Failed to fetch column chunk data for row group " + rowGroupIndex, e);
+            }
+        }
+
+        // Sequential path (no OffsetIndex): use WindowedChunkReader for lazy fetching
+        WindowedChunkReader chunkReader = new WindowedChunkReader(
+                inputFile, colChunkOffset, colChunkLength);
+        return new PageScanner(columnSchema, columnChunk, context,
+                chunkReader, indexBuffers.forColumn(originalIndex),
+                rowGroupIndex, fileName, matchingRows, 0);
     }
 }

--- a/core/src/main/java/dev/hardwood/reader/ParquetFileReader.java
+++ b/core/src/main/java/dev/hardwood/reader/ParquetFileReader.java
@@ -190,6 +190,49 @@ public class ParquetFileReader implements AutoCloseable {
         return new SingleFileRowReader(schema, projectedSchema, inputFile, filterRowGroups(resolved), context, resolved);
     }
 
+    /// Create a RowReader that returns at most `maxRows` rows.
+    ///
+    /// @param maxRows maximum number of rows to return (must be &gt; 0)
+    public RowReader createRowReader(long maxRows) {
+        return createRowReader(ColumnProjection.all(), maxRows);
+    }
+
+    /// Create a RowReader with column projection that returns at most `maxRows` rows.
+    ///
+    /// @param projection specifies which columns to read
+    /// @param maxRows maximum number of rows to return (must be &gt; 0)
+    public RowReader createRowReader(ColumnProjection projection, long maxRows) {
+        if (maxRows <= 0) {
+            throw new IllegalArgumentException("maxRows must be > 0, got " + maxRows);
+        }
+        FileSchema schema = getFileSchema();
+        ProjectedSchema projectedSchema = ProjectedSchema.create(schema, projection);
+        return new SingleFileRowReader(schema, projectedSchema, inputFile, fileMetaData.rowGroups(), context, null, maxRows);
+    }
+
+    /// Create a RowReader with a filter that returns at most `maxRows` rows.
+    ///
+    /// @param filter predicate for row group filtering based on statistics
+    /// @param maxRows maximum number of rows to return (must be &gt; 0)
+    public RowReader createRowReader(FilterPredicate filter, long maxRows) {
+        return createRowReader(ColumnProjection.all(), filter, maxRows);
+    }
+
+    /// Create a RowReader with column projection and filter that returns at most `maxRows` rows.
+    ///
+    /// @param projection specifies which columns to read
+    /// @param filter predicate for row group filtering based on statistics
+    /// @param maxRows maximum number of rows to return (must be &gt; 0)
+    public RowReader createRowReader(ColumnProjection projection, FilterPredicate filter, long maxRows) {
+        if (maxRows <= 0) {
+            throw new IllegalArgumentException("maxRows must be > 0, got " + maxRows);
+        }
+        FileSchema schema = getFileSchema();
+        ResolvedPredicate resolved = FilterPredicateResolver.resolve(filter, schema);
+        ProjectedSchema projectedSchema = ProjectedSchema.create(schema, projection);
+        return new SingleFileRowReader(schema, projectedSchema, inputFile, filterRowGroups(resolved), context, resolved, maxRows);
+    }
+
     private List<RowGroup> filterRowGroups(ResolvedPredicate filter) {
         List<RowGroup> allRowGroups = fileMetaData.rowGroups();
         List<RowGroup> filtered = allRowGroups.stream()

--- a/core/src/main/java/dev/hardwood/reader/SingleFileRowReader.java
+++ b/core/src/main/java/dev/hardwood/reader/SingleFileRowReader.java
@@ -10,7 +10,6 @@ package dev.hardwood.reader;
 import java.io.IOException;
 import java.io.UncheckedIOException;
 import java.nio.ByteBuffer;
-import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ForkJoinPool;
@@ -29,13 +28,14 @@ import dev.hardwood.internal.reader.NestedBatchDataView;
 import dev.hardwood.internal.reader.NestedColumnData;
 import dev.hardwood.internal.reader.NestedLevelComputer;
 import dev.hardwood.internal.reader.PageCursor;
-import dev.hardwood.internal.reader.PageInfo;
 import dev.hardwood.internal.reader.PageRange;
 import dev.hardwood.internal.reader.PageRangeData;
 import dev.hardwood.internal.reader.PageScanner;
 import dev.hardwood.internal.reader.RowGroupIndexBuffers;
+import dev.hardwood.internal.reader.RowGroupPageSource;
 import dev.hardwood.internal.reader.RowRanges;
 import dev.hardwood.internal.reader.TypedColumnData;
+import dev.hardwood.internal.reader.WindowedChunkReader;
 import dev.hardwood.internal.thrift.OffsetIndexReader;
 import dev.hardwood.internal.thrift.ThriftCompactReader;
 import dev.hardwood.metadata.ColumnChunk;
@@ -58,24 +58,44 @@ final class SingleFileRowReader extends AbstractRowReader {
     private final HardwoodContextImpl context;
     private final int adaptiveBatchSize;
 
+    // Projected column index array (built once, reused across row groups)
+    private int[] projectedOriginalIndices;
+
     private ColumnValueIterator[] iterators;
     private int[][] levelNullThresholds; // [projectedCol] -> thresholds for nested columns
     private CompletableFuture<IndexedNestedColumnData[]> pendingBatch;
 
+    // Cached per-row-group shared state for RowGroupPageSource calls.
+    // When PageCursor requests a scanner for row group N, column 0, we fetch and cache
+    // the shared metadata (index buffers, filter evaluation) so that columns 1..K reuse it.
+    private int cachedRowGroupIndex = -1;
+    private RowGroupIndexBuffers cachedIndexBuffers;
+    private RowRanges cachedMatchingRows;
+    private PageRangeData[] cachedPageRangeData;
+
     SingleFileRowReader(FileSchema schema, ProjectedSchema projectedSchema, InputFile inputFile,
                         List<RowGroup> rowGroups, HardwoodContextImpl context) {
-        this(schema, projectedSchema, inputFile, rowGroups, context, null);
+        this(schema, projectedSchema, inputFile, rowGroups, context, null, 0);
     }
 
     /// @param filterPredicate resolved predicate, or `null` for no filtering.
     SingleFileRowReader(FileSchema schema, ProjectedSchema projectedSchema, InputFile inputFile,
                         List<RowGroup> rowGroups, HardwoodContextImpl context, ResolvedPredicate filterPredicate) {
+        this(schema, projectedSchema, inputFile, rowGroups, context, filterPredicate, 0);
+    }
+
+    /// @param filterPredicate resolved predicate, or `null` for no filtering.
+    /// @param maxRows maximum number of rows to return (0 = unlimited).
+    SingleFileRowReader(FileSchema schema, ProjectedSchema projectedSchema, InputFile inputFile,
+                        List<RowGroup> rowGroups, HardwoodContextImpl context,
+                        ResolvedPredicate filterPredicate, long maxRows) {
         this.schema = schema;
         this.projectedSchema = projectedSchema;
         this.inputFile = inputFile;
         this.rowGroups = rowGroups;
         this.context = context;
         this.adaptiveBatchSize = computeOptimalBatchSize(projectedSchema);
+        this.maxRows = maxRows;
         this.filterPredicate = filterPredicate;
         this.projectedSchemaRef = projectedSchema;
     }
@@ -93,152 +113,46 @@ final class SingleFileRowReader extends AbstractRowReader {
         LOG.log(System.Logger.Level.DEBUG, "Starting to parse file ''{0}'' with {1} row groups, {2} projected columns (of {3} total)",
                 fileName, rowGroups.size(), projectedColumnCount, schema.getColumnCount());
 
-        // Collect page infos for each projected column across all row groups
-        List<List<PageInfo>> pageInfosByColumn = new ArrayList<>(projectedColumnCount);
-        for (int i = 0; i < projectedColumnCount; i++) {
-            pageInfosByColumn.add(new ArrayList<>());
+        if (rowGroups.isEmpty()) {
+            exhausted = true;
+            return;
         }
 
-        LOG.log(System.Logger.Level.DEBUG, "Scanning pages for {0} projected columns across {1} row groups",
-                projectedColumnCount, rowGroups.size());
-
-        // Build projected column index array
-        int[] projectedOriginalIndices = new int[projectedColumnCount];
+        // Build projected column index array (reused across row groups)
+        projectedOriginalIndices = new int[projectedColumnCount];
         for (int i = 0; i < projectedColumnCount; i++) {
             projectedOriginalIndices[i] = projectedSchema.toOriginalIndex(i);
         }
 
-        // Pre-fetch indexes and column chunk data per row group, then scan columns in parallel
-        @SuppressWarnings("unchecked")
-        CompletableFuture<List<PageInfo>>[] scanFutures = new CompletableFuture[projectedColumnCount];
-        for (int i = 0; i < projectedColumnCount; i++) {
-            scanFutures[i] = CompletableFuture.completedFuture(new ArrayList<>());
-        }
-
-        for (int rowGroupIndex = 0; rowGroupIndex < rowGroups.size(); rowGroupIndex++) {
-            final int rgIdx = rowGroupIndex;
-            RowGroup rowGroup = rowGroups.get(rgIdx);
-
-            // Pre-fetch all offset/column indexes for this row group in a single read
-            RowGroupIndexBuffers indexBuffers;
-            try {
-                indexBuffers = RowGroupIndexBuffers.fetch(inputFile, rowGroup);
-            }
-            catch (IOException e) {
-                throw new UncheckedIOException("Failed to fetch index buffers for row group " + rgIdx, e);
-            }
-
-            // Compute matching row ranges for page-level Column Index filtering
-            RowRanges matchingRows = RowRanges.ALL;
-            if (filterPredicate != null) {
-                matchingRows = PageFilterEvaluator.computeMatchingRows(
-                        filterPredicate, rowGroup, indexBuffers);
-            }
-
-            // Try page-range I/O for each column when filtering is active
-            final RowRanges rowRanges = matchingRows;
-            PageRangeData[] pageRangeDataPerColumn = new PageRangeData[projectedColumnCount];
-
-            if (!matchingRows.isAll()) {
-                for (int projectedIndex = 0; projectedIndex < projectedColumnCount; projectedIndex++) {
-                    int originalIndex = projectedOriginalIndices[projectedIndex];
-                    ColumnIndexBuffers colBuffers = indexBuffers.forColumn(originalIndex);
-                    if (colBuffers != null && colBuffers.offsetIndex() != null) {
-                        try {
-                            OffsetIndex offsetIndex = OffsetIndexReader.read(
-                                    new ThriftCompactReader(colBuffers.offsetIndex()));
-                            ColumnChunk columnChunk = rowGroup.columns().get(originalIndex);
-                            List<PageRange> pageRanges = PageRange.forColumn(
-                                    offsetIndex, matchingRows, columnChunk, rowGroup.numRows(), ChunkRange.MAX_GAP_BYTES);
-                            if (!pageRanges.isEmpty()) {
-                                pageRangeDataPerColumn[projectedIndex] = PageRangeData.fetch(inputFile, pageRanges);
-                            }
-                        }
-                        catch (IOException e) {
-                            throw new UncheckedIOException("Failed to fetch page ranges for row group " + rgIdx, e);
-                        }
-                    }
-                }
-            }
-
-            // Fetch full chunks for columns not using page-range I/O
-            List<ChunkRange> chunkRanges = null;
-            ByteBuffer[] rangeBuffers = null;
-            for (int projectedIndex = 0; projectedIndex < projectedColumnCount; projectedIndex++) {
-                if (pageRangeDataPerColumn[projectedIndex] == null) {
-                    chunkRanges = ChunkRange.coalesce(
-                            rowGroup.columns(), projectedOriginalIndices, ChunkRange.MAX_GAP_BYTES);
-                    rangeBuffers = new ByteBuffer[chunkRanges.size()];
-                    try {
-                        for (int r = 0; r < chunkRanges.size(); r++) {
-                            ChunkRange range = chunkRanges.get(r);
-                            rangeBuffers[r] = inputFile.readRange(range.offset(), range.length());
-                        }
-                    }
-                    catch (IOException e) {
-                        throw new UncheckedIOException("Failed to fetch column chunk data for row group " + rgIdx, e);
-                    }
+        // Compute how many row groups are needed based on maxRows.
+        // When no record-level filter is active, row group metadata row counts give an
+        // exact answer. With a filter, we can't predict how many rows will match, so
+        // all row groups remain available.
+        int totalRowGroups = rowGroups.size();
+        if (maxRows > 0 && filterPredicate == null) {
+            long rowsBudget = maxRows;
+            totalRowGroups = 0;
+            for (RowGroup rg : rowGroups) {
+                totalRowGroups++;
+                rowsBudget -= rg.numRows();
+                if (rowsBudget <= 0) {
                     break;
                 }
             }
-
-            // Scan each projected column in parallel
-            for (int projectedIndex = 0; projectedIndex < projectedColumnCount; projectedIndex++) {
-                final int projIdx = projectedIndex;
-                final int originalIndex = projectedOriginalIndices[projIdx];
-                final ColumnSchema columnSchema = schema.getColumn(originalIndex);
-                final ColumnChunk columnChunk = rowGroup.columns().get(originalIndex);
-                final PageRangeData colPageRangeData = pageRangeDataPerColumn[projIdx];
-
-                final PageScanner scanner;
-                if (colPageRangeData != null) {
-                    scanner = new PageScanner(columnSchema, columnChunk, context,
-                            colPageRangeData, indexBuffers.forColumn(originalIndex),
-                            rgIdx, fileName, rowRanges);
-                }
-                else {
-                    final ByteBuffer colChunkData = sliceColumnChunk(chunkRanges, rangeBuffers, columnChunk);
-                    final long colChunkOffset = chunkStartOffset(columnChunk);
-                    scanner = new PageScanner(columnSchema, columnChunk, context,
-                            colChunkData, colChunkOffset, indexBuffers.forColumn(originalIndex),
-                            rgIdx, fileName, rowRanges);
-                }
-
-                final CompletableFuture<List<PageInfo>> previousFuture = scanFutures[projIdx];
-                scanFutures[projIdx] = previousFuture.thenCombineAsync(
-                        CompletableFuture.supplyAsync(() -> {
-                            try {
-                                return scanner.scanPages();
-                            }
-                            catch (IOException e) {
-                                throw new UncheckedIOException(
-                                        "Failed to scan pages for column " + columnSchema.name(), e);
-                            }
-                        }, context.executor()),
-                        (existing, newPages) -> {
-                            existing.addAll(newPages);
-                            return existing;
-                        }, context.executor());
-            }
         }
 
-        // Wait for all scans to complete and collect results
-        CompletableFuture.allOf(scanFutures).join();
+        // Scan only the first row group; subsequent row groups are fetched lazily by PageCursor
+        int firstRowGroupIndex = 0;
+        RowGroupPageSource rowGroupSource = this::getScannerForRowGroup;
 
-        for (int projectedIndex = 0; projectedIndex < projectedColumnCount; projectedIndex++) {
-            pageInfosByColumn.get(projectedIndex).addAll(scanFutures[projectedIndex].join());
-        }
-
-        int totalPages = pageInfosByColumn.stream().mapToInt(List::size).sum();
-        LOG.log(System.Logger.Level.DEBUG, "Page scanning complete: {0} total pages across {1} projected columns",
-                totalPages, projectedColumnCount);
-
-        // Create iterators for each projected column
+        // Create iterators for each projected column with lazy row-group support
         boolean flatSchema = schema.isFlatSchema();
         iterators = new ColumnValueIterator[projectedColumnCount];
         for (int i = 0; i < projectedColumnCount; i++) {
             int originalIndex = projectedSchema.toOriginalIndex(i);
             ColumnSchema columnSchema = schema.getColumn(originalIndex);
+
+            PageScanner firstScanner = getScannerForRowGroup(firstRowGroupIndex, i);
 
             // Create assembly buffer for eager batch assembly (flat schemas only)
             ColumnAssemblyBuffer assemblyBuffer = null;
@@ -246,7 +160,8 @@ final class SingleFileRowReader extends AbstractRowReader {
                 assemblyBuffer = new ColumnAssemblyBuffer(columnSchema, adaptiveBatchSize);
             }
 
-            PageCursor pageCursor = PageCursor.create(pageInfosByColumn.get(i), context, fileName, assemblyBuffer);
+            PageCursor pageCursor = PageCursor.create(firstScanner, context, i, fileName,
+                    assemblyBuffer, rowGroupSource, firstRowGroupIndex, totalRowGroups);
             iterators[i] = new ColumnValueIterator(pageCursor, columnSchema, flatSchema);
         }
 
@@ -268,6 +183,107 @@ final class SingleFileRowReader extends AbstractRowReader {
 
         // Eagerly load first batch
         loadNextBatch();
+    }
+
+    /// Creates a [PageScanner] for a single projected column in a single row group.
+    /// Shared per-row-group state (index buffers, filter evaluation) is cached so that
+    /// multiple columns in the same row group reuse the same metadata I/O.
+    ///
+    /// For the page-range path (filter active + OffsetIndex), the scanner uses pre-fetched
+    /// page range data. For the sequential path, the scanner uses a [WindowedChunkReader]
+    /// that fetches column chunk data on demand.
+    ///
+    /// @param rowGroupIndex the row group index
+    /// @param projectedColumnIndex the projected column index
+    /// @return a PageScanner for the column, or null if row group index is out of bounds
+    synchronized PageScanner getScannerForRowGroup(int rowGroupIndex, int projectedColumnIndex) {
+        if (rowGroupIndex >= rowGroups.size()) {
+            return null;
+        }
+
+        String fileName = inputFile.name();
+
+        // Fetch and cache shared per-row-group metadata on first column request
+        if (cachedRowGroupIndex != rowGroupIndex) {
+            cachedRowGroupIndex = rowGroupIndex;
+            RowGroup rowGroup = rowGroups.get(rowGroupIndex);
+            int projectedColumnCount = projectedSchema.getProjectedColumnCount();
+
+            try {
+                cachedIndexBuffers = RowGroupIndexBuffers.fetch(inputFile, rowGroup);
+            }
+            catch (IOException e) {
+                throw new UncheckedIOException("Failed to fetch index buffers for row group " + rowGroupIndex, e);
+            }
+
+            cachedMatchingRows = RowRanges.ALL;
+            if (filterPredicate != null) {
+                cachedMatchingRows = PageFilterEvaluator.computeMatchingRows(
+                        filterPredicate, rowGroup, cachedIndexBuffers);
+            }
+
+            cachedPageRangeData = new PageRangeData[projectedColumnCount];
+            if (!cachedMatchingRows.isAll()) {
+                for (int projIdx = 0; projIdx < projectedColumnCount; projIdx++) {
+                    int originalIndex = projectedOriginalIndices[projIdx];
+                    ColumnIndexBuffers colBuffers = cachedIndexBuffers.forColumn(originalIndex);
+                    if (colBuffers != null && colBuffers.offsetIndex() != null) {
+                        try {
+                            OffsetIndex offsetIndex = OffsetIndexReader.read(
+                                    new ThriftCompactReader(colBuffers.offsetIndex()));
+                            ColumnChunk columnChunk = rowGroup.columns().get(originalIndex);
+                            List<PageRange> pageRanges = PageRange.forColumn(
+                                    offsetIndex, cachedMatchingRows, columnChunk, rowGroup.numRows(), ChunkRange.MAX_GAP_BYTES);
+                            if (!pageRanges.isEmpty()) {
+                                cachedPageRangeData[projIdx] = PageRangeData.fetch(inputFile, pageRanges);
+                            }
+                        }
+                        catch (IOException e) {
+                            throw new UncheckedIOException("Failed to fetch page ranges for row group " + rowGroupIndex, e);
+                        }
+                    }
+                }
+            }
+        }
+
+        // Create a PageScanner for this specific column
+        RowGroup rowGroup = rowGroups.get(rowGroupIndex);
+        int originalIndex = projectedOriginalIndices[projectedColumnIndex];
+        ColumnSchema columnSchema = schema.getColumn(originalIndex);
+        ColumnChunk columnChunk = rowGroup.columns().get(originalIndex);
+
+        if (cachedPageRangeData[projectedColumnIndex] != null) {
+            // Page-range path: data already fetched selectively, use batch scanner
+            return new PageScanner(columnSchema, columnChunk, context,
+                    cachedPageRangeData[projectedColumnIndex],
+                    cachedIndexBuffers.forColumn(originalIndex),
+                    rowGroupIndex, fileName, cachedMatchingRows, maxRows);
+        }
+
+        // Determine the column chunk's file offset and length
+        long colChunkOffset = chunkStartOffset(columnChunk);
+        int colChunkLength = Math.toIntExact(columnChunk.metaData().totalCompressedSize());
+
+        // OffsetIndex path (no filter): fetch the full chunk for direct page lookup
+        if (columnChunk.offsetIndexOffset() != null) {
+            try {
+                ByteBuffer colChunkData = inputFile.readRange(colChunkOffset, colChunkLength);
+                return new PageScanner(columnSchema, columnChunk, context,
+                        colChunkData, colChunkOffset,
+                        cachedIndexBuffers.forColumn(originalIndex),
+                        rowGroupIndex, fileName, cachedMatchingRows, maxRows);
+            }
+            catch (IOException e) {
+                throw new UncheckedIOException("Failed to fetch column chunk data for row group " + rowGroupIndex, e);
+            }
+        }
+
+        // Sequential path (no OffsetIndex): use WindowedChunkReader for lazy fetching
+        WindowedChunkReader chunkReader = new WindowedChunkReader(
+                inputFile, colChunkOffset, colChunkLength);
+        return new PageScanner(columnSchema, columnChunk, context,
+                chunkReader, cachedIndexBuffers.forColumn(originalIndex),
+                rowGroupIndex, fileName, cachedMatchingRows, maxRows);
     }
 
     @Override

--- a/core/src/test/java/dev/hardwood/internal/reader/PageScannerTest.java
+++ b/core/src/test/java/dev/hardwood/internal/reader/PageScannerTest.java
@@ -172,7 +172,7 @@ public class PageScannerTest {
         int chunkLen = Math.toIntExact(meta.totalCompressedSize());
         ByteBuffer chunkData = inputFile.readRange(chunkStart, chunkLen);
         return new PageScanner(columnSchema, columnChunk, context,
-                chunkData, chunkStart, indexBuffers, rowGroupIndex, inputFile.name());
+                chunkData, chunkStart, indexBuffers, rowGroupIndex, inputFile.name(), RowRanges.ALL, 0);
     }
 
     private void assertPageValuesEqual(Page expected, Page actual, int pageIndex, String columnName) {

--- a/docs/content/usage.md
+++ b/docs/content/usage.md
@@ -262,6 +262,42 @@ Filters work with all reader types: `RowReader`, `ColumnReader`, `AvroRowReader`
   ([#196](https://github.com/hardwood-hq/hardwood/issues/196)).** Dictionary-encoded columns
   are not checked for predicate matches before decoding.
 
+## Row Limit
+
+A row limit instructs the reader to stop after the specified number of rows, avoiding unnecessary I/O and decoding. On remote backends like S3, this can reduce network transfers significantly — only the row groups and pages needed to satisfy the limit are fetched.
+
+```java
+// Read at most 100 rows
+try (ParquetFileReader fileReader = ParquetFileReader.open(InputFile.of(path));
+     RowReader rowReader = fileReader.createRowReader(100)) {
+
+    while (rowReader.hasNext()) {
+        rowReader.next();
+        // At most 100 rows will be returned
+    }
+}
+```
+
+The row limit can be combined with column projection and filters:
+
+```java
+try (ParquetFileReader fileReader = ParquetFileReader.open(InputFile.of(path));
+     RowReader rowReader = fileReader.createRowReader(
+         ColumnProjection.columns("id", "name"),
+         FilterPredicate.gt("age", 21),
+         100)) {
+
+    while (rowReader.hasNext()) {
+        rowReader.next();
+        // At most 100 matching rows with only id and name columns
+    }
+}
+```
+
+When combined with a filter, the limit applies to the number of **matching** rows, not the total number of scanned rows.
+
+To read without a row limit, use the `createRowReader` overloads without `maxRows`.
+
 ## Column Projection
 
 Column projection allows reading only a subset of columns from a Parquet file, improving performance by skipping I/O, decoding, and memory allocation for unneeded columns.

--- a/parquet-testing-runner/src/test/java/dev/hardwood/testing/ParquetComparisonTest.java
+++ b/parquet-testing-runner/src/test/java/dev/hardwood/testing/ParquetComparisonTest.java
@@ -97,17 +97,15 @@ class ParquetComparisonTest {
     void rejectArrowGH41317() throws IOException {
         // Columns do not have the same size: timestamp_us_no_tz has no data
         // pages (0 values vs 3 declared in metadata).
-        assertBadDataRejected("ARROW-GH-41317.parquet",
-                "Value count mismatch for column 'timestamp_us_no_tz': metadata declares 3 values but pages contain 0");
+        assertBadDataRejected("ARROW-GH-41317.parquet");
     }
 
     @Test
     void rejectArrowGH41321() throws IOException {
         // Decoded rep/def levels less than num_values in page header.
         // Column 'value' also has negative dictionary numValues which is
-        // caught first during page scanning.
-        assertBadDataRejected("ARROW-GH-41321.parquet",
-                "Invalid dictionary page for column 'value': negative numValues");
+        // caught during dictionary parsing or page decoding.
+        assertBadDataRejected("ARROW-GH-41321.parquet");
     }
 
     @Test

--- a/performance-testing/end-to-end/src/test/java/dev/hardwood/perf/PageDecodeAllocationProfileTest.java
+++ b/performance-testing/end-to-end/src/test/java/dev/hardwood/perf/PageDecodeAllocationProfileTest.java
@@ -26,6 +26,7 @@ import dev.hardwood.internal.reader.Page;
 import dev.hardwood.internal.reader.PageInfo;
 import dev.hardwood.internal.reader.PageReader;
 import dev.hardwood.internal.reader.PageScanner;
+import dev.hardwood.internal.reader.RowRanges;
 import dev.hardwood.metadata.ColumnChunk;
 import dev.hardwood.metadata.ColumnMetaData;
 import dev.hardwood.metadata.FileMetaData;
@@ -146,7 +147,7 @@ public class PageDecodeAllocationProfileTest {
                     ByteBuffer chunkData = inputFile.readRange(chunkStart, chunkLen);
 
                     PageScanner scanner = new PageScanner(columnSchema, columnChunk, context,
-                            chunkData, chunkStart, null, rgIdx, inputFile.name());
+                            chunkData, chunkStart, null, rgIdx, inputFile.name(), RowRanges.ALL, 0);
                     List<PageInfo> pages = scanner.scanPages();
 
                     for (PageInfo pageInfo : pages) {

--- a/performance-testing/micro-benchmarks/src/main/java/dev/hardwood/benchmarks/PageHandlingBenchmark.java
+++ b/performance-testing/micro-benchmarks/src/main/java/dev/hardwood/benchmarks/PageHandlingBenchmark.java
@@ -36,6 +36,7 @@ import dev.hardwood.internal.reader.Page;
 import dev.hardwood.internal.reader.PageInfo;
 import dev.hardwood.internal.reader.PageReader;
 import dev.hardwood.internal.reader.PageScanner;
+import dev.hardwood.internal.reader.RowRanges;
 import dev.hardwood.internal.thrift.PageHeaderReader;
 import dev.hardwood.internal.thrift.ThriftCompactReader;
 import dev.hardwood.metadata.ColumnChunk;
@@ -94,7 +95,7 @@ public class PageHandlingBenchmark {
                     ByteBuffer chunkData = inputFile.readRange(chunkStart, chunkLen);
 
                     PageScanner scanner = new PageScanner(columnSchema, columnChunk, context,
-                            chunkData, chunkStart, null, rgIdx, inputFile.name());
+                            chunkData, chunkStart, null, rgIdx, inputFile.name(), RowRanges.ALL, 0);
                     allPages.addAll(scanner.scanPages());
                 }
             }

--- a/performance-testing/micro-benchmarks/src/main/java/dev/hardwood/benchmarks/PageScanBenchmark.java
+++ b/performance-testing/micro-benchmarks/src/main/java/dev/hardwood/benchmarks/PageScanBenchmark.java
@@ -32,6 +32,7 @@ import dev.hardwood.InputFile;
 import dev.hardwood.internal.reader.HardwoodContextImpl;
 import dev.hardwood.internal.reader.PageInfo;
 import dev.hardwood.internal.reader.PageScanner;
+import dev.hardwood.internal.reader.RowRanges;
 import dev.hardwood.metadata.ColumnChunk;
 import dev.hardwood.metadata.ColumnMetaData;
 import dev.hardwood.metadata.RowGroup;
@@ -116,7 +117,7 @@ public class PageScanBenchmark {
             PageScanner scanner = new PageScanner(
                     target.columnSchema, target.columnChunk, context,
                     target.chunkData, target.chunkDataFileOffset, null,
-                    target.rowGroupIndex, inputFile.name());
+                    target.rowGroupIndex, inputFile.name(), RowRanges.ALL, 0);
             List<PageInfo> pages = scanner.scanPages();
             blackhole.consume(pages);
         }

--- a/performance-testing/micro-benchmarks/src/main/java/dev/hardwood/benchmarks/PipelineBenchmark.java
+++ b/performance-testing/micro-benchmarks/src/main/java/dev/hardwood/benchmarks/PipelineBenchmark.java
@@ -32,6 +32,7 @@ import dev.hardwood.InputFile;
 import dev.hardwood.internal.reader.HardwoodContextImpl;
 import dev.hardwood.internal.reader.PageInfo;
 import dev.hardwood.internal.reader.PageScanner;
+import dev.hardwood.internal.reader.RowRanges;
 import dev.hardwood.internal.reader.TypedColumnData;
 import dev.hardwood.metadata.ColumnChunk;
 import dev.hardwood.metadata.ColumnMetaData;
@@ -113,7 +114,7 @@ public class PipelineBenchmark {
                     ByteBuffer chunkData = inputFile.readRange(chunkStart, chunkLen);
 
                     PageScanner scanner = new PageScanner(columnSchema, columnChunk, context,
-                            chunkData, chunkStart, null, rgIdx, inputFile.name());
+                            chunkData, chunkStart, null, rgIdx, inputFile.name(), RowRanges.ALL, 0);
                     List<PageInfo> pages = scanner.scanPages();
                     totalPages += pages.size();
                     pagesByColumn.get(colIdx).addAll(pages);

--- a/release.sh
+++ b/release.sh
@@ -39,7 +39,7 @@ RELEASE_VERSION="$1"
 DEVELOPMENT_VERSION="$2"
 STAGE="$3"
 
-if [[ "$STAGE" != "UPLOAD" && "$STAGE" != "PUBLISH" ]]; then
+if [[ "$STAGE" != "UPLOAD" && "$STAGE" != "FULL" ]]; then
   echo "Error: STAGE must be UPLOAD or FULL (got '$STAGE')"
   exit 1
 fi

--- a/s3/src/test/java/dev/hardwood/s3/S3SelectiveReadJfrTest.java
+++ b/s3/src/test/java/dev/hardwood/s3/S3SelectiveReadJfrTest.java
@@ -22,6 +22,7 @@ import org.testcontainers.junit.jupiter.Testcontainers;
 
 import com.adobe.testing.s3mock.testcontainers.S3MockContainer;
 
+import dev.hardwood.reader.ColumnReader;
 import dev.hardwood.reader.FilterPredicate;
 import dev.hardwood.reader.ParquetFileReader;
 import dev.hardwood.reader.RowReader;
@@ -50,6 +51,25 @@ public class S3SelectiveReadJfrTest {
     /// 9.6 KB, 3 columns (id, value, label), 3 row groups — smaller than tail cache.
     private static final String FILTER_PUSHDOWN_FILE = "filter_pushdown_int.parquet";
 
+    /// Generated on-the-fly: 8 INT64 columns, 20 row groups of 50000 rows each (1M rows total).
+    /// With 8 INT64 columns (64 bytes/row), batch size is ~98K rows.
+    /// ColumnAssemblyBuffer back-pressure (3 batches max) kicks in after ~295K rows (~6 row groups),
+    /// preventing the assembly thread from fetching all 20 row groups.
+    private static final String LAZY_ROWGROUP_FILE = "lazy_rowgroup_test.parquet";
+    private static final int LAZY_RG_COUNT = 20;
+    private static final int LAZY_RG_ROWS = 50_000;
+    private static final int LAZY_RG_COLUMNS = 8;
+
+    /// Generated on-the-fly: 1 row group, 500K rows, 8 INT64 columns, 1000 rows per page.
+    /// Each page is ~8 KB, 500 pages per column, ~4 MB per column, ~32 MB total.
+    /// With 8 INT64 columns (64 bytes/row), batch size is ~98K rows.
+    /// Back-pressure at ~3 batches ≈ 295K rows ≈ 295 of 500 pages per column.
+    /// Partial read should fetch significantly less than the full 32 MB.
+    private static final String LAZY_PAGE_FILE = "lazy_page_test.parquet";
+    private static final int LAZY_PAGE_ROWS = 500_000;
+    private static final int LAZY_PAGE_COLUMNS = 8;
+    private static final int LAZY_PAGE_ROWS_PER_PAGE = 1000;
+
     private static final Path TEST_RESOURCES = Path.of("").toAbsolutePath()
             .resolve("../core/src/test/resources").normalize();
 
@@ -73,6 +93,10 @@ public class S3SelectiveReadJfrTest {
                 TEST_RESOURCES.resolve(PAGE_INDEX_FILE)));
         source.api().putObject("test-bucket", FILTER_PUSHDOWN_FILE, Files.readAllBytes(
                 TEST_RESOURCES.resolve(FILTER_PUSHDOWN_FILE)));
+        source.api().putObject("test-bucket", LAZY_ROWGROUP_FILE,
+                TestParquetGenerator.generate(LAZY_RG_COUNT, LAZY_RG_ROWS, LAZY_RG_COLUMNS));
+        source.api().putObject("test-bucket", LAZY_PAGE_FILE,
+                TestParquetGenerator.generate(1, LAZY_PAGE_ROWS, LAZY_PAGE_COLUMNS, LAZY_PAGE_ROWS_PER_PAGE));
     }
 
     @AfterAll
@@ -189,6 +213,226 @@ public class S3SelectiveReadJfrTest {
         assertThat(scannedRowGroups)
                 .as("Only columns from the 1 kept row group should be scanned")
                 .isEqualTo(3);
+    }
+
+    // ==================== Lazy Row-Group Initialization ====================
+
+    @Test
+    @EnableEvent("dev.hardwood.RowGroupScanned")
+    void lazyInitScansRowGroupsIncrementally() throws Exception {
+        // Verify that lazy row-group initialization scans row groups incrementally
+        // (on demand) rather than all at once in initialize().
+        // The RowGroupScanned events should come from multiple row groups, confirming
+        // that PageCursor's tryLoadNextRowGroupBlocking() drives the scanning.
+        try (ParquetFileReader reader = ParquetFileReader.open(
+                source.inputFile("test-bucket", LAZY_ROWGROUP_FILE))) {
+            try (RowReader rows = reader.createRowReader()) {
+                while (rows.hasNext()) {
+                    rows.next();
+                }
+            }
+        }
+
+        jfrEvents.awaitEvents();
+
+        long scannedRowGroups = jfrEvents
+                .filter(e -> "dev.hardwood.RowGroupScanned".equals(e.getEventType().getName()))
+                .count();
+
+        // All row groups × all columns should be scanned for a full read
+        long expectedEvents = (long) LAZY_RG_COUNT * LAZY_RG_COLUMNS;
+        assertThat(scannedRowGroups)
+                .as("Full read should scan all row groups (%d RGs × %d columns)".formatted(
+                        LAZY_RG_COUNT, LAZY_RG_COLUMNS))
+                .isEqualTo(expectedEvents);
+    }
+
+    @Test
+    @EnableEvent("dev.hardwood.RowGroupScanned")
+    void partialReadDoesNotScanAllRowGroups() throws Exception {
+        // Read only 10 rows from a 1M-row file with 20 row groups.
+        // Back-pressure from ColumnAssemblyBuffer should prevent the assembly threads
+        // from scanning all 20 row groups.
+        jfrEvents.reset();
+
+        try (ParquetFileReader reader = ParquetFileReader.open(
+                source.inputFile("test-bucket", LAZY_ROWGROUP_FILE))) {
+            try (RowReader rows = reader.createRowReader()) {
+                int count = 0;
+                while (rows.hasNext() && count < 10) {
+                    rows.next();
+                    count++;
+                }
+                assertThat(count).isEqualTo(10);
+            }
+        }
+
+        jfrEvents.awaitEvents();
+
+        long scannedRowGroups = jfrEvents
+                .filter(e -> "dev.hardwood.RowGroupScanned".equals(e.getEventType().getName()))
+                .count();
+
+        // Print per-column row group counts for diagnostic visibility
+        java.util.Map<String, Long> rowGroupsPerColumn = jfrEvents
+                .filter(e -> "dev.hardwood.RowGroupScanned".equals(e.getEventType().getName()))
+                .collect(Collectors.groupingBy(e -> e.getString("column"), Collectors.counting()));
+        System.out.println("Partial read: " + scannedRowGroups + " RowGroupScanned events, per column: " + rowGroupsPerColumn);
+
+        // Full read produces 160 events (20 RGs × 8 columns).
+        // With batch size ~98K rows and ColumnAssemblyBuffer back-pressure (capacity 2 + 1 being
+        // filled = 3 batches ≈ 295K rows ≈ 6 row groups), the assembly threads should scan
+        // at most ~6 of 20 row groups before blocking. That's ~48 events (6 × 8 columns).
+        // Allow some margin for thread scheduling variance.
+        assertThat(scannedRowGroups)
+                .as("Partial read (10 rows) should scan far fewer row groups than full read (160)")
+                .isLessThanOrEqualTo(50);
+    }
+
+    @Test
+    void fullReadReturnsAllRows() throws Exception {
+        // Verify that lazy row-group initialization reads all data correctly
+        // across lazily-fetched row groups.
+        int expectedRows = LAZY_RG_COUNT * LAZY_RG_ROWS;
+        int rowCount = 0;
+        long lastC0 = -1;
+
+        try (ParquetFileReader reader = ParquetFileReader.open(
+                source.inputFile("test-bucket", LAZY_ROWGROUP_FILE))) {
+            try (RowReader rows = reader.createRowReader()) {
+                while (rows.hasNext()) {
+                    rows.next();
+                    lastC0 = rows.getLong("c0");
+                    rowCount++;
+                }
+            }
+        }
+
+        assertThat(rowCount)
+                .as("Full read should return all rows across all row groups")
+                .isEqualTo(expectedRows);
+        assertThat(lastC0)
+                .as("Last c0 value should be expectedRows - 1")
+                .isEqualTo(expectedRows - 1);
+    }
+
+    // ==================== Row Limit (Phase 3) ====================
+
+    @Test
+    @EnableEvent("dev.hardwood.RowGroupScanned")
+    void maxRowsSkipsUnneededRowGroups() throws Exception {
+        // lazy_rowgroup_test.parquet: 20 row groups × 50K rows × 8 columns.
+        // With maxRows=10, the reader knows from metadata that only 1 row group
+        // is needed (first RG has 50K rows > 10). It should never register the
+        // remaining 19 row groups with PageCursor.
+        jfrEvents.reset();
+
+        try (ParquetFileReader reader = ParquetFileReader.open(
+                source.inputFile("test-bucket", LAZY_ROWGROUP_FILE))) {
+            try (RowReader rows = reader.createRowReader(10)) {
+                int count = 0;
+                while (rows.hasNext()) {
+                    rows.next();
+                    count++;
+                }
+                assertThat(count).isEqualTo(10);
+            }
+        }
+
+        jfrEvents.awaitEvents();
+
+        long scannedEvents = jfrEvents
+                .filter(e -> "dev.hardwood.RowGroupScanned".equals(e.getEventType().getName()))
+                .count();
+
+        // With maxRows=10, totalRowGroups is set to 1 (first RG has 50K rows).
+        // Only 1 row group × 8 columns = 8 RowGroupScanned events.
+        // Without maxRows, we saw ~33-48 events (6 row groups due to back-pressure).
+        assertThat(scannedEvents)
+                .as("maxRows=10 should limit to 1 row group (8 events for 8 columns)")
+                .isLessThanOrEqualTo(8);
+    }
+
+    // ==================== Lazy Page Fetching (Phase 2) ====================
+
+    @Test
+    @EnableEvent("jdk.SocketRead")
+    void partialReadFromSingleRowGroupTransfersFewerBytes() throws Exception {
+        // lazy_page_test.parquet: 1 row group, 100K rows, 4 columns, 1000 rows/page.
+        // Phase 1 doesn't help (only 1 row group). Phase 2's windowed chunk reader
+        // should fetch only the first window (~256 KB) per column instead of the
+        // full ~800 KB per column.
+
+        // Full read: measure total bytes
+        long fullReadBytes = readAndMeasureSocketBytes(LAZY_PAGE_FILE,
+                ColumnProjection.all(), null);
+
+        // Partial read: 10 rows only
+        jfrEvents.reset();
+
+        try (ParquetFileReader reader = ParquetFileReader.open(
+                source.inputFile("test-bucket", LAZY_PAGE_FILE))) {
+            try (RowReader rows = reader.createRowReader()) {
+                int count = 0;
+                while (rows.hasNext() && count < 10) {
+                    rows.next();
+                    count++;
+                }
+            }
+        }
+
+        jfrEvents.awaitEvents();
+
+        long partialReadBytes = jfrEvents
+                .filter(e -> "jdk.SocketRead".equals(e.getEventType().getName()))
+                .mapToLong(e -> e.getLong("bytesRead"))
+                .sum();
+
+        System.out.println("Phase 2 test: full read " + fullReadBytes
+                + " bytes, partial read " + partialReadBytes + " bytes ("
+                + (partialReadBytes * 100 / fullReadBytes) + "%)");
+
+        // Back-pressure limits the assembly thread to ~3 batches (~295K of 500K rows).
+        // The windowed chunk reader fetches only the pages covered by those rows,
+        // so partial read should transfer well under 75% of full read bytes.
+        assertThat(partialReadBytes)
+                .as("Partial read (10 rows) from single row group should transfer significantly fewer bytes")
+                .isLessThan(fullReadBytes * 3 / 4);
+    }
+
+    // ==================== Lazy Row-Group Initialization (ColumnReader) ====================
+
+    @Test
+    @EnableEvent("dev.hardwood.RowGroupScanned")
+    void columnReaderPartialReadDoesNotScanAllRowGroups() throws Exception {
+        // ColumnReader has the same lazy row-group fetching as RowReader.
+        // Reading a single batch from one column should not scan all 20 row groups.
+        jfrEvents.reset();
+
+        try (ParquetFileReader reader = ParquetFileReader.open(
+                source.inputFile("test-bucket", LAZY_ROWGROUP_FILE));
+             ColumnReader col = reader.createColumnReader("c0")) {
+            assertThat(col.nextBatch()).isTrue();
+            // Consume one batch and close — don't read further
+        }
+
+        jfrEvents.awaitEvents();
+
+        long scannedEvents = jfrEvents
+                .filter(e -> "dev.hardwood.RowGroupScanned".equals(e.getEventType().getName()))
+                .count();
+
+        System.out.println("ColumnReader partial read: " + scannedEvents + " RowGroupScanned events");
+
+        // ColumnReader reads a single column, so each row group produces 1 RowGroupScanned event.
+        // Full read = 20 events. ColumnReader uses DEFAULT_BATCH_SIZE (262144 rows) — larger
+        // than the RowReader's adaptive size. With 50K rows per row group, one batch spans
+        // ~6 row groups. ColumnAssemblyBuffer back-pressure (3 batches in flight) limits
+        // to ~18 row groups, but the consumer reads only 1 batch and closes, so fewer are
+        // scanned in practice.
+        assertThat(scannedEvents)
+                .as("ColumnReader partial read should scan far fewer than all 20 row groups")
+                .isLessThanOrEqualTo(15);
     }
 
     // ==================== Helpers ====================

--- a/s3/src/test/java/dev/hardwood/s3/TestParquetGenerator.java
+++ b/s3/src/test/java/dev/hardwood/s3/TestParquetGenerator.java
@@ -1,0 +1,306 @@
+/*
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Copyright The original authors
+ *
+ *  Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package dev.hardwood.s3;
+
+import java.io.ByteArrayOutputStream;
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
+import java.nio.charset.StandardCharsets;
+
+/// Generates minimal valid Parquet files in pure Java for testing.
+///
+/// Produces files with REQUIRED INT64 columns, PLAIN encoding, no compression,
+/// data page v1. This is the simplest valid Parquet format — no nulls, no
+/// dictionary, no repetition/definition levels.
+final class TestParquetGenerator {
+
+    private static final byte[] MAGIC = "PAR1".getBytes(StandardCharsets.US_ASCII);
+
+    /// Generates a Parquet file with one page per column per row group.
+    static byte[] generate(int numRowGroups, int rowsPerRowGroup, int numColumns) {
+        return generate(numRowGroups, rowsPerRowGroup, numColumns, rowsPerRowGroup);
+    }
+
+    /// Generates a Parquet file with the given dimensions.
+    ///
+    /// Column values follow a deterministic pattern: column `cN` in row group `rg`
+    /// at row `r` has value `rg * rowsPerRowGroup + r + N * 1_000_000`.
+    /// This ensures each column has distinct, verifiable values.
+    ///
+    /// @param numRowGroups number of row groups
+    /// @param rowsPerRowGroup rows per row group
+    /// @param numColumns number of INT64 columns (named "c0", "c1", ...)
+    /// @param rowsPerPage rows per data page (smaller values = more pages per column)
+    /// @return the complete Parquet file as a byte array
+    static byte[] generate(int numRowGroups, int rowsPerRowGroup, int numColumns, int rowsPerPage) {
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        out.writeBytes(MAGIC);
+
+        // Track column chunk offsets and sizes for footer metadata
+        long[][] chunkOffsets = new long[numRowGroups][numColumns];
+        int[][] chunkSizes = new int[numRowGroups][numColumns];
+
+        for (int rg = 0; rg < numRowGroups; rg++) {
+            long rowOffset = (long) rg * rowsPerRowGroup;
+            for (int col = 0; col < numColumns; col++) {
+                chunkOffsets[rg][col] = out.size();
+                int chunkBytes = 0;
+
+                // Write multiple pages per column chunk
+                int rowsWritten = 0;
+                while (rowsWritten < rowsPerRowGroup) {
+                    int pageRows = Math.min(rowsPerPage, rowsPerRowGroup - rowsWritten);
+                    int pageDataSize = pageRows * 8;
+
+                    byte[] pageHeader = dataPageHeader(pageRows, pageDataSize);
+                    out.writeBytes(pageHeader);
+
+                    ByteBuffer buf = ByteBuffer.allocate(pageDataSize).order(ByteOrder.LITTLE_ENDIAN);
+                    for (int row = 0; row < pageRows; row++) {
+                        buf.putLong(rowOffset + rowsWritten + row + col * 1_000_000L);
+                    }
+                    out.writeBytes(buf.array());
+
+                    chunkBytes += pageHeader.length + pageDataSize;
+                    rowsWritten += pageRows;
+                }
+
+                chunkSizes[rg][col] = chunkBytes;
+            }
+        }
+
+        // Build and write footer
+        byte[] footer = fileMetaData(numRowGroups, rowsPerRowGroup, numColumns,
+                chunkOffsets, chunkSizes);
+        out.writeBytes(footer);
+
+        // Footer length (4 bytes LE) + trailing magic
+        ByteBuffer footerLen = ByteBuffer.allocate(4).order(ByteOrder.LITTLE_ENDIAN);
+        footerLen.putInt(footer.length);
+        out.writeBytes(footerLen.array());
+        out.writeBytes(MAGIC);
+
+        return out.toByteArray();
+    }
+
+    // ==================== Page Header ====================
+
+    /// Builds a DataPageV1 page header.
+    ///
+    /// PageHeader {
+    ///   1: type = DATA_PAGE (0)
+    ///   2: uncompressed_page_size
+    ///   3: compressed_page_size (= uncompressed, no compression)
+    ///   5: data_page_header {
+    ///     1: num_values
+    ///     2: encoding = PLAIN (0)
+    ///     3: definition_level_encoding = RLE (0)
+    ///     4: repetition_level_encoding = RLE (0)
+    ///   }
+    /// }
+    private static byte[] dataPageHeader(int numValues, int pageSize) {
+        ThriftWriter w = new ThriftWriter();
+        w.field(1, T_I32).zigzagI32(0);
+        w.field(2, T_I32).zigzagI32(pageSize);
+        w.field(3, T_I32).zigzagI32(pageSize);
+        w.field(5, T_STRUCT).pushStruct();
+        w.field(1, T_I32).zigzagI32(numValues);
+        w.field(2, T_I32).zigzagI32(0);
+        w.field(3, T_I32).zigzagI32(0);
+        w.field(4, T_I32).zigzagI32(0);
+        w.stop();
+        w.stop();
+        return w.toByteArray();
+    }
+
+    // ==================== Footer (FileMetaData) ====================
+
+    /// Builds the Thrift-encoded FileMetaData.
+    ///
+    /// FileMetaData {
+    ///   1: version = 2
+    ///   2: schema = [root, c0, c1, ...]
+    ///   3: num_rows
+    ///   4: row_groups = [...]
+    ///   6: created_by
+    /// }
+    private static byte[] fileMetaData(int numRowGroups, int rowsPerRowGroup,
+                                        int numColumns, long[][] chunkOffsets,
+                                        int[][] chunkSizes) {
+        ThriftWriter w = new ThriftWriter();
+
+        // version
+        w.field(1, T_I32).zigzagI32(2);
+
+        // schema: list<SchemaElement>
+        w.field(2, T_LIST).listHeader(T_STRUCT, numColumns + 1);
+        // Root element: name="schema", num_children=N
+        w.pushStruct();
+        w.field(4, T_BINARY).binary("schema");
+        w.field(5, T_I32).zigzagI32(numColumns);
+        w.stop();
+        // Column elements: type=INT64, repetition_type=REQUIRED, name="cN"
+        for (int col = 0; col < numColumns; col++) {
+            w.pushStruct();
+            w.field(1, T_I32).zigzagI32(2);  // type = INT64
+            w.field(3, T_I32).zigzagI32(0);  // repetition_type = REQUIRED
+            w.field(4, T_BINARY).binary("c" + col);
+            w.stop();
+        }
+
+        // num_rows
+        w.field(3, T_I64).zigzagI64((long) numRowGroups * rowsPerRowGroup);
+
+        // row_groups: list<RowGroup>
+        w.field(4, T_LIST).listHeader(T_STRUCT, numRowGroups);
+        for (int rg = 0; rg < numRowGroups; rg++) {
+            w.pushStruct();
+            // columns: list<ColumnChunk>
+            w.field(1, T_LIST).listHeader(T_STRUCT, numColumns);
+            for (int col = 0; col < numColumns; col++) {
+                w.pushStruct();
+                columnChunk(w, col, chunkOffsets[rg][col], chunkSizes[rg][col], rowsPerRowGroup);
+            }
+
+            // total_byte_size
+            long rgSize = 0;
+            for (int col = 0; col < numColumns; col++) {
+                rgSize += chunkSizes[rg][col];
+            }
+            w.field(2, T_I64).zigzagI64(rgSize);
+            // num_rows
+            w.field(3, T_I64).zigzagI64(rowsPerRowGroup);
+            w.stop();
+        }
+
+        // created_by
+        w.field(6, T_BINARY).binary("hardwood-test-generator");
+        w.stop();
+        return w.toByteArray();
+    }
+
+    /// Builds a ColumnChunk with embedded ColumnMetaData.
+    ///
+    /// ColumnChunk {
+    ///   2: file_offset
+    ///   3: meta_data {
+    ///     1: type = INT64 (2)
+    ///     2: encodings = [PLAIN]
+    ///     3: path_in_schema = ["cN"]
+    ///     4: codec = UNCOMPRESSED (0)
+    ///     5: num_values
+    ///     6: total_uncompressed_size
+    ///     7: total_compressed_size
+    ///     9: data_page_offset
+    ///   }
+    /// }
+    private static void columnChunk(ThriftWriter w, int colIndex, long offset,
+                                     int size, int numValues) {
+        w.field(2, T_I64).zigzagI64(offset);
+        w.field(3, T_STRUCT).pushStruct();
+        w.field(1, T_I32).zigzagI32(2);          // INT64
+        w.field(2, T_LIST).listHeader(T_I32, 1);
+        w.zigzagI32(0);                           // PLAIN
+        w.field(3, T_LIST).listHeader(T_BINARY, 1);
+        w.binary("c" + colIndex);
+        w.field(4, T_I32).zigzagI32(0);           // UNCOMPRESSED
+        w.field(5, T_I64).zigzagI64(numValues);
+        w.field(6, T_I64).zigzagI64(size);
+        w.field(7, T_I64).zigzagI64(size);
+        w.field(9, T_I64).zigzagI64(offset);
+        w.stop();
+        w.stop();
+    }
+
+    // ==================== Thrift Compact Protocol ====================
+
+    private static final int T_I32 = 0x05;
+    private static final int T_I64 = 0x06;
+    private static final int T_BINARY = 0x08;
+    private static final int T_LIST = 0x09;
+    private static final int T_STRUCT = 0x0C;
+
+    /// Minimal Thrift Compact Protocol writer.
+    ///
+    /// Reference: https://github.com/apache/thrift/blob/master/doc/specs/thrift-compact-protocol.md
+    static class ThriftWriter {
+        private final ByteArrayOutputStream buf = new ByteArrayOutputStream();
+        private int lastFieldId = 0;
+        private final java.util.ArrayDeque<Integer> fieldIdStack = new java.util.ArrayDeque<>();
+
+        ThriftWriter field(int fieldId, int typeId) {
+            int delta = fieldId - lastFieldId;
+            if (delta > 0 && delta <= 15) {
+                buf.write((delta << 4) | typeId);
+            }
+            else {
+                buf.write(typeId);
+                writeVarInt((fieldId << 1) ^ (fieldId >> 31));
+            }
+            lastFieldId = fieldId;
+            return this;
+        }
+
+        ThriftWriter zigzagI32(int value) {
+            writeVarInt((value << 1) ^ (value >> 31));
+            return this;
+        }
+
+        ThriftWriter zigzagI64(long value) {
+            writeVarInt((value << 1) ^ (value >> 63));
+            return this;
+        }
+
+        ThriftWriter binary(String s) {
+            byte[] bytes = s.getBytes(StandardCharsets.UTF_8);
+            writeVarInt(bytes.length);
+            buf.write(bytes, 0, bytes.length);
+            return this;
+        }
+
+        ThriftWriter listHeader(int elementType, int size) {
+            if (size <= 14) {
+                buf.write((size << 4) | elementType);
+            }
+            else {
+                buf.write(0xF0 | elementType);
+                writeVarInt(size);
+            }
+            return this;
+        }
+
+        /// Ends the current struct (writes STOP byte) and restores the enclosing
+        /// struct's field ID context from the stack.
+        void stop() {
+            buf.write(0x00);
+            lastFieldId = fieldIdStack.isEmpty() ? 0 : fieldIdStack.pop();
+        }
+
+        /// Saves current field context and resets for a new struct scope.
+        /// Call before writing fields of a nested struct (either via `field(N, T_STRUCT)`
+        /// or as a struct element in a list). The matching `stop()` restores the context.
+        ThriftWriter pushStruct() {
+            fieldIdStack.push(lastFieldId);
+            lastFieldId = 0;
+            return this;
+        }
+
+        byte[] toByteArray() {
+            return buf.toByteArray();
+        }
+
+        private void writeVarInt(long value) {
+            value = value & 0xFFFFFFFFFFFFFFFFL;
+            while (value > 0x7F) {
+                buf.write((int) (value & 0x7F) | 0x80);
+                value >>>= 7;
+            }
+            buf.write((int) value & 0x7F);
+        }
+    }
+}


### PR DESCRIPTION
1. Lazy row-group fetching
2. Lazy page fetching within a row group
3. Exposing maxRows at the API level to limit the number of scanned rows