### PR TITLE
#284 Narrow CI artifact uploads to newly-built modules

### DIFF
--- a/.github/workflows/main-build.yml
+++ b/.github/workflows/main-build.yml
@@ -277,6 +277,7 @@ jobs:
   integration-tests:
     needs: build-core
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     name: 'Integration Tests'
 
     steps:

--- a/.github/workflows/main-build.yml
+++ b/.github/workflows/main-build.yml
@@ -53,7 +53,11 @@ jobs:
         uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f  # v7 — https://github.com/actions/upload-artifact/releases/tag/v7
         with:
           name: maven-repo-core
-          path: ~/.m2/repository/dev/hardwood/
+          path: |
+            ~/.m2/repository/dev/hardwood/hardwood-bom/
+            ~/.m2/repository/dev/hardwood/hardwood-test-bom/
+            ~/.m2/repository/dev/hardwood/hardwood-core/
+            ~/.m2/repository/dev/hardwood/hardwood-avro/
           retention-days: 1
 
   build-s3:
@@ -96,7 +100,9 @@ jobs:
         uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f  # v7 — https://github.com/actions/upload-artifact/releases/tag/v7
         with:
           name: maven-repo-s3
-          path: ~/.m2/repository/dev/hardwood/
+          path: |
+            ~/.m2/repository/dev/hardwood/hardwood-s3/
+            ~/.m2/repository/dev/hardwood/hardwood-aws-auth/
           retention-days: 1
 
   build-cli:
@@ -127,11 +133,12 @@ jobs:
             maven-${{ runner.os }}-build-core-
             maven-${{ runner.os }}-
 
-      - name: 'Download s3 artifacts'
+      - name: 'Download core and s3 artifacts'
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c  # v8 — https://github.com/actions/download-artifact/releases/tag/v8
         with:
-          name: maven-repo-s3
+          pattern: maven-repo-{core,s3}
           path: ~/.m2/repository/dev/hardwood/
+          merge-multiple: true
 
       - name: 'Build and install cli'
         run: ./mvnw -B clean install -pl :hardwood-cli
@@ -140,7 +147,7 @@ jobs:
         uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f  # v7 — https://github.com/actions/upload-artifact/releases/tag/v7
         with:
           name: maven-repo-cli
-          path: ~/.m2/repository/dev/hardwood/
+          path: ~/.m2/repository/dev/hardwood/hardwood-cli/
           retention-days: 1
 
   build-parquet-java-compat:
@@ -171,11 +178,12 @@ jobs:
             maven-${{ runner.os }}-build-core-
             maven-${{ runner.os }}-
 
-      - name: 'Download s3 artifacts'
+      - name: 'Download core and s3 artifacts'
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c  # v8 — https://github.com/actions/download-artifact/releases/tag/v8
         with:
-          name: maven-repo-s3
+          pattern: maven-repo-{core,s3}
           path: ~/.m2/repository/dev/hardwood/
+          merge-multiple: true
 
       - name: 'Build and install parquet-java-compat'
         run: ./mvnw -B clean install -pl :hardwood-parquet-java-compat
@@ -184,7 +192,7 @@ jobs:
         uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f  # v7 — https://github.com/actions/upload-artifact/releases/tag/v7
         with:
           name: maven-repo-parquet-java-compat
-          path: ~/.m2/repository/dev/hardwood/
+          path: ~/.m2/repository/dev/hardwood/hardwood-parquet-java-compat/
           retention-days: 1
 
   build-parquet-testing-runner:
@@ -227,7 +235,7 @@ jobs:
         uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f  # v7 — https://github.com/actions/upload-artifact/releases/tag/v7
         with:
           name: maven-repo-parquet-testing-runner
-          path: ~/.m2/repository/dev/hardwood/
+          path: ~/.m2/repository/dev/hardwood/hardwood-parquet-testing-runner/
           retention-days: 1
 
   javadoc:

--- a/.github/workflows/pr-build.yml
+++ b/.github/workflows/pr-build.yml
@@ -53,7 +53,11 @@ jobs:
         uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f  # v7 — https://github.com/actions/upload-artifact/releases/tag/v7
         with:
           name: maven-repo-core
-          path: ~/.m2/repository/dev/hardwood/
+          path: |
+            ~/.m2/repository/dev/hardwood/hardwood-bom/
+            ~/.m2/repository/dev/hardwood/hardwood-test-bom/
+            ~/.m2/repository/dev/hardwood/hardwood-core/
+            ~/.m2/repository/dev/hardwood/hardwood-avro/
           retention-days: 1
 
   build-s3:
@@ -96,7 +100,9 @@ jobs:
         uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f  # v7 — https://github.com/actions/upload-artifact/releases/tag/v7
         with:
           name: maven-repo-s3
-          path: ~/.m2/repository/dev/hardwood/
+          path: |
+            ~/.m2/repository/dev/hardwood/hardwood-s3/
+            ~/.m2/repository/dev/hardwood/hardwood-aws-auth/
           retention-days: 1
 
   build-cli:
@@ -127,11 +133,12 @@ jobs:
             maven-${{ runner.os }}-build-core-
             maven-${{ runner.os }}-
 
-      - name: 'Download s3 artifacts'
+      - name: 'Download core and s3 artifacts'
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c  # v8 — https://github.com/actions/download-artifact/releases/tag/v8
         with:
-          name: maven-repo-s3
+          pattern: maven-repo-{core,s3}
           path: ~/.m2/repository/dev/hardwood/
+          merge-multiple: true
 
       - name: 'Build and install cli'
         run: ./mvnw -B clean install -pl :hardwood-cli
@@ -140,7 +147,7 @@ jobs:
         uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f  # v7 — https://github.com/actions/upload-artifact/releases/tag/v7
         with:
           name: maven-repo-cli
-          path: ~/.m2/repository/dev/hardwood/
+          path: ~/.m2/repository/dev/hardwood/hardwood-cli/
           retention-days: 1
 
   build-parquet-java-compat:
@@ -171,11 +178,12 @@ jobs:
             maven-${{ runner.os }}-build-core-
             maven-${{ runner.os }}-
 
-      - name: 'Download s3 artifacts'
+      - name: 'Download core and s3 artifacts'
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c  # v8 — https://github.com/actions/download-artifact/releases/tag/v8
         with:
-          name: maven-repo-s3
+          pattern: maven-repo-{core,s3}
           path: ~/.m2/repository/dev/hardwood/
+          merge-multiple: true
 
       - name: 'Build and install parquet-java-compat'
         run: ./mvnw -B clean install -pl :hardwood-parquet-java-compat
@@ -184,7 +192,7 @@ jobs:
         uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f  # v7 — https://github.com/actions/upload-artifact/releases/tag/v7
         with:
           name: maven-repo-parquet-java-compat
-          path: ~/.m2/repository/dev/hardwood/
+          path: ~/.m2/repository/dev/hardwood/hardwood-parquet-java-compat/
           retention-days: 1
 
   build-parquet-testing-runner:
@@ -227,7 +235,7 @@ jobs:
         uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f  # v7 — https://github.com/actions/upload-artifact/releases/tag/v7
         with:
           name: maven-repo-parquet-testing-runner
-          path: ~/.m2/repository/dev/hardwood/
+          path: ~/.m2/repository/dev/hardwood/hardwood-parquet-testing-runner/
           retention-days: 1
 
   javadoc:
@@ -360,11 +368,12 @@ jobs:
             maven-${{ runner.os }}-build-core-
             maven-${{ runner.os }}-
 
-      - name: 'Download s3 artifacts'
+      - name: 'Download core and s3 artifacts'
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c  # v8 — https://github.com/actions/download-artifact/releases/tag/v8
         with:
-          name: maven-repo-s3
+          pattern: maven-repo-{core,s3}
           path: ~/.m2/repository/dev/hardwood/
+          merge-multiple: true
 
       - name: 'Cache taxi data'
         uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7  # v5 — https://github.com/actions/cache/releases/tag/v5
@@ -415,11 +424,12 @@ jobs:
             maven-${{ runner.os }}-build-core-
             maven-${{ runner.os }}-
 
-      - name: 'Download cli artifacts'
+      - name: 'Download built artifacts'
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c  # v8 — https://github.com/actions/download-artifact/releases/tag/v8
         with:
-          name: maven-repo-cli
+          pattern: maven-repo-{core,s3,cli}
           path: ~/.m2/repository/dev/hardwood/
+          merge-multiple: true
 
       - name: 'Build Native Image'
         # -DskipSurefire=true skips the JVM @QuarkusMainTest suite (already run

--- a/.github/workflows/pr-build.yml
+++ b/.github/workflows/pr-build.yml
@@ -277,6 +277,7 @@ jobs:
   integration-tests:
     needs: build-core
     runs-on: ubuntu-latest
+    timeout-minutes: 15
 
     strategy:
       matrix:
@@ -321,7 +322,21 @@ jobs:
 
       - name: 'Install libdeflate'
         if: ${{ matrix.install_libdeflate }}
-        run: sudo apt-get update && sudo apt-get install -y libdeflate-dev
+        env:
+          DEBIAN_FRONTEND: noninteractive
+          NEEDRESTART_MODE: a
+        run: |
+          # Freshly booted ubuntu-24.04 runners may still be running
+          # unattended-upgrades, which holds /var/lib/dpkg/lock-frontend and
+          # makes apt-get block indefinitely. Stop the service and wait for
+          # the lock to clear before installing.
+          sudo systemctl stop unattended-upgrades.service 2>/dev/null || true
+          while sudo fuser /var/lib/dpkg/lock-frontend >/dev/null 2>&1; do
+            echo "Waiting for dpkg lock..."
+            sleep 2
+          done
+          sudo -E apt-get update
+          sudo -E apt-get install -y libdeflate-dev
 
       - name: 'Download core artifacts'
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c  # v8 — https://github.com/actions/download-artifact/releases/tag/v8

--- a/core/src/main/java/dev/hardwood/internal/reader/FlatColumnWorker.java
+++ b/core/src/main/java/dev/hardwood/internal/reader/FlatColumnWorker.java
@@ -70,6 +70,9 @@ public class FlatColumnWorker extends ColumnWorker<BatchExchange.Batch> {
 
             if (rowsInCurrentBatch >= batchCapacity) {
                 publishCurrentBatch();
+                if (done) {
+                    return;
+                }
             }
 
             // Check if we've hit the limit after publishing
@@ -96,15 +99,18 @@ public class FlatColumnWorker extends ColumnWorker<BatchExchange.Batch> {
         long t0 = System.nanoTime();
         try {
             if (!exchange.publish(currentBatch)) {
-                return; // stopped during publish
+                done = true; // stopped during publish
+                return;
             }
             currentBatch = exchange.takeBatch();
             if (currentBatch == null) {
-                return; // stopped during take
+                done = true; // stopped during take
+                return;
             }
         }
         catch (InterruptedException e) {
             Thread.currentThread().interrupt();
+            done = true;
             return;
         }
         publishBlockNanos += System.nanoTime() - t0;

--- a/core/src/main/java/dev/hardwood/internal/reader/NestedColumnWorker.java
+++ b/core/src/main/java/dev/hardwood/internal/reader/NestedColumnWorker.java
@@ -88,6 +88,9 @@ public class NestedColumnWorker extends ColumnWorker<NestedBatch> {
                 // Previous record is complete — check if batch is full
                 if (rowsInCurrentBatch >= batchCapacity) {
                     publishCurrentBatch();
+                    if (done) {
+                        return;
+                    }
                 }
 
                 // Check maxRows after publishing
@@ -151,15 +154,18 @@ public class NestedColumnWorker extends ColumnWorker<NestedBatch> {
         long t0 = System.nanoTime();
         try {
             if (!exchange.publish(currentBatch)) {
-                return; // stopped during publish
+                done = true; // stopped during publish
+                return;
             }
             currentBatch = exchange.takeBatch();
             if (currentBatch == null) {
-                return; // stopped during take
+                done = true; // stopped during take
+                return;
             }
         }
         catch (InterruptedException e) {
             Thread.currentThread().interrupt();
+            done = true;
             return;
         }
         publishBlockNanos += System.nanoTime() - t0;

--- a/core/src/test/java/dev/hardwood/internal/reader/ColumnWorkerTest.java
+++ b/core/src/test/java/dev/hardwood/internal/reader/ColumnWorkerTest.java
@@ -389,6 +389,93 @@ class ColumnWorkerTest {
         }
     }
 
+    /// Regression test for #300. When the exchange is stopped during the
+    /// publish/take handshake, `publishCurrentBatch` must set `done = true`
+    /// before returning — otherwise the outer `assemblePage` loop continues
+    /// and dereferences the now-null `currentBatch` in `copyPageData`.
+    @Test
+    @Timeout(value = 10, unit = TimeUnit.SECONDS)
+    void flatPublishCurrentBatchMarksDoneAfterTakeReturnsNull() throws Exception {
+        try (HardwoodContextImpl context = HardwoodContextImpl.create()) {
+            ColumnSchema column = new ColumnSchema(
+                    dev.hardwood.metadata.FieldPath.of("col"),
+                    PhysicalType.INT32,
+                    dev.hardwood.metadata.RepetitionType.REQUIRED,
+                    null, 0, 0, 0, null);
+            int batchCapacity = 64;
+
+            BatchExchange<BatchExchange.Batch> exchange = BatchExchange.recycling(
+                    column.name(), () -> {
+                        BatchExchange.Batch b = new BatchExchange.Batch();
+                        b.values = BatchExchange.allocateArray(column.type(), batchCapacity);
+                        return b;
+                    });
+            FlatColumnWorker worker = new FlatColumnWorker(
+                    null, exchange, column, batchCapacity,
+                    context.decompressorFactory(), context.executor(), 0);
+
+            worker.initDrainState();
+            worker.currentBatch = exchange.takeBatch();
+            worker.rowsInCurrentBatch = batchCapacity;
+
+            // Finish the exchange and drain the free queue so the subsequent
+            // takeBatch() inside publishCurrentBatch() returns null.
+            exchange.finish();
+            while (exchange.takeBatch() != null) {
+                // drain
+            }
+
+            worker.publishCurrentBatch();
+
+            assertThat(worker.done)
+                    .as("done must be set when the exchange was stopped during take")
+                    .isTrue();
+            assertThat(worker.currentBatch).isNull();
+        }
+    }
+
+    /// Regression test for #300, nested variant. Same contract as the flat
+    /// worker: `done` must propagate out of the stopped-during-handshake paths
+    /// so `assemblePage` doesn't dereference a null `currentBatch`.
+    @Test
+    @Timeout(value = 10, unit = TimeUnit.SECONDS)
+    void nestedPublishCurrentBatchMarksDoneAfterTakeReturnsNull() throws Exception {
+        try (HardwoodContextImpl context = HardwoodContextImpl.create()) {
+            ColumnSchema column = new ColumnSchema(
+                    dev.hardwood.metadata.FieldPath.of("col"),
+                    PhysicalType.INT32,
+                    dev.hardwood.metadata.RepetitionType.REQUIRED,
+                    null, 0, 0, 0, null);
+            int batchCapacity = 64;
+
+            BatchExchange<NestedBatch> exchange = BatchExchange.recycling(
+                    column.name(), () -> {
+                        NestedBatch b = new NestedBatch();
+                        b.values = BatchExchange.allocateArray(column.type(), batchCapacity * 2);
+                        return b;
+                    });
+            NestedColumnWorker worker = new NestedColumnWorker(
+                    null, exchange, column, batchCapacity,
+                    context.decompressorFactory(), context.executor(), 0, null);
+
+            worker.initDrainState();
+            worker.currentBatch = exchange.takeBatch();
+            worker.rowsInCurrentBatch = batchCapacity;
+
+            exchange.finish();
+            while (exchange.takeBatch() != null) {
+                // drain
+            }
+
+            worker.publishCurrentBatch();
+
+            assertThat(worker.done)
+                    .as("done must be set when the exchange was stopped during take")
+                    .isTrue();
+            assertThat(worker.currentBatch).isNull();
+        }
+    }
+
     // ==================== Helpers ====================
 
     private static RowGroupIterator createIterator(Path file, FileSchema schema,


### PR DESCRIPTION
Each build-* job previously uploaded the entire ~/.m2/repository/dev/hardwood/ directory, which meant downstream artifacts carried duplicate copies of upstream modules. javadoc's merge-multiple download then extracted the same JAR up to three times, multiplying the exposure to flaky actions/upload-artifact round-trips (seen as java.util.zip.ZipException 'invalid distance too far back').

Now each job uploads only the module paths it actually built, and downstream jobs pull the chain via actions/download-artifact's pattern field. Each JAR is uploaded/downloaded exactly once.