### PR TITLE
#298 Run most CLI tests in-process instead of through QuarkusMainTest

### DIFF
--- a/cli/src/test/java/dev/hardwood/cli/command/Cli.java
+++ b/cli/src/test/java/dev/hardwood/cli/command/Cli.java
@@ -1,0 +1,60 @@
+/*
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Copyright The original authors
+ *
+ *  Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package dev.hardwood.cli.command;
+
+import java.io.PrintWriter;
+import java.io.StringWriter;
+
+import picocli.CommandLine;
+
+/// In-process launcher for CLI command tests. Executes the top-level `hardwood`
+/// command directly via picocli with stdout and stderr captured into strings,
+/// avoiding the Quarkus bootstrap that `@QuarkusMainTest` pays per test class.
+///
+/// Mirrors the configuration applied to the production `CommandLine`
+/// produced by [HardwoodCommand.getCommandLineInstance] so tests exercise the
+/// same parser behaviour.
+final class Cli {
+
+    private Cli() {
+    }
+
+    static Result launch(String... args) {
+        StringWriter out = new StringWriter();
+        StringWriter err = new StringWriter();
+
+        CommandLine commandLine = new CommandLine(new HardwoodCommand())
+                .setCaseInsensitiveEnumValuesAllowed(true)
+                .setOut(new PrintWriter(out, true))
+                .setErr(new PrintWriter(err, true));
+
+        int exitCode = commandLine.execute(args);
+        return new Result(exitCode, stripTrailingNewlines(out.toString()), stripTrailingNewlines(err.toString()));
+    }
+
+    /// `QuarkusMainLauncher` strips the trailing line separator from captured
+    /// output. Match that so assertions using text blocks (which have no
+    /// trailing newline) behave identically whether launched directly or via
+    /// Quarkus.
+    private static String stripTrailingNewlines(String s) {
+        int end = s.length();
+        while (end > 0) {
+            char c = s.charAt(end - 1);
+            if (c == '\n' || c == '\r') {
+                end--;
+            }
+            else {
+                break;
+            }
+        }
+        return s.substring(0, end);
+    }
+
+    record Result(int exitCode, String output, String errorOutput) {
+    }
+}

--- a/cli/src/test/java/dev/hardwood/cli/command/ConvertCommandContract.java
+++ b/cli/src/test/java/dev/hardwood/cli/command/ConvertCommandContract.java
@@ -9,9 +9,6 @@ package dev.hardwood.cli.command;
 
 import org.junit.jupiter.api.Test;
 
-import io.quarkus.test.junit.main.LaunchResult;
-import io.quarkus.test.junit.main.QuarkusMainLauncher;
-
 import static org.assertj.core.api.Assertions.assertThat;
 
 /// Shared test contract for the `convert` command.
@@ -26,11 +23,11 @@ interface ConvertCommandContract {
     String nonexistentFile();
 
     @Test
-    default void csvOutput(QuarkusMainLauncher launcher) {
-        LaunchResult result = launcher.launch("convert", "-f", plainFile(), "--format", "csv");
+    default void csvOutput() {
+        Cli.Result result = Cli.launch("convert", "-f", plainFile(), "--format", "csv");
 
         assertThat(result.exitCode()).isZero();
-        assertThat(result.getOutput()).isEqualTo("""
+        assertThat(result.output()).isEqualTo("""
                 id,value
                 1,100
                 2,200
@@ -38,11 +35,11 @@ interface ConvertCommandContract {
     }
 
     @Test
-    default void jsonOutput(QuarkusMainLauncher launcher) {
-        LaunchResult result = launcher.launch("convert", "-f", plainFile(), "--format", "json");
+    default void jsonOutput() {
+        Cli.Result result = Cli.launch("convert", "-f", plainFile(), "--format", "json");
 
         assertThat(result.exitCode()).isZero();
-        assertThat(result.getOutput()).isEqualTo("""
+        assertThat(result.output()).isEqualTo("""
                 [
                   {"id":"1","value":"100"},
                   {"id":"2","value":"200"},
@@ -51,11 +48,11 @@ interface ConvertCommandContract {
     }
 
     @Test
-    default void csvColumnsFilter(QuarkusMainLauncher launcher) {
-        LaunchResult result = launcher.launch("convert", "-f", plainFile(), "--format", "csv", "--columns", "id");
+    default void csvColumnsFilter() {
+        Cli.Result result = Cli.launch("convert", "-f", plainFile(), "--format", "csv", "--columns", "id");
 
         assertThat(result.exitCode()).isZero();
-        assertThat(result.getOutput()).isEqualTo("""
+        assertThat(result.output()).isEqualTo("""
                 id
                 1
                 2
@@ -63,11 +60,11 @@ interface ConvertCommandContract {
     }
 
     @Test
-    default void csvWithNestedStructColumns(QuarkusMainLauncher launcher) {
-        LaunchResult result = launcher.launch("convert", "-f", deepNestedFile(), "--format", "csv", "--columns", "customer_id,name");
+    default void csvWithNestedStructColumns() {
+        Cli.Result result = Cli.launch("convert", "-f", deepNestedFile(), "--format", "csv", "--columns", "customer_id,name");
 
         assertThat(result.exitCode()).isZero();
-        assertThat(result.getOutput()).isEqualTo("""
+        assertThat(result.output()).isEqualTo("""
                 customer_id,name
                 1,Alice
                 2,Bob
@@ -76,11 +73,11 @@ interface ConvertCommandContract {
     }
 
     @Test
-    default void csvFlattensNestedStructs(QuarkusMainLauncher launcher) {
-        LaunchResult result = launcher.launch("convert", "-f", deepNestedFile(), "--format", "csv", "--columns", "name,account");
+    default void csvFlattensNestedStructs() {
+        Cli.Result result = Cli.launch("convert", "-f", deepNestedFile(), "--format", "csv", "--columns", "name,account");
 
         assertThat(result.exitCode()).isZero();
-        assertThat(result.getOutput()).isEqualTo("""
+        assertThat(result.output()).isEqualTo("""
                 name,account.id,account.organization.name,account.organization.address.street,account.organization.address.city,account.organization.address.zip
                 Alice,ACC-001,Acme Corp,123 Main St,New York,10001
                 Bob,ACC-002,TechStart,null,null,null
@@ -89,11 +86,11 @@ interface ConvertCommandContract {
     }
 
     @Test
-    default void csvWithListColumns(QuarkusMainLauncher launcher) {
-        LaunchResult result = launcher.launch("convert", "-f", listFile(), "--format", "csv");
+    default void csvWithListColumns() {
+        Cli.Result result = Cli.launch("convert", "-f", listFile(), "--format", "csv");
 
         assertThat(result.exitCode()).isZero();
-        assertThat(result.getOutput()).isEqualTo("""
+        assertThat(result.output()).isEqualTo("""
                 id,tags,scores
                 1,"[a, b, c]","[10, 20, 30]"
                 2,[],[100]
@@ -102,15 +99,15 @@ interface ConvertCommandContract {
     }
 
     @Test
-    default void rejectsUnknownColumn(QuarkusMainLauncher launcher) {
-        LaunchResult result = launcher.launch("convert", "-f", plainFile(), "--format", "csv", "--columns", "unknown");
+    default void rejectsUnknownColumn() {
+        Cli.Result result = Cli.launch("convert", "-f", plainFile(), "--format", "csv", "--columns", "unknown");
 
         assertThat(result.exitCode()).isNotZero();
     }
 
     @Test
-    default void failsOnNonexistentFile(QuarkusMainLauncher launcher) {
-        LaunchResult result = launcher.launch("convert", "-f", nonexistentFile(), "--format", "csv");
+    default void failsOnNonexistentFile() {
+        Cli.Result result = Cli.launch("convert", "-f", nonexistentFile(), "--format", "csv");
 
         assertThat(result.exitCode()).isNotZero();
     }

--- a/cli/src/test/java/dev/hardwood/cli/command/ConvertCommandTest.java
+++ b/cli/src/test/java/dev/hardwood/cli/command/ConvertCommandTest.java
@@ -14,13 +14,8 @@ import java.nio.file.Path;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
-import io.quarkus.test.junit.main.LaunchResult;
-import io.quarkus.test.junit.main.QuarkusMainLauncher;
-import io.quarkus.test.junit.main.QuarkusMainTest;
-
 import static org.assertj.core.api.Assertions.assertThat;
 
-@QuarkusMainTest
 class ConvertCommandTest implements ConvertCommandContract {
 
     @Override
@@ -44,10 +39,10 @@ class ConvertCommandTest implements ConvertCommandContract {
     }
 
     @Test
-    void outputToFile(@TempDir Path tempDir, QuarkusMainLauncher launcher) throws IOException {
+    void outputToFile(@TempDir Path tempDir) throws IOException {
         Path out = tempDir.resolve("output.csv");
 
-        LaunchResult result = launcher.launch("convert", "-f", plainFile(), "--format", "csv", "-o", out.toString());
+        Cli.Result result = Cli.launch("convert", "-f", plainFile(), "--format", "csv", "-o", out.toString());
 
         assertThat(result.exitCode()).isZero();
         assertThat(Files.readString(out))
@@ -56,16 +51,16 @@ class ConvertCommandTest implements ConvertCommandContract {
     }
 
     @Test
-    void rejectsRemoteUri(QuarkusMainLauncher launcher) {
-        LaunchResult result = launcher.launch("convert", "-f", "gs://bucket/data.parquet", "--format", "csv");
+    void rejectsRemoteUri() {
+        Cli.Result result = Cli.launch("convert", "-f", "gs://bucket/data.parquet", "--format", "csv");
 
         assertThat(result.exitCode()).isNotZero();
-        assertThat(result.getErrorOutput()).contains("not implemented yet");
+        assertThat(result.errorOutput()).contains("not implemented yet");
     }
 
     @Test
-    void requiresFormatFlag(QuarkusMainLauncher launcher) {
-        LaunchResult result = launcher.launch("convert", "-f", plainFile());
+    void requiresFormatFlag() {
+        Cli.Result result = Cli.launch("convert", "-f", plainFile());
 
         assertThat(result.exitCode()).isNotZero();
     }

--- a/cli/src/test/java/dev/hardwood/cli/command/ConvertS3CommandTest.java
+++ b/cli/src/test/java/dev/hardwood/cli/command/ConvertS3CommandTest.java
@@ -7,9 +7,6 @@
  */
 package dev.hardwood.cli.command;
 
-import io.quarkus.test.junit.main.QuarkusMainTest;
-
-@QuarkusMainTest
 class ConvertS3CommandTest extends AbstractS3CommandTest implements ConvertCommandContract {
 
     @Override

--- a/cli/src/test/java/dev/hardwood/cli/command/FooterCommandContract.java
+++ b/cli/src/test/java/dev/hardwood/cli/command/FooterCommandContract.java
@@ -9,9 +9,6 @@ package dev.hardwood.cli.command;
 
 import org.junit.jupiter.api.Test;
 
-import io.quarkus.test.junit.main.LaunchResult;
-import io.quarkus.test.junit.main.QuarkusMainLauncher;
-
 import static org.assertj.core.api.Assertions.assertThat;
 
 /// Shared test contract for the `footer` command.
@@ -22,11 +19,11 @@ interface FooterCommandContract {
     String nonexistentFile();
 
     @Test
-    default void displaysFooterInfo(QuarkusMainLauncher launcher) {
-        LaunchResult result = launcher.launch("footer", "-f", plainFile());
+    default void displaysFooterInfo() {
+        Cli.Result result = Cli.launch("footer", "-f", plainFile());
 
         assertThat(result.exitCode()).isZero();
-        assertThat(result.getOutput()).isEqualTo("""
+        assertThat(result.output()).isEqualTo("""
                 File Size:     722 bytes
                 Footer Offset: 178 bytes
                 Footer Length: 536 bytes
@@ -35,8 +32,8 @@ interface FooterCommandContract {
     }
 
     @Test
-    default void failsOnNonexistentFile(QuarkusMainLauncher launcher) {
-        LaunchResult result = launcher.launch("footer", "-f", nonexistentFile());
+    default void failsOnNonexistentFile() {
+        Cli.Result result = Cli.launch("footer", "-f", nonexistentFile());
 
         assertThat(result.exitCode()).isNotZero();
     }

--- a/cli/src/test/java/dev/hardwood/cli/command/FooterCommandTest.java
+++ b/cli/src/test/java/dev/hardwood/cli/command/FooterCommandTest.java
@@ -9,13 +9,8 @@ package dev.hardwood.cli.command;
 
 import org.junit.jupiter.api.Test;
 
-import io.quarkus.test.junit.main.LaunchResult;
-import io.quarkus.test.junit.main.QuarkusMainLauncher;
-import io.quarkus.test.junit.main.QuarkusMainTest;
-
 import static org.assertj.core.api.Assertions.assertThat;
 
-@QuarkusMainTest
 class FooterCommandTest implements FooterCommandContract {
 
     @Override
@@ -29,10 +24,10 @@ class FooterCommandTest implements FooterCommandContract {
     }
 
     @Test
-    void rejectsRemoteUri(QuarkusMainLauncher launcher) {
-        LaunchResult result = launcher.launch("footer", "-f", "gs://bucket/data.parquet");
+    void rejectsRemoteUri() {
+        Cli.Result result = Cli.launch("footer", "-f", "gs://bucket/data.parquet");
 
         assertThat(result.exitCode()).isNotZero();
-        assertThat(result.getErrorOutput()).contains("not implemented yet");
+        assertThat(result.errorOutput()).contains("not implemented yet");
     }
 }

--- a/cli/src/test/java/dev/hardwood/cli/command/FooterS3CommandTest.java
+++ b/cli/src/test/java/dev/hardwood/cli/command/FooterS3CommandTest.java
@@ -7,9 +7,6 @@
  */
 package dev.hardwood.cli.command;
 
-import io.quarkus.test.junit.main.QuarkusMainTest;
-
-@QuarkusMainTest
 class FooterS3CommandTest extends AbstractS3CommandTest implements FooterCommandContract {
 
     @Override

--- a/cli/src/test/java/dev/hardwood/cli/command/InfoCommandContract.java
+++ b/cli/src/test/java/dev/hardwood/cli/command/InfoCommandContract.java
@@ -9,9 +9,6 @@ package dev.hardwood.cli.command;
 
 import org.junit.jupiter.api.Test;
 
-import io.quarkus.test.junit.main.LaunchResult;
-import io.quarkus.test.junit.main.QuarkusMainLauncher;
-
 import static org.assertj.core.api.Assertions.assertThat;
 
 /// Shared test contract for the `info` command.
@@ -22,11 +19,11 @@ interface InfoCommandContract {
     String nonexistentFile();
 
     @Test
-    default void displaysFileInfo(QuarkusMainLauncher launcher) {
-        LaunchResult result = launcher.launch("info", "-f", plainFile());
+    default void displaysFileInfo() {
+        Cli.Result result = Cli.launch("info", "-f", plainFile());
 
         assertThat(result.exitCode()).isZero();
-        assertThat(result.getOutput()).isEqualTo("""
+        assertThat(result.output()).isEqualTo("""
                 Format Version:    2
                 Created By:        parquet-cpp-arrow version 22.0.0
                 Row Groups:        1
@@ -36,8 +33,8 @@ interface InfoCommandContract {
     }
 
     @Test
-    default void failsOnNonexistentFile(QuarkusMainLauncher launcher) {
-        LaunchResult result = launcher.launch("info", "-f", nonexistentFile());
+    default void failsOnNonexistentFile() {
+        Cli.Result result = Cli.launch("info", "-f", nonexistentFile());
 
         assertThat(result.exitCode()).isNotZero();
     }

--- a/cli/src/test/java/dev/hardwood/cli/command/InfoCommandTest.java
+++ b/cli/src/test/java/dev/hardwood/cli/command/InfoCommandTest.java
@@ -9,13 +9,8 @@ package dev.hardwood.cli.command;
 
 import org.junit.jupiter.api.Test;
 
-import io.quarkus.test.junit.main.LaunchResult;
-import io.quarkus.test.junit.main.QuarkusMainLauncher;
-import io.quarkus.test.junit.main.QuarkusMainTest;
-
 import static org.assertj.core.api.Assertions.assertThat;
 
-@QuarkusMainTest
 class InfoCommandTest implements InfoCommandContract {
 
     @Override
@@ -29,10 +24,10 @@ class InfoCommandTest implements InfoCommandContract {
     }
 
     @Test
-    void rejectsRemoteUri(QuarkusMainLauncher launcher) {
-        LaunchResult result = launcher.launch("info", "-f", "gs://bucket/data.parquet");
+    void rejectsRemoteUri() {
+        Cli.Result result = Cli.launch("info", "-f", "gs://bucket/data.parquet");
 
         assertThat(result.exitCode()).isNotZero();
-        assertThat(result.getErrorOutput()).contains("not implemented yet");
+        assertThat(result.errorOutput()).contains("not implemented yet");
     }
 }

--- a/cli/src/test/java/dev/hardwood/cli/command/InfoS3CommandTest.java
+++ b/cli/src/test/java/dev/hardwood/cli/command/InfoS3CommandTest.java
@@ -7,9 +7,6 @@
  */
 package dev.hardwood.cli.command;
 
-import io.quarkus.test.junit.main.QuarkusMainTest;
-
-@QuarkusMainTest
 class InfoS3CommandTest extends AbstractS3CommandTest implements InfoCommandContract {
 
     @Override

--- a/cli/src/test/java/dev/hardwood/cli/command/InspectColumnsCommandContract.java
+++ b/cli/src/test/java/dev/hardwood/cli/command/InspectColumnsCommandContract.java
@@ -9,9 +9,6 @@ package dev.hardwood.cli.command;
 
 import org.junit.jupiter.api.Test;
 
-import io.quarkus.test.junit.main.LaunchResult;
-import io.quarkus.test.junit.main.QuarkusMainLauncher;
-
 import static org.assertj.core.api.Assertions.assertThat;
 
 /// Shared test contract for the `inspect columns` command.
@@ -24,11 +21,11 @@ interface InspectColumnsCommandContract {
     String nonexistentFile();
 
     @Test
-    default void displaysRankedColumns(QuarkusMainLauncher launcher) {
-        LaunchResult result = launcher.launch("inspect", "columns", "-f", plainFile());
+    default void displaysRankedColumns() {
+        Cli.Result result = Cli.launch("inspect", "columns", "-f", plainFile());
 
         assertThat(result.exitCode()).isZero();
-        assertThat(result.getOutput()).isEqualTo("""
+        assertThat(result.output()).isEqualTo("""
                 +------+--------+-------+------------+--------------+--------+---------+
                 | Rank | Column | Type  | Compressed | Uncompressed | Ratio  | # Pages |
                 +------+--------+-------+------------+--------------+--------+---------+
@@ -38,11 +35,11 @@ interface InspectColumnsCommandContract {
     }
 
     @Test
-    default void populatesPageCountWhenPageIndexAvailable(QuarkusMainLauncher launcher) {
-        LaunchResult result = launcher.launch("inspect", "columns", "-f", pageIndexFile());
+    default void populatesPageCountWhenPageIndexAvailable() {
+        Cli.Result result = Cli.launch("inspect", "columns", "-f", pageIndexFile());
 
         assertThat(result.exitCode()).isZero();
-        assertThat(result.getOutput()).isEqualTo("""
+        assertThat(result.output()).isEqualTo("""
                 +------+--------+-------+------------+--------------+--------+---------+
                 | Rank | Column | Type  | Compressed | Uncompressed | Ratio  | # Pages |
                 +------+--------+-------+------------+--------------+--------+---------+
@@ -52,8 +49,8 @@ interface InspectColumnsCommandContract {
     }
 
     @Test
-    default void failsOnNonexistentFile(QuarkusMainLauncher launcher) {
-        LaunchResult result = launcher.launch("inspect", "columns", "-f", nonexistentFile());
+    default void failsOnNonexistentFile() {
+        Cli.Result result = Cli.launch("inspect", "columns", "-f", nonexistentFile());
 
         assertThat(result.exitCode()).isNotZero();
     }

--- a/cli/src/test/java/dev/hardwood/cli/command/InspectColumnsCommandTest.java
+++ b/cli/src/test/java/dev/hardwood/cli/command/InspectColumnsCommandTest.java
@@ -9,13 +9,8 @@ package dev.hardwood.cli.command;
 
 import org.junit.jupiter.api.Test;
 
-import io.quarkus.test.junit.main.LaunchResult;
-import io.quarkus.test.junit.main.QuarkusMainLauncher;
-import io.quarkus.test.junit.main.QuarkusMainTest;
-
 import static org.assertj.core.api.Assertions.assertThat;
 
-@QuarkusMainTest
 class InspectColumnsCommandTest implements InspectColumnsCommandContract {
 
     @Override
@@ -34,10 +29,10 @@ class InspectColumnsCommandTest implements InspectColumnsCommandContract {
     }
 
     @Test
-    void rejectsRemoteUri(QuarkusMainLauncher launcher) {
-        LaunchResult result = launcher.launch("inspect", "columns", "-f", "gs://bucket/data.parquet");
+    void rejectsRemoteUri() {
+        Cli.Result result = Cli.launch("inspect", "columns", "-f", "gs://bucket/data.parquet");
 
         assertThat(result.exitCode()).isNotZero();
-        assertThat(result.getErrorOutput()).contains("not implemented yet");
+        assertThat(result.errorOutput()).contains("not implemented yet");
     }
 }

--- a/cli/src/test/java/dev/hardwood/cli/command/InspectColumnsS3CommandTest.java
+++ b/cli/src/test/java/dev/hardwood/cli/command/InspectColumnsS3CommandTest.java
@@ -7,9 +7,6 @@
  */
 package dev.hardwood.cli.command;
 
-import io.quarkus.test.junit.main.QuarkusMainTest;
-
-@QuarkusMainTest
 class InspectColumnsS3CommandTest extends AbstractS3CommandTest implements InspectColumnsCommandContract {
 
     @Override

--- a/cli/src/test/java/dev/hardwood/cli/command/InspectDictionaryCommandContract.java
+++ b/cli/src/test/java/dev/hardwood/cli/command/InspectDictionaryCommandContract.java
@@ -9,9 +9,6 @@ package dev.hardwood.cli.command;
 
 import org.junit.jupiter.api.Test;
 
-import io.quarkus.test.junit.main.LaunchResult;
-import io.quarkus.test.junit.main.QuarkusMainLauncher;
-
 import static org.assertj.core.api.Assertions.assertThat;
 
 /// Shared test contract for the `inspect dictionary` command.
@@ -24,11 +21,11 @@ interface InspectDictionaryCommandContract {
     String nonexistentFile();
 
     @Test
-    default void printsDictionaryEntriesForDictColumn(QuarkusMainLauncher launcher) {
-        LaunchResult result = launcher.launch("inspect", "dictionary", "-f", dictFile(), "--column", "category");
+    default void printsDictionaryEntriesForDictColumn() {
+        Cli.Result result = Cli.launch("inspect", "dictionary", "-f", dictFile(), "--column", "category");
 
         assertThat(result.exitCode()).isZero();
-        assertThat(result.getOutput()).isEqualTo("""
+        assertThat(result.output()).isEqualTo("""
                 Row Group 0 / category
                   Dictionary size: 3 entries
                   [   0] A
@@ -37,26 +34,26 @@ interface InspectDictionaryCommandContract {
     }
 
     @Test
-    default void printsNoDictionaryMessageForPlainColumn(QuarkusMainLauncher launcher) {
-        LaunchResult result = launcher.launch("inspect", "dictionary", "-f", plainFile(), "--column", "id");
+    default void printsNoDictionaryMessageForPlainColumn() {
+        Cli.Result result = Cli.launch("inspect", "dictionary", "-f", plainFile(), "--column", "id");
 
         assertThat(result.exitCode()).isZero();
-        assertThat(result.getOutput()).isEqualTo("""
+        assertThat(result.output()).isEqualTo("""
                 Row Group 0 / id
                   No dictionary (column is not dictionary-encoded)""");
     }
 
     @Test
-    default void rejectsUnknownColumn(QuarkusMainLauncher launcher) {
-        LaunchResult result = launcher.launch("inspect", "dictionary", "-f", dictFile(), "--column", "nonexistent");
+    default void rejectsUnknownColumn() {
+        Cli.Result result = Cli.launch("inspect", "dictionary", "-f", dictFile(), "--column", "nonexistent");
 
         assertThat(result.exitCode()).isNotZero();
-        assertThat(result.getErrorOutput()).contains("Unknown column");
+        assertThat(result.errorOutput()).contains("Unknown column");
     }
 
     @Test
-    default void failsOnNonexistentFile(QuarkusMainLauncher launcher) {
-        LaunchResult result = launcher.launch("inspect", "dictionary", "-f", nonexistentFile(), "--column", "id");
+    default void failsOnNonexistentFile() {
+        Cli.Result result = Cli.launch("inspect", "dictionary", "-f", nonexistentFile(), "--column", "id");
 
         assertThat(result.exitCode()).isNotZero();
     }

--- a/cli/src/test/java/dev/hardwood/cli/command/InspectDictionaryCommandTest.java
+++ b/cli/src/test/java/dev/hardwood/cli/command/InspectDictionaryCommandTest.java
@@ -9,13 +9,8 @@ package dev.hardwood.cli.command;
 
 import org.junit.jupiter.api.Test;
 
-import io.quarkus.test.junit.main.LaunchResult;
-import io.quarkus.test.junit.main.QuarkusMainLauncher;
-import io.quarkus.test.junit.main.QuarkusMainTest;
-
 import static org.assertj.core.api.Assertions.assertThat;
 
-@QuarkusMainTest
 class InspectDictionaryCommandTest implements InspectDictionaryCommandContract {
 
     @Override
@@ -34,18 +29,18 @@ class InspectDictionaryCommandTest implements InspectDictionaryCommandContract {
     }
 
     @Test
-    void requiresColumnOption(QuarkusMainLauncher launcher) {
-        LaunchResult result = launcher.launch("inspect", "dictionary", "-f", dictFile());
+    void requiresColumnOption() {
+        Cli.Result result = Cli.launch("inspect", "dictionary", "-f", dictFile());
 
         assertThat(result.exitCode()).isNotZero();
     }
 
     @Test
-    void rejectsRemoteUri(QuarkusMainLauncher launcher) {
-        LaunchResult result = launcher.launch("inspect", "dictionary", "-f", "gs://bucket/data.parquet",
+    void rejectsRemoteUri() {
+        Cli.Result result = Cli.launch("inspect", "dictionary", "-f", "gs://bucket/data.parquet",
                 "--column", "id");
 
         assertThat(result.exitCode()).isNotZero();
-        assertThat(result.getErrorOutput()).contains("not implemented yet");
+        assertThat(result.errorOutput()).contains("not implemented yet");
     }
 }

--- a/cli/src/test/java/dev/hardwood/cli/command/InspectDictionaryS3CommandTest.java
+++ b/cli/src/test/java/dev/hardwood/cli/command/InspectDictionaryS3CommandTest.java
@@ -7,9 +7,6 @@
  */
 package dev.hardwood.cli.command;
 
-import io.quarkus.test.junit.main.QuarkusMainTest;
-
-@QuarkusMainTest
 class InspectDictionaryS3CommandTest extends AbstractS3CommandTest implements InspectDictionaryCommandContract {
 
     @Override

--- a/cli/src/test/java/dev/hardwood/cli/command/InspectPagesCommandContract.java
+++ b/cli/src/test/java/dev/hardwood/cli/command/InspectPagesCommandContract.java
@@ -9,9 +9,6 @@ package dev.hardwood.cli.command;
 
 import org.junit.jupiter.api.Test;
 
-import io.quarkus.test.junit.main.LaunchResult;
-import io.quarkus.test.junit.main.QuarkusMainLauncher;
-
 import static org.assertj.core.api.Assertions.assertThat;
 
 /// Shared test contract for the `inspect pages` command.
@@ -28,11 +25,11 @@ interface InspectPagesCommandContract {
     String nonexistentFile();
 
     @Test
-    default void printsPageDetails(QuarkusMainLauncher launcher) {
-        LaunchResult result = launcher.launch("inspect", "pages", "-f", plainFile());
+    default void printsPageDetails() {
+        Cli.Result result = Cli.launch("inspect", "pages", "-f", plainFile());
 
         assertThat(result.exitCode()).isZero();
-        assertThat(result.getOutput()).isEqualTo("""
+        assertThat(result.output()).isEqualTo("""
                 id  (stats: inline)
                 +----+-------+------+----------+-----------+------------+--------+-----+-----+-------+
                 | RG | Page  | Type | Encoding | First Row | Compressed | Values | Min | Max | Nulls |
@@ -53,11 +50,11 @@ interface InspectPagesCommandContract {
     }
 
     @Test
-    default void printsDictionaryPageForDictFile(QuarkusMainLauncher launcher) {
-        LaunchResult result = launcher.launch("inspect", "pages", "-f", dictFile());
+    default void printsDictionaryPageForDictFile() {
+        Cli.Result result = Cli.launch("inspect", "pages", "-f", dictFile());
 
         assertThat(result.exitCode()).isZero();
-        assertThat(result.getOutput()).isEqualTo("""
+        assertThat(result.output()).isEqualTo("""
                 id  (stats: inline)
                 +----+-------+------+----------+-----------+------------+--------+-----+-----+-------+
                 | RG | Page  | Type | Encoding | First Row | Compressed | Values | Min | Max | Nulls |
@@ -79,11 +76,11 @@ interface InspectPagesCommandContract {
     }
 
     @Test
-    default void columnFilterRestrictsOutput(QuarkusMainLauncher launcher) {
-        LaunchResult result = launcher.launch("inspect", "pages", "-f", plainFile(), "--column", "id");
+    default void columnFilterRestrictsOutput() {
+        Cli.Result result = Cli.launch("inspect", "pages", "-f", plainFile(), "--column", "id");
 
         assertThat(result.exitCode()).isZero();
-        assertThat(result.getOutput()).isEqualTo("""
+        assertThat(result.output()).isEqualTo("""
                 id  (stats: inline)
                 +----+-------+------+----------+-----------+------------+--------+-----+-----+-------+
                 | RG | Page  | Type | Encoding | First Row | Compressed | Values | Min | Max | Nulls |
@@ -95,19 +92,19 @@ interface InspectPagesCommandContract {
     }
 
     @Test
-    default void rejectsUnknownColumn(QuarkusMainLauncher launcher) {
-        LaunchResult result = launcher.launch("inspect", "pages", "-f", plainFile(), "--column", "nonexistent");
+    default void rejectsUnknownColumn() {
+        Cli.Result result = Cli.launch("inspect", "pages", "-f", plainFile(), "--column", "nonexistent");
 
         assertThat(result.exitCode()).isNotZero();
-        assertThat(result.getErrorOutput()).contains("Unknown column");
+        assertThat(result.errorOutput()).contains("Unknown column");
     }
 
     @Test
-    default void enrichesOutputWithPageIndex(QuarkusMainLauncher launcher) {
-        LaunchResult result = launcher.launch("inspect", "pages", "-f", pageIndexFile(), "--column", "id");
+    default void enrichesOutputWithPageIndex() {
+        Cli.Result result = Cli.launch("inspect", "pages", "-f", pageIndexFile(), "--column", "id");
 
         assertThat(result.exitCode()).isZero();
-        assertThat(result.getOutput()).isEqualTo("""
+        assertThat(result.output()).isEqualTo("""
                 id  (stats: ColumnIndex)
                 +----+-------+---------+----------+-----------+------------+--------+------+------+-------+
                 | RG | Page  | Type    | Encoding | First Row | Compressed | Values | Min  | Max  | Nulls |
@@ -128,11 +125,11 @@ interface InspectPagesCommandContract {
     }
 
     @Test
-    default void noStatsSuppressesPageIndexColumns(QuarkusMainLauncher launcher) {
-        LaunchResult result = launcher.launch("inspect", "pages", "-f", pageIndexFile(), "--column", "id", "--no-stats");
+    default void noStatsSuppressesPageIndexColumns() {
+        Cli.Result result = Cli.launch("inspect", "pages", "-f", pageIndexFile(), "--column", "id", "--no-stats");
 
         assertThat(result.exitCode()).isZero();
-        assertThat(result.getOutput()).contains("| RG | Page  | Type    | Encoding | Compressed | Values |")
+        assertThat(result.output()).contains("| RG | Page  | Type    | Encoding | Compressed | Values |")
                 .doesNotContain("First Row")
                 .doesNotContain("Min")
                 .doesNotContain("Max")
@@ -140,18 +137,18 @@ interface InspectPagesCommandContract {
     }
 
     @Test
-    default void columnFilterAcceptsNestedPath(QuarkusMainLauncher launcher) {
-        LaunchResult result = launcher.launch("inspect", "pages", "-f", nestedFile(), "--column", "tags.list.element");
+    default void columnFilterAcceptsNestedPath() {
+        Cli.Result result = Cli.launch("inspect", "pages", "-f", nestedFile(), "--column", "tags.list.element");
 
         assertThat(result.exitCode()).isZero();
-        assertThat(result.getOutput())
+        assertThat(result.output())
                 .startsWith("tags.list.element  (stats: ")
                 .contains("| DATA |");
     }
 
     @Test
-    default void failsOnNonexistentFile(QuarkusMainLauncher launcher) {
-        LaunchResult result = launcher.launch("inspect", "pages", "-f", nonexistentFile());
+    default void failsOnNonexistentFile() {
+        Cli.Result result = Cli.launch("inspect", "pages", "-f", nonexistentFile());
 
         assertThat(result.exitCode()).isNotZero();
     }

--- a/cli/src/test/java/dev/hardwood/cli/command/InspectPagesCommandTest.java
+++ b/cli/src/test/java/dev/hardwood/cli/command/InspectPagesCommandTest.java
@@ -9,13 +9,8 @@ package dev.hardwood.cli.command;
 
 import org.junit.jupiter.api.Test;
 
-import io.quarkus.test.junit.main.LaunchResult;
-import io.quarkus.test.junit.main.QuarkusMainLauncher;
-import io.quarkus.test.junit.main.QuarkusMainTest;
-
 import static org.assertj.core.api.Assertions.assertThat;
 
-@QuarkusMainTest
 class InspectPagesCommandTest implements InspectPagesCommandContract {
 
     @Override
@@ -44,10 +39,10 @@ class InspectPagesCommandTest implements InspectPagesCommandContract {
     }
 
     @Test
-    void rejectsRemoteUri(QuarkusMainLauncher launcher) {
-        LaunchResult result = launcher.launch("inspect", "pages", "-f", "gs://bucket/data.parquet");
+    void rejectsRemoteUri() {
+        Cli.Result result = Cli.launch("inspect", "pages", "-f", "gs://bucket/data.parquet");
 
         assertThat(result.exitCode()).isNotZero();
-        assertThat(result.getErrorOutput()).contains("not implemented yet");
+        assertThat(result.errorOutput()).contains("not implemented yet");
     }
 }

--- a/cli/src/test/java/dev/hardwood/cli/command/InspectPagesS3CommandTest.java
+++ b/cli/src/test/java/dev/hardwood/cli/command/InspectPagesS3CommandTest.java
@@ -7,9 +7,6 @@
  */
 package dev.hardwood.cli.command;
 
-import io.quarkus.test.junit.main.QuarkusMainTest;
-
-@QuarkusMainTest
 class InspectPagesS3CommandTest extends AbstractS3CommandTest implements InspectPagesCommandContract {
 
     @Override

--- a/cli/src/test/java/dev/hardwood/cli/command/InspectRowGroupsCommandContract.java
+++ b/cli/src/test/java/dev/hardwood/cli/command/InspectRowGroupsCommandContract.java
@@ -9,9 +9,6 @@ package dev.hardwood.cli.command;
 
 import org.junit.jupiter.api.Test;
 
-import io.quarkus.test.junit.main.LaunchResult;
-import io.quarkus.test.junit.main.QuarkusMainLauncher;
-
 import static org.assertj.core.api.Assertions.assertThat;
 
 /// Shared test contract for the `inspect rowgroups` command.
@@ -22,11 +19,11 @@ interface InspectRowGroupsCommandContract {
     String nonexistentFile();
 
     @Test
-    default void displaysRowGroups(QuarkusMainLauncher launcher) {
-        LaunchResult result = launcher.launch("inspect", "rowgroups", "-f", plainFile());
+    default void displaysRowGroups() {
+        Cli.Result result = Cli.launch("inspect", "rowgroups", "-f", plainFile());
 
         assertThat(result.exitCode()).isZero();
-        assertThat(result.getOutput()).isEqualTo("""
+        assertThat(result.output()).isEqualTo("""
                 Row Group 0  (3 rows, 174 B uncompressed)
                 +--------+-------+--------------+------------+--------------+
                 | Column | Type  | Codec        | Compressed | Uncompressed |
@@ -37,8 +34,8 @@ interface InspectRowGroupsCommandContract {
     }
 
     @Test
-    default void failsOnNonexistentFile(QuarkusMainLauncher launcher) {
-        LaunchResult result = launcher.launch("inspect", "rowgroups", "-f", nonexistentFile());
+    default void failsOnNonexistentFile() {
+        Cli.Result result = Cli.launch("inspect", "rowgroups", "-f", nonexistentFile());
 
         assertThat(result.exitCode()).isNotZero();
     }

--- a/cli/src/test/java/dev/hardwood/cli/command/InspectRowGroupsCommandTest.java
+++ b/cli/src/test/java/dev/hardwood/cli/command/InspectRowGroupsCommandTest.java
@@ -9,13 +9,8 @@ package dev.hardwood.cli.command;
 
 import org.junit.jupiter.api.Test;
 
-import io.quarkus.test.junit.main.LaunchResult;
-import io.quarkus.test.junit.main.QuarkusMainLauncher;
-import io.quarkus.test.junit.main.QuarkusMainTest;
-
 import static org.assertj.core.api.Assertions.assertThat;
 
-@QuarkusMainTest
 class InspectRowGroupsCommandTest implements InspectRowGroupsCommandContract {
 
     @Override
@@ -29,10 +24,10 @@ class InspectRowGroupsCommandTest implements InspectRowGroupsCommandContract {
     }
 
     @Test
-    void rejectsRemoteUri(QuarkusMainLauncher launcher) {
-        LaunchResult result = launcher.launch("inspect", "rowgroups", "-f", "hdfs://namenode/data.parquet");
+    void rejectsRemoteUri() {
+        Cli.Result result = Cli.launch("inspect", "rowgroups", "-f", "hdfs://namenode/data.parquet");
 
         assertThat(result.exitCode()).isNotZero();
-        assertThat(result.getErrorOutput()).contains("not implemented yet");
+        assertThat(result.errorOutput()).contains("not implemented yet");
     }
 }

--- a/cli/src/test/java/dev/hardwood/cli/command/InspectRowGroupsS3CommandTest.java
+++ b/cli/src/test/java/dev/hardwood/cli/command/InspectRowGroupsS3CommandTest.java
@@ -7,9 +7,6 @@
  */
 package dev.hardwood.cli.command;
 
-import io.quarkus.test.junit.main.QuarkusMainTest;
-
-@QuarkusMainTest
 class InspectRowGroupsS3CommandTest extends AbstractS3CommandTest implements InspectRowGroupsCommandContract {
 
     @Override

--- a/cli/src/test/java/dev/hardwood/cli/command/PrintCommandContract.java
+++ b/cli/src/test/java/dev/hardwood/cli/command/PrintCommandContract.java
@@ -9,9 +9,6 @@ package dev.hardwood.cli.command;
 
 import org.junit.jupiter.api.Test;
 
-import io.quarkus.test.junit.main.LaunchResult;
-import io.quarkus.test.junit.main.QuarkusMainLauncher;
-
 import static org.assertj.core.api.Assertions.assertThat;
 
 /// Shared test contract for the `print` command.
@@ -32,11 +29,11 @@ interface PrintCommandContract {
     String multiRowGroupIntFile();
 
     @Test
-    default void printsAsciiTableDefault(QuarkusMainLauncher launcher) {
-        LaunchResult result = launcher.launch("print", "-f", plainFile());
+    default void printsAsciiTableDefault() {
+        Cli.Result result = Cli.launch("print", "-f", plainFile());
 
         assertThat(result.exitCode()).isZero();
-        assertThat(result.getOutput()).isEqualTo("""
+        assertThat(result.output()).isEqualTo("""
                 +----+-------+
                 | id | value |
                 +----+-------+
@@ -47,11 +44,11 @@ interface PrintCommandContract {
     }
 
     @Test
-    default void lineSeparatorBetweenRows(QuarkusMainLauncher launcher) {
-        LaunchResult result = launcher.launch("print", "-f", plainFile(), "--row-delimiter");
+    default void lineSeparatorBetweenRows() {
+        Cli.Result result = Cli.launch("print", "-f", plainFile(), "--row-delimiter");
 
         assertThat(result.exitCode()).isZero();
-        assertThat(result.getOutput()).isEqualTo("""
+        assertThat(result.output()).isEqualTo("""
                 +----+-------+
                 | id | value |
                 +----+-------+
@@ -64,11 +61,11 @@ interface PrintCommandContract {
     }
 
     @Test
-    default void tail(QuarkusMainLauncher launcher) {
-        LaunchResult result = launcher.launch("print", "-f", plainFile(), "-n", "-2");
+    default void tail() {
+        Cli.Result result = Cli.launch("print", "-f", plainFile(), "-n", "-2");
 
         assertThat(result.exitCode()).isZero();
-        assertThat(result.getOutput()).isEqualTo("""
+        assertThat(result.output()).isEqualTo("""
                 +----+-------+
                 | id | value |
                 +----+-------+
@@ -78,15 +75,15 @@ interface PrintCommandContract {
     }
 
     @Test
-    default void tailOnMultipleRowGroups(QuarkusMainLauncher launcher) {
+    default void tailOnMultipleRowGroups() {
         // filter_pushdown_int.parquet has three row groups of 100 rows each.
         // The tail must reflect the last rows of the file regardless of the
         // row-group layout; this also exercises the code path that skips
         // row groups outside the tail.
-        LaunchResult result = launcher.launch("print", "-f", multiRowGroupIntFile(), "-n", "-3");
+        Cli.Result result = Cli.launch("print", "-f", multiRowGroupIntFile(), "-n", "-3");
 
         assertThat(result.exitCode()).isZero();
-        assertThat(result.getOutput()).isEqualTo("""
+        assertThat(result.output()).isEqualTo("""
                 +-----+-------+---------+
                 | id  | value | label   |
                 +-----+-------+---------+
@@ -97,11 +94,11 @@ interface PrintCommandContract {
     }
 
     @Test
-    default void head(QuarkusMainLauncher launcher) {
-        LaunchResult result = launcher.launch("print", "-f", plainFile(), "-n", "2");
+    default void head() {
+        Cli.Result result = Cli.launch("print", "-f", plainFile(), "-n", "2");
 
         assertThat(result.exitCode()).isZero();
-        assertThat(result.getOutput()).isEqualTo("""
+        assertThat(result.output()).isEqualTo("""
                 +----+-------+
                 | id | value |
                 +----+-------+
@@ -111,11 +108,11 @@ interface PrintCommandContract {
     }
 
     @Test
-    default void showsRowIndexWhenEnabled(QuarkusMainLauncher launcher) {
-        LaunchResult result = launcher.launch("print", "-f", plainFile(), "-ri");
+    default void showsRowIndexWhenEnabled() {
+        Cli.Result result = Cli.launch("print", "-f", plainFile(), "-ri");
 
         assertThat(result.exitCode()).isZero();
-        assertThat(result.getOutput()).isEqualTo("""
+        assertThat(result.output()).isEqualTo("""
                 +----------+----+-------+
                 | rowIndex | id | value |
                 +----------+----+-------+
@@ -126,11 +123,11 @@ interface PrintCommandContract {
     }
 
     @Test
-    default void columnsFilterOutput(QuarkusMainLauncher launcher) {
-        LaunchResult result = launcher.launch("print", "-f", plainFile(), "--columns", "value");
+    default void columnsFilterOutput() {
+        Cli.Result result = Cli.launch("print", "-f", plainFile(), "--columns", "value");
 
         assertThat(result.exitCode()).isZero();
-        assertThat(result.getOutput()).isEqualTo("""
+        assertThat(result.output()).isEqualTo("""
                 +-------+
                 | value |
                 +-------+
@@ -141,11 +138,11 @@ interface PrintCommandContract {
     }
 
     @Test
-    default void columnsFilterWithNestedStruct(QuarkusMainLauncher launcher) {
-        LaunchResult result = launcher.launch("print", "-f", deepNestedFile(), "--columns", "name,account", "-mw", "150");
+    default void columnsFilterWithNestedStruct() {
+        Cli.Result result = Cli.launch("print", "-f", deepNestedFile(), "--columns", "name,account", "-mw", "150");
 
         assertThat(result.exitCode()).isZero();
-        assertThat(result.getOutput()).isEqualTo("""
+        assertThat(result.output()).isEqualTo("""
                 +---------+-------------------------------------------------------------------------------------------------------------------------+
                 | name    | account                                                                                                                 |
                 +---------+-------------------------------------------------------------------------------------------------------------------------+
@@ -157,11 +154,11 @@ interface PrintCommandContract {
     }
 
     @Test
-    default void columnsFilterExcludesNestedColumn(QuarkusMainLauncher launcher) {
-        LaunchResult result = launcher.launch("print", "-f", deepNestedFile(), "--columns", "customer_id,name");
+    default void columnsFilterExcludesNestedColumn() {
+        Cli.Result result = Cli.launch("print", "-f", deepNestedFile(), "--columns", "customer_id,name");
 
         assertThat(result.exitCode()).isZero();
-        assertThat(result.getOutput()).isEqualTo("""
+        assertThat(result.output()).isEqualTo("""
                 +-------------+---------+
                 | customer_id | name    |
                 +-------------+---------+
@@ -173,11 +170,11 @@ interface PrintCommandContract {
     }
 
     @Test
-    default void columnsFilterWithNestedSubField(QuarkusMainLauncher launcher) {
-        LaunchResult result = launcher.launch("print", "-f", deepNestedFile(), "--columns", "name,account.id");
+    default void columnsFilterWithNestedSubField() {
+        Cli.Result result = Cli.launch("print", "-f", deepNestedFile(), "--columns", "name,account.id");
 
         assertThat(result.exitCode()).isZero();
-        assertThat(result.getOutput()).isEqualTo("""
+        assertThat(result.output()).isEqualTo("""
                 +---------+------------------+
                 | name    | account          |
                 +---------+------------------+
@@ -189,18 +186,18 @@ interface PrintCommandContract {
     }
 
     @Test
-    default void rejectsUnknownColumn(QuarkusMainLauncher launcher) {
-        LaunchResult result = launcher.launch("print", "-f", plainFile(), "--columns", "unknown");
+    default void rejectsUnknownColumn() {
+        Cli.Result result = Cli.launch("print", "-f", plainFile(), "--columns", "unknown");
 
         assertThat(result.exitCode()).isNotZero();
     }
 
     @Test
-    default void explicitAllShowsEveryRow(QuarkusMainLauncher launcher) {
-        LaunchResult result = launcher.launch("print", "-f", plainFile(), "-n", "ALL");
+    default void explicitAllShowsEveryRow() {
+        Cli.Result result = Cli.launch("print", "-f", plainFile(), "-n", "ALL");
 
         assertThat(result.exitCode()).isZero();
-        assertThat(result.getOutput()).isEqualTo("""
+        assertThat(result.output()).isEqualTo("""
                 +----+-------+
                 | id | value |
                 +----+-------+
@@ -211,11 +208,11 @@ interface PrintCommandContract {
     }
 
     @Test
-    default void transposesRows(QuarkusMainLauncher launcher) {
-        LaunchResult result = launcher.launch("print", "-f", byteArrayFile(), "-tp", "-n", "3");
+    default void transposesRows() {
+        Cli.Result result = Cli.launch("print", "-f", byteArrayFile(), "-tp", "-n", "3");
 
         assertThat(result.exitCode()).isZero();
-        assertThat(result.getOutput()).isEqualTo("""
+        assertThat(result.output()).isEqualTo("""
                 +-----------------+-------+
                 |              id |     1 |
                 +-----------------+-------+
@@ -240,11 +237,11 @@ interface PrintCommandContract {
     }
 
     @Test
-    default void byteArrayAsString(QuarkusMainLauncher launcher) {
-        LaunchResult result = launcher.launch("print", "-f", byteArrayFile());
+    default void byteArrayAsString() {
+        Cli.Result result = Cli.launch("print", "-f", byteArrayFile());
 
         assertThat(result.exitCode()).isZero();
-        assertThat(result.getOutput()).isEqualTo("""
+        assertThat(result.output()).isEqualTo("""
                 +----+----------------+-----------------+
                 | id | prefix_strings | varying_strings |
                 +----+----------------+-----------------+
@@ -260,11 +257,11 @@ interface PrintCommandContract {
     }
 
     @Test
-    default void displaysNestedStructFields(QuarkusMainLauncher launcher) {
-        LaunchResult result = launcher.launch("print", "-f", deepNestedFile(), "-mw", "150");
+    default void displaysNestedStructFields() {
+        Cli.Result result = Cli.launch("print", "-f", deepNestedFile(), "-mw", "150");
 
         assertThat(result.exitCode()).isZero();
-        assertThat(result.getOutput()).isEqualTo("""
+        assertThat(result.output()).isEqualTo("""
                 +-------------+---------+-------------------------------------------------------------------------------------------------------------------------+
                 | customer_id | name    | account                                                                                                                 |
                 +-------------+---------+-------------------------------------------------------------------------------------------------------------------------+
@@ -276,11 +273,11 @@ interface PrintCommandContract {
     }
 
     @Test
-    default void wrapsWhenTruncationDisabled(QuarkusMainLauncher launcher) {
-        LaunchResult result = launcher.launch("print", "-f", byteArrayFile(), "--no-truncate", "-mw", "5");
+    default void wrapsWhenTruncationDisabled() {
+        Cli.Result result = Cli.launch("print", "-f", byteArrayFile(), "--no-truncate", "-mw", "5");
 
         assertThat(result.exitCode()).isZero();
-        assertThat(result.getOutput()).isEqualTo("""
+        assertThat(result.output()).isEqualTo("""
                 +----+-------+-------+
                 | id | prefi | varyi |
                 |    | x_str | ng_st |
@@ -306,11 +303,11 @@ interface PrintCommandContract {
     }
 
     @Test
-    default void displaysListColumns(QuarkusMainLauncher launcher) {
-        LaunchResult result = launcher.launch("print", "-f", listFile());
+    default void displaysListColumns() {
+        Cli.Result result = Cli.launch("print", "-f", listFile());
 
         assertThat(result.exitCode()).isZero();
-        assertThat(result.getOutput()).isEqualTo("""
+        assertThat(result.output()).isEqualTo("""
                 +----+-----------+--------------+
                 | id | tags      | scores       |
                 +----+-----------+--------------+
@@ -322,18 +319,18 @@ interface PrintCommandContract {
     }
 
     @Test
-    default void failsOnNonexistentFile(QuarkusMainLauncher launcher) {
-        LaunchResult result = launcher.launch("print", "-f", nonexistentFile());
+    default void failsOnNonexistentFile() {
+        Cli.Result result = Cli.launch("print", "-f", nonexistentFile());
 
         assertThat(result.exitCode()).isNotZero();
     }
 
     @Test
-    default void displaysUnsignedIntegersAsPositiveNumbers(QuarkusMainLauncher launcher) {
-        LaunchResult result = launcher.launch("print", "-f", unsignedIntFile());
+    default void displaysUnsignedIntegersAsPositiveNumbers() {
+        Cli.Result result = Cli.launch("print", "-f", unsignedIntFile());
 
         assertThat(result.exitCode()).isZero();
-        assertThat(result.getOutput()).isEqualTo("""
+        assertThat(result.output()).isEqualTo("""
             +----+------------+----------------------+
             | id | uint32_val | uint64_val           |
             +----+------------+----------------------+

--- a/cli/src/test/java/dev/hardwood/cli/command/PrintCommandTest.java
+++ b/cli/src/test/java/dev/hardwood/cli/command/PrintCommandTest.java
@@ -9,13 +9,8 @@ package dev.hardwood.cli.command;
 
 import org.junit.jupiter.api.Test;
 
-import io.quarkus.test.junit.main.LaunchResult;
-import io.quarkus.test.junit.main.QuarkusMainLauncher;
-import io.quarkus.test.junit.main.QuarkusMainTest;
-
 import static org.assertj.core.api.Assertions.assertThat;
 
-@QuarkusMainTest
 class PrintCommandTest implements PrintCommandContract {
 
     @Override
@@ -54,10 +49,10 @@ class PrintCommandTest implements PrintCommandContract {
     }
 
     @Test
-    void rejectsRemoteUri(QuarkusMainLauncher launcher) {
-        LaunchResult result = launcher.launch("print", "-f", "gs://bucket/data.parquet");
+    void rejectsRemoteUri() {
+        Cli.Result result = Cli.launch("print", "-f", "gs://bucket/data.parquet");
 
         assertThat(result.exitCode()).isNotZero();
-        assertThat(result.getErrorOutput()).isEqualTo("Remote URIs are not implemented yet.");
+        assertThat(result.errorOutput()).isEqualTo("Remote URIs are not implemented yet.");
     }
 }

--- a/cli/src/test/java/dev/hardwood/cli/command/PrintS3CommandTest.java
+++ b/cli/src/test/java/dev/hardwood/cli/command/PrintS3CommandTest.java
@@ -7,9 +7,6 @@
  */
 package dev.hardwood.cli.command;
 
-import io.quarkus.test.junit.main.QuarkusMainTest;
-
-@QuarkusMainTest
 class PrintS3CommandTest extends AbstractS3CommandTest implements PrintCommandContract {
 
     @Override

--- a/cli/src/test/java/dev/hardwood/cli/command/SchemaCommandContract.java
+++ b/cli/src/test/java/dev/hardwood/cli/command/SchemaCommandContract.java
@@ -9,9 +9,6 @@ package dev.hardwood.cli.command;
 
 import org.junit.jupiter.api.Test;
 
-import io.quarkus.test.junit.main.LaunchResult;
-import io.quarkus.test.junit.main.QuarkusMainLauncher;
-
 import static org.assertj.core.api.Assertions.assertThat;
 
 /// Shared test contract for the `schema` command.
@@ -22,11 +19,11 @@ interface SchemaCommandContract {
     String nonexistentFile();
 
     @Test
-    default void displaysNativeSchemaByDefault(QuarkusMainLauncher launcher) {
-        LaunchResult result = launcher.launch("schema", "-f", plainFile());
+    default void displaysNativeSchemaByDefault() {
+        Cli.Result result = Cli.launch("schema", "-f", plainFile());
 
         assertThat(result.exitCode()).isZero();
-        assertThat(result.getOutput()).isEqualTo("""
+        assertThat(result.output()).isEqualTo("""
                 message schema {
                   required int64 id;
                   required int64 value;
@@ -34,11 +31,11 @@ interface SchemaCommandContract {
     }
 
     @Test
-    default void displaysAvroSchema(QuarkusMainLauncher launcher) {
-        LaunchResult result = launcher.launch("schema", "-f", plainFile(), "--format", "AVRO");
+    default void displaysAvroSchema() {
+        Cli.Result result = Cli.launch("schema", "-f", plainFile(), "--format", "AVRO");
 
         assertThat(result.exitCode()).isZero();
-        assertThat(result.getOutput()).isEqualTo("""
+        assertThat(result.output()).isEqualTo("""
                 {
                   "type": "record",
                   "name": "Schema",
@@ -50,11 +47,11 @@ interface SchemaCommandContract {
     }
 
     @Test
-    default void displaysProtoSchema(QuarkusMainLauncher launcher) {
-        LaunchResult result = launcher.launch("schema", "-f", plainFile(), "--format", "PROTO");
+    default void displaysProtoSchema() {
+        Cli.Result result = Cli.launch("schema", "-f", plainFile(), "--format", "PROTO");
 
         assertThat(result.exitCode()).isZero();
-        assertThat(result.getOutput()).isEqualTo("""
+        assertThat(result.output()).isEqualTo("""
                 syntax = "proto3";
 
                 message Schema {
@@ -64,8 +61,8 @@ interface SchemaCommandContract {
     }
 
     @Test
-    default void failsOnNonexistentFile(QuarkusMainLauncher launcher) {
-        LaunchResult result = launcher.launch("schema", "-f", nonexistentFile());
+    default void failsOnNonexistentFile() {
+        Cli.Result result = Cli.launch("schema", "-f", nonexistentFile());
 
         assertThat(result.exitCode()).isNotZero();
     }

--- a/cli/src/test/java/dev/hardwood/cli/command/SchemaCommandTest.java
+++ b/cli/src/test/java/dev/hardwood/cli/command/SchemaCommandTest.java
@@ -9,13 +9,8 @@ package dev.hardwood.cli.command;
 
 import org.junit.jupiter.api.Test;
 
-import io.quarkus.test.junit.main.LaunchResult;
-import io.quarkus.test.junit.main.QuarkusMainLauncher;
-import io.quarkus.test.junit.main.QuarkusMainTest;
-
 import static org.assertj.core.api.Assertions.assertThat;
 
-@QuarkusMainTest
 class SchemaCommandTest implements SchemaCommandContract {
 
     private final String NESTED_FILE = this.getClass().getResource("/nested_struct_test.parquet").getPath();
@@ -31,28 +26,28 @@ class SchemaCommandTest implements SchemaCommandContract {
     }
 
     @Test
-    void displaysAvroSchemaForNestedFile(QuarkusMainLauncher launcher) {
-        LaunchResult result = launcher.launch("schema", "-f", NESTED_FILE, "--format", "AVRO");
+    void displaysAvroSchemaForNestedFile() {
+        Cli.Result result = Cli.launch("schema", "-f", NESTED_FILE, "--format", "AVRO");
 
         assertThat(result.exitCode()).isZero();
-        assertThat(result.getOutput()).contains("\"type\": \"record\"");
+        assertThat(result.output()).contains("\"type\": \"record\"");
     }
 
     @Test
-    void displaysProtoSchemaForNestedFile(QuarkusMainLauncher launcher) {
-        LaunchResult result = launcher.launch("schema", "-f", NESTED_FILE, "--format", "PROTO");
+    void displaysProtoSchemaForNestedFile() {
+        Cli.Result result = Cli.launch("schema", "-f", NESTED_FILE, "--format", "PROTO");
 
         assertThat(result.exitCode()).isZero();
-        assertThat(result.getOutput())
+        assertThat(result.output())
                 .contains("syntax = \"proto3\"")
                 .contains("message");
     }
 
     @Test
-    void rejectsRemoteUri(QuarkusMainLauncher launcher) {
-        LaunchResult result = launcher.launch("schema", "-f", "gs://bucket/data.parquet");
+    void rejectsRemoteUri() {
+        Cli.Result result = Cli.launch("schema", "-f", "gs://bucket/data.parquet");
 
         assertThat(result.exitCode()).isNotZero();
-        assertThat(result.getErrorOutput()).contains("not implemented yet");
+        assertThat(result.errorOutput()).contains("not implemented yet");
     }
 }

--- a/cli/src/test/java/dev/hardwood/cli/command/SchemaS3CommandTest.java
+++ b/cli/src/test/java/dev/hardwood/cli/command/SchemaS3CommandTest.java
@@ -7,9 +7,6 @@
  */
 package dev.hardwood.cli.command;
 
-import io.quarkus.test.junit.main.QuarkusMainTest;
-
-@QuarkusMainTest
 class SchemaS3CommandTest extends AbstractS3CommandTest implements SchemaCommandContract {
 
     @Override


### PR DESCRIPTION
Each @QuarkusMainTest class pays a Quarkus bootstrap per run, which dominates CLI test time (~800ms for small classes, ~3s for larger ones). The commands themselves are plain picocli Callables with no CDI usage, so they can be executed directly via `new CommandLine(new HardwoodCommand())` with stdout/stderr redirected into StringWriters — the same approach kcctl uses.

Introduces a small in-process launcher `Cli` that mirrors the production picocli configuration (setCaseInsensitiveEnumValuesAllowed). All command test contracts and their local/S3 subclasses now invoke `Cli.launch(...)` instead of `QuarkusMainLauncher`. S3 tests retain AbstractS3CommandTest, whose static init starts s3proxy once and exposes AWS endpoint/credentials as system properties — picked up by FileMixin regardless of how the command is launched.

HardwoodCommandTest remains a @QuarkusMainTest as end-to-end coverage of the Quarkus-wired top command. The native-image smoke tests (NativeBinarySmokeIT, NativeBinaryS3SmokeIT) are unchanged; they still use @QuarkusMainIntegrationTest to exercise the compiled binary.

Local benchmark: 141 tests, 30s -> 6.3s.