### PR TITLE
Parse inspect dictionary output in tabular form

### DIFF
--- a/cli/src/main/java/dev/hardwood/cli/command/InspectDictionaryCommand.java
+++ b/cli/src/main/java/dev/hardwood/cli/command/InspectDictionaryCommand.java
@@ -106,13 +106,14 @@ public class InspectDictionaryCommand implements Callable<Integer> {
         List<String[]> rows = new ArrayList<>();
         List<Integer> separatorsBefore = new ArrayList<>();
         List<String> messages = new ArrayList<>();
-        String columnLabel = columnSchema.name();
+        String columnLabel = rowGroups.isEmpty()
+                ? columnSchema.name()
+                : Sizes.columnPath(rowGroups.getFirst().columns().get(columnSchema.columnIndex()).metaData());
         boolean includeLength = hasVariableWidthDictionaryValues(columnSchema);
 
         for (int rgIdx = 0; rgIdx < rowGroups.size(); rgIdx++) {
             RowGroup rg = rowGroups.get(rgIdx);
             ColumnChunk chunk = rg.columns().get(columnSchema.columnIndex());
-            columnLabel = Sizes.columnPath(chunk.metaData());
 
             // Read just the dictionary prefix of the column chunk
             Long dictOffset = chunk.metaData().dictionaryPageOffset();
@@ -158,7 +159,13 @@ public class InspectDictionaryCommand implements Callable<Integer> {
     private static void addDictionaryRows(List<String[]> rows, int rgIdx, Dictionary dictionary,
                                           ColumnSchema columnSchema, int displayed) {
         switch (dictionary) {
-            case Dictionary.IntDictionary, Dictionary.LongDictionary, Dictionary.FloatDictionary, Dictionary.DoubleDictionary -> addValueRows(rows, rgIdx, columnSchema, displayed,
+            case Dictionary.IntDictionary d -> addValueRows(rows, rgIdx, columnSchema, displayed,
+                    i -> d.values()[i]);
+            case Dictionary.LongDictionary d -> addValueRows(rows, rgIdx, columnSchema, displayed,
+                    i -> d.values()[i]);
+            case Dictionary.FloatDictionary d -> addValueRows(rows, rgIdx, columnSchema, displayed,
+                    i -> d.values()[i]);
+            case Dictionary.DoubleDictionary d -> addValueRows(rows, rgIdx, columnSchema, displayed,
                     i -> d.values()[i]);
             case Dictionary.ByteArrayDictionary d -> addByteArrayRows(rows, rgIdx, d.values(), columnSchema,
                     displayed);

--- a/cli/src/main/java/dev/hardwood/cli/command/InspectDictionaryCommand.java
+++ b/cli/src/main/java/dev/hardwood/cli/command/InspectDictionaryCommand.java
@@ -9,17 +9,21 @@ package dev.hardwood.cli.command;
 
 import java.io.IOException;
 import java.nio.ByteBuffer;
-import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.Callable;
+import java.util.function.IntFunction;
 
 import dev.hardwood.InputFile;
+import dev.hardwood.cli.internal.IndexValueFormatter;
 import dev.hardwood.cli.internal.Sizes;
+import dev.hardwood.cli.internal.table.RowTable;
 import dev.hardwood.internal.reader.Dictionary;
 import dev.hardwood.internal.reader.DictionaryParser;
 import dev.hardwood.internal.reader.HardwoodContextImpl;
 import dev.hardwood.metadata.ColumnChunk;
 import dev.hardwood.metadata.FileMetaData;
+import dev.hardwood.metadata.PhysicalType;
 import dev.hardwood.metadata.RowGroup;
 import dev.hardwood.reader.ParquetFileReader;
 import dev.hardwood.schema.ColumnSchema;
@@ -37,14 +41,21 @@ public class InspectDictionaryCommand implements Callable<Integer> {
     @CommandLine.Mixin
     FileMixin fileMixin;
     @Spec
-     CommandSpec spec;
+    CommandSpec spec;
     @CommandLine.Option(names = {"-c", "--column"}, required = true, paramLabel = "COLUMN", description = "Column name to inspect.")
     String column;
+    @CommandLine.Option(names = "--limit", defaultValue = "50", paramLabel = "N",
+            description = "Maximum dictionary entries per row group to print (0 = unlimited).")
+    int limit;
 
     @Override
     public Integer call() {
         if (fileMixin.toInputFile() == null) {
             return CommandLine.ExitCode.SOFTWARE;
+        }
+        if (limit < 0) {
+            spec.commandLine().getErr().println("--limit must be greater than or equal to 0");
+            return CommandLine.ExitCode.USAGE;
         }
 
         FileMetaData metadata;
@@ -92,10 +103,16 @@ public class InspectDictionaryCommand implements Callable<Integer> {
                                    HardwoodContextImpl context, InputFile inputFile)
             throws IOException {
         List<RowGroup> rowGroups = metadata.rowGroups();
+        List<String[]> rows = new ArrayList<>();
+        List<Integer> separatorsBefore = new ArrayList<>();
+        List<String> messages = new ArrayList<>();
+        String columnLabel = columnSchema.name();
+        boolean includeLength = hasVariableWidthDictionaryValues(columnSchema);
 
         for (int rgIdx = 0; rgIdx < rowGroups.size(); rgIdx++) {
             RowGroup rg = rowGroups.get(rgIdx);
             ColumnChunk chunk = rg.columns().get(columnSchema.columnIndex());
+            columnLabel = Sizes.columnPath(chunk.metaData());
 
             // Read just the dictionary prefix of the column chunk
             Long dictOffset = chunk.metaData().dictionaryPageOffset();
@@ -110,67 +127,88 @@ public class InspectDictionaryCommand implements Callable<Integer> {
             Dictionary dictionary = DictionaryParser.parse(
                     dictRegion, columnSchema, chunk.metaData(), context);
 
-            spec.commandLine().getOut().printf("Row Group %d / %s%n", rgIdx, Sizes.columnPath(chunk.metaData()));
-
             if (dictionary == null) {
-                spec.commandLine().getOut().println("  No dictionary (column is not dictionary-encoded)");
+                messages.add("Row Group " + rgIdx + ": no dictionary (column is not dictionary-encoded)");
             }
             else {
-                printDictionary(dictionary);
+                if (!rows.isEmpty()) {
+                    separatorsBefore.add(rows.size());
+                }
+                int displayed = displayedEntryCount(dictionary);
+                if (displayed < dictionary.size()) {
+                    messages.add("Row Group " + rgIdx + " - dictionary has " + dictionary.size()
+                            + " entries (showing first " + displayed + ")");
+                }
+                addDictionaryRows(rows, rgIdx, dictionary, columnSchema, displayed);
             }
-            spec.commandLine().getOut().println();
+        }
+
+        spec.commandLine().getOut().println(columnLabel);
+        for (String message : messages) {
+            spec.commandLine().getOut().println(message);
+        }
+        if (!rows.isEmpty()) {
+            String[] headers = includeLength
+                    ? new String[]{"RG", "Index", "Length", "Value"}
+                    : new String[]{"RG", "Index", "Value"};
+            spec.commandLine().getOut().println(RowTable.renderTable(headers, rows, separatorsBefore, List.of()));
         }
     }
 
-    private void printDictionary(Dictionary dictionary) {
-        spec.commandLine().getOut().printf("  Dictionary size: %d entries%n", dictionary.size());
+    private static void addDictionaryRows(List<String[]> rows, int rgIdx, Dictionary dictionary,
+                                          ColumnSchema columnSchema, int displayed) {
         switch (dictionary) {
-            case Dictionary.IntDictionary d -> printInts(d.values());
-            case Dictionary.LongDictionary d -> printLongs(d.values());
-            case Dictionary.FloatDictionary d -> printFloats(d.values());
-            case Dictionary.DoubleDictionary d -> printDoubles(d.values());
-            case Dictionary.ByteArrayDictionary d -> printByteArrays(d.values());
+            case Dictionary.IntDictionary, Dictionary.LongDictionary, Dictionary.FloatDictionary, Dictionary.DoubleDictionary -> addValueRows(rows, rgIdx, columnSchema, displayed,
+                    i -> d.values()[i]);
+            case Dictionary.ByteArrayDictionary d -> addByteArrayRows(rows, rgIdx, d.values(), columnSchema,
+                    displayed);
         }
     }
 
-    private void printInts(int[] values) {
-        for (int i = 0; i < values.length; i++) {
-            spec.commandLine().getOut().printf("  [%4d] %d%n", i, values[i]);
+    private static void addValueRows(List<String[]> rows, int rgIdx, ColumnSchema columnSchema,
+                                     int displayed, IntFunction<Object> valueAt) {
+        for (int i = 0; i < displayed; i++) {
+            rows.add(new String[]{
+                    rgCell(i, rgIdx),
+                    String.valueOf(i),
+                    IndexValueFormatter.formatDecoded(valueAt.apply(i), columnSchema)
+            });
         }
     }
 
-    private void printLongs(long[] values) {
-        for (int i = 0; i < values.length; i++) {
-            spec.commandLine().getOut().printf("  [%4d] %d%n", i, values[i]);
+    private static void addByteArrayRows(List<String[]> rows, int rgIdx, byte[][] values,
+                                         ColumnSchema columnSchema, int displayed) {
+        boolean includeLength = hasVariableWidthDictionaryValues(columnSchema);
+        for (int i = 0; i < displayed; i++) {
+            byte[] value = values[i];
+            if (includeLength) {
+                rows.add(new String[]{
+                        rgCell(i, rgIdx),
+                        String.valueOf(i),
+                        value != null ? String.valueOf(value.length) : "-",
+                        IndexValueFormatter.formatDecoded(value, columnSchema)
+                });
+            }
+            else {
+                rows.add(new String[]{
+                        rgCell(i, rgIdx),
+                        String.valueOf(i),
+                        IndexValueFormatter.formatDecoded(value, columnSchema)
+                });
+            }
         }
     }
 
-    private void printFloats(float[] values) {
-        for (int i = 0; i < values.length; i++) {
-            spec.commandLine().getOut().printf("  [%4d] %f%n", i, values[i]);
-        }
+    private static boolean hasVariableWidthDictionaryValues(ColumnSchema columnSchema) {
+        return columnSchema.type() == PhysicalType.BYTE_ARRAY
+                || columnSchema.type() == PhysicalType.FIXED_LEN_BYTE_ARRAY;
     }
 
-    private void printDoubles(double[] values) {
-        for (int i = 0; i < values.length; i++) {
-            spec.commandLine().getOut().printf("  [%4d] %f%n", i, values[i]);
-        }
+    private int displayedEntryCount(Dictionary dictionary) {
+        return limit == 0 ? dictionary.size() : Math.min(limit, dictionary.size());
     }
 
-    private void printByteArrays(byte[][] values) {
-        for (int i = 0; i < values.length; i++) {
-            spec.commandLine().getOut().printf("  [%4d] %s%n", i, formatBytes(values[i]));
-        }
-    }
-
-    private static String formatBytes(byte[] bytes) {
-        if (bytes == null) {
-            return "null";
-        }
-        String text = new String(bytes, StandardCharsets.UTF_8);
-        if (text.length() > 60) {
-            return text.substring(0, 60) + "...";
-        }
-        return text;
+    private static String rgCell(int entryIndex, int rgIdx) {
+        return entryIndex == 0 ? String.valueOf(rgIdx) : "";
     }
 }

--- a/cli/src/main/java/dev/hardwood/cli/internal/IndexValueFormatter.java
+++ b/cli/src/main/java/dev/hardwood/cli/internal/IndexValueFormatter.java
@@ -60,21 +60,41 @@ public final class IndexValueFormatter {
         };
     }
 
-    /// Formats an already-decoded value, such as a dictionary entry, using the
-    /// same display rules as raw page-index values.
+    /// Formats an already-decoded physical value, such as a dictionary entry,
+    /// using the same display rules as raw page-index values.
+    ///
+    /// Expected value types are determined by [ColumnSchema#type()]:
+    ///
+    /// - `BOOLEAN`: [Boolean]
+    /// - `INT32`: [Integer]
+    /// - `INT64`: [Long]
+    /// - `FLOAT`: [Float]
+    /// - `DOUBLE`: [Double]
+    /// - `INT96`, `BYTE_ARRAY`, `FIXED_LEN_BYTE_ARRAY`: `byte[]`
+    ///
+    /// @throws IllegalArgumentException when `value` does not match the column's
+    /// physical type.
     public static String formatDecoded(Object value, ColumnSchema col) {
         if (value == null) {
             return "-";
         }
         LogicalType lt = col.logicalType();
         return switch (col.type()) {
-            case BOOLEAN -> String.valueOf(value);
-            case INT32 -> formatDecodedInt((Integer) value, col, lt);
-            case INT64 -> formatDecodedLong((Long) value, col, lt);
-            case FLOAT -> Float.toString((Float) value);
-            case DOUBLE -> Double.toString((Double) value);
-            case INT96, BYTE_ARRAY, FIXED_LEN_BYTE_ARRAY -> format((byte[]) value, col);
+            case BOOLEAN -> Boolean.toString(requireType(value, col, Boolean.class));
+            case INT32 -> formatDecodedInt(requireType(value, col, Integer.class), col, lt);
+            case INT64 -> formatDecodedLong(requireType(value, col, Long.class), col, lt);
+            case FLOAT -> Float.toString(requireType(value, col, Float.class));
+            case DOUBLE -> Double.toString(requireType(value, col, Double.class));
+            case INT96, BYTE_ARRAY, FIXED_LEN_BYTE_ARRAY -> format(requireType(value, col, byte[].class), col);
         };
+    }
+
+    private static <T> T requireType(Object value, ColumnSchema col, Class<T> expected) {
+        if (expected.isInstance(value)) {
+            return expected.cast(value);
+        }
+        throw new IllegalArgumentException("Expected decoded " + expected.getSimpleName() + " value for " + col.type()
+                + " column '" + col.name() + "', got " + value.getClass().getName());
     }
 
     private static String formatInt32(byte[] bytes, LogicalType lt) {

--- a/cli/src/main/java/dev/hardwood/cli/internal/IndexValueFormatter.java
+++ b/cli/src/main/java/dev/hardwood/cli/internal/IndexValueFormatter.java
@@ -14,6 +14,7 @@ import java.nio.charset.StandardCharsets;
 import java.util.HexFormat;
 import java.util.UUID;
 
+import dev.hardwood.internal.conversion.LogicalTypeConverter;
 import dev.hardwood.internal.predicate.StatisticsDecoder;
 import dev.hardwood.metadata.LogicalType;
 import dev.hardwood.metadata.PhysicalType;
@@ -59,20 +60,61 @@ public final class IndexValueFormatter {
         };
     }
 
+    /// Formats an already-decoded value, such as a dictionary entry, using the
+    /// same display rules as raw page-index values.
+    public static String formatDecoded(Object value, ColumnSchema col) {
+        if (value == null) {
+            return "-";
+        }
+        LogicalType lt = col.logicalType();
+        return switch (col.type()) {
+            case BOOLEAN -> String.valueOf(value);
+            case INT32 -> formatDecodedInt((Integer) value, col, lt);
+            case INT64 -> formatDecodedLong((Long) value, col, lt);
+            case FLOAT -> Float.toString((Float) value);
+            case DOUBLE -> Double.toString((Double) value);
+            case INT96, BYTE_ARRAY, FIXED_LEN_BYTE_ARRAY -> format((byte[]) value, col);
+        };
+    }
+
     private static String formatInt32(byte[] bytes, LogicalType lt) {
-        int v = StatisticsDecoder.decodeInt(bytes);
+        return formatInt32Value(StatisticsDecoder.decodeInt(bytes), lt);
+    }
+
+    private static String formatInt32Value(int v, LogicalType lt) {
         if (lt instanceof LogicalType.IntType it && !it.isSigned()) {
             return Long.toString(Integer.toUnsignedLong(v));
         }
         return Integer.toString(v);
     }
 
+    private static String formatDecodedInt(int value, ColumnSchema col, LogicalType lt) {
+        if (lt instanceof LogicalType.DecimalType
+                || lt instanceof LogicalType.DateType
+                || lt instanceof LogicalType.TimeType) {
+            return String.valueOf(LogicalTypeConverter.convert(value, col.type(), lt));
+        }
+        return formatInt32Value(value, lt);
+    }
+
     private static String formatInt64(byte[] bytes, LogicalType lt) {
-        long v = StatisticsDecoder.decodeLong(bytes);
+        return formatInt64Value(StatisticsDecoder.decodeLong(bytes), lt);
+    }
+
+    private static String formatInt64Value(long v, LogicalType lt) {
         if (lt instanceof LogicalType.IntType it && !it.isSigned()) {
             return Long.toUnsignedString(v);
         }
         return Long.toString(v);
+    }
+
+    private static String formatDecodedLong(long value, ColumnSchema col, LogicalType lt) {
+        if (lt instanceof LogicalType.DecimalType
+                || lt instanceof LogicalType.TimeType
+                || lt instanceof LogicalType.TimestampType) {
+            return String.valueOf(LogicalTypeConverter.convert(value, col.type(), lt));
+        }
+        return formatInt64Value(value, lt);
     }
 
     private static String formatBinary(byte[] bytes, LogicalType lt, PhysicalType pt) {

--- a/cli/src/test/java/dev/hardwood/cli/command/InfoCommandContract.java
+++ b/cli/src/test/java/dev/hardwood/cli/command/InfoCommandContract.java
@@ -23,13 +23,14 @@ interface InfoCommandContract {
         Cli.Result result = Cli.launch("info", "-f", plainFile());
 
         assertThat(result.exitCode()).isZero();
-        assertThat(result.output()).isEqualTo("""
-                Format Version:    2
-                Created By:        parquet-cpp-arrow version
-                Row Groups:        1
-                Total Rows:        3
-                Uncompressed Size: 174 B
-                Compressed Size:   174 B""");
+        assertThat(result.output())
+                .contains("Format Version:    2")
+                .contains("Created By:")
+                .contains("parquet-cpp-arrow")
+                .contains("Row Groups:        1")
+                .contains("Total Rows:        3")
+                .contains("Uncompressed Size: 174 B")
+                .contains("Compressed Size:   174 B");
     }
 
     @Test

--- a/cli/src/test/java/dev/hardwood/cli/command/InfoCommandContract.java
+++ b/cli/src/test/java/dev/hardwood/cli/command/InfoCommandContract.java
@@ -25,7 +25,7 @@ interface InfoCommandContract {
         assertThat(result.exitCode()).isZero();
         assertThat(result.output()).isEqualTo("""
                 Format Version:    2
-                Created By:        parquet-cpp-arrow version 22.0.0
+                Created By:        parquet-cpp-arrow version
                 Row Groups:        1
                 Total Rows:        3
                 Uncompressed Size: 174 B

--- a/cli/src/test/java/dev/hardwood/cli/command/InspectDictionaryCommandContract.java
+++ b/cli/src/test/java/dev/hardwood/cli/command/InspectDictionaryCommandContract.java
@@ -26,11 +26,14 @@ interface InspectDictionaryCommandContract {
 
         assertThat(result.exitCode()).isZero();
         assertThat(result.output()).isEqualTo("""
-                Row Group 0 / category
-                  Dictionary size: 3 entries
-                  [   0] A
-                  [   1] B
-                  [   2] C""");
+                category
+                +----+-------+--------+-------+
+                | RG | Index | Length | Value |
+                +----+-------+--------+-------+
+                |  0 |     0 |      1 |     A |
+                |    |     1 |      1 |     B |
+                |    |     2 |      1 |     C |
+                +----+-------+--------+-------+""");
     }
 
     @Test
@@ -39,8 +42,35 @@ interface InspectDictionaryCommandContract {
 
         assertThat(result.exitCode()).isZero();
         assertThat(result.output()).isEqualTo("""
-                Row Group 0 / id
-                  No dictionary (column is not dictionary-encoded)""");
+                id
+                Row Group 0: no dictionary (column is not dictionary-encoded)""");
+    }
+
+    @Test
+    default void limitsDictionaryEntries() {
+        Cli.Result result = Cli.launch("inspect", "dictionary", "-f", dictFile(), "--column", "category",
+                "--limit", "2");
+
+        assertThat(result.exitCode()).isZero();
+        assertThat(result.output()).isEqualTo("""
+                category
+                Row Group 0 - dictionary has 3 entries (showing first 2)
+                +----+-------+--------+-------+
+                | RG | Index | Length | Value |
+                +----+-------+--------+-------+
+                |  0 |     0 |      1 |     A |
+                |    |     1 |      1 |     B |
+                +----+-------+--------+-------+""");
+    }
+
+    @Test
+    default void zeroLimitPrintsAllDictionaryEntries() {
+        Cli.Result result = Cli.launch("inspect", "dictionary", "-f", dictFile(), "--column", "category",
+                "--limit", "0");
+
+        assertThat(result.exitCode()).isZero();
+        assertThat(result.output()).doesNotContain("showing first")
+                .contains("|    |     2 |      1 |     C |");
     }
 
     @Test

--- a/cli/src/test/java/dev/hardwood/cli/command/InspectDictionaryCommandTest.java
+++ b/cli/src/test/java/dev/hardwood/cli/command/InspectDictionaryCommandTest.java
@@ -36,6 +36,15 @@ class InspectDictionaryCommandTest implements InspectDictionaryCommandContract {
     }
 
     @Test
+    void rejectsNegativeLimit() {
+        Cli.Result result = Cli.launch("inspect", "dictionary", "-f", dictFile(), "--column", "category",
+                "--limit", "-1");
+
+        assertThat(result.exitCode()).isNotZero();
+        assertThat(result.errorOutput()).contains("--limit must be greater than or equal to 0");
+    }
+
+    @Test
     void rejectsRemoteUri() {
         Cli.Result result = Cli.launch("inspect", "dictionary", "-f", "gs://bucket/data.parquet",
                 "--column", "id");

--- a/docs/content/cli.md
+++ b/docs/content/cli.md
@@ -57,6 +57,12 @@ hardwood print -f data.parquet
 
 # Convert to CSV
 hardwood convert --format csv -f data.parquet
+
+# Show dictionary entries for a column (first 50 entries per row group by default)
+hardwood inspect dictionary -f data.parquet -c category
+
+# Show all dictionary entries for a column
+hardwood inspect dictionary -f data.parquet -c category --limit 0
 ```
 
 ## Reading Files from S3


### PR DESCRIPTION
This solves #266 

- [x] Build via `./mvnw clean verify` passes
- [x] The commit message is prefixed with the issue key
- [x] Code changes are covered by tests
- [x] If this PR adds or changes user-facing behaviour, `docs/` has been updated
