### PR TITLE
#257 Join VThreads and await in-flight decodes in ColumnWorker.close()

### DIFF
--- a/core/src/main/java/dev/hardwood/internal/reader/ColumnWorker.java
+++ b/core/src/main/java/dev/hardwood/internal/reader/ColumnWorker.java
@@ -7,7 +7,9 @@
  */
 package dev.hardwood.internal.reader;
 
+import java.util.Set;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.Executor;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.concurrent.atomic.AtomicReferenceArray;
@@ -67,8 +69,11 @@ public abstract class ColumnWorker<B> implements AutoCloseable {
     private final AtomicReference<Throwable> error = new AtomicReference<>();
 
     // === Thread references (for unpark) ===
-    private volatile Thread retrieverThread;
-    private volatile Thread drainThread;
+    volatile Thread retrieverThread;
+    volatile Thread drainThread;
+
+    // === In-flight decode tasks (tracked so close() can await them) ===
+    private final Set<CompletableFuture<Void>> inFlightDecodes = ConcurrentHashMap.newKeySet();
 
     // === Drain assembly state (drain thread only) ===
     final long maxRows;
@@ -126,14 +131,41 @@ public abstract class ColumnWorker<B> implements AutoCloseable {
         retrieverThread.start();
     }
 
-    /// Signals the worker to stop. In-flight decodes run to completion but
-    /// their results are not drained.
+    /// Signals the worker to stop and blocks until the pipeline has fully quiesced:
+    /// both VThreads have exited and every in-flight decode task has completed.
+    ///
+    /// This is required so that callers can safely release resources owned by the
+    /// underlying [dev.hardwood.InputFile] (mapped or direct byte buffers, HTTP
+    /// connections, etc.) without risking a SIGSEGV from a decode task still
+    /// reading from a freed buffer.
     @Override
     public void close() {
         done = true;
         exchange.finish();  // signals BatchExchange's timeout loops to exit
         LockSupport.unpark(retrieverThread);
         LockSupport.unpark(drainThread);
+
+        try {
+            retrieverThread.join();
+            drainThread.join();
+        }
+        catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+        }
+
+        // The retriever has exited, so no new decode tasks will be submitted.
+        // Drain any that are still running. Tasks that hadn't yet started early-return
+        // via the `done` check in decode(), so this typically waits only on the small
+        // number that were mid-execution when `done` was set.
+        CompletableFuture<?>[] pending = inFlightDecodes.toArray(new CompletableFuture<?>[0]);
+        if (pending.length > 0) {
+            try {
+                CompletableFuture.allOf(pending).join();
+            }
+            catch (Exception ignored) {
+                // decode tasks call signalError on failure; nothing to re-raise here
+            }
+        }
     }
 
     /// Whether the pipeline has stopped producing batches (for any reason —
@@ -194,7 +226,10 @@ public abstract class ColumnWorker<B> implements AutoCloseable {
                 int slot = seq % MAX_INFLIGHT_PAGES;
                 PageInfo pi = pageInfo;
                 PageDecoder rdr = pageDecoder;
-                CompletableFuture.runAsync(() -> decode(slot, pi, rdr), decodeExecutor);
+                CompletableFuture<Void> f = CompletableFuture.runAsync(
+                        () -> decode(slot, pi, rdr), decodeExecutor);
+                inFlightDecodes.add(f);
+                f.whenComplete((v, t) -> inFlightDecodes.remove(f));
             }
 
             if (!done) {

--- a/core/src/test/java/dev/hardwood/internal/reader/ColumnWorkerTest.java
+++ b/core/src/test/java/dev/hardwood/internal/reader/ColumnWorkerTest.java
@@ -8,7 +8,10 @@
 package dev.hardwood.internal.reader;
 
 import java.nio.file.Path;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.Executor;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
 
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
@@ -308,6 +311,81 @@ class ColumnWorkerTest {
             assertThat(sawPreComputedIndex)
                     .as("Nested column should have pre-computed multi-level offsets")
                     .isTrue();
+        }
+    }
+
+    /// close() must not return until both VThreads have exited and every in-flight
+    /// decode task submitted to the executor has completed. Otherwise an
+    /// `InputFile` that releases memory in its own `close()` could free a buffer
+    /// a decode task is still reading from.
+    @Test
+    @Timeout(value = 30, unit = TimeUnit.SECONDS)
+    void closeJoinsThreadsAndAwaitsInFlightDecodes() throws Exception {
+        try (HardwoodContextImpl context = HardwoodContextImpl.create();
+             ParquetFileReader reader = ParquetFileReader.open(InputFile.of(TEST_FILE))) {
+
+            FileSchema schema = reader.getFileSchema();
+            RowGroupIterator iterator = createIterator(TEST_FILE, schema, context);
+            ColumnSchema column = schema.getColumn(0);
+            int batchCapacity = 64;
+
+            CountDownLatch release = new CountDownLatch(1);
+            CountDownLatch firstSubmitted = new CountDownLatch(1);
+            AtomicInteger decodesEntered = new AtomicInteger();
+            AtomicInteger decodesFinished = new AtomicInteger();
+
+            Executor stalledExecutor = command -> Thread.ofVirtual().start(() -> {
+                decodesEntered.incrementAndGet();
+                firstSubmitted.countDown();
+                try {
+                    release.await();
+                }
+                catch (InterruptedException e) {
+                    Thread.currentThread().interrupt();
+                    return;
+                }
+                command.run();
+                decodesFinished.incrementAndGet();
+            });
+
+            BatchExchange<BatchExchange.Batch> exchange = BatchExchange.recycling(
+                    column.name(), () -> {
+                        BatchExchange.Batch b = new BatchExchange.Batch();
+                        b.values = BatchExchange.allocateArray(column.type(), batchCapacity);
+                        return b;
+                    });
+            FlatColumnWorker worker = new FlatColumnWorker(
+                    new PageSource(iterator, 0), exchange, column, batchCapacity,
+                    context.decompressorFactory(), stalledExecutor, 0);
+            worker.start();
+
+            assertThat(firstSubmitted.await(5, TimeUnit.SECONDS))
+                    .as("retriever should have submitted at least one decode task")
+                    .isTrue();
+
+            Thread closer = Thread.ofVirtual().start(worker::close);
+
+            // close() must still be running — decodes are stalled on the latch.
+            Thread.sleep(300);
+            assertThat(closer.isAlive())
+                    .as("close() must not return while decode tasks are still in flight")
+                    .isTrue();
+
+            release.countDown();
+            closer.join(TimeUnit.SECONDS.toMillis(10));
+
+            assertThat(closer.isAlive())
+                    .as("close() should return once decodes drain")
+                    .isFalse();
+            assertThat(worker.retrieverThread.isAlive())
+                    .as("retriever thread must have exited")
+                    .isFalse();
+            assertThat(worker.drainThread.isAlive())
+                    .as("drain thread must have exited")
+                    .isFalse();
+            assertThat(decodesFinished.get())
+                    .as("every submitted decode task should have finished")
+                    .isEqualTo(decodesEntered.get());
         }
     }
 


### PR DESCRIPTION
## Summary

Fixes #257. `ColumnWorker.close()` now blocks until the pipeline has fully quiesced — both the retriever and drain virtual threads have exited, and every in-flight decode task submitted to the shared executor has completed — before returning.

Previously, `close()` set `done`, finished the exchange, unparked the two VThreads, and returned immediately. Asynchronous decode tasks could still be reading `PageInfo.pageData()` slices over chunk byte buffers owned by the underlying `InputFile`. No crash is reachable today because every current `InputFile` keeps its memory GC-rooted via slice parents, but that invariant was undocumented and would quietly produce a SIGSEGV the moment an `InputFile` implementation (future eager-unmap on `MappedInputFile`, GCS/HDFS/Azure backends, encrypted local file, etc.) released memory eagerly in its own `close()`.

## Changes

- `ColumnWorker` now tracks each submitted decode future in a `ConcurrentHashMap.newKeySet()`, self-removing via `whenComplete` to keep the set bounded.
- `close()` joins `retrieverThread` and `drainThread`, then `CompletableFuture.allOf(pending).join()` on whatever decode tasks were mid-execution when `done` was set. Tasks that had not yet started early-return via the existing `done || error != null` check, so the wait is typically short.
- `retrieverThread` / `drainThread` relaxed from `private` to package-private so tests can assert they exited.

Scope is local to `ColumnWorker`; no public API change.

## Test plan

- [x] New `ColumnWorkerTest.closeJoinsThreadsAndAwaitsInFlightDecodes` uses a `CountDownLatch`-stalled executor to deterministically prove:
  - `close()` does not return while a decode task is still in flight
  - Once decodes complete, both VThreads have exited and every submitted task finished
- [x] Confirmed the new test fails against the old `close()` and passes after the fix.
- [x] `./mvnw verify` — 858 tests, 0 failures.