### PR TITLE
#244 Fix HIGH CVEs: upgrade lz4-java to 1.10.1, assertj-core to 3.27.7

### DIFF
--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -91,7 +91,7 @@
       <dependency>
         <groupId>at.yawk.lz4</groupId>
         <artifactId>lz4-java</artifactId>
-        <version>1.8.1</version>
+        <version>1.10.1</version>
       </dependency>
       <dependency>
         <groupId>com.aayushatharva.brotli4j</groupId>

--- a/test-bom/pom.xml
+++ b/test-bom/pom.xml
@@ -39,7 +39,7 @@
       <dependency>
         <groupId>org.assertj</groupId>
         <artifactId>assertj-core</artifactId>
-        <version>3.27.6</version>
+        <version>3.27.7</version>
       </dependency>
       <dependency>
         <groupId>org.apache.logging.log4j</groupId>


### PR DESCRIPTION
Fixes #244 

- at.yawk.lz4:lz4-java 1.8.1 → 1.10.1: fixes CVE-2025-66566 (information leak in Java safe decompressor via crafted compressed input)
- org.assertj:assertj-core 3.27.6 → 3.27.7: fixes CVE-2026-24400 (XXE vulnerability in isXmlEqualTo assertion via XmlStringPrettyFormatter)

## Checklist

- [X] Build via `./mvnw clean verify` passes
- [ ] The commit message is prefixed with the issue key ("#123 Adding support for...")
- [ ] Code changes are covered by tests
- [ ] If this PR adds or changes user-facing behaviour, `docs/` has been updated
