### PR TITLE
#90 Include file name in all exceptions raised during reading

### DIFF
--- a/core/src/main/java/dev/hardwood/internal/ExceptionContext.java
+++ b/core/src/main/java/dev/hardwood/internal/ExceptionContext.java
@@ -1,0 +1,98 @@
+/*
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Copyright The original authors
+ *
+ *  Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package dev.hardwood.internal;
+
+import java.io.IOException;
+import java.io.UncheckedIOException;
+
+/// Utility for enriching exception messages with file-name context.
+///
+/// All exception-wrapping for file-name enrichment is centralised here so that
+/// reader classes share the same logic.
+public final class ExceptionContext {
+
+    private ExceptionContext() {
+    }
+
+    /// Amends the exception message with a `[fileName] ` prefix. Preserves the
+    /// original exception type and cause chain. Returns the original exception
+    /// unchanged when the file name is unavailable or the prefix is already present.
+    ///
+    /// @param fileName the originating file name, may be `null`
+    /// @param e        the exception to enrich
+    /// @return the enriched (or original) exception — never `null`
+    public static RuntimeException addFileContext(String fileName, RuntimeException e) {
+        if (fileName == null || fileName.isEmpty()) {
+            return e;
+        }
+        String prefix = "[" + fileName + "] ";
+        String originalMessage = e.getMessage();
+        if (hasFilePrefix(originalMessage)) {
+            return e;
+        }
+        // If the cause already carries file context (e.g. assembly-thread error
+        // propagated through CompletionException), don't add a second layer.
+        Throwable cause = e.getCause();
+        if (cause != null && hasFilePrefix(cause.getMessage())) {
+            return e;
+        }
+        String newMessage = prefix + (originalMessage != null ? originalMessage : e.getClass().getSimpleName());
+
+        if (e instanceof UncheckedIOException uio) {
+            // UncheckedIOException requires an IOException cause, so we can't chain
+            // the original UncheckedIOException as the cause. Preserve it as suppressed.
+            IOException ioCause = uio.getCause();
+            if (ioCause == null) {
+                ioCause = new IOException(originalMessage);
+            }
+            UncheckedIOException wrapped = new UncheckedIOException(newMessage, ioCause);
+            wrapped.addSuppressed(e);
+            return wrapped;
+        }
+        if (e.getClass() == IllegalArgumentException.class) {
+            return new IllegalArgumentException(newMessage, e);
+        }
+        if (e.getClass() == IllegalStateException.class) {
+            return new IllegalStateException(newMessage, e);
+        }
+        if (e.getClass() == NullPointerException.class) {
+            NullPointerException wrapped = new NullPointerException(newMessage);
+            wrapped.initCause(e);
+            return wrapped;
+        }
+        if (e.getClass() == IndexOutOfBoundsException.class) {
+            IndexOutOfBoundsException wrapped = new IndexOutOfBoundsException(newMessage);
+            wrapped.initCause(e);
+            return wrapped;
+        }
+
+        // For CompletionException and other wrapper types: try to preserve the type
+        // via the (String, Throwable) constructor. For CompletionException, preserve
+        // the original cause rather than wrapping the CompletionException itself,
+        // so the cause chain stays shallow.
+        try {
+            Throwable preservedCause = (e instanceof java.util.concurrent.CompletionException && e.getCause() != null)
+                    ? e.getCause()
+                    : e;
+            return e.getClass()
+                    .getConstructor(String.class, Throwable.class)
+                    .newInstance(newMessage, preservedCause);
+        }
+        catch (ReflectiveOperationException ignored) {
+            // Type cannot be preserved
+        }
+        return new RuntimeException(newMessage, e);
+    }
+
+    private static boolean hasFilePrefix(String message) {
+        if (message == null || message.isEmpty() || message.charAt(0) != '[') {
+            return false;
+        }
+        return message.indexOf("] ") > 1;
+    }
+}

--- a/core/src/main/java/dev/hardwood/internal/reader/BatchExchange.java
+++ b/core/src/main/java/dev/hardwood/internal/reader/BatchExchange.java
@@ -39,6 +39,7 @@ public class BatchExchange<B> {
         public Object values;
         public BitSet nulls;
         public int recordCount;
+        public String fileName;
     }
 
     private final ArrayBlockingQueue<B> readyQueue;

--- a/core/src/main/java/dev/hardwood/internal/reader/ColumnWorker.java
+++ b/core/src/main/java/dev/hardwood/internal/reader/ColumnWorker.java
@@ -15,6 +15,7 @@ import java.util.concurrent.atomic.AtomicReference;
 import java.util.concurrent.atomic.AtomicReferenceArray;
 import java.util.concurrent.locks.LockSupport;
 
+import dev.hardwood.internal.ExceptionContext;
 import dev.hardwood.internal.compression.DecompressorFactory;
 import dev.hardwood.metadata.PhysicalType;
 import dev.hardwood.schema.ColumnSchema;
@@ -57,6 +58,13 @@ public abstract class ColumnWorker<B> implements AutoCloseable {
     // === Circular reorder buffer: decode tasks write, drain thread reads ===
     private final AtomicReferenceArray<Page> reorderBuffer;
 
+    // === File name per reorder-buffer slot (retriever writes, drain reads) ===
+    // Visibility: retriever writes fileNameBuffer[slot] before submitting the
+    // decode task. The decode task's volatile write to reorderBuffer[slot]
+    // happens-after the retriever's plain write. The drain's volatile read of
+    // reorderBuffer[slot] sees the fileName via the happens-before chain.
+    private final String[] fileNameBuffer;
+
     // === Drain position (only modified by drain thread, read by retriever for throttle) ===
     private volatile int consumePosition;
 
@@ -80,6 +88,10 @@ public abstract class ColumnWorker<B> implements AutoCloseable {
     long totalRowsAssembled;
     B currentBatch;
     int rowsInCurrentBatch;
+
+    /// File name of the file being assembled into the current batch.
+    /// Written only by the drain thread.
+    String currentBatchFileName;
 
     // === Instrumentation (drain thread only) ===
     long publishBlockNanos;
@@ -108,6 +120,7 @@ public abstract class ColumnWorker<B> implements AutoCloseable {
         this.decodeExecutor = decodeExecutor;
         this.maxRows = maxRows;
         this.reorderBuffer = new AtomicReferenceArray<>(MAX_INFLIGHT_PAGES);
+        this.fileNameBuffer = new String[MAX_INFLIGHT_PAGES];
     }
 
     /// Initializes subclass-specific drain state (called at the start of `runDrain`).
@@ -224,6 +237,7 @@ public abstract class ColumnWorker<B> implements AutoCloseable {
                 int seq = nextSeq++;
                 totalPagesSubmitted++;
                 int slot = seq % MAX_INFLIGHT_PAGES;
+                fileNameBuffer[slot] = pageSource.getCurrentFileName();
                 PageInfo pi = pageInfo;
                 PageDecoder rdr = pageDecoder;
                 CompletableFuture<Void> f = CompletableFuture.runAsync(
@@ -253,7 +267,7 @@ public abstract class ColumnWorker<B> implements AutoCloseable {
                     sourceNanos / 1_000_000.0, throttleNanos / 1_000_000.0, throttleParks);
         }
         catch (Throwable t) {
-            signalError(t);
+            signalError(enrichWithFileName(t, pageSource.getCurrentFileName()));
         }
     }
 
@@ -267,7 +281,7 @@ public abstract class ColumnWorker<B> implements AutoCloseable {
             reorderBuffer.set(slot, page);
         }
         catch (Throwable t) {
-            signalError(t);
+            signalError(enrichWithFileName(t, fileNameBuffer[slot]));
         }
         LockSupport.unpark(drainThread);
     }
@@ -311,7 +325,7 @@ public abstract class ColumnWorker<B> implements AutoCloseable {
                     publishBlockNanos / 1_000_000.0);
         }
         catch (Throwable t) {
-            signalError(t);
+            signalError(enrichWithFileName(t, currentBatchFileName));
         }
     }
 
@@ -329,6 +343,17 @@ public abstract class ColumnWorker<B> implements AutoCloseable {
                 finishDrain();
                 return true;
             }
+
+            // Detect file boundary: flush the current batch when the file changes
+            // so that each batch is attributed to a single file.
+            String pageFileName = fileNameBuffer[slot];
+            if (pageFileName != null && currentBatchFileName != null
+                    && !pageFileName.equals(currentBatchFileName)
+                    && rowsInCurrentBatch > 0) {
+                publishCurrentBatch();
+            }
+            currentBatchFileName = pageFileName;
+
             assemblePage(page);
             consumePosition++;
             totalPagesDrained++;
@@ -358,6 +383,17 @@ public abstract class ColumnWorker<B> implements AutoCloseable {
         exchange.signalError(t);
         LockSupport.unpark(retrieverThread);
         LockSupport.unpark(drainThread);
+    }
+
+    /// Enriches a throwable with file-name context if possible.
+    private static Throwable enrichWithFileName(Throwable t, String fileName) {
+        if (fileName == null || fileName.isEmpty()) {
+            return t;
+        }
+        if (t instanceof RuntimeException re) {
+            return ExceptionContext.addFileContext(fileName, re);
+        }
+        return t;
     }
 
     private void unparkRetriever() {

--- a/core/src/main/java/dev/hardwood/internal/reader/FlatColumnWorker.java
+++ b/core/src/main/java/dev/hardwood/internal/reader/FlatColumnWorker.java
@@ -92,6 +92,7 @@ public class FlatColumnWorker extends ColumnWorker<BatchExchange.Batch> {
         currentBatch.nulls = (currentNulls != null && !currentNulls.isEmpty())
                 ? (BitSet) currentNulls.clone()
                 : null;
+        currentBatch.fileName = currentBatchFileName;
 
         long t0 = System.nanoTime();
         try {

--- a/core/src/main/java/dev/hardwood/internal/reader/FlatRowReader.java
+++ b/core/src/main/java/dev/hardwood/internal/reader/FlatRowReader.java
@@ -15,6 +15,7 @@ import java.time.LocalTime;
 import java.util.BitSet;
 import java.util.UUID;
 
+import dev.hardwood.internal.ExceptionContext;
 import dev.hardwood.internal.conversion.LogicalTypeConverter;
 import dev.hardwood.internal.predicate.ResolvedPredicate;
 import dev.hardwood.internal.util.StringToIntMap;
@@ -59,6 +60,9 @@ public final class FlatRowReader implements RowReader {
     private int rowIndex = -1;
     private int batchSize = 0;
     private boolean exhausted;
+
+    // File name from the current batch — used for exception enrichment
+    private String currentFileName;
 
     public FlatRowReader(BatchExchange<BatchExchange.Batch>[] exchanges, FlatColumnWorker[] columnWorkers,
                          FileSchema fileSchema, ProjectedSchema projectedSchema) {
@@ -153,13 +157,18 @@ public final class FlatRowReader implements RowReader {
 
     @Override
     public boolean hasNext() {
-        if (exhausted) {
-            return false;
+        try {
+            if (exhausted) {
+                return false;
+            }
+            if (rowIndex + 1 < batchSize) {
+                return true;
+            }
+            return loadNextBatch();
         }
-        if (rowIndex + 1 < batchSize) {
-            return true;
+        catch (RuntimeException e) {
+            throw wrapException(e);
         }
-        return loadNextBatch();
     }
 
     @Override
@@ -171,227 +180,367 @@ public final class FlatRowReader implements RowReader {
 
     @Override
     public boolean isNull(int columnIndex) {
-        return flatNulls[columnIndex].get(rowIndex);
+        try {
+            return flatNulls[columnIndex].get(rowIndex);
+        }
+        catch (RuntimeException e) {
+            throw wrapException(e);
+        }
     }
 
     @Override
     public boolean isNull(String name) {
-        return isNull(resolveIndex(name));
+        try {
+            return isNull(resolveIndex(name));
+        }
+        catch (RuntimeException e) {
+            throw wrapException(e);
+        }
     }
 
     // ==================== Primitive Accessors by Index ====================
 
     @Override
     public int getInt(int columnIndex) {
-        if (flatNulls[columnIndex].get(rowIndex)) {
-            throwNull(columnIndex);
+        try {
+            if (flatNulls[columnIndex].get(rowIndex)) {
+                throwNull(columnIndex);
+            }
+            return ((int[]) flatValueArrays[columnIndex])[rowIndex];
         }
-        return ((int[]) flatValueArrays[columnIndex])[rowIndex];
+        catch (RuntimeException e) {
+            throw wrapException(e);
+        }
     }
 
     @Override
     public long getLong(int columnIndex) {
-        if (flatNulls[columnIndex].get(rowIndex)) {
-            throwNull(columnIndex);
+        try {
+            if (flatNulls[columnIndex].get(rowIndex)) {
+                throwNull(columnIndex);
+            }
+            return ((long[]) flatValueArrays[columnIndex])[rowIndex];
         }
-        return ((long[]) flatValueArrays[columnIndex])[rowIndex];
+        catch (RuntimeException e) {
+            throw wrapException(e);
+        }
     }
 
     @Override
     public float getFloat(int columnIndex) {
-        if (flatNulls[columnIndex].get(rowIndex)) {
-            throwNull(columnIndex);
+        try {
+            if (flatNulls[columnIndex].get(rowIndex)) {
+                throwNull(columnIndex);
+            }
+            return ((float[]) flatValueArrays[columnIndex])[rowIndex];
         }
-        return ((float[]) flatValueArrays[columnIndex])[rowIndex];
+        catch (RuntimeException e) {
+            throw wrapException(e);
+        }
     }
 
     @Override
     public double getDouble(int columnIndex) {
-        if (flatNulls[columnIndex].get(rowIndex)) {
-            throwNull(columnIndex);
+        try {
+            if (flatNulls[columnIndex].get(rowIndex)) {
+                throwNull(columnIndex);
+            }
+            return ((double[]) flatValueArrays[columnIndex])[rowIndex];
         }
-        return ((double[]) flatValueArrays[columnIndex])[rowIndex];
+        catch (RuntimeException e) {
+            throw wrapException(e);
+        }
     }
 
     @Override
     public boolean getBoolean(int columnIndex) {
-        if (flatNulls[columnIndex].get(rowIndex)) {
-            throwNull(columnIndex);
+        try {
+            if (flatNulls[columnIndex].get(rowIndex)) {
+                throwNull(columnIndex);
+            }
+            return ((boolean[]) flatValueArrays[columnIndex])[rowIndex];
         }
-        return ((boolean[]) flatValueArrays[columnIndex])[rowIndex];
+        catch (RuntimeException e) {
+            throw wrapException(e);
+        }
     }
 
     // ==================== Primitive Accessors by Name ====================
 
     @Override
     public int getInt(String name) {
-        return getInt(resolveAndValidate(name, PhysicalType.INT32));
+        try {
+            return getInt(resolveAndValidate(name, PhysicalType.INT32));
+        }
+        catch (RuntimeException e) {
+            throw wrapException(e);
+        }
     }
 
     @Override
     public long getLong(String name) {
-        return getLong(resolveAndValidate(name, PhysicalType.INT64));
+        try {
+            return getLong(resolveAndValidate(name, PhysicalType.INT64));
+        }
+        catch (RuntimeException e) {
+            throw wrapException(e);
+        }
     }
 
     @Override
     public float getFloat(String name) {
-        return getFloat(resolveAndValidate(name, PhysicalType.FLOAT));
+        try {
+            return getFloat(resolveAndValidate(name, PhysicalType.FLOAT));
+        }
+        catch (RuntimeException e) {
+            throw wrapException(e);
+        }
     }
 
     @Override
     public double getDouble(String name) {
-        return getDouble(resolveAndValidate(name, PhysicalType.DOUBLE));
+        try {
+            return getDouble(resolveAndValidate(name, PhysicalType.DOUBLE));
+        }
+        catch (RuntimeException e) {
+            throw wrapException(e);
+        }
     }
 
     @Override
     public boolean getBoolean(String name) {
-        return getBoolean(resolveAndValidate(name, PhysicalType.BOOLEAN));
+        try {
+            return getBoolean(resolveAndValidate(name, PhysicalType.BOOLEAN));
+        }
+        catch (RuntimeException e) {
+            throw wrapException(e);
+        }
     }
 
     // ==================== String / Binary ====================
 
     @Override
     public String getString(int columnIndex) {
-        if (isNull(columnIndex)) {
-            return null;
+        try {
+            if (isNull(columnIndex)) {
+                return null;
+            }
+            return new String(((byte[][]) flatValueArrays[columnIndex])[rowIndex], StandardCharsets.UTF_8);
         }
-        return new String(((byte[][]) flatValueArrays[columnIndex])[rowIndex], StandardCharsets.UTF_8);
+        catch (RuntimeException e) {
+            throw wrapException(e);
+        }
     }
 
     @Override
     public String getString(String name) {
-        return getString(resolveIndex(name));
+        try {
+            return getString(resolveIndex(name));
+        }
+        catch (RuntimeException e) {
+            throw wrapException(e);
+        }
     }
 
     @Override
     public byte[] getBinary(int columnIndex) {
-        if (isNull(columnIndex)) {
-            return null;
+        try {
+            if (isNull(columnIndex)) {
+                return null;
+            }
+            return ((byte[][]) flatValueArrays[columnIndex])[rowIndex];
         }
-        return ((byte[][]) flatValueArrays[columnIndex])[rowIndex];
+        catch (RuntimeException e) {
+            throw wrapException(e);
+        }
     }
 
     @Override
     public byte[] getBinary(String name) {
-        return getBinary(resolveIndex(name));
+        try {
+            return getBinary(resolveIndex(name));
+        }
+        catch (RuntimeException e) {
+            throw wrapException(e);
+        }
     }
 
     // ==================== Logical Type Accessors ====================
 
     @Override
     public LocalDate getDate(int columnIndex) {
-        if (isNull(columnIndex)) {
-            return null;
+        try {
+            if (isNull(columnIndex)) {
+                return null;
+            }
+            int rawValue = ((int[]) flatValueArrays[columnIndex])[rowIndex];
+            return LogicalTypeConverter.convertToDate(rawValue, physicalTypes[columnIndex]);
         }
-        int rawValue = ((int[]) flatValueArrays[columnIndex])[rowIndex];
-        return LogicalTypeConverter.convertToDate(rawValue, physicalTypes[columnIndex]);
+        catch (RuntimeException e) {
+            throw wrapException(e);
+        }
     }
 
     @Override
     public LocalDate getDate(String name) {
-        return getDate(resolveIndex(name));
+        try {
+            return getDate(resolveIndex(name));
+        }
+        catch (RuntimeException e) {
+            throw wrapException(e);
+        }
     }
 
     @Override
     public LocalTime getTime(int columnIndex) {
-        if (isNull(columnIndex)) {
-            return null;
+        try {
+            if (isNull(columnIndex)) {
+                return null;
+            }
+            ColumnSchema col = columnSchemas[columnIndex];
+            Object rawValue;
+            if (col.type() == PhysicalType.INT32) {
+                rawValue = ((int[]) flatValueArrays[columnIndex])[rowIndex];
+            }
+            else {
+                rawValue = ((long[]) flatValueArrays[columnIndex])[rowIndex];
+            }
+            return LogicalTypeConverter.convertToTime(rawValue, col.type(),
+                    (LogicalType.TimeType) col.logicalType());
         }
-        ColumnSchema col = columnSchemas[columnIndex];
-        Object rawValue;
-        if (col.type() == PhysicalType.INT32) {
-            rawValue = ((int[]) flatValueArrays[columnIndex])[rowIndex];
+        catch (RuntimeException e) {
+            throw wrapException(e);
         }
-        else {
-            rawValue = ((long[]) flatValueArrays[columnIndex])[rowIndex];
-        }
-        return LogicalTypeConverter.convertToTime(rawValue, col.type(),
-                (LogicalType.TimeType) col.logicalType());
     }
 
     @Override
     public LocalTime getTime(String name) {
-        return getTime(resolveIndex(name));
+        try {
+            return getTime(resolveIndex(name));
+        }
+        catch (RuntimeException e) {
+            throw wrapException(e);
+        }
     }
 
     @Override
     public Instant getTimestamp(int columnIndex) {
-        if (isNull(columnIndex)) {
-            return null;
+        try {
+            if (isNull(columnIndex)) {
+                return null;
+            }
+            ColumnSchema col = columnSchemas[columnIndex];
+            if (col.type() == PhysicalType.INT96) {
+                byte[] rawValue = ((byte[][]) flatValueArrays[columnIndex])[rowIndex];
+                return LogicalTypeConverter.int96ToInstant(rawValue);
+            }
+            long rawValue = ((long[]) flatValueArrays[columnIndex])[rowIndex];
+            return LogicalTypeConverter.convertToTimestamp(rawValue, col.type(),
+                    (LogicalType.TimestampType) col.logicalType());
         }
-        ColumnSchema col = columnSchemas[columnIndex];
-        if (col.type() == PhysicalType.INT96) {
-            byte[] rawValue = ((byte[][]) flatValueArrays[columnIndex])[rowIndex];
-            return LogicalTypeConverter.int96ToInstant(rawValue);
+        catch (RuntimeException e) {
+            throw wrapException(e);
         }
-        long rawValue = ((long[]) flatValueArrays[columnIndex])[rowIndex];
-        return LogicalTypeConverter.convertToTimestamp(rawValue, col.type(),
-                (LogicalType.TimestampType) col.logicalType());
     }
 
     @Override
     public Instant getTimestamp(String name) {
-        return getTimestamp(resolveIndex(name));
+        try {
+            return getTimestamp(resolveIndex(name));
+        }
+        catch (RuntimeException e) {
+            throw wrapException(e);
+        }
     }
 
     @Override
     public BigDecimal getDecimal(int columnIndex) {
-        if (isNull(columnIndex)) {
-            return null;
+        try {
+            if (isNull(columnIndex)) {
+                return null;
+            }
+            ColumnSchema col = columnSchemas[columnIndex];
+            Object rawValue = switch (col.type()) {
+                case INT32 -> ((int[]) flatValueArrays[columnIndex])[rowIndex];
+                case INT64 -> ((long[]) flatValueArrays[columnIndex])[rowIndex];
+                case BYTE_ARRAY, FIXED_LEN_BYTE_ARRAY -> ((byte[][]) flatValueArrays[columnIndex])[rowIndex];
+                default -> throw new IllegalArgumentException(
+                        "Unexpected physical type for DECIMAL: " + col.type());
+            };
+            return LogicalTypeConverter.convertToDecimal(rawValue, col.type(),
+                    (LogicalType.DecimalType) col.logicalType());
         }
-        ColumnSchema col = columnSchemas[columnIndex];
-        Object rawValue = switch (col.type()) {
-            case INT32 -> ((int[]) flatValueArrays[columnIndex])[rowIndex];
-            case INT64 -> ((long[]) flatValueArrays[columnIndex])[rowIndex];
-            case BYTE_ARRAY, FIXED_LEN_BYTE_ARRAY -> ((byte[][]) flatValueArrays[columnIndex])[rowIndex];
-            default -> throw new IllegalArgumentException(
-                    "Unexpected physical type for DECIMAL: " + col.type());
-        };
-        return LogicalTypeConverter.convertToDecimal(rawValue, col.type(),
-                (LogicalType.DecimalType) col.logicalType());
+        catch (RuntimeException e) {
+            throw wrapException(e);
+        }
     }
 
     @Override
     public BigDecimal getDecimal(String name) {
-        return getDecimal(resolveIndex(name));
+        try {
+            return getDecimal(resolveIndex(name));
+        }
+        catch (RuntimeException e) {
+            throw wrapException(e);
+        }
     }
 
     @Override
     public UUID getUuid(int columnIndex) {
-        if (isNull(columnIndex)) {
-            return null;
+        try {
+            if (isNull(columnIndex)) {
+                return null;
+            }
+            return LogicalTypeConverter.convertToUuid(
+                    ((byte[][]) flatValueArrays[columnIndex])[rowIndex],
+                    physicalTypes[columnIndex]);
         }
-        return LogicalTypeConverter.convertToUuid(
-                ((byte[][]) flatValueArrays[columnIndex])[rowIndex],
-                physicalTypes[columnIndex]);
+        catch (RuntimeException e) {
+            throw wrapException(e);
+        }
     }
 
     @Override
     public UUID getUuid(String name) {
-        return getUuid(resolveIndex(name));
+        try {
+            return getUuid(resolveIndex(name));
+        }
+        catch (RuntimeException e) {
+            throw wrapException(e);
+        }
     }
 
     // ==================== Generic Value ====================
 
     @Override
     public Object getValue(int columnIndex) {
-        if (isNull(columnIndex)) {
-            return null;
+        try {
+            if (isNull(columnIndex)) {
+                return null;
+            }
+            return switch (physicalTypes[columnIndex]) {
+                case INT32 -> ((int[]) flatValueArrays[columnIndex])[rowIndex];
+                case INT64 -> ((long[]) flatValueArrays[columnIndex])[rowIndex];
+                case FLOAT -> ((float[]) flatValueArrays[columnIndex])[rowIndex];
+                case DOUBLE -> ((double[]) flatValueArrays[columnIndex])[rowIndex];
+                case BOOLEAN -> ((boolean[]) flatValueArrays[columnIndex])[rowIndex];
+                case BYTE_ARRAY, FIXED_LEN_BYTE_ARRAY, INT96 ->
+                        ((byte[][]) flatValueArrays[columnIndex])[rowIndex];
+            };
         }
-        return switch (physicalTypes[columnIndex]) {
-            case INT32 -> ((int[]) flatValueArrays[columnIndex])[rowIndex];
-            case INT64 -> ((long[]) flatValueArrays[columnIndex])[rowIndex];
-            case FLOAT -> ((float[]) flatValueArrays[columnIndex])[rowIndex];
-            case DOUBLE -> ((double[]) flatValueArrays[columnIndex])[rowIndex];
-            case BOOLEAN -> ((boolean[]) flatValueArrays[columnIndex])[rowIndex];
-            case BYTE_ARRAY, FIXED_LEN_BYTE_ARRAY, INT96 ->
-                    ((byte[][]) flatValueArrays[columnIndex])[rowIndex];
-        };
+        catch (RuntimeException e) {
+            throw wrapException(e);
+        }
     }
 
     @Override
     public Object getValue(String name) {
-        return getValue(resolveIndex(name));
+        try {
+            return getValue(resolveIndex(name));
+        }
+        catch (RuntimeException e) {
+            throw wrapException(e);
+        }
     }
 
     // ==================== Nested (not supported for flat) ====================
@@ -459,6 +608,7 @@ public final class FlatRowReader implements RowReader {
             previousBatches[i] = batch;
             if (i == 0) {
                 batchSize = batch.recordCount;
+                currentFileName = batch.fileName;
             }
         }
         rowIndex = -1;
@@ -487,6 +637,10 @@ public final class FlatRowReader implements RowReader {
     }
 
     // ==================== Internal ====================
+
+    private RuntimeException wrapException(RuntimeException e) {
+        return ExceptionContext.addFileContext(currentFileName, e);
+    }
 
     private int resolveIndex(String name) {
         int index = nameToIndex.get(name);

--- a/core/src/main/java/dev/hardwood/internal/reader/NestedBatch.java
+++ b/core/src/main/java/dev/hardwood/internal/reader/NestedBatch.java
@@ -30,6 +30,9 @@ public final class NestedBatch {
     public int[] repetitionLevels;
     public int[] recordOffsets;
 
+    // File name of the originating file (set by drain before publish)
+    public String fileName;
+
     // Pre-computed index (computed by drain before publish)
     public BitSet elementNulls;
     public int[][] multiLevelOffsets;

--- a/core/src/main/java/dev/hardwood/internal/reader/NestedColumnWorker.java
+++ b/core/src/main/java/dev/hardwood/internal/reader/NestedColumnWorker.java
@@ -143,6 +143,7 @@ public class NestedColumnWorker extends ColumnWorker<NestedBatch> {
         currentBatch.repetitionLevels = Arrays.copyOf(nestedRepLevels, nestedValueCount);
         currentBatch.recordOffsets = Arrays.copyOf(nestedRecordOffsets, rowsInCurrentBatch);
         currentBatch.values = trimValues(nestedValues, nestedValueCount);
+        currentBatch.fileName = currentBatchFileName;
 
         // Compute index structures before publishing so the consumer thread
         // doesn't need to do expensive index computation.

--- a/core/src/main/java/dev/hardwood/internal/reader/NestedRowReader.java
+++ b/core/src/main/java/dev/hardwood/internal/reader/NestedRowReader.java
@@ -13,6 +13,7 @@ import java.time.LocalDate;
 import java.time.LocalTime;
 import java.util.UUID;
 
+import dev.hardwood.internal.ExceptionContext;
 import dev.hardwood.internal.predicate.ResolvedPredicate;
 import dev.hardwood.metadata.PhysicalType;
 import dev.hardwood.reader.RowReader;
@@ -48,6 +49,9 @@ public final class NestedRowReader implements RowReader {
     private int rowIndex = -1;
     private int batchSize = 0;
     private boolean exhausted;
+
+    // File name from the current batch — used for exception enrichment
+    private String currentFileName;
 
 
     NestedRowReader(BatchExchange<NestedBatch>[] exchanges, NestedColumnWorker[] columnWorkers,
@@ -141,13 +145,18 @@ public final class NestedRowReader implements RowReader {
 
     @Override
     public boolean hasNext() {
-        if (exhausted) {
-            return false;
+        try {
+            if (exhausted) {
+                return false;
+            }
+            if (rowIndex + 1 < batchSize) {
+                return true;
+            }
+            return loadNextBatch();
         }
-        if (rowIndex + 1 < batchSize) {
-            return true;
+        catch (RuntimeException e) {
+            throw wrapException(e);
         }
-        return loadNextBatch();
     }
 
     @Override
@@ -194,6 +203,7 @@ public final class NestedRowReader implements RowReader {
         }
 
         batchSize = batches[0].recordCount;
+        currentFileName = batches[0].fileName;
 
         // Index structures are pre-computed by the drain — just assemble the view
         dataView.setBatchData(batches, columnSchemas);
@@ -203,50 +213,50 @@ public final class NestedRowReader implements RowReader {
 
     // ==================== Accessors (delegate to NestedBatchDataView) ====================
 
-    @Override public boolean isNull(int i) { return dataView.isNull(i); }
-    @Override public boolean isNull(String name) { return dataView.isNull(name); }
+    @Override public boolean isNull(int i) { try { return dataView.isNull(i); } catch (RuntimeException e) { throw wrapException(e); } }
+    @Override public boolean isNull(String name) { try { return dataView.isNull(name); } catch (RuntimeException e) { throw wrapException(e); } }
 
-    @Override public int getInt(int i) { return dataView.getInt(i); }
-    @Override public int getInt(String name) { return dataView.getInt(name); }
-    @Override public long getLong(int i) { return dataView.getLong(i); }
-    @Override public long getLong(String name) { return dataView.getLong(name); }
-    @Override public float getFloat(int i) { return dataView.getFloat(i); }
-    @Override public float getFloat(String name) { return dataView.getFloat(name); }
-    @Override public double getDouble(int i) { return dataView.getDouble(i); }
-    @Override public double getDouble(String name) { return dataView.getDouble(name); }
-    @Override public boolean getBoolean(int i) { return dataView.getBoolean(i); }
-    @Override public boolean getBoolean(String name) { return dataView.getBoolean(name); }
+    @Override public int getInt(int i) { try { return dataView.getInt(i); } catch (RuntimeException e) { throw wrapException(e); } }
+    @Override public int getInt(String name) { try { return dataView.getInt(name); } catch (RuntimeException e) { throw wrapException(e); } }
+    @Override public long getLong(int i) { try { return dataView.getLong(i); } catch (RuntimeException e) { throw wrapException(e); } }
+    @Override public long getLong(String name) { try { return dataView.getLong(name); } catch (RuntimeException e) { throw wrapException(e); } }
+    @Override public float getFloat(int i) { try { return dataView.getFloat(i); } catch (RuntimeException e) { throw wrapException(e); } }
+    @Override public float getFloat(String name) { try { return dataView.getFloat(name); } catch (RuntimeException e) { throw wrapException(e); } }
+    @Override public double getDouble(int i) { try { return dataView.getDouble(i); } catch (RuntimeException e) { throw wrapException(e); } }
+    @Override public double getDouble(String name) { try { return dataView.getDouble(name); } catch (RuntimeException e) { throw wrapException(e); } }
+    @Override public boolean getBoolean(int i) { try { return dataView.getBoolean(i); } catch (RuntimeException e) { throw wrapException(e); } }
+    @Override public boolean getBoolean(String name) { try { return dataView.getBoolean(name); } catch (RuntimeException e) { throw wrapException(e); } }
 
-    @Override public String getString(int i) { return dataView.getString(i); }
-    @Override public String getString(String name) { return dataView.getString(name); }
-    @Override public byte[] getBinary(int i) { return dataView.getBinary(i); }
-    @Override public byte[] getBinary(String name) { return dataView.getBinary(name); }
-    @Override public LocalDate getDate(int i) { return dataView.getDate(i); }
-    @Override public LocalDate getDate(String name) { return dataView.getDate(name); }
-    @Override public LocalTime getTime(int i) { return dataView.getTime(i); }
-    @Override public LocalTime getTime(String name) { return dataView.getTime(name); }
-    @Override public Instant getTimestamp(int i) { return dataView.getTimestamp(i); }
-    @Override public Instant getTimestamp(String name) { return dataView.getTimestamp(name); }
-    @Override public BigDecimal getDecimal(int i) { return dataView.getDecimal(i); }
-    @Override public BigDecimal getDecimal(String name) { return dataView.getDecimal(name); }
-    @Override public UUID getUuid(int i) { return dataView.getUuid(i); }
-    @Override public UUID getUuid(String name) { return dataView.getUuid(name); }
+    @Override public String getString(int i) { try { return dataView.getString(i); } catch (RuntimeException e) { throw wrapException(e); } }
+    @Override public String getString(String name) { try { return dataView.getString(name); } catch (RuntimeException e) { throw wrapException(e); } }
+    @Override public byte[] getBinary(int i) { try { return dataView.getBinary(i); } catch (RuntimeException e) { throw wrapException(e); } }
+    @Override public byte[] getBinary(String name) { try { return dataView.getBinary(name); } catch (RuntimeException e) { throw wrapException(e); } }
+    @Override public LocalDate getDate(int i) { try { return dataView.getDate(i); } catch (RuntimeException e) { throw wrapException(e); } }
+    @Override public LocalDate getDate(String name) { try { return dataView.getDate(name); } catch (RuntimeException e) { throw wrapException(e); } }
+    @Override public LocalTime getTime(int i) { try { return dataView.getTime(i); } catch (RuntimeException e) { throw wrapException(e); } }
+    @Override public LocalTime getTime(String name) { try { return dataView.getTime(name); } catch (RuntimeException e) { throw wrapException(e); } }
+    @Override public Instant getTimestamp(int i) { try { return dataView.getTimestamp(i); } catch (RuntimeException e) { throw wrapException(e); } }
+    @Override public Instant getTimestamp(String name) { try { return dataView.getTimestamp(name); } catch (RuntimeException e) { throw wrapException(e); } }
+    @Override public BigDecimal getDecimal(int i) { try { return dataView.getDecimal(i); } catch (RuntimeException e) { throw wrapException(e); } }
+    @Override public BigDecimal getDecimal(String name) { try { return dataView.getDecimal(name); } catch (RuntimeException e) { throw wrapException(e); } }
+    @Override public UUID getUuid(int i) { try { return dataView.getUuid(i); } catch (RuntimeException e) { throw wrapException(e); } }
+    @Override public UUID getUuid(String name) { try { return dataView.getUuid(name); } catch (RuntimeException e) { throw wrapException(e); } }
 
-    @Override public Object getValue(int i) { return dataView.getValue(i); }
-    @Override public Object getValue(String name) { return dataView.getValue(name); }
+    @Override public Object getValue(int i) { try { return dataView.getValue(i); } catch (RuntimeException e) { throw wrapException(e); } }
+    @Override public Object getValue(String name) { try { return dataView.getValue(name); } catch (RuntimeException e) { throw wrapException(e); } }
 
-    @Override public PqStruct getStruct(String name) { return dataView.getStruct(name); }
-    @Override public PqStruct getStruct(int i) { return dataView.getStruct(i); }
-    @Override public PqIntList getListOfInts(String name) { return dataView.getListOfInts(name); }
-    @Override public PqIntList getListOfInts(int i) { return dataView.getListOfInts(i); }
-    @Override public PqLongList getListOfLongs(String name) { return dataView.getListOfLongs(name); }
-    @Override public PqLongList getListOfLongs(int i) { return dataView.getListOfLongs(i); }
-    @Override public PqDoubleList getListOfDoubles(String name) { return dataView.getListOfDoubles(name); }
-    @Override public PqDoubleList getListOfDoubles(int i) { return dataView.getListOfDoubles(i); }
-    @Override public PqList getList(String name) { return dataView.getList(name); }
-    @Override public PqList getList(int i) { return dataView.getList(i); }
-    @Override public PqMap getMap(String name) { return dataView.getMap(name); }
-    @Override public PqMap getMap(int i) { return dataView.getMap(i); }
+    @Override public PqStruct getStruct(String name) { try { return dataView.getStruct(name); } catch (RuntimeException e) { throw wrapException(e); } }
+    @Override public PqStruct getStruct(int i) { try { return dataView.getStruct(i); } catch (RuntimeException e) { throw wrapException(e); } }
+    @Override public PqIntList getListOfInts(String name) { try { return dataView.getListOfInts(name); } catch (RuntimeException e) { throw wrapException(e); } }
+    @Override public PqIntList getListOfInts(int i) { try { return dataView.getListOfInts(i); } catch (RuntimeException e) { throw wrapException(e); } }
+    @Override public PqLongList getListOfLongs(String name) { try { return dataView.getListOfLongs(name); } catch (RuntimeException e) { throw wrapException(e); } }
+    @Override public PqLongList getListOfLongs(int i) { try { return dataView.getListOfLongs(i); } catch (RuntimeException e) { throw wrapException(e); } }
+    @Override public PqDoubleList getListOfDoubles(String name) { try { return dataView.getListOfDoubles(name); } catch (RuntimeException e) { throw wrapException(e); } }
+    @Override public PqDoubleList getListOfDoubles(int i) { try { return dataView.getListOfDoubles(i); } catch (RuntimeException e) { throw wrapException(e); } }
+    @Override public PqList getList(String name) { try { return dataView.getList(name); } catch (RuntimeException e) { throw wrapException(e); } }
+    @Override public PqList getList(int i) { try { return dataView.getList(i); } catch (RuntimeException e) { throw wrapException(e); } }
+    @Override public PqMap getMap(String name) { try { return dataView.getMap(name); } catch (RuntimeException e) { throw wrapException(e); } }
+    @Override public PqMap getMap(int i) { try { return dataView.getMap(i); } catch (RuntimeException e) { throw wrapException(e); } }
 
     // ==================== Metadata ====================
 
@@ -258,6 +268,12 @@ public final class NestedRowReader implements RowReader {
     @Override
     public String getFieldName(int index) {
         return dataView.getFieldName(index);
+    }
+
+    // ==================== Internal ====================
+
+    private RuntimeException wrapException(RuntimeException e) {
+        return ExceptionContext.addFileContext(currentFileName, e);
     }
 
     // ==================== Close ====================

--- a/core/src/main/java/dev/hardwood/internal/reader/PageSource.java
+++ b/core/src/main/java/dev/hardwood/internal/reader/PageSource.java
@@ -44,6 +44,12 @@ public class PageSource {
         this.workItemIterator = rowGroupIterator.getWorkItems().iterator();
     }
 
+    /// Returns the name of the file currently being read, or `null` if no work item
+    /// is active. Only valid on the retriever thread.
+    public String getCurrentFileName() {
+        return currentWorkItem != null ? currentWorkItem.inputFile().name() : null;
+    }
+
     public PageInfo next() {
         while (true) {
             if (currentPlan != null && currentPlan.hasNext()) {

--- a/core/src/main/java/dev/hardwood/reader/ColumnReader.java
+++ b/core/src/main/java/dev/hardwood/reader/ColumnReader.java
@@ -12,6 +12,7 @@ import java.util.BitSet;
 import java.util.List;
 
 import dev.hardwood.InputFile;
+import dev.hardwood.internal.ExceptionContext;
 import dev.hardwood.internal.predicate.ResolvedPredicate;
 import dev.hardwood.internal.reader.BatchExchange;
 import dev.hardwood.internal.reader.FlatColumnWorker;
@@ -94,6 +95,9 @@ public class ColumnReader implements AutoCloseable {
     private BitSet elementNulls;
     private boolean nestedDataComputed;
 
+    // File name from the current batch — used for exception enrichment
+    private String currentFileName;
+
     @SuppressWarnings("unchecked")
     private ColumnReader(ColumnSchema column, boolean nested,
                          BatchExchange<?> buffer, AutoCloseable columnWorker,
@@ -126,6 +130,15 @@ public class ColumnReader implements AutoCloseable {
     ///
     /// @return true if a batch is available, false if exhausted
     public boolean nextBatch() {
+        try {
+            return nextBatchInternal();
+        }
+        catch (RuntimeException e) {
+            throw wrapException(e);
+        }
+    }
+
+    private boolean nextBatchInternal() {
         if (exhausted) {
             return false;
         }
@@ -143,6 +156,7 @@ public class ColumnReader implements AutoCloseable {
             currentFlatBatch = null;
             recordCount = batch.recordCount;
             valueCount = batch.valueCount;
+            currentFileName = batch.fileName;
         }
         else {
             BatchExchange.Batch batch = pollFlatBatch();
@@ -157,6 +171,7 @@ public class ColumnReader implements AutoCloseable {
             currentNestedBatch = null;
             recordCount = batch.recordCount;
             valueCount = batch.recordCount;
+            currentFileName = batch.fileName;
         }
 
         // Reset lazy nested computation
@@ -194,65 +209,105 @@ public class ColumnReader implements AutoCloseable {
 
     /// Number of top-level records in the current batch.
     public int getRecordCount() {
-        checkBatchAvailable();
-        return recordCount;
+        try {
+            checkBatchAvailable();
+            return recordCount;
+        }
+        catch (RuntimeException e) {
+            throw wrapException(e);
+        }
     }
 
     /// Total number of leaf values in the current batch.
     /// For flat columns, this equals [#getRecordCount()].
     public int getValueCount() {
-        checkBatchAvailable();
-        return valueCount;
+        try {
+            checkBatchAvailable();
+            return valueCount;
+        }
+        catch (RuntimeException e) {
+            throw wrapException(e);
+        }
     }
 
     // ==================== Typed Value Arrays ====================
 
     public int[] getInts() {
-        checkBatchAvailable();
-        if (!(currentValues() instanceof int[] a)) {
-            throw typeMismatch("int");
+        try {
+            checkBatchAvailable();
+            if (!(currentValues() instanceof int[] a)) {
+                throw typeMismatch("int");
+            }
+            return a;
         }
-        return a;
+        catch (RuntimeException e) {
+            throw wrapException(e);
+        }
     }
 
     public long[] getLongs() {
-        checkBatchAvailable();
-        if (!(currentValues() instanceof long[] a)) {
-            throw typeMismatch("long");
+        try {
+            checkBatchAvailable();
+            if (!(currentValues() instanceof long[] a)) {
+                throw typeMismatch("long");
+            }
+            return a;
         }
-        return a;
+        catch (RuntimeException e) {
+            throw wrapException(e);
+        }
     }
 
     public float[] getFloats() {
-        checkBatchAvailable();
-        if (!(currentValues() instanceof float[] a)) {
-            throw typeMismatch("float");
+        try {
+            checkBatchAvailable();
+            if (!(currentValues() instanceof float[] a)) {
+                throw typeMismatch("float");
+            }
+            return a;
         }
-        return a;
+        catch (RuntimeException e) {
+            throw wrapException(e);
+        }
     }
 
     public double[] getDoubles() {
-        checkBatchAvailable();
-        if (!(currentValues() instanceof double[] a)) {
-            throw typeMismatch("double");
+        try {
+            checkBatchAvailable();
+            if (!(currentValues() instanceof double[] a)) {
+                throw typeMismatch("double");
+            }
+            return a;
         }
-        return a;
+        catch (RuntimeException e) {
+            throw wrapException(e);
+        }
     }
 
     public boolean[] getBooleans() {
-        checkBatchAvailable();
-        if (!(currentValues() instanceof boolean[] a)) {
-            throw typeMismatch("boolean");
+        try {
+            checkBatchAvailable();
+            if (!(currentValues() instanceof boolean[] a)) {
+                throw typeMismatch("boolean");
+            }
+            return a;
         }
-        return a;
+        catch (RuntimeException e) {
+            throw wrapException(e);
+        }
     }
 
     public byte[][] getBinaries() {
-        checkBatchAvailable();
-        if (!(currentValues() instanceof byte[][] a)) {
-            throw typeMismatch("byte[]");
+        try {
+            checkBatchAvailable();
+            if (!(currentValues() instanceof byte[][] a)) {
+                throw typeMismatch("byte[]");
+            }
+            return a;
         }
-        return a;
+        catch (RuntimeException e) {
+            throw wrapException(e);
+        }
     }
 
     // ==================== Logical Type Accessors ====================
@@ -265,18 +320,23 @@ public class ColumnReader implements AutoCloseable {
     /// @return String array with converted values
     /// @throws IllegalStateException if the column is not a BYTE_ARRAY type
     public String[] getStrings() {
-        byte[][] raw = getBinaries();
-        BitSet nulls = getElementNulls();
-        String[] result = new String[valueCount];
-        for (int i = 0; i < valueCount; i++) {
-            if (nulls != null && nulls.get(i)) {
-                result[i] = null;
+        try {
+            byte[][] raw = getBinaries();
+            BitSet nulls = getElementNulls();
+            String[] result = new String[valueCount];
+            for (int i = 0; i < valueCount; i++) {
+                if (nulls != null && nulls.get(i)) {
+                    result[i] = null;
+                }
+                else {
+                    result[i] = new String(raw[i], StandardCharsets.UTF_8);
+                }
             }
-            else {
-                result[i] = new String(raw[i], StandardCharsets.UTF_8);
-            }
+            return result;
         }
-        return result;
+        catch (RuntimeException e) {
+            throw wrapException(e);
+        }
     }
 
     // ==================== Null Handling ====================
@@ -285,12 +345,17 @@ public class ColumnReader implements AutoCloseable {
     ///
     /// @return BitSet where set bits indicate null values, or null if all elements are required
     public BitSet getElementNulls() {
-        checkBatchAvailable();
-        if (!nested) {
-            return currentFlatBatch.nulls;
+        try {
+            checkBatchAvailable();
+            if (!nested) {
+                return currentFlatBatch.nulls;
+            }
+            ensureNestedDataComputed();
+            return elementNulls;
         }
-        ensureNestedDataComputed();
-        return elementNulls;
+        catch (RuntimeException e) {
+            throw wrapException(e);
+        }
     }
 
     /// Null bitmap at a given nesting level. Only valid for nested columns
@@ -299,10 +364,15 @@ public class ColumnReader implements AutoCloseable {
     /// @param level the nesting level (0 = outermost group)
     /// @return BitSet where set bits indicate null groups, or null if that level is required
     public BitSet getLevelNulls(int level) {
-        checkBatchAvailable();
-        checkNestedLevel(level);
-        ensureNestedDataComputed();
-        return levelNulls[level];
+        try {
+            checkBatchAvailable();
+            checkNestedLevel(level);
+            ensureNestedDataComputed();
+            return levelNulls[level];
+        }
+        catch (RuntimeException e) {
+            throw wrapException(e);
+        }
     }
 
     // ==================== Offsets for Repeated Columns ====================
@@ -318,10 +388,15 @@ public class ColumnReader implements AutoCloseable {
     /// @param level the nesting level (0-indexed)
     /// @return offset array for the given level
     public int[] getOffsets(int level) {
-        checkBatchAvailable();
-        checkNestedLevel(level);
-        ensureNestedDataComputed();
-        return multiLevelOffsets[level];
+        try {
+            checkBatchAvailable();
+            checkNestedLevel(level);
+            ensureNestedDataComputed();
+            return multiLevelOffsets[level];
+        }
+        catch (RuntimeException e) {
+            throw wrapException(e);
+        }
     }
 
     // ==================== Metadata ====================
@@ -346,6 +421,10 @@ public class ColumnReader implements AutoCloseable {
     }
 
     // ==================== Internal ====================
+
+    private RuntimeException wrapException(RuntimeException e) {
+        return ExceptionContext.addFileContext(currentFileName, e);
+    }
 
     /// Returns the values array from the current batch (flat or nested).
     private Object currentValues() {

--- a/core/src/test/java/dev/hardwood/FileNameInExceptionTest.java
+++ b/core/src/test/java/dev/hardwood/FileNameInExceptionTest.java
@@ -1,0 +1,167 @@
+/*
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Copyright The original authors
+ *
+ *  Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package dev.hardwood;
+
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+
+import dev.hardwood.reader.ColumnReader;
+import dev.hardwood.reader.MultiFileColumnReaders;
+import dev.hardwood.reader.MultiFileParquetReader;
+import dev.hardwood.reader.ParquetFileReader;
+import dev.hardwood.reader.RowReader;
+import dev.hardwood.schema.ColumnProjection;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/// Tests that every exception escaping a reader includes the originating file name.
+/// See <a href="https://github.com/hardwood-hq/hardwood/issues/90">issue #90</a>.
+class FileNameInExceptionTest {
+
+    private static final Path TEST_FILE = Paths.get("src/test/resources/plain_uncompressed.parquet");
+    private static final String FILE_NAME = "plain_uncompressed.parquet";
+
+    // ==================== RowReader (single file) ====================
+
+    @Test
+    void rowReaderTypeMismatchIncludesFileName() throws Exception {
+        try (ParquetFileReader fileReader = ParquetFileReader.open(InputFile.of(TEST_FILE));
+             RowReader reader = fileReader.createRowReader()) {
+
+            assertThat(reader.hasNext()).isTrue();
+            reader.next();
+
+            // "id" column is LONG — requesting INT should throw with file name
+            assertThatThrownBy(() -> reader.getInt("id"))
+                    .isInstanceOf(RuntimeException.class)
+                    .hasMessageContaining("[" + FILE_NAME + "]");
+        }
+    }
+
+    @Test
+    void rowReaderMissingColumnIncludesFileName() throws Exception {
+        try (ParquetFileReader fileReader = ParquetFileReader.open(InputFile.of(TEST_FILE));
+             RowReader reader = fileReader.createRowReader()) {
+
+            assertThat(reader.hasNext()).isTrue();
+            reader.next();
+
+            // Non-existent column should throw with file name
+            assertThatThrownBy(() -> reader.getLong("nonexistent"))
+                    .isInstanceOf(RuntimeException.class)
+                    .hasMessageContaining("[" + FILE_NAME + "]");
+        }
+    }
+
+    // ==================== RowReader (multi-file) ====================
+
+    @Test
+    void multiFileRowReaderIncludesCorrectFileName() throws Exception {
+        List<Path> files = List.of(TEST_FILE, TEST_FILE);
+
+        try (Hardwood hardwood = Hardwood.create();
+             MultiFileParquetReader parquet = hardwood.openAll(InputFile.ofPaths(files));
+             RowReader reader = parquet.createRowReader()) {
+
+            // Read through both files and provoke an error on each
+            while (reader.hasNext()) {
+                reader.next();
+                // All rows come from the same physical file
+                assertThatThrownBy(() -> reader.getInt("id"))
+                        .isInstanceOf(RuntimeException.class)
+                        .hasMessageContaining("[" + FILE_NAME + "]");
+            }
+        }
+    }
+
+    // ==================== ColumnReader (single file) ====================
+
+    @Test
+    void columnReaderTypeMismatchIncludesFileName() throws Exception {
+        try (ParquetFileReader fileReader = ParquetFileReader.open(InputFile.of(TEST_FILE));
+             ColumnReader reader = fileReader.createColumnReader("id")) {
+
+            assertThat(reader.nextBatch()).isTrue();
+
+            // "id" is LONG — requesting INTs should throw with file name
+            assertThatThrownBy(reader::getInts)
+                    .isInstanceOf(RuntimeException.class)
+                    .hasMessageContaining("[" + FILE_NAME + "]");
+        }
+    }
+
+    @Test
+    void columnReaderNoBatchIncludesFileName() throws Exception {
+        try (ParquetFileReader fileReader = ParquetFileReader.open(InputFile.of(TEST_FILE));
+             ColumnReader reader = fileReader.createColumnReader("id")) {
+
+            // No nextBatch() called — should throw. File name may or may not be
+            // available (no batch loaded yet), so we just verify no NPE
+            assertThatThrownBy(reader::getLongs)
+                    .isInstanceOf(RuntimeException.class);
+        }
+    }
+
+    // ==================== ColumnReader (multi-file) ====================
+
+    @Test
+    void multiFileColumnReaderIncludesFileName() throws Exception {
+        List<Path> files = List.of(TEST_FILE, TEST_FILE);
+
+        try (Hardwood hardwood = Hardwood.create();
+             MultiFileParquetReader parquet = hardwood.openAll(InputFile.ofPaths(files));
+             MultiFileColumnReaders columns = parquet.createColumnReaders(ColumnProjection.columns("id"))) {
+
+            ColumnReader idReader = columns.getColumnReader("id");
+
+            while (idReader.nextBatch()) {
+                // Type mismatch on each batch should include file name
+                assertThatThrownBy(idReader::getInts)
+                        .isInstanceOf(RuntimeException.class)
+                        .hasMessageContaining("[" + FILE_NAME + "]");
+            }
+        }
+    }
+
+    // ==================== Exception type preservation ====================
+
+    @Test
+    void exceptionTypeIsPreserved() throws Exception {
+        try (ParquetFileReader fileReader = ParquetFileReader.open(InputFile.of(TEST_FILE));
+             RowReader reader = fileReader.createRowReader()) {
+
+            assertThat(reader.hasNext()).isTrue();
+            reader.next();
+
+            // Type mismatch throws IllegalArgumentException — verify it is preserved
+            assertThatThrownBy(() -> reader.getInt("id"))
+                    .isInstanceOf(IllegalArgumentException.class)
+                    .hasMessageContaining("[" + FILE_NAME + "]");
+        }
+    }
+
+    // ==================== Format verification ====================
+
+    @Test
+    void bracketedFormatIsCorrect() throws Exception {
+        try (ParquetFileReader fileReader = ParquetFileReader.open(InputFile.of(TEST_FILE));
+             RowReader reader = fileReader.createRowReader()) {
+
+            assertThat(reader.hasNext()).isTrue();
+            reader.next();
+
+            assertThatThrownBy(() -> reader.getInt("id"))
+                    .isInstanceOf(RuntimeException.class)
+                    .hasMessageMatching("^\\[" + FILE_NAME.replace(".", "\\.") + "] .*");
+        }
+    }
+}

--- a/core/src/test/java/dev/hardwood/PqRowApiTest.java
+++ b/core/src/test/java/dev/hardwood/PqRowApiTest.java
@@ -1376,19 +1376,19 @@ public class PqRowApiTest {
             assertThat(rowReader.isNull("nullable_int")).isTrue();
             assertThatThrownBy(() -> rowReader.getInt("nullable_int"))
                     .isInstanceOf(NullPointerException.class)
-                    .hasMessage("Column 'nullable_int' is null at row 1");
+                    .hasMessageContaining("Column 'nullable_int' is null at row 1");
             assertThatThrownBy(() -> rowReader.getLong("nullable_long"))
                     .isInstanceOf(NullPointerException.class)
-                    .hasMessage("Column 'nullable_long' is null at row 1");
+                    .hasMessageContaining("Column 'nullable_long' is null at row 1");
             assertThatThrownBy(() -> rowReader.getFloat("nullable_float"))
                     .isInstanceOf(NullPointerException.class)
-                    .hasMessage("Column 'nullable_float' is null at row 1");
+                    .hasMessageContaining("Column 'nullable_float' is null at row 1");
             assertThatThrownBy(() -> rowReader.getDouble("nullable_double"))
                     .isInstanceOf(NullPointerException.class)
-                    .hasMessage("Column 'nullable_double' is null at row 1");
+                    .hasMessageContaining("Column 'nullable_double' is null at row 1");
             assertThatThrownBy(() -> rowReader.getBoolean("nullable_bool"))
                     .isInstanceOf(NullPointerException.class)
-                    .hasMessage("Column 'nullable_bool' is null at row 1");
+                    .hasMessageContaining("Column 'nullable_bool' is null at row 1");
         }
     }
 
@@ -1412,19 +1412,19 @@ public class PqRowApiTest {
             assertThat(rowReader.isNull(1)).isTrue();
             assertThatThrownBy(() -> rowReader.getInt(1))
                     .isInstanceOf(NullPointerException.class)
-                    .hasMessage("Column 'nullable_int' is null at row 1");
+                    .hasMessageContaining("Column 'nullable_int' is null at row 1");
             assertThatThrownBy(() -> rowReader.getLong(2))
                     .isInstanceOf(NullPointerException.class)
-                    .hasMessage("Column 'nullable_long' is null at row 1");
+                    .hasMessageContaining("Column 'nullable_long' is null at row 1");
             assertThatThrownBy(() -> rowReader.getFloat(3))
                     .isInstanceOf(NullPointerException.class)
-                    .hasMessage("Column 'nullable_float' is null at row 1");
+                    .hasMessageContaining("Column 'nullable_float' is null at row 1");
             assertThatThrownBy(() -> rowReader.getDouble(4))
                     .isInstanceOf(NullPointerException.class)
-                    .hasMessage("Column 'nullable_double' is null at row 1");
+                    .hasMessageContaining("Column 'nullable_double' is null at row 1");
             assertThatThrownBy(() -> rowReader.getBoolean(5))
                     .isInstanceOf(NullPointerException.class)
-                    .hasMessage("Column 'nullable_bool' is null at row 1");
+                    .hasMessageContaining("Column 'nullable_bool' is null at row 1");
         }
     }
 }

--- a/core/src/test/java/dev/hardwood/internal/ExceptionContextTest.java
+++ b/core/src/test/java/dev/hardwood/internal/ExceptionContextTest.java
@@ -1,0 +1,85 @@
+/*
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Copyright The original authors
+ *
+ *  Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package dev.hardwood.internal;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/// Unit tests for [ExceptionContext].
+class ExceptionContextTest {
+
+    @Test
+    void addsFileContextToMessage() {
+        IllegalStateException original = new IllegalStateException("something broke");
+        RuntimeException wrapped = ExceptionContext.addFileContext("test.parquet", original);
+
+        assertThat(wrapped).isInstanceOf(IllegalStateException.class);
+        assertThat(wrapped.getMessage()).isEqualTo("[test.parquet] something broke");
+        assertThat(wrapped.getCause()).isSameAs(original);
+    }
+
+    @Test
+    void preservesIllegalArgumentException() {
+        IllegalArgumentException original = new IllegalArgumentException("bad arg");
+        RuntimeException wrapped = ExceptionContext.addFileContext("file.parquet", original);
+
+        assertThat(wrapped).isInstanceOf(IllegalArgumentException.class);
+        assertThat(wrapped.getMessage()).startsWith("[file.parquet]");
+    }
+
+    @Test
+    void preservesUnsupportedOperationException() {
+        UnsupportedOperationException original = new UnsupportedOperationException("nope");
+        RuntimeException wrapped = ExceptionContext.addFileContext("file.parquet", original);
+
+        assertThat(wrapped).isInstanceOf(UnsupportedOperationException.class);
+        assertThat(wrapped.getMessage()).startsWith("[file.parquet]");
+    }
+
+    @Test
+    void idempotentWhenAlreadyWrapped() {
+        IllegalStateException original = new IllegalStateException("[test.parquet] already wrapped");
+        RuntimeException wrapped = ExceptionContext.addFileContext("test.parquet", original);
+
+        assertThat(wrapped).isSameAs(original);
+    }
+
+    @Test
+    void nullFileNameReturnsOriginal() {
+        IllegalStateException original = new IllegalStateException("error");
+        RuntimeException wrapped = ExceptionContext.addFileContext(null, original);
+
+        assertThat(wrapped).isSameAs(original);
+    }
+
+    @Test
+    void nullMessageHandledGracefully() {
+        RuntimeException original = new RuntimeException((String) null);
+        RuntimeException wrapped = ExceptionContext.addFileContext("test.parquet", original);
+
+        assertThat(wrapped.getMessage()).isEqualTo("[test.parquet] RuntimeException");
+    }
+
+    @Test
+    void fallsBackToRuntimeExceptionForExoticType() {
+        // A custom RuntimeException subclass without a (String, Throwable) constructor
+        RuntimeException original = new CustomException();
+        RuntimeException wrapped = ExceptionContext.addFileContext("test.parquet", original);
+
+        assertThat(wrapped).isInstanceOf(RuntimeException.class);
+        assertThat(wrapped.getMessage()).startsWith("[test.parquet]");
+        assertThat(wrapped.getCause()).isSameAs(original);
+    }
+
+    private static class CustomException extends RuntimeException {
+        CustomException() {
+            super("custom error");
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Closes #90 — every exception escaping a reader now includes the originating file name in the format `[fileName] original message`.

## Design

### ExceptionContext utility
Centralised in `dev.hardwood.internal.ExceptionContext.addFileContext()` — single source of truth for exception wrapping used by `FlatRowReader`, `NestedRowReader`, and `ColumnReader`. Type-preserving logic:

- **Exact-class checks** for `IllegalArgumentException`, `IllegalStateException`, `NullPointerException`, `IndexOutOfBoundsException` — avoids downgrading subclass types
- **`instanceof`** for `UncheckedIOException` (preserves `IOException` cause)
- **CompletionException** — preserves original cause chain (not the CompletionException wrapper itself)
- **Reflection fallback** for other types with `(String, Throwable)` constructor
- **`RuntimeException` wrapper** as last resort
- **Idempotency** — skips wrapping if `[fileName]` prefix is already present

### File name tracking through the v3 pipeline

```
PageSource (tracks currentWorkItem with InputFile)
  → ColumnWorker (fileNameBuffer[] parallel to reorderBuffer, file boundary detection in drain)
    → BatchExchange.Batch / NestedBatch (each batch carries its fileName)
      → FlatRowReader / NestedRowReader / ColumnReader (reads fileName from batch)
```

- **PageSource:** exposes `getCurrentFileName()` from the current work item's `InputFile.name()`
- **ColumnWorker:** the retriever thread stores the file name in a parallel `fileNameBuffer[slot]` before submitting decode tasks. The drain thread detects file boundary changes and flushes the current batch, ensuring each batch maps to exactly one file. Errors from retriever, decode, and drain threads are enriched with file context before `signalError()`
- **FlatColumnWorker / NestedColumnWorker:** `publishCurrentBatch()` stamps `currentBatchFileName` onto the outgoing batch
- **FlatRowReader / NestedRowReader:** `loadNextBatch()` reads `currentFileName` from the first column's batch. All ~29/40 public accessor methods are wrapped with try-catch that delegates to `ExceptionContext`
- **ColumnReader:** `nextBatchInternal()` reads `currentFileName` from the batch. All typed getters, null accessors, and offset methods are wrapped

### Memory ordering

The `fileNameBuffer[]` in `ColumnWorker` is a plain `String[]` (no volatile/atomic). Safety is guaranteed by the existing happens-before chain: retriever writes `fileNameBuffer[slot]` before submitting the decode task, which does a volatile write to `reorderBuffer[slot]` via `AtomicReferenceArray.set()`, and the drain thread does a volatile read via `getAndSet()`. Slot reuse is safe because the retriever throttles when `nextSeq - consumePosition >= MAX_INFLIGHT_PAGES`.

### Coverage

All public accessor methods in `FlatRowReader` (~29 methods) and `NestedRowReader` (~40 methods) are wrapped with try-catch blocks that delegate to `ExceptionContext`. `ColumnReader` wraps `nextBatch()`, all typed value getters, null accessors, and offset methods.

`FilteredRowReader` is a pure delegate — no wrapping needed since the underlying reader already wraps.

## Tests

15 new tests:

**FileNameInExceptionTest** (8 tests):
- Single-file RowReader: type mismatch, missing column
- Multi-file RowReader: correct attribution across files
- Single-file ColumnReader: type mismatch, no-batch state
- Multi-file ColumnReader: correct attribution across batches
- Exception type preservation (IllegalArgumentException)
- Bracketed format verification (`[fileName] ...` regex)

**ExceptionContextTest** (7 tests):
- Type preservation for common exception types
- Idempotency (already-wrapped exceptions returned as-is)
- Null file name passthrough
- Null message handling
- Exotic exception type fallback

Updated `PqRowApiTest` null-column assertions to use `hasMessageContaining()` to accommodate the file name prefix.

All 643 core tests pass.