### PR TITLE
#214 Skip row groups outside tail in print command tail mode

### DIFF
--- a/cli/src/main/java/dev/hardwood/cli/command/PrintCommand.java
+++ b/cli/src/main/java/dev/hardwood/cli/command/PrintCommand.java
@@ -8,7 +8,6 @@
 package dev.hardwood.cli.command;
 
 import java.io.IOException;
-import java.util.ArrayDeque;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Spliterator;
@@ -84,15 +83,13 @@ public class PrintCommand implements Callable<Integer> {
 
         try (ParquetFileReader reader = ParquetFileReader.open(inputFile)) {
             FileSchema fileSchema = reader.getFileSchema();
-            // Pass positive row limits to the reader so it can stop fetching early.
-            // Negative limits (tail) and no limit require reading all rows.
-            try (RowReader rowReader = rowLimit > 0
+            try (RowReader rowReader = rowLimit != 0
                     ? reader.createRowReader(projection, null, rowLimit)
                     : reader.createRowReader(projection)) {
                 String[] headers = RowTable.topLevelFieldNames(fileSchema, projection);
                 List<SchemaNode> fields = projectedFields(fileSchema, projection);
                 AtomicLong rowIndex = addRowIndex ? new AtomicLong() : null;
-                Stream<Object[]> stream = prepareSampling(rowReader, headers, rowLimit);
+                Stream<Object[]> stream = stream(rowReader).map(r -> toData(r, headers.length));
                 if (transpose) {
                     printTransposed(stream, headers, fields, rowIndex);
                 } else {
@@ -173,24 +170,6 @@ public class PrintCommand implements Callable<Integer> {
                 .filter(child -> projection.getProjectedColumnNames().stream()
                         .anyMatch(name -> name.equals(child.name()) || name.startsWith(child.name() + ".")))
                 .toList();
-    }
-
-    private Stream<Object[]> prepareSampling(RowReader rowReader, String[] headers, int rowLimit) {
-        if (rowLimit > 0) {
-            return stream(rowReader).limit(rowLimit).map(r -> toData(r, headers.length));
-        }
-        if (rowLimit < 0) {
-            int tailSize = -rowLimit;
-            ArrayDeque<Object[]> buffer = new ArrayDeque<>(tailSize);
-            stream(rowReader).forEach(r -> {
-                if (buffer.size() == tailSize) {
-                    buffer.removeFirst();
-                }
-                buffer.addLast(toData(r, headers.length));
-            });
-            return buffer.stream();
-        }
-        return stream(rowReader).map(r -> toData(r, headers.length));
     }
 
     private Object[] toData(RowReader rowReader, int fieldCount) {

--- a/cli/src/test/java/dev/hardwood/cli/command/AbstractS3CommandTest.java
+++ b/cli/src/test/java/dev/hardwood/cli/command/AbstractS3CommandTest.java
@@ -32,6 +32,7 @@ abstract class AbstractS3CommandTest {
     protected static final String S3_NONEXISTENT_FILE = "s3://test-bucket/nonexistent.parquet";
     protected static final String S3_UNSIGNED_INT_FILE = "s3://test-bucket/unsigned_int_test.parquet";
     protected static final String S3_PAGE_INDEX_FILE = "s3://test-bucket/column_index_pushdown.parquet";
+    protected static final String S3_MULTI_ROW_GROUP_INT_FILE = "s3://test-bucket/filter_pushdown_int.parquet";
 
     private static final Path TEST_RESOURCES = Path.of("").toAbsolutePath()
             .resolve("../core/src/test/resources").normalize();
@@ -50,7 +51,9 @@ abstract class AbstractS3CommandTest {
             .withCopyFileToContainer(fixture("unsigned_int_test.parquet"),
                     S3ProxyContainers.objectPath("unsigned_int_test.parquet"))
             .withCopyFileToContainer(fixture("column_index_pushdown.parquet"),
-                    S3ProxyContainers.objectPath("column_index_pushdown.parquet"));
+                    S3ProxyContainers.objectPath("column_index_pushdown.parquet"))
+            .withCopyFileToContainer(fixture("filter_pushdown_int.parquet"),
+                    S3ProxyContainers.objectPath("filter_pushdown_int.parquet"));
 
     private static MountableFile fixture(String name) {
         return MountableFile.forHostPath(TEST_RESOURCES.resolve(name));

--- a/cli/src/test/java/dev/hardwood/cli/command/PrintCommandContract.java
+++ b/cli/src/test/java/dev/hardwood/cli/command/PrintCommandContract.java
@@ -29,6 +29,8 @@ interface PrintCommandContract {
 
     String unsignedIntFile();
 
+    String multiRowGroupIntFile();
+
     @Test
     default void printsAsciiTableDefault(QuarkusMainLauncher launcher) {
         LaunchResult result = launcher.launch("print", "-f", plainFile());
@@ -73,6 +75,25 @@ interface PrintCommandContract {
                 | 2  | 200   |
                 | 3  | 300   |
                 +----+-------+""");
+    }
+
+    @Test
+    default void tailOnMultipleRowGroups(QuarkusMainLauncher launcher) {
+        // filter_pushdown_int.parquet has three row groups of 100 rows each.
+        // The tail must reflect the last rows of the file regardless of the
+        // row-group layout; this also exercises the code path that skips
+        // row groups outside the tail.
+        LaunchResult result = launcher.launch("print", "-f", multiRowGroupIntFile(), "-n", "-3");
+
+        assertThat(result.exitCode()).isZero();
+        assertThat(result.getOutput()).isEqualTo("""
+                +-----+-------+---------+
+                | id  | value | label   |
+                +-----+-------+---------+
+                | 298 | 298   | rg3_298 |
+                | 299 | 299   | rg3_299 |
+                | 300 | 300   | rg3_300 |
+                +-----+-------+---------+""");
     }
 
     @Test

--- a/cli/src/test/java/dev/hardwood/cli/command/PrintCommandTest.java
+++ b/cli/src/test/java/dev/hardwood/cli/command/PrintCommandTest.java
@@ -48,6 +48,11 @@ class PrintCommandTest implements PrintCommandContract {
         return getClass().getResource("/unsigned_int_test.parquet").getPath();
     }
 
+    @Override
+    public String multiRowGroupIntFile() {
+        return getClass().getResource("/filter_pushdown_int.parquet").getPath();
+    }
+
     @Test
     void rejectsRemoteUri(QuarkusMainLauncher launcher) {
         LaunchResult result = launcher.launch("print", "-f", "gs://bucket/data.parquet");

--- a/cli/src/test/java/dev/hardwood/cli/command/PrintS3CommandTest.java
+++ b/cli/src/test/java/dev/hardwood/cli/command/PrintS3CommandTest.java
@@ -41,4 +41,9 @@ class PrintS3CommandTest extends AbstractS3CommandTest implements PrintCommandCo
     public String unsignedIntFile() {
         return S3_UNSIGNED_INT_FILE;
     }
+
+    @Override
+    public String multiRowGroupIntFile() {
+        return S3_MULTI_ROW_GROUP_INT_FILE;
+    }
 }

--- a/core/src/main/java/dev/hardwood/reader/ParquetFileReader.java
+++ b/core/src/main/java/dev/hardwood/reader/ParquetFileReader.java
@@ -176,7 +176,7 @@ public class ParquetFileReader implements AutoCloseable {
     /// @param projection specifies which columns to read
     /// @return a RowReader for the selected columns
     public RowReader createRowReader(ColumnProjection projection) {
-        return createRowReaderInternal(projection, null, 0);
+        return createRowReaderInternal(projection, null, 0, fileMetaData.rowGroups());
     }
 
     /// Create a RowReader that iterates over selected columns in only matching row groups.
@@ -184,22 +184,59 @@ public class ParquetFileReader implements AutoCloseable {
     /// @param projection specifies which columns to read
     /// @param filter predicate for row group filtering based on statistics
     public RowReader createRowReader(ColumnProjection projection, FilterPredicate filter) {
-        return createRowReaderInternal(projection, filter, 0);
+        return createRowReaderInternal(projection, filter, 0, fileMetaData.rowGroups());
     }
 
-    /// Create a RowReader with column projection and filter that returns at most `maxRows` rows.
+    /// Create a RowReader that returns at most `|maxRows|` rows.
+    ///
+    /// The sign of `maxRows` selects the end of the file to read from:
+    ///
+    /// - `maxRows > 0` — **head**: return the first `maxRows` rows.
+    /// - `maxRows < 0` — **tail**: return the last `-maxRows` rows. Row groups
+    ///   that do not overlap the tail are skipped entirely, so pages for
+    ///   earlier row groups are never fetched or decoded (useful on remote
+    ///   backends like S3).
+    ///
+    /// Tail mode cannot currently be combined with a filter: the set of
+    /// matching rows is not known from row-group statistics alone, so the
+    /// reader cannot determine which row groups cover the last `-maxRows`
+    /// **matching** rows without scanning the whole file.
     ///
     /// @param projection specifies which columns to read
-    /// @param filter predicate for row group filtering based on statistics
-    /// @param maxRows maximum number of rows to return (must be &gt; 0)
+    /// @param filter predicate for row group filtering based on statistics (must be `null` when `maxRows < 0`)
+    /// @param maxRows row count with direction (must be non-zero)
     public RowReader createRowReader(ColumnProjection projection, FilterPredicate filter, long maxRows) {
-        if (maxRows <= 0) {
-            throw new IllegalArgumentException("maxRows must be > 0, got " + maxRows);
+        if (maxRows == 0) {
+            throw new IllegalArgumentException("maxRows must be non-zero");
         }
-        return createRowReaderInternal(projection, filter, maxRows);
+        if (maxRows < 0) {
+            if (filter != null) {
+                throw new IllegalArgumentException("Tail reading (negative maxRows) cannot be combined with a filter");
+            }
+            return createTailRowReader(projection, -maxRows);
+        }
+        return createRowReaderInternal(projection, filter, maxRows, fileMetaData.rowGroups());
     }
 
-    private RowReader createRowReaderInternal(ColumnProjection projection, FilterPredicate filter, long maxRows) {
+    private RowReader createTailRowReader(ColumnProjection projection, long tailRows) {
+        List<RowGroup> subset = tailRowGroups(fileMetaData.rowGroups(), tailRows);
+        long rowsInSubset = 0;
+        for (RowGroup rg : subset) {
+            rowsInSubset += rg.numRows();
+        }
+        long skip = Math.max(0, rowsInSubset - tailRows);
+
+        RowReader reader = createRowReaderInternal(projection, null, 0, subset);
+        for (long i = 0; i < skip; i++) {
+            if (!reader.hasNext()) {
+                break;
+            }
+            reader.next();
+        }
+        return reader;
+    }
+
+    private RowReader createRowReaderInternal(ColumnProjection projection, FilterPredicate filter, long maxRows, List<RowGroup> rowGroups) {
         FileSchema schema = getFileSchema();
         ResolvedPredicate resolved = filter != null
                 ? FilterPredicateResolver.resolve(filter, schema) : null;
@@ -208,11 +245,24 @@ public class ParquetFileReader implements AutoCloseable {
 
         RowGroupIterator rowGroupIterator = new RowGroupIterator(
                 List.of(inputFile), context, maxRows);
-        rowGroupIterator.setFirstFile(schema, fileMetaData.rowGroups());
+        rowGroupIterator.setFirstFile(schema, rowGroups);
         rowGroupIterator.initialize(projectedSchema, resolved);
         rowGroupIterators.add(rowGroupIterator);
 
         return RowReader.create(rowGroupIterator, schema, projectedSchema, context, resolved, maxRows);
+    }
+
+    private static List<RowGroup> tailRowGroups(List<RowGroup> rowGroups, long tailRows) {
+        int startIndex = rowGroups.size();
+        long accumulated = 0;
+        for (int i = rowGroups.size() - 1; i >= 0; i--) {
+            accumulated += rowGroups.get(i).numRows();
+            startIndex = i;
+            if (accumulated >= tailRows) {
+                break;
+            }
+        }
+        return rowGroups.subList(startIndex, rowGroups.size());
     }
 
     private List<RowGroup> filterRowGroups(ResolvedPredicate filter) {

--- a/core/src/test/java/dev/hardwood/ParquetReaderTest.java
+++ b/core/src/test/java/dev/hardwood/ParquetReaderTest.java
@@ -20,6 +20,8 @@ import dev.hardwood.metadata.PhysicalType;
 import dev.hardwood.metadata.RepetitionType;
 import dev.hardwood.reader.ColumnReader;
 import dev.hardwood.reader.ParquetFileReader;
+import dev.hardwood.reader.RowReader;
+import dev.hardwood.schema.ColumnProjection;
 import dev.hardwood.schema.ColumnSchema;
 import dev.hardwood.schema.FileSchema;
 
@@ -298,6 +300,100 @@ class ParquetReaderTest {
 
             // Bare leaf name "element" must not resolve — it's ambiguous
             assertThatThrownBy(() -> schema.getColumn("element"))
+                    .isInstanceOf(IllegalArgumentException.class);
+        }
+    }
+
+    @Test
+    void negativeMaxRowsReturnsTailAndSkipsEarlierRowGroups() throws Exception {
+        // filter_pushdown_int.parquet has three row groups of 100 rows each:
+        // RG0: id 1-100, RG1: id 101-200, RG2: id 201-300.
+        Path parquetFile = Paths.get("src/test/resources/filter_pushdown_int.parquet");
+
+        try (ParquetFileReader reader = ParquetFileReader.open(InputFile.of(parquetFile))) {
+            // Tail of 10 fits inside RG2 so the reader must skip RG0 and RG1
+            // entirely and yield exactly ids 291..300.
+            try (RowReader rows = reader.createRowReader(
+                    ColumnProjection.columns("id"), null, -10L)) {
+                long firstId = Long.MAX_VALUE;
+                long lastId = Long.MIN_VALUE;
+                long count = 0;
+                while (rows.hasNext()) {
+                    rows.next();
+                    long id = rows.getLong(0);
+                    firstId = Math.min(firstId, id);
+                    lastId = Math.max(lastId, id);
+                    count++;
+                }
+                assertThat(count).isEqualTo(10);
+                assertThat(firstId).isEqualTo(291L);
+                assertThat(lastId).isEqualTo(300L);
+            }
+        }
+    }
+
+    @Test
+    void negativeMaxRowsSpansMultipleRowGroupsWhenNeeded() throws Exception {
+        Path parquetFile = Paths.get("src/test/resources/filter_pushdown_int.parquet");
+
+        try (ParquetFileReader reader = ParquetFileReader.open(InputFile.of(parquetFile))) {
+            // Tail of 150 crosses the RG1/RG2 boundary: reader must include RG1
+            // and RG2 but skip RG0, and trim the 50 leading rows of RG1.
+            try (RowReader rows = reader.createRowReader(
+                    ColumnProjection.columns("id"), null, -150L)) {
+                long firstId = Long.MAX_VALUE;
+                long lastId = Long.MIN_VALUE;
+                long count = 0;
+                while (rows.hasNext()) {
+                    rows.next();
+                    long id = rows.getLong(0);
+                    firstId = Math.min(firstId, id);
+                    lastId = Math.max(lastId, id);
+                    count++;
+                }
+                assertThat(count).isEqualTo(150);
+                assertThat(firstId).isEqualTo(151L);
+                assertThat(lastId).isEqualTo(300L);
+            }
+        }
+    }
+
+    @Test
+    void negativeMaxRowsLargerThanFileReadsAllRows() throws Exception {
+        Path parquetFile = Paths.get("src/test/resources/filter_pushdown_int.parquet");
+
+        try (ParquetFileReader reader = ParquetFileReader.open(InputFile.of(parquetFile))) {
+            try (RowReader rows = reader.createRowReader(
+                    ColumnProjection.columns("id"), null, -10_000L)) {
+                long count = 0;
+                while (rows.hasNext()) {
+                    rows.next();
+                    count++;
+                }
+                assertThat(count).isEqualTo(300);
+            }
+        }
+    }
+
+    @Test
+    void zeroMaxRowsIsRejected() throws Exception {
+        Path parquetFile = Paths.get("src/test/resources/filter_pushdown_int.parquet");
+
+        try (ParquetFileReader reader = ParquetFileReader.open(InputFile.of(parquetFile))) {
+            assertThatThrownBy(() -> reader.createRowReader(ColumnProjection.all(), null, 0L))
+                    .isInstanceOf(IllegalArgumentException.class);
+        }
+    }
+
+    @Test
+    void negativeMaxRowsWithFilterIsRejected() throws Exception {
+        Path parquetFile = Paths.get("src/test/resources/filter_pushdown_int.parquet");
+
+        try (ParquetFileReader reader = ParquetFileReader.open(InputFile.of(parquetFile))) {
+            assertThatThrownBy(() -> reader.createRowReader(
+                    ColumnProjection.all(),
+                    dev.hardwood.reader.FilterPredicate.gt("id", 0L),
+                    -10L))
                     .isInstanceOf(IllegalArgumentException.class);
         }
     }

--- a/docs/content/usage.md
+++ b/docs/content/usage.md
@@ -321,6 +321,24 @@ When combined with a filter, the limit applies to the number of **matching** row
 
 To read without a row limit, use the `createRowReader` overloads without `maxRows`.
 
+### Reading the Tail of a File
+
+Passing a **negative** `maxRows` reads the trailing rows of the file instead of the leading ones. Row groups that do not overlap the tail are skipped entirely, so pages for earlier row groups are never fetched or decoded — especially useful on remote backends like S3, where unneeded row groups avoid HTTP range requests altogether.
+
+```java
+// Read the last 10 rows; earlier row groups are skipped.
+try (ParquetFileReader fileReader = ParquetFileReader.open(InputFile.of(path));
+     RowReader rowReader = fileReader.createRowReader(ColumnProjection.all(), null, -10)) {
+
+    while (rowReader.hasNext()) {
+        rowReader.next();
+        // ...
+    }
+}
+```
+
+Tail mode cannot currently be combined with a filter predicate — the set of matching rows is not known from row-group statistics alone, so the reader cannot identify which row groups cover the last N matching rows without scanning the whole file.
+
 ## Column Projection
 
 Column projection allows reading only a subset of columns from a Parquet file, improving performance by skipping I/O, decoding, and memory allocation for unneeded columns.

--- a/s3/src/test/java/dev/hardwood/s3/S3SelectiveReadJfrTest.java
+++ b/s3/src/test/java/dev/hardwood/s3/S3SelectiveReadJfrTest.java
@@ -339,6 +339,77 @@ public class S3SelectiveReadJfrTest {
                 .isLessThan(fullReadBytes / 10);
     }
 
+    @Test
+    @EnableEvent("dev.hardwood.RowGroupScanned")
+    @EnableEvent("jdk.SocketRead")
+    void negativeMaxRowsOnlyFetchesLastRowGroup() throws Exception {
+        // lazy_rowgroup_test.parquet: 20 row groups × 50K rows × 8 columns.
+        // A tail of 10 rows fits entirely within the last row group, so only
+        // that row group should be fetched; bytes transferred should be a small
+        // fraction of a full read.
+
+        long fullReadBytes = readAndMeasureSocketBytes(LAZY_ROWGROUP_FILE,
+                ColumnProjection.all(), null);
+
+        jfrEvents.reset();
+
+        long expectedFirstC0 = (long) LAZY_RG_COUNT * LAZY_RG_ROWS - 10;
+        long expectedLastC0 = (long) LAZY_RG_COUNT * LAZY_RG_ROWS - 1;
+
+        long firstC0 = -1;
+        long lastC0 = -1;
+        int count = 0;
+        try (ParquetFileReader reader = ParquetFileReader.open(
+                source.inputFile("test-bucket", LAZY_ROWGROUP_FILE))) {
+            try (RowReader rows = reader.createRowReader(ColumnProjection.all(), null, -10L)) {
+                while (rows.hasNext()) {
+                    rows.next();
+                    long c0 = rows.getLong("c0");
+                    if (count == 0) {
+                        firstC0 = c0;
+                    }
+                    lastC0 = c0;
+                    count++;
+                }
+            }
+        }
+
+        assertThat(count).isEqualTo(10);
+        assertThat(firstC0).isEqualTo(expectedFirstC0);
+        assertThat(lastC0).isEqualTo(expectedLastC0);
+
+        jfrEvents.awaitEvents();
+
+        long scannedEvents = jfrEvents
+                .filter(e -> "dev.hardwood.RowGroupScanned".equals(e.getEventType().getName()))
+                .count();
+
+        long partialReadBytes = jfrEvents
+                .filter(e -> "jdk.SocketRead".equals(e.getEventType().getName()))
+                .mapToLong(e -> e.getLong("bytesRead"))
+                .sum();
+
+        LOG.log(System.Logger.Level.INFO,
+                "negativeMaxRowsOnlyFetchesLastRowGroup: full={0} bytes, tail=-10 read={1} bytes ({2}%), scanned={3} events",
+                fullReadBytes, partialReadBytes, partialReadBytes * 100 / fullReadBytes, scannedEvents);
+
+        // Tail of 10 rows fits inside the final row group, so only 1 RG ×
+        // 8 columns = 8 RowGroupScanned events should fire.
+        assertThat(scannedEvents)
+                .as("Tail of 10 rows should scan only the final row group (8 events for 8 columns); "
+                        + "scanned=%d".formatted(scannedEvents))
+                .isLessThanOrEqualTo(LAZY_RG_COLUMNS);
+
+        // Tail fetches only 1 of 20 row groups — bytes transferred should be
+        // well under 10% of a full read.
+        assertThat(partialReadBytes)
+                .as("Tail of 10 rows should transfer well under 10%% of full read; "
+                        + "full=%,d bytes, partial=%,d bytes (%d%%)"
+                                .formatted(fullReadBytes, partialReadBytes,
+                                        partialReadBytes * 100 / fullReadBytes))
+                .isLessThan(fullReadBytes / 10);
+    }
+
     // ==================== Lazy Fetch: Early Close ====================
 
     @Test


### PR DESCRIPTION
Previously `hardwood print -n -N` read every row in the file, keeping only the last N in a sliding ArrayDeque buffer. For multi-row-group files this decoded rows that were never displayed and, on remote backends like S3, issued HTTP range requests for data that would be discarded.

Extend `createRowReader(projection, filter, maxRows)` to accept a negative `maxRows`, interpreted as the tail size: row groups that do not overlap the last `-maxRows` rows are skipped entirely, and the returned reader yields exactly that many rows. The combination with a filter is rejected because the set of matching rows is not known from row-group statistics alone.

PrintCommand now routes tail mode through the same call as head mode, so the sliding ArrayDeque buffer is no longer needed.
