### PR TITLE
#90 Include file name in all exceptions raised during reading

### DIFF
--- a/core/src/main/java/dev/hardwood/internal/ExceptionContext.java
+++ b/core/src/main/java/dev/hardwood/internal/ExceptionContext.java
@@ -1,0 +1,111 @@
+/*
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Copyright The original authors
+ *
+ *  Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package dev.hardwood.internal;
+
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.util.concurrent.CompletionException;
+
+/// Utility for enriching exception messages with file-name context.
+///
+/// All exception-wrapping for file-name enrichment is centralised here so that
+/// reader classes share the same logic.
+public final class ExceptionContext {
+
+    private ExceptionContext() {
+    }
+
+    /// Returns the `[fileName] ` prefix used to mark exception messages with
+    /// their originating file. Returns the empty string when `fileName` is `null`,
+    /// so callers can always concatenate the result without a null check.
+    public static String filePrefix(String fileName) {
+        return fileName != null ? "[" + fileName + "] " : "";
+    }
+
+    /// Amends the exception message with a `[fileName] ` prefix. Preserves the
+    /// original exception type and cause chain. Returns the original exception
+    /// unchanged when the file name is unavailable or the prefix is already present.
+    ///
+    /// **Cause-chain note for [UncheckedIOException]:** because the type requires
+    /// an [IOException] cause, the original [UncheckedIOException] is attached as
+    /// a suppressed exception rather than as the cause; the cause slot holds the
+    /// inner [IOException].
+    ///
+    /// @param fileName the originating file name, may be `null`
+    /// @param e        the exception to enrich
+    /// @return the enriched (or original) exception — never `null`
+    public static RuntimeException addFileContext(String fileName, RuntimeException e) {
+        if (fileName == null || fileName.isEmpty()) {
+            return e;
+        }
+        String prefix = "[" + fileName + "] ";
+        String originalMessage = e.getMessage();
+        if (hasFilePrefix(originalMessage)) {
+            return e;
+        }
+        // If the cause already carries file context (e.g. assembly-thread error
+        // propagated through CompletionException), don't add a second layer.
+        Throwable cause = e.getCause();
+        if (cause != null && hasFilePrefix(cause.getMessage())) {
+            return e;
+        }
+        String newMessage = prefix + (originalMessage != null ? originalMessage : e.getClass().getSimpleName());
+
+        if (e instanceof UncheckedIOException uio) {
+            // UncheckedIOException requires an IOException cause, so we can't chain
+            // the original UncheckedIOException as the cause. Preserve it as suppressed.
+            IOException ioCause = uio.getCause();
+            if (ioCause == null) {
+                ioCause = new IOException(originalMessage);
+            }
+            UncheckedIOException wrapped = new UncheckedIOException(newMessage, ioCause);
+            wrapped.addSuppressed(e);
+            return wrapped;
+        }
+        if (e.getClass() == IllegalArgumentException.class) {
+            return new IllegalArgumentException(newMessage, e);
+        }
+        if (e.getClass() == IllegalStateException.class) {
+            return new IllegalStateException(newMessage, e);
+        }
+        if (e.getClass() == NullPointerException.class) {
+            NullPointerException wrapped = new NullPointerException(newMessage);
+            wrapped.initCause(e);
+            return wrapped;
+        }
+        if (e.getClass() == IndexOutOfBoundsException.class) {
+            IndexOutOfBoundsException wrapped = new IndexOutOfBoundsException(newMessage);
+            wrapped.initCause(e);
+            return wrapped;
+        }
+
+        // For CompletionException and other wrapper types: try to preserve the type
+        // via the (String, Throwable) constructor. For CompletionException, preserve
+        // the original cause rather than wrapping the CompletionException itself,
+        // so the cause chain stays shallow.
+        try {
+            Throwable preservedCause = (e instanceof CompletionException && e.getCause() != null)
+                    ? e.getCause()
+                    : e;
+            return e.getClass()
+                    .getConstructor(String.class, Throwable.class)
+                    .newInstance(newMessage, preservedCause);
+        }
+        catch (ReflectiveOperationException ignored) {
+            // Type cannot be preserved
+        }
+        return new RuntimeException(newMessage, e);
+    }
+
+    private static boolean hasFilePrefix(String message) {
+        if (message == null || message.isEmpty() || message.charAt(0) != '[') {
+            return false;
+        }
+        return message.indexOf("] ") > 1;
+    }
+}

--- a/core/src/main/java/dev/hardwood/internal/reader/BatchExchange.java
+++ b/core/src/main/java/dev/hardwood/internal/reader/BatchExchange.java
@@ -39,6 +39,7 @@ public class BatchExchange<B> {
         public Object values;
         public BitSet nulls;
         public int recordCount;
+        public String fileName;
     }
 
     private final ArrayBlockingQueue<B> readyQueue;

--- a/core/src/main/java/dev/hardwood/internal/reader/ChunkHandle.java
+++ b/core/src/main/java/dev/hardwood/internal/reader/ChunkHandle.java
@@ -13,6 +13,7 @@ import java.nio.ByteBuffer;
 import java.util.concurrent.CompletableFuture;
 
 import dev.hardwood.InputFile;
+import dev.hardwood.internal.ExceptionContext;
 
 /// Lazy fetch handle for a contiguous byte range in a Parquet file.
 ///
@@ -111,8 +112,10 @@ public class ChunkHandle {
                 data = inputFile.readRange(fileOffset, length);
             }
             catch (IOException e) {
-                throw new UncheckedIOException("Failed to fetch chunk at offset " + fileOffset
-                        + " (length " + length + ") from " + inputFile.name(), e);
+                throw new UncheckedIOException(
+                        ExceptionContext.filePrefix(inputFile.name())
+                        + "Failed to fetch chunk at offset " + fileOffset
+                        + " (length " + length + ")", e);
             }
         }
     }

--- a/core/src/main/java/dev/hardwood/internal/reader/ColumnWorker.java
+++ b/core/src/main/java/dev/hardwood/internal/reader/ColumnWorker.java
@@ -7,6 +7,8 @@
  */
 package dev.hardwood.internal.reader;
 
+import java.io.IOException;
+import java.io.UncheckedIOException;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
@@ -15,6 +17,7 @@ import java.util.concurrent.atomic.AtomicReference;
 import java.util.concurrent.atomic.AtomicReferenceArray;
 import java.util.concurrent.locks.LockSupport;
 
+import dev.hardwood.internal.ExceptionContext;
 import dev.hardwood.internal.compression.DecompressorFactory;
 import dev.hardwood.metadata.PhysicalType;
 import dev.hardwood.schema.ColumnSchema;
@@ -57,6 +60,20 @@ public abstract class ColumnWorker<B> implements AutoCloseable {
     // === Circular reorder buffer: decode tasks write, drain thread reads ===
     private final AtomicReferenceArray<Page> reorderBuffer;
 
+    // === File name per reorder-buffer slot (retriever writes, drain reads) ===
+    // Visibility: retriever writes fileNameBuffer[slot] before submitting the
+    // decode task. The decode task's volatile write to reorderBuffer[slot]
+    // happens-after the retriever's plain write. The drain's volatile read of
+    // reorderBuffer[slot] sees the fileName via the happens-before chain.
+    //
+    // Slot reuse safety: the retriever may only reuse a slot once consumePosition
+    // has advanced past it (throttle: nextSeq - consumePosition < MAX_INFLIGHT_PAGES).
+    // drainReadyPages reads fileNameBuffer[slot] before incrementing consumePosition,
+    // so the previous occupant's fileName is always read before being overwritten.
+    // Any future change to the throttle or to the read-then-increment ordering must
+    // preserve this invariant.
+    private final String[] fileNameBuffer;
+
     // === Drain position (only modified by drain thread, read by retriever for throttle) ===
     private volatile int consumePosition;
 
@@ -80,6 +97,10 @@ public abstract class ColumnWorker<B> implements AutoCloseable {
     long totalRowsAssembled;
     B currentBatch;
     int rowsInCurrentBatch;
+
+    /// File name of the file being assembled into the current batch.
+    /// Written only by the drain thread.
+    String currentBatchFileName;
 
     // === Instrumentation (drain thread only) ===
     long publishBlockNanos;
@@ -108,6 +129,7 @@ public abstract class ColumnWorker<B> implements AutoCloseable {
         this.decodeExecutor = decodeExecutor;
         this.maxRows = maxRows;
         this.reorderBuffer = new AtomicReferenceArray<>(MAX_INFLIGHT_PAGES);
+        this.fileNameBuffer = new String[MAX_INFLIGHT_PAGES];
     }
 
     /// Initializes subclass-specific drain state (called at the start of `runDrain`).
@@ -224,6 +246,7 @@ public abstract class ColumnWorker<B> implements AutoCloseable {
                 int seq = nextSeq++;
                 totalPagesSubmitted++;
                 int slot = seq % MAX_INFLIGHT_PAGES;
+                fileNameBuffer[slot] = pageSource.getCurrentFileName();
                 PageInfo pi = pageInfo;
                 PageDecoder rdr = pageDecoder;
                 CompletableFuture<Void> f = CompletableFuture.runAsync(
@@ -253,7 +276,7 @@ public abstract class ColumnWorker<B> implements AutoCloseable {
                     sourceNanos / 1_000_000.0, throttleNanos / 1_000_000.0, throttleParks);
         }
         catch (Throwable t) {
-            signalError(t);
+            signalError(enrichWithFileName(t, pageSource.getCurrentFileName()));
         }
     }
 
@@ -269,7 +292,7 @@ public abstract class ColumnWorker<B> implements AutoCloseable {
             reorderBuffer.set(slot, page);
         }
         catch (Throwable t) {
-            signalError(t);
+            signalError(enrichWithFileName(t, fileNameBuffer[slot]));
         }
         LockSupport.unpark(drainThread);
     }
@@ -313,7 +336,7 @@ public abstract class ColumnWorker<B> implements AutoCloseable {
                     publishBlockNanos / 1_000_000.0);
         }
         catch (Throwable t) {
-            signalError(t);
+            signalError(enrichWithFileName(t, currentBatchFileName));
         }
     }
 
@@ -331,6 +354,19 @@ public abstract class ColumnWorker<B> implements AutoCloseable {
                 finishDrain();
                 return true;
             }
+
+            // Detect file boundary: flush the current batch when the file changes
+            // so that each batch is attributed to a single file.
+            String pageFileName = fileNameBuffer[slot];
+            if (pageFileName != null) {
+                if (currentBatchFileName != null
+                        && !pageFileName.equals(currentBatchFileName)
+                        && rowsInCurrentBatch > 0) {
+                    publishCurrentBatch();
+                }
+                currentBatchFileName = pageFileName;
+            }
+
             assemblePage(page);
             consumePosition++;
             totalPagesDrained++;
@@ -360,6 +396,30 @@ public abstract class ColumnWorker<B> implements AutoCloseable {
         exchange.signalError(t);
         LockSupport.unpark(retrieverThread);
         LockSupport.unpark(drainThread);
+    }
+
+    /// Enriches a throwable with file-name context if possible.
+    ///
+    /// `RuntimeException` is enriched in-place via [ExceptionContext#addFileContext],
+    /// preserving the original type. `IOException` is wrapped in a fresh
+    /// [UncheckedIOException] carrying the prefix; this prevents
+    /// [BatchExchange#checkError] from later wrapping it in a generic
+    /// `RuntimeException("Error in pipeline for column 'X'")` that would lose the
+    /// file context. `Error` and other throwables propagate unchanged.
+    private static Throwable enrichWithFileName(Throwable t, String fileName) {
+        if (fileName == null || fileName.isEmpty()) {
+            return t;
+        }
+        if (t instanceof RuntimeException re) {
+            return ExceptionContext.addFileContext(fileName, re);
+        }
+        if (t instanceof IOException ioe) {
+            return new UncheckedIOException(
+                    ExceptionContext.filePrefix(fileName)
+                            + (ioe.getMessage() != null ? ioe.getMessage() : "I/O failure"),
+                    ioe);
+        }
+        return t;
     }
 
     private void unparkRetriever() {

--- a/core/src/main/java/dev/hardwood/internal/reader/FlatColumnWorker.java
+++ b/core/src/main/java/dev/hardwood/internal/reader/FlatColumnWorker.java
@@ -95,6 +95,7 @@ public class FlatColumnWorker extends ColumnWorker<BatchExchange.Batch> {
         currentBatch.nulls = (currentNulls != null && !currentNulls.isEmpty())
                 ? (BitSet) currentNulls.clone()
                 : null;
+        currentBatch.fileName = currentBatchFileName;
 
         long t0 = System.nanoTime();
         try {

--- a/core/src/main/java/dev/hardwood/internal/reader/FlatRowReader.java
+++ b/core/src/main/java/dev/hardwood/internal/reader/FlatRowReader.java
@@ -15,6 +15,7 @@ import java.time.LocalTime;
 import java.util.BitSet;
 import java.util.UUID;
 
+import dev.hardwood.internal.ExceptionContext;
 import dev.hardwood.internal.conversion.LogicalTypeConverter;
 import dev.hardwood.internal.predicate.ResolvedPredicate;
 import dev.hardwood.internal.util.StringToIntMap;
@@ -60,6 +61,9 @@ public final class FlatRowReader implements RowReader {
     private int rowIndex = -1;
     private int batchSize = 0;
     private boolean exhausted;
+
+    // File name from the current batch — used for exception enrichment
+    private String currentFileName;
 
     public FlatRowReader(BatchExchange<BatchExchange.Batch>[] exchanges, FlatColumnWorker[] columnWorkers,
                          FileSchema fileSchema, ProjectedSchema projectedSchema) {
@@ -285,7 +289,12 @@ public final class FlatRowReader implements RowReader {
             return null;
         }
         int rawValue = ((int[]) flatValueArrays[columnIndex])[rowIndex];
-        return LogicalTypeConverter.convertToDate(rawValue, physicalTypes[columnIndex]);
+        try {
+            return LogicalTypeConverter.convertToDate(rawValue, physicalTypes[columnIndex]);
+        }
+        catch (RuntimeException e) {
+            throw ExceptionContext.addFileContext(currentFileName, e);
+        }
     }
 
     @Override
@@ -306,8 +315,13 @@ public final class FlatRowReader implements RowReader {
         else {
             rawValue = ((long[]) flatValueArrays[columnIndex])[rowIndex];
         }
-        return LogicalTypeConverter.convertToTime(rawValue, col.type(),
-                (LogicalType.TimeType) col.logicalType());
+        try {
+            return LogicalTypeConverter.convertToTime(rawValue, col.type(),
+                    (LogicalType.TimeType) col.logicalType());
+        }
+        catch (RuntimeException e) {
+            throw ExceptionContext.addFileContext(currentFileName, e);
+        }
     }
 
     @Override
@@ -321,13 +335,18 @@ public final class FlatRowReader implements RowReader {
             return null;
         }
         ColumnSchema col = columnSchemas[columnIndex];
-        if (col.type() == PhysicalType.INT96) {
-            byte[] rawValue = ((byte[][]) flatValueArrays[columnIndex])[rowIndex];
-            return LogicalTypeConverter.int96ToInstant(rawValue);
+        try {
+            if (col.type() == PhysicalType.INT96) {
+                byte[] rawValue = ((byte[][]) flatValueArrays[columnIndex])[rowIndex];
+                return LogicalTypeConverter.int96ToInstant(rawValue);
+            }
+            long rawValue = ((long[]) flatValueArrays[columnIndex])[rowIndex];
+            return LogicalTypeConverter.convertToTimestamp(rawValue, col.type(),
+                    (LogicalType.TimestampType) col.logicalType());
         }
-        long rawValue = ((long[]) flatValueArrays[columnIndex])[rowIndex];
-        return LogicalTypeConverter.convertToTimestamp(rawValue, col.type(),
-                (LogicalType.TimestampType) col.logicalType());
+        catch (RuntimeException e) {
+            throw ExceptionContext.addFileContext(currentFileName, e);
+        }
     }
 
     @Override
@@ -345,11 +364,16 @@ public final class FlatRowReader implements RowReader {
             case INT32 -> ((int[]) flatValueArrays[columnIndex])[rowIndex];
             case INT64 -> ((long[]) flatValueArrays[columnIndex])[rowIndex];
             case BYTE_ARRAY, FIXED_LEN_BYTE_ARRAY -> ((byte[][]) flatValueArrays[columnIndex])[rowIndex];
-            default -> throw new IllegalArgumentException(
-                    "Unexpected physical type for DECIMAL: " + col.type());
+            default -> throw new IllegalArgumentException(prefix()
+                    + "Unexpected physical type for DECIMAL: " + col.type());
         };
-        return LogicalTypeConverter.convertToDecimal(rawValue, col.type(),
-                (LogicalType.DecimalType) col.logicalType());
+        try {
+            return LogicalTypeConverter.convertToDecimal(rawValue, col.type(),
+                    (LogicalType.DecimalType) col.logicalType());
+        }
+        catch (RuntimeException e) {
+            throw ExceptionContext.addFileContext(currentFileName, e);
+        }
     }
 
     @Override
@@ -362,9 +386,14 @@ public final class FlatRowReader implements RowReader {
         if (isNull(columnIndex)) {
             return null;
         }
-        return LogicalTypeConverter.convertToUuid(
-                ((byte[][]) flatValueArrays[columnIndex])[rowIndex],
-                physicalTypes[columnIndex]);
+        try {
+            return LogicalTypeConverter.convertToUuid(
+                    ((byte[][]) flatValueArrays[columnIndex])[rowIndex],
+                    physicalTypes[columnIndex]);
+        }
+        catch (RuntimeException e) {
+            throw ExceptionContext.addFileContext(currentFileName, e);
+        }
     }
 
     @Override
@@ -449,8 +478,8 @@ public final class FlatRowReader implements RowReader {
                 // If earlier columns returned data but this one is empty,
                 // the file is corrupt (column count mismatch).
                 if (i > 0) {
-                    throw new IllegalStateException(
-                            "Column count mismatch: column " + i + " produced no data"
+                    throw new IllegalStateException(prefix()
+                            + "Column count mismatch: column " + i + " produced no data"
                             + " while earlier columns had " + batchSize + " records");
                 }
                 exhausted = true;
@@ -461,6 +490,7 @@ public final class FlatRowReader implements RowReader {
             previousBatches[i] = batch;
             if (i == 0) {
                 batchSize = batch.recordCount;
+                currentFileName = batch.fileName;
             }
         }
         rowIndex = -1;
@@ -487,10 +517,14 @@ public final class FlatRowReader implements RowReader {
 
     // ==================== Internal ====================
 
+    private String prefix() {
+        return ExceptionContext.filePrefix(currentFileName);
+    }
+
     private int resolveIndex(String name) {
         int index = nameToIndex.get(name);
         if (index < 0) {
-            throw new IllegalArgumentException("Column not in projection: " + name);
+            throw new IllegalArgumentException(prefix() + "Column not in projection: " + name);
         }
         return index;
     }
@@ -498,16 +532,16 @@ public final class FlatRowReader implements RowReader {
     private int resolveAndValidate(String name, PhysicalType expectedType) {
         int index = resolveIndex(name);
         if (physicalTypes[index] != expectedType) {
-            throw new IllegalArgumentException(
-                    "Field '" + name + "' has physical type " + physicalTypes[index]
-                            + ", expected " + expectedType);
+            throw new IllegalArgumentException(prefix()
+                    + "Field '" + name + "' has physical type " + physicalTypes[index]
+                    + ", expected " + expectedType);
         }
         return index;
     }
 
     private void throwNull(int columnIndex) {
         String name = getFieldName(columnIndex);
-        throw new NullPointerException("Column '" + name + "' is null at row " + rowIndex);
+        throw new NullPointerException(prefix() + "Column '" + name + "' is null at row " + rowIndex);
     }
 
     private static UnsupportedOperationException nestedUnsupported() {

--- a/core/src/main/java/dev/hardwood/internal/reader/NestedBatch.java
+++ b/core/src/main/java/dev/hardwood/internal/reader/NestedBatch.java
@@ -30,6 +30,9 @@ public final class NestedBatch {
     public int[] repetitionLevels;
     public int[] recordOffsets;
 
+    // File name of the originating file (set by drain before publish)
+    public String fileName;
+
     // Pre-computed index (computed by drain before publish)
     public BitSet elementNulls;
     public int[][] multiLevelOffsets;

--- a/core/src/main/java/dev/hardwood/internal/reader/NestedBatchDataView.java
+++ b/core/src/main/java/dev/hardwood/internal/reader/NestedBatchDataView.java
@@ -15,6 +15,7 @@ import java.time.LocalTime;
 import java.util.BitSet;
 import java.util.UUID;
 
+import dev.hardwood.internal.ExceptionContext;
 import dev.hardwood.internal.conversion.LogicalTypeConverter;
 import dev.hardwood.internal.variant.PqVariantImpl;
 import dev.hardwood.internal.variant.VariantMetadata;
@@ -46,6 +47,9 @@ public final class NestedBatchDataView {
 
     private NestedBatchIndex batchIndex;
     private int rowIndex;
+
+    // File name from the current batch — used to enrich exception messages
+    private String currentFileName;
 
     // Cached value indices: precomputed per row to avoid repeated offset lookups.
     // cachedValueIndex[projCol] = offsets[projCol][rowIndex] (or rowIndex if no offsets)
@@ -83,10 +87,15 @@ public final class NestedBatchDataView {
 
     /// Install batch data from [NestedBatch] objects whose index fields
     /// have been pre-computed by the drain thread.
-    public void setBatchData(NestedBatch[] batches, ColumnSchema[] columnSchemas) {
+    public void setBatchData(NestedBatch[] batches, ColumnSchema[] columnSchemas, String fileName) {
         this.batchIndex = NestedBatchIndex.buildFromBatches(
                 batches, columnSchemas, schema, projectedSchema, fieldMap);
+        this.currentFileName = fileName;
         cacheFieldArrays();
+    }
+
+    private String prefix() {
+        return ExceptionContext.filePrefix(currentFileName);
     }
 
     public void setRowIndex(int rowIndex) {
@@ -107,14 +116,14 @@ public final class NestedBatchDataView {
     private TopLevelFieldMap.FieldDesc.Primitive lookupPrimitive(String name) {
         TopLevelFieldMap.FieldDesc desc = lookupField(name);
         if (!(desc instanceof TopLevelFieldMap.FieldDesc.Primitive prim)) {
-            throw new IllegalArgumentException("Field '" + name + "' is not a primitive type");
+            throw new IllegalArgumentException(prefix() + "Field '" + name + "' is not a primitive type");
         }
         return prim;
     }
 
     private TopLevelFieldMap.FieldDesc.Primitive lookupPrimitiveByIndex(int projectedIndex) {
         if (!(fieldDescs[projectedIndex] instanceof TopLevelFieldMap.FieldDesc.Primitive prim)) {
-            throw new IllegalArgumentException("Field at index " + projectedIndex + " is not a primitive type");
+            throw new IllegalArgumentException(prefix() + "Field at index " + projectedIndex + " is not a primitive type");
         }
         return prim;
     }
@@ -188,7 +197,7 @@ public final class NestedBatchDataView {
         int projCol = p.projectedCol();
         int valueIdx = cachedValueIndex[projCol];
         if (batchIndex.isElementNull(projCol, valueIdx)) {
-            throw new NullPointerException("Column '" + name + "' is null");
+            throw new NullPointerException(prefix() + "Column '" + name + "' is null");
         }
         return ((int[]) batchIndex.valueArrays[projCol])[valueIdx];
     }
@@ -198,7 +207,7 @@ public final class NestedBatchDataView {
         int projCol = p.projectedCol();
         int valueIdx = cachedValueIndex[projCol];
         if (batchIndex.isElementNull(projCol, valueIdx)) {
-            throw new NullPointerException("Column '" + name + "' is null");
+            throw new NullPointerException(prefix() + "Column '" + name + "' is null");
         }
         return ((long[]) batchIndex.valueArrays[projCol])[valueIdx];
     }
@@ -208,7 +217,7 @@ public final class NestedBatchDataView {
         int projCol = p.projectedCol();
         int valueIdx = cachedValueIndex[projCol];
         if (batchIndex.isElementNull(projCol, valueIdx)) {
-            throw new NullPointerException("Column '" + name + "' is null");
+            throw new NullPointerException(prefix() + "Column '" + name + "' is null");
         }
         return ((float[]) batchIndex.valueArrays[projCol])[valueIdx];
     }
@@ -218,7 +227,7 @@ public final class NestedBatchDataView {
         int projCol = p.projectedCol();
         int valueIdx = cachedValueIndex[projCol];
         if (batchIndex.isElementNull(projCol, valueIdx)) {
-            throw new NullPointerException("Column '" + name + "' is null");
+            throw new NullPointerException(prefix() + "Column '" + name + "' is null");
         }
         return ((double[]) batchIndex.valueArrays[projCol])[valueIdx];
     }
@@ -228,7 +237,7 @@ public final class NestedBatchDataView {
         int projCol = p.projectedCol();
         int valueIdx = cachedValueIndex[projCol];
         if (batchIndex.isElementNull(projCol, valueIdx)) {
-            throw new NullPointerException("Column '" + name + "' is null");
+            throw new NullPointerException(prefix() + "Column '" + name + "' is null");
         }
         return ((boolean[]) batchIndex.valueArrays[projCol])[valueIdx];
     }
@@ -239,7 +248,7 @@ public final class NestedBatchDataView {
         int valueIdx = cachedValueIndex[fieldToProjCol[projectedIndex]];
         BitSet nulls = fieldElementNulls[projectedIndex];
         if (nulls != null && nulls.get(valueIdx)) {
-            throw new NullPointerException("Column " + projectedIndex + " is null");
+            throw new NullPointerException(prefix() + "Column " + projectedIndex + " is null");
         }
         return ((int[]) fieldValueArrays[projectedIndex])[valueIdx];
     }
@@ -248,7 +257,7 @@ public final class NestedBatchDataView {
         int valueIdx = cachedValueIndex[fieldToProjCol[projectedIndex]];
         BitSet nulls = fieldElementNulls[projectedIndex];
         if (nulls != null && nulls.get(valueIdx)) {
-            throw new NullPointerException("Column " + projectedIndex + " is null");
+            throw new NullPointerException(prefix() + "Column " + projectedIndex + " is null");
         }
         return ((long[]) fieldValueArrays[projectedIndex])[valueIdx];
     }
@@ -257,7 +266,7 @@ public final class NestedBatchDataView {
         int valueIdx = cachedValueIndex[fieldToProjCol[projectedIndex]];
         BitSet nulls = fieldElementNulls[projectedIndex];
         if (nulls != null && nulls.get(valueIdx)) {
-            throw new NullPointerException("Column " + projectedIndex + " is null");
+            throw new NullPointerException(prefix() + "Column " + projectedIndex + " is null");
         }
         return ((float[]) fieldValueArrays[projectedIndex])[valueIdx];
     }
@@ -266,7 +275,7 @@ public final class NestedBatchDataView {
         int valueIdx = cachedValueIndex[fieldToProjCol[projectedIndex]];
         BitSet nulls = fieldElementNulls[projectedIndex];
         if (nulls != null && nulls.get(valueIdx)) {
-            throw new NullPointerException("Column " + projectedIndex + " is null");
+            throw new NullPointerException(prefix() + "Column " + projectedIndex + " is null");
         }
         return ((double[]) fieldValueArrays[projectedIndex])[valueIdx];
     }
@@ -275,7 +284,7 @@ public final class NestedBatchDataView {
         int valueIdx = cachedValueIndex[fieldToProjCol[projectedIndex]];
         BitSet nulls = fieldElementNulls[projectedIndex];
         if (nulls != null && nulls.get(valueIdx)) {
-            throw new NullPointerException("Column " + projectedIndex + " is null");
+            throw new NullPointerException(prefix() + "Column " + projectedIndex + " is null");
         }
         return ((boolean[]) fieldValueArrays[projectedIndex])[valueIdx];
     }
@@ -356,7 +365,7 @@ public final class NestedBatchDataView {
     public PqStruct getStruct(String name) {
         TopLevelFieldMap.FieldDesc desc = lookupField(name);
         if (!(desc instanceof TopLevelFieldMap.FieldDesc.Struct structDesc)) {
-            throw new IllegalArgumentException("Field '" + name + "' is not a struct");
+            throw new IllegalArgumentException(prefix() + "Field '" + name + "' is not a struct");
         }
         if (isStructNull(structDesc)) {
             return null;
@@ -387,7 +396,7 @@ public final class NestedBatchDataView {
     public PqMap getMap(String name) {
         TopLevelFieldMap.FieldDesc desc = lookupField(name);
         if (!(desc instanceof TopLevelFieldMap.FieldDesc.MapOf mapDesc)) {
-            throw new IllegalArgumentException("Field '" + name + "' is not a map");
+            throw new IllegalArgumentException(prefix() + "Field '" + name + "' is not a map");
         }
         return createMap(mapDesc);
     }
@@ -396,7 +405,7 @@ public final class NestedBatchDataView {
 
     public PqStruct getStruct(int projectedIndex) {
         if (!(fieldDescs[projectedIndex] instanceof TopLevelFieldMap.FieldDesc.Struct structDesc)) {
-            throw new IllegalArgumentException("Field at index " + projectedIndex + " is not a struct");
+            throw new IllegalArgumentException(prefix() + "Field at index " + projectedIndex + " is not a struct");
         }
         if (isStructNull(structDesc)) {
             return null;
@@ -422,7 +431,7 @@ public final class NestedBatchDataView {
 
     public PqMap getMap(int projectedIndex) {
         if (!(fieldDescs[projectedIndex] instanceof TopLevelFieldMap.FieldDesc.MapOf mapDesc)) {
-            throw new IllegalArgumentException("Field at index " + projectedIndex + " is not a map");
+            throw new IllegalArgumentException(prefix() + "Field at index " + projectedIndex + " is not a map");
         }
         return createMap(mapDesc);
     }
@@ -496,17 +505,22 @@ public final class NestedBatchDataView {
         if (resultClass.isInstance(rawValue)) {
             return resultClass.cast(rawValue);
         }
-        if (resultClass == Instant.class && p.schema().type() == PhysicalType.INT96) {
-            return resultClass.cast(LogicalTypeConverter.int96ToInstant((byte[]) rawValue));
+        try {
+            if (resultClass == Instant.class && p.schema().type() == PhysicalType.INT96) {
+                return resultClass.cast(LogicalTypeConverter.int96ToInstant((byte[]) rawValue));
+            }
+            Object converted = LogicalTypeConverter.convert(rawValue, p.schema().type(), p.schema().logicalType());
+            return resultClass.cast(converted);
         }
-        Object converted = LogicalTypeConverter.convert(rawValue, p.schema().type(), p.schema().logicalType());
-        return resultClass.cast(converted);
+        catch (RuntimeException e) {
+            throw ExceptionContext.addFileContext(currentFileName, e);
+        }
     }
 
     private TopLevelFieldMap.FieldDesc.ListOf lookupList(String name) {
         TopLevelFieldMap.FieldDesc desc = lookupField(name);
         if (!(desc instanceof TopLevelFieldMap.FieldDesc.ListOf listDesc)) {
-            throw new IllegalArgumentException("Field '" + name + "' is not a list");
+            throw new IllegalArgumentException(prefix() + "Field '" + name + "' is not a list");
         }
         return listDesc;
     }
@@ -557,14 +571,14 @@ public final class NestedBatchDataView {
     public PqVariant getVariant(String name) {
         TopLevelFieldMap.FieldDesc desc = lookupField(name);
         if (!(desc instanceof TopLevelFieldMap.FieldDesc.Variant variantDesc)) {
-            throw new IllegalArgumentException("Field '" + name + "' is not annotated as VARIANT");
+            throw new IllegalArgumentException(prefix() + "Field '" + name + "' is not annotated as VARIANT");
         }
         return createVariant(variantDesc);
     }
 
     public PqVariant getVariant(int projectedIndex) {
         if (!(fieldDescs[projectedIndex] instanceof TopLevelFieldMap.FieldDesc.Variant variantDesc)) {
-            throw new IllegalArgumentException("Field at index " + projectedIndex + " is not annotated as VARIANT");
+            throw new IllegalArgumentException(prefix() + "Field at index " + projectedIndex + " is not annotated as VARIANT");
         }
         return createVariant(variantDesc);
     }
@@ -579,8 +593,8 @@ public final class NestedBatchDataView {
             return null;
         }
         if (desc.metadataCol() < 0) {
-            throw new IllegalStateException(
-                    "Variant column '" + desc.schema().name() + "' requires its 'metadata' child in the projection");
+            throw new IllegalStateException(prefix()
+                    + "Variant column '" + desc.schema().name() + "' requires its 'metadata' child in the projection");
         }
         int metaIdx = cachedValueIndex[desc.metadataCol()];
         byte[] metadataBytes = ((byte[][]) batchIndex.valueArrays[desc.metadataCol()])[metaIdx];
@@ -602,8 +616,8 @@ public final class NestedBatchDataView {
         // Unshredded: the raw value bytes ARE the canonical value bytes.
         int valueCol = desc.valueCol();
         if (valueCol < 0) {
-            throw new IllegalStateException(
-                    "Variant column '" + desc.schema().name() + "' requires its 'value' child in the projection");
+            throw new IllegalStateException(prefix()
+                    + "Variant column '" + desc.schema().name() + "' requires its 'value' child in the projection");
         }
         int valIdx = cachedValueIndex[valueCol];
         byte[] value = ((byte[][]) batchIndex.valueArrays[valueCol])[valIdx];

--- a/core/src/main/java/dev/hardwood/internal/reader/NestedColumnWorker.java
+++ b/core/src/main/java/dev/hardwood/internal/reader/NestedColumnWorker.java
@@ -146,6 +146,7 @@ public class NestedColumnWorker extends ColumnWorker<NestedBatch> {
         currentBatch.repetitionLevels = Arrays.copyOf(nestedRepLevels, nestedValueCount);
         currentBatch.recordOffsets = Arrays.copyOf(nestedRecordOffsets, rowsInCurrentBatch);
         currentBatch.values = trimValues(nestedValues, nestedValueCount);
+        currentBatch.fileName = currentBatchFileName;
 
         // Compute index structures before publishing so the consumer thread
         // doesn't need to do expensive index computation.

--- a/core/src/main/java/dev/hardwood/internal/reader/NestedRowReader.java
+++ b/core/src/main/java/dev/hardwood/internal/reader/NestedRowReader.java
@@ -184,7 +184,8 @@ public final class NestedRowReader implements RowReader {
                 }
                 if (i > 0) {
                     throw new IllegalStateException(
-                            "Column count mismatch: column " + i + " produced no data"
+                            "[" + batches[0].fileName + "] "
+                            + "Column count mismatch: column " + i + " produced no data"
                             + " while earlier columns had " + batches[0].recordCount + " records");
                 }
                 exhausted = true;
@@ -197,7 +198,7 @@ public final class NestedRowReader implements RowReader {
         batchSize = batches[0].recordCount;
 
         // Index structures are pre-computed by the drain — just assemble the view
-        dataView.setBatchData(batches, columnSchemas);
+        dataView.setBatchData(batches, columnSchemas, batches[0].fileName);
         rowIndex = -1;
         return true;
     }

--- a/core/src/main/java/dev/hardwood/internal/reader/PageSource.java
+++ b/core/src/main/java/dev/hardwood/internal/reader/PageSource.java
@@ -44,6 +44,12 @@ public class PageSource {
         this.workItemIterator = rowGroupIterator.getWorkItems().iterator();
     }
 
+    /// Returns the name of the file currently being read, or `null` if no work item
+    /// is active. Only valid on the retriever thread.
+    public String getCurrentFileName() {
+        return currentWorkItem != null ? currentWorkItem.inputFile().name() : null;
+    }
+
     public PageInfo next() {
         while (true) {
             if (currentPlan != null && currentPlan.hasNext()) {

--- a/core/src/main/java/dev/hardwood/internal/reader/ParquetMetadataReader.java
+++ b/core/src/main/java/dev/hardwood/internal/reader/ParquetMetadataReader.java
@@ -14,6 +14,7 @@ import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 
 import dev.hardwood.InputFile;
+import dev.hardwood.internal.ExceptionContext;
 import dev.hardwood.internal.thrift.FileMetaDataReader;
 import dev.hardwood.internal.thrift.ThriftCompactReader;
 import dev.hardwood.metadata.FileMetaData;
@@ -40,7 +41,8 @@ public final class ParquetMetadataReader {
     public static FileMetaData readMetadata(InputFile inputFile) throws IOException {
         long fileSize = inputFile.length();
         if (fileSize < MAGIC_SIZE + MAGIC_SIZE + FOOTER_LENGTH_SIZE) {
-            throw new IOException("File too small to be a valid Parquet file: " + inputFile.name());
+            throw new IOException(ExceptionContext.filePrefix(inputFile.name())
+                    + "File too small to be a valid Parquet file");
         }
 
         // Validate magic number at start
@@ -48,7 +50,8 @@ public final class ParquetMetadataReader {
         byte[] startMagic = new byte[MAGIC_SIZE];
         startMagicBuf.get(startMagic);
         if (!Arrays.equals(startMagic, MAGIC)) {
-            throw new IOException("Not a Parquet file (invalid magic number at start): " + inputFile.name());
+            throw new IOException(ExceptionContext.filePrefix(inputFile.name())
+                    + "Not a Parquet file (invalid magic number at start)");
         }
 
         // Read footer size and magic number at end
@@ -59,7 +62,8 @@ public final class ParquetMetadataReader {
         byte[] endMagic = new byte[MAGIC_SIZE];
         footerInfoBuf.get(endMagic);
         if (!Arrays.equals(endMagic, MAGIC)) {
-            throw new IOException("Not a Parquet file (invalid magic number at end): " + inputFile.name());
+            throw new IOException(ExceptionContext.filePrefix(inputFile.name())
+                    + "Not a Parquet file (invalid magic number at end)");
         }
 
         // Validate footer length

--- a/core/src/main/java/dev/hardwood/internal/reader/RowGroupIterator.java
+++ b/core/src/main/java/dev/hardwood/internal/reader/RowGroupIterator.java
@@ -14,10 +14,12 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionException;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicIntegerArray;
 
 import dev.hardwood.InputFile;
+import dev.hardwood.internal.ExceptionContext;
 import dev.hardwood.internal.predicate.PageDropPredicates;
 import dev.hardwood.internal.predicate.PageFilterEvaluator;
 import dev.hardwood.internal.predicate.ResolvedPredicate;
@@ -34,6 +36,7 @@ import dev.hardwood.metadata.PageLocation;
 import dev.hardwood.metadata.PhysicalType;
 import dev.hardwood.metadata.RepetitionType;
 import dev.hardwood.metadata.RowGroup;
+import dev.hardwood.reader.SchemaIncompatibleException;
 import dev.hardwood.schema.ColumnProjection;
 import dev.hardwood.schema.ColumnSchema;
 import dev.hardwood.schema.FileSchema;
@@ -246,8 +249,9 @@ public class RowGroupIterator {
                 return new SharedRowGroupMetadata(indexBuffers, matchingRows);
             }
             catch (IOException e) {
-                throw new UncheckedIOException("Failed to fetch metadata for row group "
-                        + workItem.rowGroupIndex() + " in " + workItem.inputFile().name(), e);
+                throw new UncheckedIOException(
+                        ExceptionContext.filePrefix(workItem.inputFile().name())
+                        + "Failed to fetch metadata for row group " + workItem.rowGroupIndex(), e);
             }
         });
     }
@@ -574,10 +578,27 @@ public class RowGroupIterator {
     }
 
     /// Gets or loads a prepared file, blocking if necessary.
+    ///
+    /// Unwraps the [CompletionException] that [CompletableFuture#join] would
+    /// otherwise wrap around the load failure, so callers see the original
+    /// exception (e.g. [SchemaIncompatibleException], [UncheckedIOException])
+    /// directly rather than as a `CompletionException` cause.
     private PreparedFile getPreparedFile(int fileIndex) {
         CompletableFuture<PreparedFile> future = fileFutures.computeIfAbsent(
                 fileIndex, this::loadFileAsync);
-        return future.join();
+        try {
+            return future.join();
+        }
+        catch (CompletionException e) {
+            Throwable cause = e.getCause();
+            if (cause instanceof RuntimeException re) {
+                throw re;
+            }
+            if (cause instanceof Error err) {
+                throw err;
+            }
+            throw e;
+        }
     }
 
     /// Triggers async loading of the file at the given index.
@@ -597,7 +618,8 @@ public class RowGroupIterator {
             inputFile.open();
         }
         catch (IOException e) {
-            throw new UncheckedIOException("Failed to open file: " + inputFile.name(), e);
+            throw new UncheckedIOException(
+                    ExceptionContext.filePrefix(inputFile.name()) + "Failed to open file", e);
         }
 
         PreparedFile prepared = openAndReadMetadata(inputFile);
@@ -628,7 +650,14 @@ public class RowGroupIterator {
             return new PreparedFile(inputFile, metaData, schema, metaData.rowGroups());
         }
         catch (IOException e) {
-            throw new UncheckedIOException("Failed to read metadata: " + inputFile.name(), e);
+            throw new UncheckedIOException(
+                    ExceptionContext.filePrefix(inputFile.name()) + "Failed to read metadata", e);
+        }
+        catch (RuntimeException e) {
+            // RuntimeExceptions thrown during Thrift parsing (e.g. ThriftEnumLookup
+            // for corrupt enum values) escape the IOException catch above — enrich
+            // them with file context so they're attributable.
+            throw ExceptionContext.addFileContext(inputFile.name(), e);
         }
     }
 
@@ -661,40 +690,37 @@ public class RowGroupIterator {
                 fileColumn = fileSchema.getColumn(refColumn.fieldPath());
             }
             catch (IllegalArgumentException e) {
-                throw new RowGroupIterator.SchemaIncompatibleException(
-                        "Column '" + refColumn.fieldPath() + "' not found in file: " + inputFile.name());
+                throw new SchemaIncompatibleException(
+                        ExceptionContext.filePrefix(inputFile.name())
+                                + "Column '" + refColumn.fieldPath() + "' not found");
             }
 
             PhysicalType refType = refColumn.type();
             PhysicalType fileType = fileColumn.type();
             if (refType != fileType) {
-                throw new RowGroupIterator.SchemaIncompatibleException(
-                        "Column '" + refColumn.fieldPath() + "' has incompatible type in file " + inputFile.name()
+                throw new SchemaIncompatibleException(
+                        ExceptionContext.filePrefix(inputFile.name())
+                                + "Column '" + refColumn.fieldPath() + "' has incompatible type"
                                 + ": expected " + refType + " but found " + fileType);
             }
 
             LogicalType refLogical = refColumn.logicalType();
             LogicalType fileLogical = fileColumn.logicalType();
             if (!Objects.equals(refLogical, fileLogical)) {
-                throw new RowGroupIterator.SchemaIncompatibleException(
-                        "Column '" + refColumn.fieldPath() + "' has incompatible logical type in file "
-                                + inputFile.name() + ": expected " + refLogical + " but found " + fileLogical);
+                throw new SchemaIncompatibleException(
+                        ExceptionContext.filePrefix(inputFile.name())
+                                + "Column '" + refColumn.fieldPath() + "' has incompatible logical type"
+                                + ": expected " + refLogical + " but found " + fileLogical);
             }
 
             RepetitionType refRep = refColumn.repetitionType();
             RepetitionType fileRep = fileColumn.repetitionType();
             if (refRep != fileRep) {
-                throw new RowGroupIterator.SchemaIncompatibleException(
-                        "Column '" + refColumn.fieldPath() + "' has incompatible repetition type in file "
-                                + inputFile.name() + ": expected " + refRep + " but found " + fileRep);
+                throw new SchemaIncompatibleException(
+                        ExceptionContext.filePrefix(inputFile.name())
+                                + "Column '" + refColumn.fieldPath() + "' has incompatible repetition type"
+                                + ": expected " + refRep + " but found " + fileRep);
             }
-        }
-    }
-
-    /// Thrown when a file's schema is incompatible with the reference schema.
-    public static class SchemaIncompatibleException extends RuntimeException {
-        public SchemaIncompatibleException(String message) {
-            super(message);
         }
     }
 }

--- a/core/src/main/java/dev/hardwood/reader/ColumnReader.java
+++ b/core/src/main/java/dev/hardwood/reader/ColumnReader.java
@@ -12,6 +12,7 @@ import java.util.BitSet;
 import java.util.List;
 
 import dev.hardwood.InputFile;
+import dev.hardwood.internal.ExceptionContext;
 import dev.hardwood.internal.predicate.ResolvedPredicate;
 import dev.hardwood.internal.reader.BatchExchange;
 import dev.hardwood.internal.reader.FlatColumnWorker;
@@ -94,6 +95,9 @@ public class ColumnReader implements AutoCloseable {
     private BitSet elementNulls;
     private boolean nestedDataComputed;
 
+    // File name from the current batch — used for exception enrichment
+    private String currentFileName;
+
     @SuppressWarnings("unchecked")
     private ColumnReader(ColumnSchema column, boolean nested,
                          BatchExchange<?> buffer, AutoCloseable columnWorker,
@@ -143,6 +147,7 @@ public class ColumnReader implements AutoCloseable {
             currentFlatBatch = null;
             recordCount = batch.recordCount;
             valueCount = batch.valueCount;
+            currentFileName = batch.fileName;
         }
         else {
             BatchExchange.Batch batch = pollFlatBatch();
@@ -157,6 +162,7 @@ public class ColumnReader implements AutoCloseable {
             currentNestedBatch = null;
             recordCount = batch.recordCount;
             valueCount = batch.recordCount;
+            currentFileName = batch.fileName;
         }
 
         // Reset lazy nested computation
@@ -347,6 +353,10 @@ public class ColumnReader implements AutoCloseable {
 
     // ==================== Internal ====================
 
+    private String prefix() {
+        return ExceptionContext.filePrefix(currentFileName);
+    }
+
     /// Returns the values array from the current batch (flat or nested).
     private Object currentValues() {
         if (currentFlatBatch != null) {
@@ -357,23 +367,23 @@ public class ColumnReader implements AutoCloseable {
 
     private void checkBatchAvailable() {
         if (currentFlatBatch == null && currentNestedBatch == null) {
-            throw new IllegalStateException("No batch available. Call nextBatch() first.");
+            throw new IllegalStateException(prefix() + "No batch available. Call nextBatch() first.");
         }
     }
 
     private void checkNestedLevel(int level) {
         if (maxRepetitionLevel == 0) {
-            throw new IllegalStateException("Not valid for flat columns (nestingDepth=0)");
+            throw new IllegalStateException(prefix() + "Not valid for flat columns (nestingDepth=0)");
         }
         if (level < 0 || level >= maxRepetitionLevel) {
-            throw new IndexOutOfBoundsException(
-                    "Level " + level + " out of range [0, " + maxRepetitionLevel + ")");
+            throw new IndexOutOfBoundsException(prefix()
+                    + "Level " + level + " out of range [0, " + maxRepetitionLevel + ")");
         }
     }
 
     private IllegalStateException typeMismatch(String expected) {
-        return new IllegalStateException(
-                "Column '" + column.name() + "' is " + column.type() + ", not " + expected);
+        return new IllegalStateException(prefix()
+                + "Column '" + column.name() + "' is " + column.type() + ", not " + expected);
     }
 
     /// Reads pre-computed index structures from the [NestedBatch].

--- a/core/src/main/java/dev/hardwood/reader/ParquetFileReader.java
+++ b/core/src/main/java/dev/hardwood/reader/ParquetFileReader.java
@@ -13,6 +13,7 @@ import java.util.List;
 
 import dev.hardwood.HardwoodContext;
 import dev.hardwood.InputFile;
+import dev.hardwood.internal.ExceptionContext;
 import dev.hardwood.internal.predicate.FilterPredicateResolver;
 import dev.hardwood.internal.predicate.ResolvedPredicate;
 import dev.hardwood.internal.predicate.RowGroupFilterEvaluator;
@@ -107,7 +108,16 @@ public class ParquetFileReader implements AutoCloseable {
         FileOpenedEvent fileOpenedEvent = new FileOpenedEvent();
         fileOpenedEvent.begin();
 
-        FileMetaData fileMetaData = ParquetMetadataReader.readMetadata(inputFile);
+        FileMetaData fileMetaData;
+        try {
+            fileMetaData = ParquetMetadataReader.readMetadata(inputFile);
+        }
+        catch (RuntimeException e) {
+            // Thrift parsing throws RuntimeExceptions (e.g. ThriftEnumLookup for
+            // corrupt enum values) that escape the IOException-only contract of
+            // readMetadata — enrich them with file context so they're attributable.
+            throw ExceptionContext.addFileContext(inputFile.name(), e);
+        }
         FileSchema fileSchema = FileSchema.fromSchemaElements(fileMetaData.schema());
 
         fileOpenedEvent.file = inputFile.name();

--- a/core/src/main/java/dev/hardwood/reader/SchemaIncompatibleException.java
+++ b/core/src/main/java/dev/hardwood/reader/SchemaIncompatibleException.java
@@ -1,0 +1,19 @@
+/*
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Copyright The original authors
+ *
+ *  Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package dev.hardwood.reader;
+
+/// Thrown when a file's schema is incompatible with the reference schema during
+/// multi-file reading. The reference schema is the schema of the first file
+/// in the input list; subsequent files must match it for column projection,
+/// physical type, logical type, and repetition type.
+public class SchemaIncompatibleException extends RuntimeException {
+
+    public SchemaIncompatibleException(String message) {
+        super(message);
+    }
+}

--- a/core/src/test/java/dev/hardwood/FileNameInExceptionTest.java
+++ b/core/src/test/java/dev/hardwood/FileNameInExceptionTest.java
@@ -1,0 +1,171 @@
+/*
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Copyright The original authors
+ *
+ *  Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package dev.hardwood;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import dev.hardwood.reader.ColumnReader;
+import dev.hardwood.reader.MultiFileColumnReaders;
+import dev.hardwood.reader.MultiFileParquetReader;
+import dev.hardwood.reader.ParquetFileReader;
+import dev.hardwood.reader.RowReader;
+import dev.hardwood.schema.ColumnProjection;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/// Tests that every exception escaping a reader includes the originating file name.
+/// See <a href="https://github.com/hardwood-hq/hardwood/issues/90">issue #90</a>.
+class FileNameInExceptionTest {
+
+    private static final Path TEST_FILE = Paths.get("src/test/resources/plain_uncompressed.parquet");
+    private static final String FILE_NAME = "plain_uncompressed.parquet";
+
+    // ==================== RowReader (single file) ====================
+
+    @Test
+    void rowReaderTypeMismatchIncludesFileName() throws Exception {
+        try (ParquetFileReader fileReader = ParquetFileReader.open(InputFile.of(TEST_FILE));
+             RowReader reader = fileReader.createRowReader()) {
+
+            assertThat(reader.hasNext()).isTrue();
+            reader.next();
+
+            // "id" column is LONG — requesting INT throws via resolveAndValidate
+            assertThatThrownBy(() -> reader.getInt("id"))
+                    .isInstanceOf(IllegalArgumentException.class)
+                    .hasMessage("[" + FILE_NAME + "] Field 'id' has physical type INT64, expected INT32");
+        }
+    }
+
+    @Test
+    void rowReaderMissingColumnIncludesFileName() throws Exception {
+        try (ParquetFileReader fileReader = ParquetFileReader.open(InputFile.of(TEST_FILE));
+             RowReader reader = fileReader.createRowReader()) {
+
+            assertThat(reader.hasNext()).isTrue();
+            reader.next();
+
+            // Non-existent column throws via resolveIndex
+            assertThatThrownBy(() -> reader.getLong("nonexistent"))
+                    .isInstanceOf(IllegalArgumentException.class)
+                    .hasMessage("[" + FILE_NAME + "] Column not in projection: nonexistent");
+        }
+    }
+
+    // ==================== RowReader (multi-file) ====================
+
+    @Test
+    void multiFileRowReaderAttributesEachFileToItsOwnName(@TempDir Path tempDir) throws Exception {
+        // Copy the test file under a second, distinct name so the file-boundary
+        // detection in ColumnWorker is actually exercised — not just the same name twice.
+        // plain_uncompressed.parquet has 3 rows; the multi-file reader should emit
+        // rows from TEST_FILE first (rows 0–2), then from second_file (rows 3–5).
+        Path secondFile = tempDir.resolve("second_file.parquet");
+        Files.copy(TEST_FILE, secondFile);
+
+        String firstFileError = "[" + FILE_NAME + "] Field 'id' has physical type INT64, expected INT32";
+        String secondFileError = "[second_file.parquet] Field 'id' has physical type INT64, expected INT32";
+
+        try (Hardwood hardwood = Hardwood.create();
+             MultiFileParquetReader parquet = hardwood.openAll(
+                     InputFile.ofPaths(List.of(TEST_FILE, secondFile)));
+             RowReader reader = parquet.createRowReader()) {
+
+            // Rows 0–2 come from TEST_FILE
+            for (int i = 0; i < 3; i++) {
+                assertThat(reader.hasNext()).isTrue();
+                reader.next();
+                assertThatThrownBy(() -> reader.getInt("id"))
+                        .isInstanceOf(IllegalArgumentException.class)
+                        .hasMessage(firstFileError);
+            }
+
+            // Rows 3–5 come from secondFile
+            for (int i = 0; i < 3; i++) {
+                assertThat(reader.hasNext()).isTrue();
+                reader.next();
+                assertThatThrownBy(() -> reader.getInt("id"))
+                        .isInstanceOf(IllegalArgumentException.class)
+                        .hasMessage(secondFileError);
+            }
+
+            assertThat(reader.hasNext()).isFalse();
+        }
+    }
+
+    // ==================== ColumnReader (single file) ====================
+
+    @Test
+    void columnReaderTypeMismatchIncludesFileName() throws Exception {
+        try (ParquetFileReader fileReader = ParquetFileReader.open(InputFile.of(TEST_FILE));
+             ColumnReader reader = fileReader.createColumnReader("id")) {
+
+            assertThat(reader.nextBatch()).isTrue();
+
+            // "id" is LONG — requesting INTs throws via typeMismatch
+            assertThatThrownBy(reader::getInts)
+                    .isInstanceOf(IllegalStateException.class)
+                    .hasMessage("[" + FILE_NAME + "] Column 'id' is INT64, not int");
+        }
+    }
+
+    @Test
+    void columnReaderNoBatchHasNoFileName() throws Exception {
+        try (ParquetFileReader fileReader = ParquetFileReader.open(InputFile.of(TEST_FILE));
+             ColumnReader reader = fileReader.createColumnReader("id")) {
+
+            // No nextBatch() called — no batch loaded, so no file name is available.
+            // The message has no `[fileName]` prefix.
+            assertThatThrownBy(reader::getLongs)
+                    .isInstanceOf(IllegalStateException.class)
+                    .hasMessage("No batch available. Call nextBatch() first.");
+        }
+    }
+
+    // ==================== ColumnReader (multi-file) ====================
+
+    @Test
+    void multiFileColumnReaderAttributesEachBatchToItsFileName(@TempDir Path tempDir) throws Exception {
+        Path secondFile = tempDir.resolve("second_file.parquet");
+        Files.copy(TEST_FILE, secondFile);
+
+        String firstFileError = "[" + FILE_NAME + "] Column 'id' is INT64, not int";
+        String secondFileError = "[second_file.parquet] Column 'id' is INT64, not int";
+
+        try (Hardwood hardwood = Hardwood.create();
+             MultiFileParquetReader parquet = hardwood.openAll(
+                     InputFile.ofPaths(List.of(TEST_FILE, secondFile)));
+             MultiFileColumnReaders columns = parquet.createColumnReaders(ColumnProjection.columns("id"))) {
+
+            ColumnReader idReader = columns.getColumnReader("id");
+
+            // plain_uncompressed.parquet has 3 rows — well below batch capacity — so
+            // each file yields exactly one batch. File-boundary detection in
+            // ColumnWorker ensures the first batch is from TEST_FILE and the second
+            // from secondFile, each carrying its own file name.
+            assertThat(idReader.nextBatch()).isTrue();
+            assertThatThrownBy(idReader::getInts)
+                    .isInstanceOf(IllegalStateException.class)
+                    .hasMessage(firstFileError);
+
+            assertThat(idReader.nextBatch()).isTrue();
+            assertThatThrownBy(idReader::getInts)
+                    .isInstanceOf(IllegalStateException.class)
+                    .hasMessage(secondFileError);
+
+            assertThat(idReader.nextBatch()).isFalse();
+        }
+    }
+}

--- a/core/src/test/java/dev/hardwood/PqRowApiTest.java
+++ b/core/src/test/java/dev/hardwood/PqRowApiTest.java
@@ -1376,19 +1376,19 @@ public class PqRowApiTest {
             assertThat(rowReader.isNull("nullable_int")).isTrue();
             assertThatThrownBy(() -> rowReader.getInt("nullable_int"))
                     .isInstanceOf(NullPointerException.class)
-                    .hasMessage("Column 'nullable_int' is null at row 1");
+                    .hasMessage("[nullable_primitives_test.parquet] Column 'nullable_int' is null at row 1");
             assertThatThrownBy(() -> rowReader.getLong("nullable_long"))
                     .isInstanceOf(NullPointerException.class)
-                    .hasMessage("Column 'nullable_long' is null at row 1");
+                    .hasMessage("[nullable_primitives_test.parquet] Column 'nullable_long' is null at row 1");
             assertThatThrownBy(() -> rowReader.getFloat("nullable_float"))
                     .isInstanceOf(NullPointerException.class)
-                    .hasMessage("Column 'nullable_float' is null at row 1");
+                    .hasMessage("[nullable_primitives_test.parquet] Column 'nullable_float' is null at row 1");
             assertThatThrownBy(() -> rowReader.getDouble("nullable_double"))
                     .isInstanceOf(NullPointerException.class)
-                    .hasMessage("Column 'nullable_double' is null at row 1");
+                    .hasMessage("[nullable_primitives_test.parquet] Column 'nullable_double' is null at row 1");
             assertThatThrownBy(() -> rowReader.getBoolean("nullable_bool"))
                     .isInstanceOf(NullPointerException.class)
-                    .hasMessage("Column 'nullable_bool' is null at row 1");
+                    .hasMessage("[nullable_primitives_test.parquet] Column 'nullable_bool' is null at row 1");
         }
     }
 
@@ -1412,19 +1412,19 @@ public class PqRowApiTest {
             assertThat(rowReader.isNull(1)).isTrue();
             assertThatThrownBy(() -> rowReader.getInt(1))
                     .isInstanceOf(NullPointerException.class)
-                    .hasMessage("Column 'nullable_int' is null at row 1");
+                    .hasMessage("[nullable_primitives_test.parquet] Column 'nullable_int' is null at row 1");
             assertThatThrownBy(() -> rowReader.getLong(2))
                     .isInstanceOf(NullPointerException.class)
-                    .hasMessage("Column 'nullable_long' is null at row 1");
+                    .hasMessage("[nullable_primitives_test.parquet] Column 'nullable_long' is null at row 1");
             assertThatThrownBy(() -> rowReader.getFloat(3))
                     .isInstanceOf(NullPointerException.class)
-                    .hasMessage("Column 'nullable_float' is null at row 1");
+                    .hasMessage("[nullable_primitives_test.parquet] Column 'nullable_float' is null at row 1");
             assertThatThrownBy(() -> rowReader.getDouble(4))
                     .isInstanceOf(NullPointerException.class)
-                    .hasMessage("Column 'nullable_double' is null at row 1");
+                    .hasMessage("[nullable_primitives_test.parquet] Column 'nullable_double' is null at row 1");
             assertThatThrownBy(() -> rowReader.getBoolean(5))
                     .isInstanceOf(NullPointerException.class)
-                    .hasMessage("Column 'nullable_bool' is null at row 1");
+                    .hasMessage("[nullable_primitives_test.parquet] Column 'nullable_bool' is null at row 1");
         }
     }
 

--- a/core/src/test/java/dev/hardwood/SchemaCompatibilityTest.java
+++ b/core/src/test/java/dev/hardwood/SchemaCompatibilityTest.java
@@ -9,13 +9,12 @@ package dev.hardwood;
 
 import java.nio.file.Path;
 import java.nio.file.Paths;
-import java.util.concurrent.CompletionException;
 
 import org.junit.jupiter.api.Test;
 
-import dev.hardwood.internal.reader.RowGroupIterator;
 import dev.hardwood.reader.MultiFileParquetReader;
 import dev.hardwood.reader.RowReader;
+import dev.hardwood.reader.SchemaIncompatibleException;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -37,10 +36,8 @@ class SchemaCompatibilityTest {
                         reader.next();
                     }
                 }
-            }).isInstanceOf(CompletionException.class)
-                    .hasCauseInstanceOf(RowGroupIterator.SchemaIncompatibleException.class)
-                    .cause()
-                    .hasMessage("Column 'ts' has incompatible logical type in file compat_ts_millis.parquet:" +
+            }).isInstanceOf(SchemaIncompatibleException.class)
+                    .hasMessage("[compat_ts_millis.parquet] Column 'ts' has incompatible logical type:" +
                             " expected TimestampType[isAdjustedToUTC=true, unit=MICROS]" +
                             " but found TimestampType[isAdjustedToUTC=true, unit=MILLIS]");
         }
@@ -59,10 +56,8 @@ class SchemaCompatibilityTest {
                         reader.next();
                     }
                 }
-            }).isInstanceOf(CompletionException.class)
-                    .hasCauseInstanceOf(RowGroupIterator.SchemaIncompatibleException.class)
-                    .cause()
-                    .hasMessage("Column 'amount' has incompatible logical type in file compat_decimal_10_4.parquet:" +
+            }).isInstanceOf(SchemaIncompatibleException.class)
+                    .hasMessage("[compat_decimal_10_4.parquet] Column 'amount' has incompatible logical type:" +
                             " expected DecimalType[scale=2, precision=10]" +
                             " but found DecimalType[scale=4, precision=10]");
         }
@@ -81,10 +76,8 @@ class SchemaCompatibilityTest {
                         reader.next();
                     }
                 }
-            }).isInstanceOf(CompletionException.class)
-                    .hasCauseInstanceOf(RowGroupIterator.SchemaIncompatibleException.class)
-                    .cause()
-                    .hasMessage("Column 'value' has incompatible repetition type in file compat_optional_value.parquet:" +
+            }).isInstanceOf(SchemaIncompatibleException.class)
+                    .hasMessage("[compat_optional_value.parquet] Column 'value' has incompatible repetition type:" +
                             " expected REQUIRED but found OPTIONAL");
         }
     }
@@ -102,10 +95,8 @@ class SchemaCompatibilityTest {
                         reader.next();
                     }
                 }
-            }).isInstanceOf(CompletionException.class)
-                    .hasCauseInstanceOf(RowGroupIterator.SchemaIncompatibleException.class)
-                    .cause()
-                    .hasMessage("Column 'ts' has incompatible logical type in file compat_plain_int64.parquet:" +
+            }).isInstanceOf(SchemaIncompatibleException.class)
+                    .hasMessage("[compat_plain_int64.parquet] Column 'ts' has incompatible logical type:" +
                             " expected TimestampType[isAdjustedToUTC=true, unit=MICROS] but found null");
         }
     }

--- a/core/src/test/java/dev/hardwood/internal/ExceptionContextTest.java
+++ b/core/src/test/java/dev/hardwood/internal/ExceptionContextTest.java
@@ -1,0 +1,85 @@
+/*
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Copyright The original authors
+ *
+ *  Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package dev.hardwood.internal;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/// Unit tests for [ExceptionContext].
+class ExceptionContextTest {
+
+    @Test
+    void addsFileContextToMessage() {
+        IllegalStateException original = new IllegalStateException("something broke");
+        RuntimeException wrapped = ExceptionContext.addFileContext("test.parquet", original);
+
+        assertThat(wrapped).isInstanceOf(IllegalStateException.class);
+        assertThat(wrapped.getMessage()).isEqualTo("[test.parquet] something broke");
+        assertThat(wrapped.getCause()).isSameAs(original);
+    }
+
+    @Test
+    void preservesIllegalArgumentException() {
+        IllegalArgumentException original = new IllegalArgumentException("bad arg");
+        RuntimeException wrapped = ExceptionContext.addFileContext("file.parquet", original);
+
+        assertThat(wrapped).isInstanceOf(IllegalArgumentException.class);
+        assertThat(wrapped.getMessage()).isEqualTo("[file.parquet] bad arg");
+    }
+
+    @Test
+    void preservesUnsupportedOperationException() {
+        UnsupportedOperationException original = new UnsupportedOperationException("nope");
+        RuntimeException wrapped = ExceptionContext.addFileContext("file.parquet", original);
+
+        assertThat(wrapped).isInstanceOf(UnsupportedOperationException.class);
+        assertThat(wrapped.getMessage()).isEqualTo("[file.parquet] nope");
+    }
+
+    @Test
+    void idempotentWhenAlreadyWrapped() {
+        IllegalStateException original = new IllegalStateException("[test.parquet] already wrapped");
+        RuntimeException wrapped = ExceptionContext.addFileContext("test.parquet", original);
+
+        assertThat(wrapped).isSameAs(original);
+    }
+
+    @Test
+    void nullFileNameReturnsOriginal() {
+        IllegalStateException original = new IllegalStateException("error");
+        RuntimeException wrapped = ExceptionContext.addFileContext(null, original);
+
+        assertThat(wrapped).isSameAs(original);
+    }
+
+    @Test
+    void nullMessageHandledGracefully() {
+        RuntimeException original = new RuntimeException((String) null);
+        RuntimeException wrapped = ExceptionContext.addFileContext("test.parquet", original);
+
+        assertThat(wrapped.getMessage()).isEqualTo("[test.parquet] RuntimeException");
+    }
+
+    @Test
+    void fallsBackToRuntimeExceptionForExoticType() {
+        // A custom RuntimeException subclass without a (String, Throwable) constructor
+        RuntimeException original = new CustomException();
+        RuntimeException wrapped = ExceptionContext.addFileContext("test.parquet", original);
+
+        assertThat(wrapped).isInstanceOf(RuntimeException.class);
+        assertThat(wrapped.getMessage()).isEqualTo("[test.parquet] custom error");
+        assertThat(wrapped.getCause()).isSameAs(original);
+    }
+
+    private static class CustomException extends RuntimeException {
+        CustomException() {
+            super("custom error");
+        }
+    }
+}

--- a/parquet-testing-runner/src/test/java/dev/hardwood/testing/BadDataHandlingTest.java
+++ b/parquet-testing-runner/src/test/java/dev/hardwood/testing/BadDataHandlingTest.java
@@ -48,7 +48,8 @@ class BadDataHandlingTest {
     void rejectParquet1481() throws IOException {
         // Corrupted schema Thrift value: physical type field is -7
         assertBadDataRejected("PARQUET-1481.parquet",
-                "Invalid or corrupt physical type value: -7");
+                "[PARQUET-1481.parquet] Invalid or corrupt physical type value: -7 (expected 0-7)."
+                        + " File metadata may be corrupted");
     }
 
     @Test
@@ -86,21 +87,30 @@ class BadDataHandlingTest {
     void rejectArrowGH45185() throws IOException {
         // Repetition levels start with 1 instead of the required 0
         assertBadDataRejected("ARROW-GH-45185.parquet",
-                "first repetition level must be 0 but was 1");
+                "[ARROW-GH-45185.parquet] Invalid column chunk for 'element':"
+                        + " first repetition level must be 0 but was 1");
     }
 
     @Test
     void rejectCorruptChecksum() throws IOException {
-        // Intentionally corrupted CRC checksums in data pages
+        // Intentionally corrupted CRC checksums in data pages.
+        // The CRC IOException is wrapped in UncheckedIOException with file context
+        // by ColumnWorker before BatchExchange forwards it.
         assertCorruptChecksumRejected("data/datapage_v1-corrupt-checksum.parquet",
-                "CRC mismatch");
+                "[datapage_v1-corrupt-checksum.parquet]"
+                        + " CRC mismatch for column a: expected bbce3b9d but computed f4f6d0a",
+                "CRC mismatch for column a: expected bbce3b9d but computed f4f6d0a");
     }
 
     @Test
     void rejectCorruptDictionaryChecksum() throws IOException {
-        // Intentionally corrupted CRC checksum in dictionary page
+        // Intentionally corrupted CRC checksum in dictionary page.
+        // Caught and wrapped by IndexedFetchPlan as UncheckedIOException with
+        // a `[fileName]` prefix.
         assertCorruptChecksumRejected("data/rle-dict-uncompressed-corrupt-checksum.parquet",
-                "CRC mismatch");
+                "[rle-dict-uncompressed-corrupt-checksum.parquet]"
+                        + " Failed to parse dictionary for column 'long_field'",
+                "CRC mismatch for column long_field: expected 6522df6a but computed 6522df69");
     }
 
     @Test
@@ -128,7 +138,8 @@ class BadDataHandlingTest {
         Path good = repoDir.resolve("data/alltypes_plain.parquet");
         Path bad = repoDir.resolve("bad_data/PARQUET-1481.parquet");
         Utils.assertBadDataRejected("PARQUET-1481.parquet",
-                "Invalid or corrupt physical type value: -7",
+                "[PARQUET-1481.parquet] Invalid or corrupt physical type value: -7 (expected 0-7)."
+                        + " File metadata may be corrupted",
                 multiFileReadAction(good, bad));
     }
 
@@ -145,13 +156,14 @@ class BadDataHandlingTest {
         Path good = repoDir.resolve("data/good_c.parquet");
         Path bad = repoDir.resolve("bad_data/ARROW-RS-GH-6229-LEVELS.parquet");
         Utils.assertBadDataRejected("ARROW-RS-GH-6229-LEVELS.parquet",
-                "Column 'c' not found in file: ARROW-RS-GH-6229-LEVELS.parquet",
+                "[ARROW-RS-GH-6229-LEVELS.parquet] Column 'c' not found",
                 multiFileReadAction(good, bad));
     }
 
     // ==================== Helpers ====================
 
-    private void assertCorruptChecksumRejected(String relativePath, String expectedMessage) throws IOException {
+    private void assertCorruptChecksumRejected(String relativePath, String expectedMessage,
+                                                String expectedCauseMessage) throws IOException {
         Path testFile = repoDir.resolve(relativePath);
 
         assertThatThrownBy(() -> {
@@ -162,7 +174,8 @@ class BadDataHandlingTest {
                 }
             }
         }).as("Expected %s to be rejected due to corrupt checksum", relativePath)
-          .hasStackTraceContaining(expectedMessage);
+          .hasMessage(expectedMessage)
+          .hasRootCauseMessage(expectedCauseMessage);
     }
 
     private ThrowableAssert.ThrowingCallable singleFileReadAction(String fileName) {

--- a/parquet-testing-runner/src/test/java/dev/hardwood/testing/Utils.java
+++ b/parquet-testing-runner/src/test/java/dev/hardwood/testing/Utils.java
@@ -173,7 +173,7 @@ public class Utils {
     static void assertBadDataRejected(String fileName, String expectedMessage, ThrowableAssert.ThrowingCallable action) throws IOException {
         assertThatThrownBy(action)
                 .as("Expected %s to be rejected", fileName)
-                .hasStackTraceContaining(expectedMessage);
+                .hasMessage(expectedMessage);
     }
 
     /// Read all rows using parquet-java's AvroParquetReader.


### PR DESCRIPTION
Threads the originating file name from PageSource through the v3 read pipeline (retriever -> decode -> drain -> Batch) so that exceptions escaping a RowReader / ColumnReader carry a `[fileName] ` prefix.

Producer-side enrichment lives in ColumnWorker's catch blocks via ExceptionContext.addFileContext, which preserves the original exception type. The file name travels with each batch (Batch.fileName / NestedBatch.fileName), set by the drain after a per-slot fileNameBuffer[] lookup; file-boundary detection in drainReadyPages ensures each batch maps to a single file.

Reader-side: each reader caches the active batch's file name and bakes it into the message at every explicit throw site (resolveIndex, resolveAndValidate, throwNull, typeMismatch, checkBatchAvailable, checkNestedLevel, the column-count-mismatch site, and the variant projection checks in NestedBatchDataView). No try/catch wrapping on hot accessors.