### PR TITLE
#204 Support Legacy INT96-based Timestamp Compatibility 

### DIFF
--- a/cli/src/main/java/dev/hardwood/cli/internal/table/RowTable.java
+++ b/cli/src/main/java/dev/hardwood/cli/internal/table/RowTable.java
@@ -10,9 +10,7 @@ package dev.hardwood.cli.internal.table;
 import java.math.BigDecimal;
 import java.math.BigInteger;
 import java.nio.ByteBuffer;
-import java.nio.ByteOrder;
 import java.nio.charset.StandardCharsets;
-import java.time.Instant;
 import java.util.HexFormat;
 import java.util.List;
 import java.util.Set;
@@ -20,6 +18,7 @@ import java.util.UUID;
 
 import com.github.freva.asciitable.AsciiTable;
 
+import dev.hardwood.internal.conversion.LogicalTypeConverter;
 import dev.hardwood.metadata.LogicalType;
 import dev.hardwood.metadata.PhysicalType;
 import dev.hardwood.reader.RowReader;
@@ -120,17 +119,8 @@ public final class RowTable {
         };
     }
 
-    // INT96 = legacy Spark timestamp: bytes 0–7 LE nanoseconds-of-day, bytes 8–11 LE Julian day number
-    private static final long JULIAN_EPOCH_OFFSET_DAYS = 2440588L;
-
     private static String decodeInt96Timestamp(byte[] bytes) {
-        ByteBuffer bb = ByteBuffer.wrap(bytes).order(ByteOrder.LITTLE_ENDIAN);
-        long nanosOfDay = bb.getLong(0);
-        int julianDay = bb.getInt(8);
-        long daysFromEpoch = julianDay - JULIAN_EPOCH_OFFSET_DAYS;
-        long secondsFromEpoch = daysFromEpoch * 86400L + nanosOfDay / 1_000_000_000L;
-        long nanoAdjust = nanosOfDay % 1_000_000_000L;
-        return Instant.ofEpochSecond(secondsFromEpoch, nanoAdjust).toString();
+        return LogicalTypeConverter.int96ToInstant(bytes).toString();
     }
 
     private static String renderStruct(PqStruct struct, SchemaNode.GroupNode schemaNode) {

--- a/core/src/main/java/dev/hardwood/internal/conversion/LogicalTypeConverter.java
+++ b/core/src/main/java/dev/hardwood/internal/conversion/LogicalTypeConverter.java
@@ -10,6 +10,7 @@ package dev.hardwood.internal.conversion;
 import java.math.BigDecimal;
 import java.math.BigInteger;
 import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
 import java.nio.charset.StandardCharsets;
 import java.time.Instant;
 import java.time.LocalDate;
@@ -73,6 +74,24 @@ public class LogicalTypeConverter {
             case MICROS -> Instant.ofEpochSecond(rawValue / 1_000_000, (rawValue % 1_000_000) * 1000);
             case NANOS -> Instant.ofEpochSecond(rawValue / 1_000_000_000, rawValue % 1_000_000_000);
         };
+    }
+
+    /// Julian day number of the Unix epoch (1970-01-01).
+    private static final long JULIAN_EPOCH_OFFSET_DAYS = 2440588L;
+
+    /// Convert a legacy INT96 timestamp (12 bytes, little-endian: 8 bytes nanos-of-day,
+    /// 4 bytes Julian day) to an [Instant]. Used by Apache Spark and Hive.
+    public static Instant int96ToInstant(byte[] bytes) {
+        if (bytes.length != 12) {
+            throw new IllegalArgumentException("INT96 requires exactly 12 bytes, got " + bytes.length);
+        }
+        ByteBuffer bb = ByteBuffer.wrap(bytes).order(ByteOrder.LITTLE_ENDIAN);
+        long nanosOfDay = bb.getLong(0);
+        int julianDay = bb.getInt(8);
+        long epochDay = julianDay - JULIAN_EPOCH_OFFSET_DAYS;
+        long epochSecond = epochDay * 86400L + nanosOfDay / 1_000_000_000L;
+        long nanoAdjustment = nanosOfDay % 1_000_000_000L;
+        return Instant.ofEpochSecond(epochSecond, nanoAdjustment);
     }
 
     public static LocalTime convertToTime(Object value, PhysicalType physicalType,

--- a/core/src/main/java/dev/hardwood/internal/reader/FlatBatchDataView.java
+++ b/core/src/main/java/dev/hardwood/internal/reader/FlatBatchDataView.java
@@ -266,6 +266,10 @@ public final class FlatBatchDataView implements BatchDataView {
         }
         int originalIndex = projectedSchema.toOriginalIndex(projectedIndex);
         ColumnSchema col = schema.getColumn(originalIndex);
+        if (col.type() == PhysicalType.INT96) {
+            byte[] rawValue = ((FlatColumnData.ByteArrayColumn) columnData[projectedIndex]).get(rowIndex);
+            return LogicalTypeConverter.int96ToInstant(rawValue);
+        }
         long rawValue = ((FlatColumnData.LongColumn) columnData[projectedIndex]).get(rowIndex);
         return LogicalTypeConverter.convertToTimestamp(rawValue, col.type(),
                 (LogicalType.TimestampType) col.logicalType());

--- a/core/src/main/java/dev/hardwood/internal/reader/NestedBatchDataView.java
+++ b/core/src/main/java/dev/hardwood/internal/reader/NestedBatchDataView.java
@@ -17,6 +17,7 @@ import java.util.UUID;
 
 import dev.hardwood.internal.conversion.LogicalTypeConverter;
 import dev.hardwood.metadata.LogicalType;
+import dev.hardwood.metadata.PhysicalType;
 import dev.hardwood.row.PqDoubleList;
 import dev.hardwood.row.PqIntList;
 import dev.hardwood.row.PqList;
@@ -533,6 +534,9 @@ public final class NestedBatchDataView implements BatchDataView {
         Object rawValue = batchIndex.columns[projCol].getValue(valueIdx);
         if (resultClass.isInstance(rawValue)) {
             return resultClass.cast(rawValue);
+        }
+        if (resultClass == Instant.class && p.schema().type() == PhysicalType.INT96) {
+            return resultClass.cast(LogicalTypeConverter.int96ToInstant((byte[]) rawValue));
         }
         Object converted = LogicalTypeConverter.convert(rawValue, p.schema().type(), p.schema().logicalType());
         return resultClass.cast(converted);

--- a/core/src/main/java/dev/hardwood/internal/reader/ValueConverter.java
+++ b/core/src/main/java/dev/hardwood/internal/reader/ValueConverter.java
@@ -108,6 +108,9 @@ public final class ValueConverter {
         if (rawValue == null) {
             return null;
         }
+        if (schema instanceof SchemaNode.PrimitiveNode primitive && primitive.type() == PhysicalType.INT96) {
+            return LogicalTypeConverter.int96ToInstant((byte[]) rawValue);
+        }
         validateLogicalType(schema, LogicalType.TimestampType.class);
         return convertLogicalType(rawValue, schema, Instant.class);
     }
@@ -175,7 +178,7 @@ public final class ValueConverter {
             case BOOLEAN -> convertToBoolean(rawValue, schema);
             case BYTE_ARRAY -> convertToString(rawValue, schema);
             case FIXED_LEN_BYTE_ARRAY -> convertToBinary(rawValue, schema);
-            case INT96 -> rawValue; // Legacy timestamp, return as-is
+            case INT96 -> convertToTimestamp(rawValue, schema);
         };
     }
 

--- a/core/src/test/java/dev/hardwood/internal/conversion/LogicalTypeConverterTest.java
+++ b/core/src/test/java/dev/hardwood/internal/conversion/LogicalTypeConverterTest.java
@@ -1,0 +1,74 @@
+/*
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Copyright The original authors
+ *
+ *  Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package dev.hardwood.internal.conversion;
+
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
+import java.time.Instant;
+import java.util.HexFormat;
+import java.util.stream.Stream;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class LogicalTypeConverterTest {
+
+    static Stream<Arguments> int96Cases() {
+        return Stream.of(
+                // Unix epoch: nanos-of-day=0, julian-day=2440588 (JD of 1970-01-01)
+                Arguments.of("epoch", int96(0L, 2440588), Instant.EPOCH),
+                // One nanosecond after epoch
+                Arguments.of("epoch + 1 ns", int96(1L, 2440588), Instant.ofEpochSecond(0, 1)),
+                // Noon on the epoch: 12 * 3600 * 1e9 ns
+                Arguments.of("epoch noon", int96(12L * 3600 * 1_000_000_000L, 2440588),
+                        Instant.parse("1970-01-01T12:00:00Z")),
+                // Bytes copied from parquet-testing/data/int96_from_spark.parquet — row 0
+                Arguments.of("spark row 0", hex("002a1ed963430000978a2500"),
+                        Instant.parse("2024-01-01T20:34:56.123456Z")),
+                // row 1
+                Arguments.of("spark row 1", hex("00a0b83046030000978a2500"),
+                        Instant.parse("2024-01-01T01:00:00Z")),
+                // row 2 — late date
+                Arguments.of("spark row 2", hex("00e02992d20900002cfe5100"),
+                        Instant.parse("9999-12-31T03:00:00Z")),
+                // row 3
+                Arguments.of("spark row 3", hex("006096604e4b0000038c2500"),
+                        Instant.parse("2024-12-30T23:00:00Z")));
+    }
+
+    @ParameterizedTest(name = "{0}")
+    @MethodSource("int96Cases")
+    void int96ToInstantDecodesKnownValues(String name, byte[] bytes, Instant expected) {
+        assertThat(LogicalTypeConverter.int96ToInstant(bytes)).isEqualTo(expected);
+    }
+
+    @Test
+    void int96ToInstantRejectsWrongLength() {
+        assertThatThrownBy(() -> LogicalTypeConverter.int96ToInstant(new byte[11]))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("12 bytes");
+    }
+
+    /// Build a 12-byte INT96 payload from nanos-of-day and Julian day, little-endian.
+    private static byte[] int96(long nanosOfDay, int julianDay) {
+        byte[] bytes = new byte[12];
+        ByteBuffer.wrap(bytes).order(ByteOrder.LITTLE_ENDIAN)
+                .putLong(nanosOfDay)
+                .putInt(julianDay);
+        return bytes;
+    }
+
+    private static byte[] hex(String hex) {
+        return HexFormat.of().parseHex(hex);
+    }
+}

--- a/docs/content/usage.md
+++ b/docs/content/usage.md
@@ -144,7 +144,7 @@ All accessor methods are available in two forms:
 | `getString` | BYTE_ARRAY | STRING | `String` |
 | `getDate` | INT32 | DATE | `LocalDate` |
 | `getTime` | INT32 or INT64 | TIME | `LocalTime` |
-| `getTimestamp` | INT64 | TIMESTAMP | `Instant` |
+| `getTimestamp` | INT64 or INT96 | TIMESTAMP (not required for INT96) | `Instant` |
 | `getDecimal` | INT32, INT64, or FIXED_LEN_BYTE_ARRAY | DECIMAL | `BigDecimal` |
 | `getUuid` | FIXED_LEN_BYTE_ARRAY | UUID | `UUID` |
 | `getStruct` | | | `PqStruct` |

--- a/docs/content/usage.md
+++ b/docs/content/usage.md
@@ -144,7 +144,7 @@ All accessor methods are available in two forms:
 | `getString` | BYTE_ARRAY | STRING | `String` |
 | `getDate` | INT32 | DATE | `LocalDate` |
 | `getTime` | INT32 or INT64 | TIME | `LocalTime` |
-| `getTimestamp` | INT64 or INT96 | TIMESTAMP (not required for INT96) | `Instant` |
+| `getTimestamp` | INT64, or legacy INT96 | TIMESTAMP | `Instant` |
 | `getDecimal` | INT32, INT64, or FIXED_LEN_BYTE_ARRAY | DECIMAL | `BigDecimal` |
 | `getUuid` | FIXED_LEN_BYTE_ARRAY | UUID | `UUID` |
 | `getStruct` | | | `PqStruct` |
@@ -153,6 +153,8 @@ All accessor methods are available in two forms:
 | `isNull` | Any | Any | `boolean` |
 
 All methods are available as both `method(name)` and `method(index)`, except `getStruct`, `getList`, and `getMap` which are name-based only.
+
+**Legacy INT96 timestamps:** Parquet files written by older versions of Apache Spark and Hive store timestamps in the deprecated INT96 physical type without a TIMESTAMP logical type annotation. `getTimestamp` detects INT96 automatically and decodes it to an `Instant`; no caller-side handling is required.
 
 **Index-based access example:**
 

--- a/parquet-testing-runner/src/test/java/dev/hardwood/testing/Int96TimestampTest.java
+++ b/parquet-testing-runner/src/test/java/dev/hardwood/testing/Int96TimestampTest.java
@@ -1,0 +1,82 @@
+/*
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Copyright The original authors
+ *
+ *  Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package dev.hardwood.testing;
+
+import java.io.IOException;
+import java.nio.file.Path;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Stream;
+
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import dev.hardwood.InputFile;
+import dev.hardwood.metadata.PhysicalType;
+import dev.hardwood.reader.ParquetFileReader;
+import dev.hardwood.reader.RowReader;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/// End-to-end reader coverage for INT96: reads a Spark-produced file via `RowReader` and
+/// asserts that `getTimestamp` detects the INT96 physical type (no TIMESTAMP logical
+/// annotation) and returns the decoded [Instant]. Byte-level decoding is covered by
+/// `LogicalTypeConverterTest` in the core module.
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+class Int96TimestampTest {
+
+    private final List<Instant> values = new ArrayList<>();
+
+    @BeforeAll
+    void readAllRows() throws IOException {
+        Path file = ParquetTestingRepoCloner.getTestFile("data/int96_from_spark.parquet");
+        try (ParquetFileReader reader = ParquetFileReader.open(InputFile.of(file));
+             RowReader rowReader = reader.createRowReader()) {
+
+            assertThat(reader.getFileSchema().getColumn(0).type()).isEqualTo(PhysicalType.INT96);
+            assertThat(reader.getFileSchema().getColumn(0).logicalType()).isNull();
+
+            while (rowReader.hasNext()) {
+                rowReader.next();
+                values.add(rowReader.getTimestamp("a"));
+            }
+        }
+        assertThat(values).hasSize(6);
+    }
+
+    static Stream<Arguments> representableRows() {
+        return Stream.of(
+                Arguments.of(0, Instant.parse("2024-01-01T20:34:56.123456Z")),
+                Arguments.of(1, Instant.parse("2024-01-01T01:00:00Z")),
+                Arguments.of(2, Instant.parse("9999-12-31T03:00:00Z")),
+                Arguments.of(3, Instant.parse("2024-12-30T23:00:00Z")));
+    }
+
+    @ParameterizedTest(name = "row {0} -> {1}")
+    @MethodSource("representableRows")
+    void decodesRepresentableTimestamp(int rowIndex, Instant expected) {
+        assertThat(values.get(rowIndex)).isEqualTo(expected);
+    }
+
+    @Test
+    void nullRowReturnsNull() {
+        assertThat(values.get(4)).isNull();
+    }
+
+    @Test
+    void overflowRowStillReturnsInstant() {
+        // Row 5 is a year-290000 timestamp that Spark cannot faithfully encode in INT96
+        // (nanos-since-epoch overflows int64); we assert only that a value is returned.
+        assertThat(values.get(5)).isNotNull();
+    }
+}


### PR DESCRIPTION
## Description

This pull request addresses #204 by adding support for reading INT96 legacy timestamps as Instant values which can be commonly found in production data lakes (written by older versions of Apache Spark and Hive). The fix detects the INT96 physical type directly (matching parquet-java's behavior) and applies the standard Hive/Impala Julian-day conversion

## Key Changes
- Added `LogicalTypeConverter.int96ToInstant(byte[])` helper that decodes the 12-byte little-endian layout (8 bytes nanos-of-day + 4 bytes Julian day) into an Instant using the canonical epoch offset (2440588).
- Updated `ValueConverter.convertToTimestamp` and the related `convertValue()` dispatcher to route INT96 physical types through the new helper without requiring a TIMESTAMP logical annotation.
- Updated `FlatBatchDataView.getTimestamp` and `NestedBatchDataView.readLogicalType` to branch on `PhysicalType.INT96` so reader-level `getTimestamp()` works end-to-end for flat and nested columns.
- Consolidated the CLI's duplicate INT96 decoder in RowTable to delegate to the new core helper.
- Updated usage docs to detail INT96 as a supported physical type for `getTimestamp()`.

## Verification and Testing
Introduced a series of unit and Parquet-based tests (via `parquet-testing-runner`) to exercise functionality, various edge cases, and verify behavior against actual payloads. More specifically:
- Added `LogicalTypeConverterTest` in hardwood-core with parameterized cases covering synthetic edge values (e.g., epoch, epoch+1ns, noon, etc.) and four real INT96 byte payloads copied from existing test cases.
- Added `Int96TimestampTest` in parquet-testing-runner that exercises the full reader stack against the Spark-produced file to assert the various common behaviors and edge cases.

## Checklist

- [X] Build via `./mvnw clean verify` passes
- [X] The commit message is prefixed with the issue key
- [X] Code changes are covered by tests
- [X] If this PR adds or changes user-facing behavior, `docs/` has been updateds