### PR TITLE
#228 Simplify Record-Level Accessor Null Checks to Address Performance Regression

### DIFF
--- a/core/src/main/java/dev/hardwood/reader/AbstractRowReader.java
+++ b/core/src/main/java/dev/hardwood/reader/AbstractRowReader.java
@@ -54,6 +54,8 @@ abstract class AbstractRowReader implements RowReader {
     private Object[] flatValueArrays;
     private BitSet[] flatNulls;
     private boolean flatFastPath;
+    // Empty BitSet sentinel for required (non-nullable) columns, avoids null checks in accessors
+    private static final BitSet NO_NULLS = new BitSet(0);
     // Cached name-to-projected-index mapping for named fast path (built once)
     private StringToIntMap nameCache;
 
@@ -128,7 +130,8 @@ abstract class AbstractRowReader implements RowReader {
             flatNulls = new BitSet[columns];
         }
         for (int i = 0; i < columns; i++) {
-            flatNulls[i] = flatColumnData[i].nulls();
+            BitSet nulls = flatColumnData[i].nulls();
+            flatNulls[i] = nulls != null ? nulls : NO_NULLS;
             flatValueArrays[i] = extractValueArray(flatColumnData[i]);
         }
         // Build name cache once for named fast path
@@ -298,6 +301,14 @@ abstract class AbstractRowReader implements RowReader {
         return mapping;
     }
 
+    private void throwNullColumn(String name) {
+        throw new NullPointerException("Column '" + name + "' is null at row " + rowIndex);
+    }
+
+    private void throwNullColumn(int columnIndex) {
+        throw new NullPointerException("Column '" + dataView.getFieldName(columnIndex) + "' is null at row " + rowIndex);
+    }
+
     // ==================== Primitive Type Accessors ====================
 
     @Override
@@ -305,9 +316,8 @@ abstract class AbstractRowReader implements RowReader {
         if (flatFastPath) {
             int idx = nameCache.get(name);
             if (idx >= 0 && flatValueArrays[idx] instanceof int[]) {
-                BitSet n = flatNulls[idx];
-                if (n != null && n.get(rowIndex)) {
-                    throw new NullPointerException("Column '" + name + "' is null at row " + rowIndex);
+                if (flatNulls[idx].get(rowIndex)) {
+                    throwNullColumn(name);
                 }
                 return ((int[]) flatValueArrays[idx])[rowIndex];
             }
@@ -318,9 +328,8 @@ abstract class AbstractRowReader implements RowReader {
     @Override
     public int getInt(int columnIndex) {
         if (flatFastPath) {
-            BitSet n = flatNulls[columnIndex];
-            if (n != null && n.get(rowIndex)) {
-                throw new NullPointerException("Column '" + dataView.getFieldName(columnIndex) + "' is null at row " + rowIndex);
+            if (flatNulls[columnIndex].get(rowIndex)) {
+                throwNullColumn(columnIndex);
             }
             return ((int[]) flatValueArrays[columnIndex])[rowIndex];
         }
@@ -332,9 +341,8 @@ abstract class AbstractRowReader implements RowReader {
         if (flatFastPath) {
             int idx = nameCache.get(name);
             if (idx >= 0 && flatValueArrays[idx] instanceof long[]) {
-                BitSet n = flatNulls[idx];
-                if (n != null && n.get(rowIndex)) {
-                    throw new NullPointerException("Column '" + name + "' is null at row " + rowIndex);
+                if (flatNulls[idx].get(rowIndex)) {
+                    throwNullColumn(name);
                 }
                 return ((long[]) flatValueArrays[idx])[rowIndex];
             }
@@ -345,9 +353,8 @@ abstract class AbstractRowReader implements RowReader {
     @Override
     public long getLong(int columnIndex) {
         if (flatFastPath) {
-            BitSet n = flatNulls[columnIndex];
-            if (n != null && n.get(rowIndex)) {
-                throw new NullPointerException("Column '" + dataView.getFieldName(columnIndex) + "' is null at row " + rowIndex);
+            if (flatNulls[columnIndex].get(rowIndex)) {
+                throwNullColumn(columnIndex);
             }
             return ((long[]) flatValueArrays[columnIndex])[rowIndex];
         }
@@ -359,9 +366,8 @@ abstract class AbstractRowReader implements RowReader {
         if (flatFastPath) {
             int idx = nameCache.get(name);
             if (idx >= 0 && flatValueArrays[idx] instanceof float[]) {
-                BitSet n = flatNulls[idx];
-                if (n != null && n.get(rowIndex)) {
-                    throw new NullPointerException("Column '" + name + "' is null at row " + rowIndex);
+                if (flatNulls[idx].get(rowIndex)) {
+                    throwNullColumn(name);
                 }
                 return ((float[]) flatValueArrays[idx])[rowIndex];
             }
@@ -372,9 +378,8 @@ abstract class AbstractRowReader implements RowReader {
     @Override
     public float getFloat(int columnIndex) {
         if (flatFastPath) {
-            BitSet n = flatNulls[columnIndex];
-            if (n != null && n.get(rowIndex)) {
-                throw new NullPointerException("Column '" + dataView.getFieldName(columnIndex) + "' is null at row " + rowIndex);
+            if (flatNulls[columnIndex].get(rowIndex)) {
+                throwNullColumn(columnIndex);
             }
             return ((float[]) flatValueArrays[columnIndex])[rowIndex];
         }
@@ -386,9 +391,8 @@ abstract class AbstractRowReader implements RowReader {
         if (flatFastPath) {
             int idx = nameCache.get(name);
             if (idx >= 0 && flatValueArrays[idx] instanceof double[]) {
-                BitSet n = flatNulls[idx];
-                if (n != null && n.get(rowIndex)) {
-                    throw new NullPointerException("Column '" + name + "' is null at row " + rowIndex);
+                if (flatNulls[idx].get(rowIndex)) {
+                    throwNullColumn(name);
                 }
                 return ((double[]) flatValueArrays[idx])[rowIndex];
             }
@@ -399,9 +403,8 @@ abstract class AbstractRowReader implements RowReader {
     @Override
     public double getDouble(int columnIndex) {
         if (flatFastPath) {
-            BitSet n = flatNulls[columnIndex];
-            if (n != null && n.get(rowIndex)) {
-                throw new NullPointerException("Column '" + dataView.getFieldName(columnIndex) + "' is null at row " + rowIndex);
+            if (flatNulls[columnIndex].get(rowIndex)) {
+                throwNullColumn(columnIndex);
             }
             return ((double[]) flatValueArrays[columnIndex])[rowIndex];
         }
@@ -413,9 +416,8 @@ abstract class AbstractRowReader implements RowReader {
         if (flatFastPath) {
             int idx = nameCache.get(name);
             if (idx >= 0 && flatValueArrays[idx] instanceof boolean[]) {
-                BitSet n = flatNulls[idx];
-                if (n != null && n.get(rowIndex)) {
-                    throw new NullPointerException("Column '" + name + "' is null at row " + rowIndex);
+                if (flatNulls[idx].get(rowIndex)) {
+                    throwNullColumn(name);
                 }
                 return ((boolean[]) flatValueArrays[idx])[rowIndex];
             }
@@ -426,9 +428,8 @@ abstract class AbstractRowReader implements RowReader {
     @Override
     public boolean getBoolean(int columnIndex) {
         if (flatFastPath) {
-            BitSet n = flatNulls[columnIndex];
-            if (n != null && n.get(rowIndex)) {
-                throw new NullPointerException("Column '" + dataView.getFieldName(columnIndex) + "' is null at row " + rowIndex);
+            if (flatNulls[columnIndex].get(rowIndex)) {
+                throwNullColumn(columnIndex);
             }
             return ((boolean[]) flatValueArrays[columnIndex])[rowIndex];
         }
@@ -590,8 +591,7 @@ abstract class AbstractRowReader implements RowReader {
         if (flatFastPath) {
             int idx = nameCache.get(name);
             if (idx >= 0) {
-                BitSet n = flatNulls[idx];
-                return n != null && n.get(rowIndex);
+                return flatNulls[idx].get(rowIndex);
             }
         }
         return dataView.isNull(name);
@@ -600,8 +600,7 @@ abstract class AbstractRowReader implements RowReader {
     @Override
     public boolean isNull(int columnIndex) {
         if (flatFastPath) {
-            BitSet n = flatNulls[columnIndex];
-            return n != null && n.get(rowIndex);
+            return flatNulls[columnIndex].get(rowIndex);
         }
         return dataView.isNull(columnIndex);
     }


### PR DESCRIPTION
## Description
This pull request addresses a regression related to record-level filtering operations that could affect both filtered and non-filtered read operations as detailed in #228. After doing a bit of digging, it was determined that per-accessor null checks on the column null bitmap were the primary culprit, however some additional cleanup related to exception construction was performed as well.

## Key Changes
- Introduced a `NO_NULLS` bitset used to avoid unnecessary null checks for accessors by replacing null entries in the `flatNulls` array.
- Extracted the null-related exception construction within `AbstractRowReader` into separate functions (column and index respectively) as a general housekeeping improvement to avoid repeated calls.

## Verification and Testing
For testing purposes, all of the affected code is currently covered via `PredicatePushDownTest` and `PqRowApiTest` (for both null and non-null accessor paths) so the primary focus was on performance testing and throughput. 

With that in mind I took a historical-based approach by comparing the proposed fix to the previous regression as well as the commit prior to the changes introduced with the regression as seen below which revealed an equivalent comparison to the pre-regression state:

| State                   | AVG Time | Records/sec | vs Pre-regression |
|--------------------|----------|-------------|-------------------|
| **Pre-regression** | 2.31s    | 208.3M      | N/A                 |
| **Regression**     | 2.67s    | 180.1M      | -13.5%            |
| **Proposed Fix**            | 2.28s    | 210.7M      | +1.1%             |

All of the above numbers were run via `./mvnw test -Pperformance-test -pl performance-testing/end-to-end -Dtest="FlatPerformanceTest" -Dperf.contenders="HARDWOOD_MULTIFILE_INDEXED" -Dperf.runs=5` and can be seen in the chart below:

```
# Pre-Regression
Performance (all runs):
  Contender                          Time (s)     Records/sec   Records/sec/core       MB/sec
  -----------------------------------------------------------------------------------------------
  Hardwood (multifile indexed) [1]         1.78     270,510,711         19,322,194       3694.1
  Hardwood (multifile indexed) [2]         1.88     255,290,894         18,235,064       3486.2
  Hardwood (multifile indexed) [3]         2.62     183,645,683         13,117,549       2507.9
  Hardwood (multifile indexed) [4]         2.62     183,365,629         13,097,545       2504.0
  Hardwood (multifile indexed) [5]         2.64     182,046,951         13,003,354       2486.0
  Hardwood (multifile indexed) [AVG]         2.31     208,301,449         14,878,675       2844.6
                                   min: 1.78s, max: 2.64s, spread: 0.86s

# Regression
Performance (all runs):
  Contender                          Time (s)     Records/sec   Records/sec/core       MB/sec
  -----------------------------------------------------------------------------------------------
  Hardwood (multifile indexed) [1]         2.10     228,814,484         16,343,892       3124.7
  Hardwood (multifile indexed) [2]         2.44     197,522,811         14,108,772       2697.4
  Hardwood (multifile indexed) [3]         2.94     163,538,948         11,681,353       2233.3
  Hardwood (multifile indexed) [4]         2.96     162,544,118         11,610,294       2219.7
  Hardwood (multifile indexed) [5]         2.92     164,997,614         11,785,544       2253.2
  Hardwood (multifile indexed) [AVG]         2.67     180,137,845         12,866,989       2460.0
                                   min: 2.10s, max: 2.96s, spread: 0.86s

# Proposed Fix
Performance (all runs):
  Contender                          Time (s)     Records/sec   Records/sec/core       MB/sec
  -----------------------------------------------------------------------------------------------
  Hardwood (multifile indexed) [1]         1.89     255,155,462         18,225,390       3484.4
  Hardwood (multifile indexed) [2]         2.16     222,258,801         15,875,629       3035.2
  Hardwood (multifile indexed) [3]         2.46     195,594,976         13,971,070       2671.0
  Hardwood (multifile indexed) [4]         2.44     196,956,611         14,068,329       2689.6
  Hardwood (multifile indexed) [5]         2.47     194,802,772         13,914,484       2660.2
  Hardwood (multifile indexed) [AVG]         2.28     210,673,695         15,048,121       2877.0
                                   min: 1.89s, max: 2.47s, spread: 0.58s
```

## Checklist

- [X] Build via `./mvnw clean verify` passes
- [X] The commit message is prefixed with the issue key 
- [X] Code changes are covered by tests
- [X] If this PR adds or changes user-facing behavior, `docs/` has been updated
