### PR TITLE
Upgrade Testcontainers from 1.20.6 to 1.21.4

### DIFF
--- a/test-bom/pom.xml
+++ b/test-bom/pom.xml
@@ -92,7 +92,7 @@
       <dependency>
         <groupId>org.testcontainers</groupId>
         <artifactId>testcontainers-bom</artifactId>
-        <version>1.20.6</version>
+        <version>1.21.4</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>


### PR DESCRIPTION
## Problem

Testcontainers 1.20.6 uses a docker-java client that defaults to Docker API version 1.32, which is rejected by Docker Engine 29+ / Docker Desktop 4.36+ (minimum API version raised to 1.44). This causes a `BadRequestException (HTTP 400)` when Testcontainers tries to connect, making all S3 and CLI S3 tests fail locally on machines with newer Docker versions.

## Fix

Upgrade `testcontainers-bom` from 1.20.6 to 1.21.4 in `test-bom/pom.xml`. Version 1.21.4 ships an updated docker-java client that negotiates a compatible API version.

## Testing

Full `./mvnw clean verify` passes locally with Docker Desktop 4.69 (API v1.54).