### PR TITLE
#363 To ensure locale-independent numbers formatting

### DIFF
--- a/cli/src/main/java/dev/hardwood/cli/command/HardwoodCommand.java
+++ b/cli/src/main/java/dev/hardwood/cli/command/HardwoodCommand.java
@@ -9,6 +9,7 @@ package dev.hardwood.cli.command;
 
 import org.eclipse.microprofile.config.ConfigProvider;
 
+import dev.hardwood.cli.internal.Fmt;
 import io.quarkus.picocli.runtime.PicocliCommandLineFactory;
 import io.quarkus.picocli.runtime.annotations.TopCommand;
 import jakarta.enterprise.inject.Produces;
@@ -42,6 +43,6 @@ class VersionProviderWithConfigProvider implements IVersionProvider {
     public String[] getVersion() {
         String applicationName = "hardwood";
         String applicationVersion = ConfigProvider.getConfig().getValue("project.version", String.class);
-        return new String[]{ String.format("%s %s", applicationName, applicationVersion) };
+        return new String[]{ Fmt.fmt("%s %s", applicationName, applicationVersion) };
     }
 }

--- a/cli/src/main/java/dev/hardwood/cli/command/InspectColumnsCommand.java
+++ b/cli/src/main/java/dev/hardwood/cli/command/InspectColumnsCommand.java
@@ -17,6 +17,7 @@ import java.util.Map;
 import java.util.concurrent.Callable;
 
 import dev.hardwood.InputFile;
+import dev.hardwood.cli.internal.Fmt;
 import dev.hardwood.cli.internal.Sizes;
 import dev.hardwood.cli.internal.table.RowTable;
 import dev.hardwood.internal.thrift.OffsetIndexReader;
@@ -126,7 +127,7 @@ public class InspectColumnsCommand implements Callable<Integer> {
                     s.type(),
                     Sizes.format(s.compressed()),
                     Sizes.format(s.uncompressed()),
-                    String.format("%.1f%%", ratio),
+                    Fmt.fmt("%.1f%%", ratio),
                     s.pageCountAvailable() ? String.valueOf(s.pageCount()) : "-"
             });
         }

--- a/cli/src/main/java/dev/hardwood/cli/dive/internal/Chrome.java
+++ b/cli/src/main/java/dev/hardwood/cli/dive/internal/Chrome.java
@@ -13,6 +13,7 @@ import java.util.List;
 import dev.hardwood.cli.dive.NavigationStack;
 import dev.hardwood.cli.dive.ParquetModel;
 import dev.hardwood.cli.dive.ScreenState;
+import dev.hardwood.cli.internal.Fmt;
 import dev.hardwood.cli.internal.Sizes;
 import dev.tamboui.buffer.Buffer;
 import dev.tamboui.layout.Constraint;
@@ -236,7 +237,7 @@ public final class Chrome {
         if (rows < 1_000_000) {
             return rows + "";
         }
-        return String.format("%.1f M", rows / 1_000_000.0);
+        return Fmt.fmt("%.1f M", rows / 1_000_000.0);
     }
 
     private static dev.tamboui.text.Text convert(Line line) {

--- a/cli/src/main/java/dev/hardwood/cli/dive/internal/ColumnAcrossRowGroupsScreen.java
+++ b/cli/src/main/java/dev/hardwood/cli/dive/internal/ColumnAcrossRowGroupsScreen.java
@@ -13,6 +13,7 @@ import java.util.List;
 import dev.hardwood.cli.dive.NavigationStack;
 import dev.hardwood.cli.dive.ParquetModel;
 import dev.hardwood.cli.dive.ScreenState;
+import dev.hardwood.cli.internal.Fmt;
 import dev.hardwood.cli.internal.IndexValueFormatter;
 import dev.hardwood.cli.internal.Sizes;
 import dev.hardwood.metadata.ColumnChunk;
@@ -104,7 +105,7 @@ public final class ColumnAcrossRowGroupsScreen {
                     ? IndexValueFormatter.format(stats.maxValue(), col, state.logicalTypes())
                     : "—";
             String nulls = stats != null && stats.nullCount() != null
-                    ? String.format("%,d", stats.nullCount())
+                    ? Fmt.fmt("%,d", stats.nullCount())
                     : "—";
             double ratio = cmd.totalCompressedSize() == 0
                     ? 0.0
@@ -114,13 +115,13 @@ public final class ColumnAcrossRowGroupsScreen {
             // already — render "—" here.
             dev.hardwood.metadata.OffsetIndex oi = cc.offsetIndexOffset() != null
                     ? model.offsetIndex(i, state.columnIndex()) : null;
-            String pages = oi != null ? String.format("%,d", oi.pageLocations().size()) : "—";
+            String pages = oi != null ? Fmt.fmt("%,d", oi.pageLocations().size()) : "—";
             rows.add(Row.from(
                     String.valueOf(i),
-                    String.format("%,d", rg.numRows()),
+                    Fmt.fmt("%,d", rg.numRows()),
                     pages,
                     Sizes.format(cmd.totalCompressedSize()),
-                    String.format("%.1f×", ratio),
+                    Fmt.fmt("%.1f×", ratio),
                     cmd.dictionaryPageOffset() != null ? "yes" : "no",
                     cc.columnIndexOffset() != null ? "yes" : "no",
                     nulls,

--- a/cli/src/main/java/dev/hardwood/cli/dive/internal/ColumnChunkDetailScreen.java
+++ b/cli/src/main/java/dev/hardwood/cli/dive/internal/ColumnChunkDetailScreen.java
@@ -14,6 +14,7 @@ import java.util.stream.Collectors;
 import dev.hardwood.cli.dive.NavigationStack;
 import dev.hardwood.cli.dive.ParquetModel;
 import dev.hardwood.cli.dive.ScreenState;
+import dev.hardwood.cli.internal.Fmt;
 import dev.hardwood.cli.internal.IndexValueFormatter;
 import dev.hardwood.cli.internal.Sizes;
 import dev.hardwood.metadata.ColumnChunk;
@@ -220,20 +221,20 @@ public final class ColumnChunkDetailScreen {
                 .map(Enum::name)
                 .collect(Collectors.joining(", "))));
         lines.add(Line.empty());
-        lines.add(fact("Data offset", String.format("%,d", cmd.dataPageOffset())));
+        lines.add(fact("Data offset", Fmt.fmt("%,d", cmd.dataPageOffset())));
         lines.add(fact("Dict offset", cmd.dictionaryPageOffset() != null
-                ? String.format("%,d", cmd.dictionaryPageOffset())
+                ? Fmt.fmt("%,d", cmd.dictionaryPageOffset())
                 : "—"));
         lines.add(fact("Column index offset", chunk.columnIndexOffset() != null
-                ? String.format("%,d", chunk.columnIndexOffset())
+                ? Fmt.fmt("%,d", chunk.columnIndexOffset())
                 : "—"));
         lines.add(fact("Offset index offset", chunk.offsetIndexOffset() != null
-                ? String.format("%,d", chunk.offsetIndexOffset())
+                ? Fmt.fmt("%,d", chunk.offsetIndexOffset())
                 : "—"));
         lines.add(Line.empty());
-        lines.add(fact("Values", String.format("%,d", cmd.numValues())));
+        lines.add(fact("Values", Fmt.fmt("%,d", cmd.numValues())));
         lines.add(fact("Nulls", stats != null && stats.nullCount() != null
-                ? String.format("%,d", stats.nullCount())
+                ? Fmt.fmt("%,d", stats.nullCount())
                 : "—"));
         lines.add(fact("Uncompressed", Sizes.format(cmd.totalUncompressedSize())));
         lines.add(fact("Compressed", Sizes.format(cmd.totalCompressedSize())));

--- a/cli/src/main/java/dev/hardwood/cli/dive/internal/ColumnChunksScreen.java
+++ b/cli/src/main/java/dev/hardwood/cli/dive/internal/ColumnChunksScreen.java
@@ -13,6 +13,7 @@ import java.util.List;
 import dev.hardwood.cli.dive.NavigationStack;
 import dev.hardwood.cli.dive.ParquetModel;
 import dev.hardwood.cli.dive.ScreenState;
+import dev.hardwood.cli.internal.Fmt;
 import dev.hardwood.cli.internal.Sizes;
 import dev.hardwood.metadata.ColumnChunk;
 import dev.hardwood.metadata.ColumnMetaData;
@@ -91,7 +92,7 @@ public final class ColumnChunksScreen {
                     logical != null ? logical.toString() : "—",
                     cmd.codec().name(),
                     Sizes.format(cmd.totalCompressedSize()),
-                    String.format("%.1f×", ratio),
+                    Fmt.fmt("%.1f×", ratio),
                     cmd.dictionaryPageOffset() != null ? "yes" : "no"));
         }
         Row header = Row.from("#", "Column", "Type", "Logical", "Codec", "Compressed", "Ratio", "Dict")

--- a/cli/src/main/java/dev/hardwood/cli/dive/internal/ColumnIndexScreen.java
+++ b/cli/src/main/java/dev/hardwood/cli/dive/internal/ColumnIndexScreen.java
@@ -13,6 +13,7 @@ import java.util.List;
 import dev.hardwood.cli.dive.NavigationStack;
 import dev.hardwood.cli.dive.ParquetModel;
 import dev.hardwood.cli.dive.ScreenState;
+import dev.hardwood.cli.internal.Fmt;
 import dev.hardwood.cli.internal.IndexValueFormatter;
 import dev.hardwood.metadata.ColumnIndex;
 import dev.hardwood.schema.ColumnSchema;
@@ -185,7 +186,7 @@ public final class ColumnIndexScreen {
         List<Row> rows = new ArrayList<>();
         for (int idx : filtered) {
             String nulls = ci.nullCounts() != null && idx < ci.nullCounts().size()
-                    ? String.format("%,d", ci.nullCounts().get(idx))
+                    ? Fmt.fmt("%,d", ci.nullCounts().get(idx))
                     : "—";
             rows.add(Row.from(
                     String.valueOf(idx),
@@ -330,7 +331,7 @@ public final class ColumnIndexScreen {
         Line line = Line.from(
                 new Span(" / ", Style.EMPTY.fg(Theme.ACCENT).bold()),
                 new Span(state.filter() + cursor, Style.EMPTY.bold()),
-                new Span("  (" + String.format("%,d", matchCount) + " / "
+                new Span("  (" + Fmt.fmt("%,d", matchCount) + " / "
                         + Plurals.format(totalPages, "page", "pages") + ")", Style.EMPTY.fg(Theme.DIM)));
         Paragraph.builder().text(Text.from(line)).left().build().render(area, buffer);
     }

--- a/cli/src/main/java/dev/hardwood/cli/dive/internal/DataPreviewScreen.java
+++ b/cli/src/main/java/dev/hardwood/cli/dive/internal/DataPreviewScreen.java
@@ -14,6 +14,7 @@ import java.util.Set;
 
 import dev.hardwood.cli.dive.ParquetModel;
 import dev.hardwood.cli.dive.ScreenState;
+import dev.hardwood.cli.internal.Fmt;
 import dev.hardwood.cli.internal.RowValueFormatter;
 import dev.hardwood.schema.SchemaNode;
 import dev.tamboui.buffer.Buffer;
@@ -263,7 +264,7 @@ public final class DataPreviewScreen {
         long total = model.facts().totalRows();
         long lastRow = state.firstRow() + state.rows().size();
         String typeMode = state.logicalTypes() ? "" : " · physical";
-        String title = String.format(" Data preview (rows %,d–%,d of %,d · cols %d–%d of %d%s) ",
+        String title = Fmt.fmt(" Data preview (rows %,d–%,d of %,d · cols %d–%d of %d%s) ",
                 state.firstRow() + 1, lastRow, total,
                 state.columnScroll() + 1, windowEnd, columnCount, typeMode);
 
@@ -440,7 +441,7 @@ public final class DataPreviewScreen {
 
         long absRow = state.firstRow() + state.modalRow();
         Block block = Block.builder()
-                .title(String.format(" Row %,d ", absRow + 1))
+                .title(Fmt.fmt(" Row %,d ", absRow + 1))
                 .borders(Borders.ALL)
                 .borderType(BorderType.ROUNDED)
                 .borderColor(Theme.ACCENT)

--- a/cli/src/main/java/dev/hardwood/cli/dive/internal/DictionaryScreen.java
+++ b/cli/src/main/java/dev/hardwood/cli/dive/internal/DictionaryScreen.java
@@ -13,6 +13,7 @@ import java.util.List;
 import dev.hardwood.cli.dive.NavigationStack;
 import dev.hardwood.cli.dive.ParquetModel;
 import dev.hardwood.cli.dive.ScreenState;
+import dev.hardwood.cli.internal.Fmt;
 import dev.hardwood.cli.internal.RowValueFormatter;
 import dev.hardwood.internal.reader.Dictionary;
 import dev.hardwood.schema.ColumnSchema;
@@ -271,7 +272,7 @@ public final class DictionaryScreen {
         Line line = Line.from(
                 new Span(" / ", Style.EMPTY.fg(Theme.ACCENT).bold()),
                 new Span(state.filter() + cursor, Style.EMPTY.bold()),
-                new Span("  (" + String.format("%,d", filteredSize) + " / "
+                new Span("  (" + Fmt.fmt("%,d", filteredSize) + " / "
                         + Plurals.format(totalSize, "entry", "entries") + ")", Style.EMPTY.fg(Theme.DIM)));
         Paragraph.builder().text(Text.from(line)).left().build().render(area, buffer);
     }

--- a/cli/src/main/java/dev/hardwood/cli/dive/internal/FileIndexesScreen.java
+++ b/cli/src/main/java/dev/hardwood/cli/dive/internal/FileIndexesScreen.java
@@ -13,6 +13,7 @@ import java.util.List;
 import dev.hardwood.cli.dive.NavigationStack;
 import dev.hardwood.cli.dive.ParquetModel;
 import dev.hardwood.cli.dive.ScreenState;
+import dev.hardwood.cli.internal.Fmt;
 import dev.hardwood.cli.internal.Sizes;
 import dev.hardwood.metadata.ColumnChunk;
 import dev.hardwood.metadata.ColumnMetaData;
@@ -130,12 +131,12 @@ public final class FileIndexesScreen {
                 case COLUMN -> rows.add(Row.from(
                         String.valueOf(e.rowGroupIndex()),
                         columnPath,
-                        String.format("%,d", cc.columnIndexOffset()),
+                        Fmt.fmt("%,d", cc.columnIndexOffset()),
                         Sizes.format(cc.columnIndexLength())));
                 case OFFSET -> rows.add(Row.from(
                         String.valueOf(e.rowGroupIndex()),
                         columnPath,
-                        String.format("%,d", cc.offsetIndexOffset()),
+                        Fmt.fmt("%,d", cc.offsetIndexOffset()),
                         Sizes.format(cc.offsetIndexLength())));
                 case DICTIONARY -> {
                     long dictOffset = cmd.dictionaryPageOffset();
@@ -144,8 +145,8 @@ public final class FileIndexesScreen {
                     rows.add(Row.from(
                             String.valueOf(e.rowGroupIndex()),
                             columnPath,
-                            String.format("%,d", dictOffset),
-                            String.format("%,d", dataOffset),
+                            Fmt.fmt("%,d", dictOffset),
+                            Fmt.fmt("%,d", dataOffset),
                             Sizes.format(dictSpan)));
                 }
             }

--- a/cli/src/main/java/dev/hardwood/cli/dive/internal/FooterScreen.java
+++ b/cli/src/main/java/dev/hardwood/cli/dive/internal/FooterScreen.java
@@ -16,6 +16,7 @@ import java.util.TreeMap;
 import dev.hardwood.cli.dive.NavigationStack;
 import dev.hardwood.cli.dive.ParquetModel;
 import dev.hardwood.cli.dive.ScreenState;
+import dev.hardwood.cli.internal.Fmt;
 import dev.hardwood.cli.internal.Sizes;
 import dev.hardwood.metadata.ColumnChunk;
 import dev.hardwood.metadata.ColumnMetaData;
@@ -290,11 +291,11 @@ public final class FooterScreen {
         lines.add(fact("  Format version", String.valueOf(model.metadata().version())));
         lines.add(fact("  Created by",
                 model.facts().createdBy() != null ? model.facts().createdBy() : "unknown"));
-        lines.add(fact("  Footer trailer offset", String.format("%,d", footerTrailerOffset)));
+        lines.add(fact("  Footer trailer offset", Fmt.fmt("%,d", footerTrailerOffset)));
         lines.add(fact("  Trailer bytes", String.valueOf(FOOTER_TRAILER_BYTES)));
         if (stats.minDataOffset() < Long.MAX_VALUE) {
             lines.add(fact("  Data region",
-                    String.format("%,d .. %,d  (%s)",
+                    Fmt.fmt("%,d .. %,d  (%s)",
                             stats.minDataOffset(), stats.maxDataEnd(),
                             Sizes.format(stats.maxDataEnd() - stats.minDataOffset()))));
             lines.add(fact("  Footer + indexes",
@@ -336,7 +337,7 @@ public final class FooterScreen {
         lines.add(fact("  Compressed data", Sizes.dualFormat(model.facts().compressedBytes())));
         lines.add(fact("  Uncompressed data", Sizes.dualFormat(model.facts().uncompressedBytes())));
         lines.add(fact("  Compression ratio",
-                String.format("%.2f×", model.facts().compressionRatio())));
+                Fmt.fmt("%.2f×", model.facts().compressionRatio())));
         return lines;
     }
 
@@ -467,7 +468,7 @@ public final class FooterScreen {
             return "0/0";
         }
         int pct = (int) Math.round(100.0 * count / total);
-        return String.format("%,d/%,d chunks  (%d%%)", count, total, pct);
+        return Fmt.fmt("%,d/%,d chunks  (%d%%)", count, total, pct);
     }
 
     private static Line fact(String key, String value) {

--- a/cli/src/main/java/dev/hardwood/cli/dive/internal/KvMetadataFormatter.java
+++ b/cli/src/main/java/dev/hardwood/cli/dive/internal/KvMetadataFormatter.java
@@ -9,6 +9,8 @@ package dev.hardwood.cli.dive.internal;
 
 import java.util.Base64;
 
+import dev.hardwood.cli.internal.Fmt;
+
 /// Best-effort pretty-printing of key/value metadata values on the Overview
 /// modal. Most Parquet writers shove structured content into these strings:
 /// Spark writes JSON schemas under `org.apache.spark.sql.parquet.row.metadata`,
@@ -68,10 +70,10 @@ public final class KvMetadataFormatter {
         sb.append(decoded.length > 256 ? "Hex dump (first 256 bytes):\n" : "Hex dump:\n");
         int limit = Math.min(decoded.length, 256);
         for (int i = 0; i < limit; i += 16) {
-            sb.append(String.format("%04x  ", i));
+            sb.append(Fmt.fmt("%04x  ", i));
             for (int j = 0; j < 16; j++) {
                 if (i + j < limit) {
-                    sb.append(String.format("%02x ", decoded[i + j] & 0xff));
+                    sb.append(Fmt.fmt("%02x ", decoded[i + j] & 0xff));
                 }
                 else {
                     sb.append("   ");

--- a/cli/src/main/java/dev/hardwood/cli/dive/internal/OffsetIndexScreen.java
+++ b/cli/src/main/java/dev/hardwood/cli/dive/internal/OffsetIndexScreen.java
@@ -13,6 +13,7 @@ import java.util.List;
 import dev.hardwood.cli.dive.NavigationStack;
 import dev.hardwood.cli.dive.ParquetModel;
 import dev.hardwood.cli.dive.ScreenState;
+import dev.hardwood.cli.internal.Fmt;
 import dev.hardwood.cli.internal.Sizes;
 import dev.hardwood.metadata.OffsetIndex;
 import dev.hardwood.metadata.PageLocation;
@@ -105,9 +106,9 @@ public final class OffsetIndexScreen {
             PageLocation loc = locations.get(i);
             rows.add(Row.from(
                     String.valueOf(i),
-                    String.format("%,d", loc.offset()),
+                    Fmt.fmt("%,d", loc.offset()),
                     Sizes.format(loc.compressedPageSize()),
-                    String.format("%,d", loc.firstRowIndex())));
+                    Fmt.fmt("%,d", loc.firstRowIndex())));
         }
         Row header = Row.from("#", "Offset", "Size", "First row").style(Style.EMPTY.bold());
         Block block = Block.builder()

--- a/cli/src/main/java/dev/hardwood/cli/dive/internal/OverviewScreen.java
+++ b/cli/src/main/java/dev/hardwood/cli/dive/internal/OverviewScreen.java
@@ -14,6 +14,7 @@ import java.util.Map;
 import dev.hardwood.cli.dive.NavigationStack;
 import dev.hardwood.cli.dive.ParquetModel;
 import dev.hardwood.cli.dive.ScreenState;
+import dev.hardwood.cli.internal.Fmt;
 import dev.hardwood.cli.internal.Sizes;
 import dev.tamboui.buffer.Buffer;
 import dev.tamboui.layout.Constraint;
@@ -210,7 +211,7 @@ public final class OverviewScreen {
         lines.add(factsLine("Created by", f.createdBy() != null ? f.createdBy() : "unknown"));
         lines.add(factsLine("Uncompressed", Sizes.format(f.uncompressedBytes())));
         lines.add(factsLine("Compressed", Sizes.format(f.compressedBytes())));
-        lines.add(factsLine("Ratio", String.format("%.1f×", f.compressionRatio())));
+        lines.add(factsLine("Ratio", Fmt.fmt("%.1f×", f.compressionRatio())));
         List<Map.Entry<String, String>> kv = f.keyValueMetadata();
         if (!kv.isEmpty()) {
             lines.add(Line.empty());

--- a/cli/src/main/java/dev/hardwood/cli/dive/internal/PagesScreen.java
+++ b/cli/src/main/java/dev/hardwood/cli/dive/internal/PagesScreen.java
@@ -13,6 +13,7 @@ import java.util.List;
 import dev.hardwood.cli.dive.NavigationStack;
 import dev.hardwood.cli.dive.ParquetModel;
 import dev.hardwood.cli.dive.ScreenState;
+import dev.hardwood.cli.internal.Fmt;
 import dev.hardwood.cli.internal.IndexValueFormatter;
 import dev.hardwood.cli.internal.Sizes;
 import dev.hardwood.internal.metadata.DataPageHeader;
@@ -151,14 +152,14 @@ public final class PagesScreen {
                 values = dataValues(h);
                 if (offsetIndex != null && dataPageIdx < offsetIndex.pageLocations().size()) {
                     PageLocation loc = offsetIndex.pageLocations().get(dataPageIdx);
-                    firstRow = String.format("%,d", loc.firstRowIndex());
+                    firstRow = Fmt.fmt("%,d", loc.firstRowIndex());
                 }
                 if (columnIndex != null && dataPageIdx < columnIndex.getPageCount()) {
                     min = formatStat(columnIndex.minValues().get(dataPageIdx), col, state.logicalTypes());
                     max = formatStat(columnIndex.maxValues().get(dataPageIdx), col, state.logicalTypes());
                     if (columnIndex.nullCounts() != null
                             && dataPageIdx < columnIndex.nullCounts().size()) {
-                        nulls = String.format("%,d", columnIndex.nullCounts().get(dataPageIdx));
+                        nulls = Fmt.fmt("%,d", columnIndex.nullCounts().get(dataPageIdx));
                     }
                 }
                 else {
@@ -167,7 +168,7 @@ public final class PagesScreen {
                         min = formatStat(inline.minValue(), col, state.logicalTypes());
                         max = formatStat(inline.maxValue(), col, state.logicalTypes());
                         if (inline.nullCount() != null) {
-                            nulls = String.format("%,d", inline.nullCount());
+                            nulls = Fmt.fmt("%,d", inline.nullCount());
                         }
                     }
                 }
@@ -178,7 +179,7 @@ public final class PagesScreen {
                         String.valueOf(i),
                         h.type().name(),
                         firstRow,
-                        String.format("%,d", values),
+                        Fmt.fmt("%,d", values),
                         dataEncoding(h),
                         Sizes.format(h.compressedPageSize()),
                         uncompressed,
@@ -191,7 +192,7 @@ public final class PagesScreen {
                         String.valueOf(i),
                         h.type().name(),
                         firstRow,
-                        String.format("%,d", values),
+                        Fmt.fmt("%,d", values),
                         dataEncoding(h),
                         Sizes.format(h.compressedPageSize()),
                         uncompressed,
@@ -350,22 +351,22 @@ public final class PagesScreen {
         DataPageHeaderV2 dphv2 = header.dataPageHeaderV2();
         DictionaryPageHeader dictHeader = header.dictionaryPageHeader();
         if (dph != null) {
-            lines.add(kv("Num values", String.format("%,d", dph.numValues())));
+            lines.add(kv("Num values", Fmt.fmt("%,d", dph.numValues())));
             lines.add(kv("Encoding", dph.encoding().name()));
             lines.add(kv("Def-level encoding", dph.definitionLevelEncoding().name()));
             lines.add(kv("Rep-level encoding", dph.repetitionLevelEncoding().name()));
         }
         if (dphv2 != null) {
-            lines.add(kv("Num values", String.format("%,d", dphv2.numValues())));
-            lines.add(kv("Num nulls", String.format("%,d", dphv2.numNulls())));
-            lines.add(kv("Num rows", String.format("%,d", dphv2.numRows())));
+            lines.add(kv("Num values", Fmt.fmt("%,d", dphv2.numValues())));
+            lines.add(kv("Num nulls", Fmt.fmt("%,d", dphv2.numNulls())));
+            lines.add(kv("Num rows", Fmt.fmt("%,d", dphv2.numRows())));
             lines.add(kv("Encoding", dphv2.encoding().name()));
             lines.add(kv("Def-level bytes", String.valueOf(dphv2.definitionLevelsByteLength())));
             lines.add(kv("Rep-level bytes", String.valueOf(dphv2.repetitionLevelsByteLength())));
             lines.add(kv("Is compressed", String.valueOf(dphv2.isCompressed())));
         }
         if (dictHeader != null) {
-            lines.add(kv("Num values", String.format("%,d", dictHeader.numValues())));
+            lines.add(kv("Num values", Fmt.fmt("%,d", dictHeader.numValues())));
             lines.add(kv("Encoding", dictHeader.encoding().name()));
         }
         Statistics inline = inlineStats(header);
@@ -375,7 +376,7 @@ public final class PagesScreen {
             lines.add(kv("  Min", formatStatFull(inline.minValue(), col, logical)));
             lines.add(kv("  Max", formatStatFull(inline.maxValue(), col, logical)));
             if (inline.nullCount() != null) {
-                lines.add(kv("  Nulls", String.format("%,d", inline.nullCount())));
+                lines.add(kv("  Nulls", Fmt.fmt("%,d", inline.nullCount())));
             }
         }
         lines.add(Line.empty());

--- a/cli/src/main/java/dev/hardwood/cli/dive/internal/Plurals.java
+++ b/cli/src/main/java/dev/hardwood/cli/dive/internal/Plurals.java
@@ -7,6 +7,8 @@
  */
 package dev.hardwood.cli.dive.internal;
 
+import dev.hardwood.cli.internal.Fmt;
+
 /// Renders `count + noun` strings consistently across the `dive` TUI: picks
 /// singular vs plural form based on the count, and formats the number with
 /// the locale-independent grouping separator (comma). Handles irregular
@@ -18,7 +20,7 @@ public final class Plurals {
     }
 
     public static String format(long count, String singular, String plural) {
-        return String.format("%,d", count) + " " + (count == 1 ? singular : plural);
+        return Fmt.fmt("%,d", count) + " " + (count == 1 ? singular : plural);
     }
 
     /// Renders an approximate "X-Y of Z" range string for a list-shaped
@@ -37,11 +39,11 @@ public final class Plurals {
         int v = Math.max(1, viewport);
         if (total <= v) {
             return total == 1 ? "1 of 1"
-                    : "1-" + String.format("%,d", total) + " of " + String.format("%,d", total);
+                    : "1-" + Fmt.fmt("%,d", total) + " of " + Fmt.fmt("%,d", total);
         }
         int sel = Math.max(0, Math.min(selection, total - 1));
         int end = Math.min(total, Math.max(v, sel + 1));
         int start = Math.max(1, end - v + 1);
-        return String.format("%,d-%,d of %,d", start, end, total);
+        return Fmt.fmt("%,d-%,d of %,d", start, end, total);
     }
 }

--- a/cli/src/main/java/dev/hardwood/cli/dive/internal/RowGroupDetailScreen.java
+++ b/cli/src/main/java/dev/hardwood/cli/dive/internal/RowGroupDetailScreen.java
@@ -16,6 +16,7 @@ import java.util.stream.Collectors;
 import dev.hardwood.cli.dive.NavigationStack;
 import dev.hardwood.cli.dive.ParquetModel;
 import dev.hardwood.cli.dive.ScreenState;
+import dev.hardwood.cli.internal.Fmt;
 import dev.hardwood.cli.internal.Sizes;
 import dev.hardwood.metadata.ColumnChunk;
 import dev.hardwood.metadata.ColumnMetaData;
@@ -143,14 +144,14 @@ public final class RowGroupDetailScreen {
 
         List<Line> lines = new ArrayList<>();
         lines.add(fact("Row group index", String.valueOf(state.rowGroupIndex())));
-        lines.add(fact("Rows", String.format("%,d", rg.numRows())));
+        lines.add(fact("Rows", Fmt.fmt("%,d", rg.numRows())));
         lines.add(fact("Column chunks", String.valueOf(chunkCount)));
         lines.add(fact("Total byte size", Sizes.dualFormat(rg.totalByteSize())));
         lines.add(Line.empty());
         lines.add(Line.from(new Span(" Compression ", Style.EMPTY.bold())));
         lines.add(fact("  Compressed", Sizes.dualFormat(compressed)));
         lines.add(fact("  Uncompressed", Sizes.dualFormat(uncompressed)));
-        lines.add(fact("  Ratio", String.format("%.2f×", ratio)));
+        lines.add(fact("  Ratio", Fmt.fmt("%.2f×", ratio)));
         lines.add(Line.empty());
         lines.add(Line.from(new Span(" Encoding mix ", Style.EMPTY.bold())));
         lines.add(fact("  Encodings", mix(encodingCounts)));

--- a/cli/src/main/java/dev/hardwood/cli/dive/internal/RowGroupIndexesScreen.java
+++ b/cli/src/main/java/dev/hardwood/cli/dive/internal/RowGroupIndexesScreen.java
@@ -13,6 +13,7 @@ import java.util.List;
 import dev.hardwood.cli.dive.NavigationStack;
 import dev.hardwood.cli.dive.ParquetModel;
 import dev.hardwood.cli.dive.ScreenState;
+import dev.hardwood.cli.internal.Fmt;
 import dev.hardwood.cli.internal.Sizes;
 import dev.hardwood.metadata.ColumnChunk;
 import dev.hardwood.metadata.RowGroup;
@@ -135,7 +136,7 @@ public final class RowGroupIndexesScreen {
             rows.add(Row.from(
                     Sizes.columnPath(e.chunk().metaData()),
                     e.typeLabel(),
-                    String.format("%,d", e.offset()),
+                    Fmt.fmt("%,d", e.offset()),
                     Sizes.format(e.size())));
         }
         Row header = Row.from("Column", "Index type", "Offset", "Size")

--- a/cli/src/main/java/dev/hardwood/cli/dive/internal/RowGroupsScreen.java
+++ b/cli/src/main/java/dev/hardwood/cli/dive/internal/RowGroupsScreen.java
@@ -13,6 +13,7 @@ import java.util.List;
 import dev.hardwood.cli.dive.NavigationStack;
 import dev.hardwood.cli.dive.ParquetModel;
 import dev.hardwood.cli.dive.ScreenState;
+import dev.hardwood.cli.internal.Fmt;
 import dev.hardwood.cli.internal.Sizes;
 import dev.hardwood.metadata.ColumnChunk;
 import dev.hardwood.metadata.ColumnMetaData;
@@ -100,7 +101,7 @@ public final class RowGroupsScreen {
                     formatLong(rg.numRows()),
                     Sizes.format(uncompressed),
                     Sizes.format(compressed),
-                    String.format("%.1f×", ratio),
+                    Fmt.fmt("%.1f×", ratio),
                     ciCount + "/" + chunkCount,
                     oiCount + "/" + chunkCount));
         }
@@ -148,6 +149,6 @@ public final class RowGroupsScreen {
         if (v < 1000) {
             return Long.toString(v);
         }
-        return String.format("%,d", v);
+        return Fmt.fmt("%,d", v);
     }
 }

--- a/cli/src/main/java/dev/hardwood/cli/dive/internal/SchemaScreen.java
+++ b/cli/src/main/java/dev/hardwood/cli/dive/internal/SchemaScreen.java
@@ -16,6 +16,7 @@ import java.util.Set;
 import dev.hardwood.cli.dive.NavigationStack;
 import dev.hardwood.cli.dive.ParquetModel;
 import dev.hardwood.cli.dive.ScreenState;
+import dev.hardwood.cli.internal.Fmt;
 import dev.hardwood.schema.FileSchema;
 import dev.hardwood.schema.SchemaNode;
 import dev.tamboui.buffer.Buffer;
@@ -295,7 +296,7 @@ public final class SchemaScreen {
         Line line = Line.from(
                 new Span(" / ", Style.EMPTY.fg(Theme.ACCENT).bold()),
                 new Span(state.filter() + cursor, Style.EMPTY.bold()),
-                new Span("  (" + String.format("%,d", matchCount) + " / "
+                new Span("  (" + Fmt.fmt("%,d", matchCount) + " / "
                         + Plurals.format(totalColumns, "leaf", "leaves") + ")", Style.EMPTY.fg(Theme.DIM)));
         Paragraph.builder().text(Text.from(line)).left().build().render(area, buffer);
     }

--- a/cli/src/main/java/dev/hardwood/cli/internal/Fmt.java
+++ b/cli/src/main/java/dev/hardwood/cli/internal/Fmt.java
@@ -1,0 +1,19 @@
+/*
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Copyright The original authors
+ *
+ *  Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package dev.hardwood.cli.internal;
+
+import java.util.Locale;
+
+/// Ensures desired formatting
+public final class Fmt {
+    private Fmt() {}
+    /// Wrapper for `String.format()` to ensure locale-independent formatting with `Locale.ROOT`
+    public static String fmt(String pattern, Object... args) {
+        return String.format(Locale.ROOT, pattern, args);
+    }
+}

--- a/cli/src/main/java/dev/hardwood/cli/internal/Sizes.java
+++ b/cli/src/main/java/dev/hardwood/cli/internal/Sizes.java
@@ -23,12 +23,12 @@ public class Sizes {
             return bytes + " B";
         }
         if (bytes < 1_024 * 1_024) {
-            return String.format("%.1f KB", bytes / 1_024.0);
+            return Fmt.fmt("%.1f KB", bytes / 1_024.0);
         }
         if (bytes < 1_024L * 1_024 * 1_024) {
-            return String.format("%.1f MB", bytes / (1_024.0 * 1_024));
+            return Fmt.fmt("%.1f MB", bytes / (1_024.0 * 1_024));
         }
-        return String.format("%.1f GB", bytes / (1_024.0 * 1_024 * 1_024));
+        return Fmt.fmt("%.1f GB", bytes / (1_024.0 * 1_024 * 1_024));
     }
 
     /// Renders bytes as a human-readable form plus the raw byte count in
@@ -39,6 +39,6 @@ public class Sizes {
         if (bytes < 1_024) {
             return format(bytes);
         }
-        return format(bytes) + "  (" + String.format("%,d", bytes) + " B)";
+        return format(bytes) + "  (" + Fmt.fmt("%,d", bytes) + " B)";
     }
 }

--- a/cli/src/main/java/dev/hardwood/cli/internal/table/RowTable.java
+++ b/cli/src/main/java/dev/hardwood/cli/internal/table/RowTable.java
@@ -21,6 +21,7 @@ import java.util.List;
 import java.util.Set;
 import java.util.UUID;
 
+import dev.hardwood.cli.internal.Fmt;
 import dev.hardwood.internal.conversion.LogicalTypeConverter;
 import dev.hardwood.metadata.LogicalType;
 import dev.hardwood.metadata.PhysicalType;
@@ -280,7 +281,7 @@ public final class RowTable {
                 case '\f' -> sb.append("\\f");
                 default -> {
                     if (c < 0x20) {
-                        sb.append(String.format("\\u%04x", (int) c));
+                        sb.append(Fmt.fmt("\\u%04x", (int) c));
                     }
                     else {
                         sb.append(c);


### PR DESCRIPTION
## Checklist

- [x] Build via `./mvnw clean verify` passes
- [x] The commit message is prefixed with the issue key ("#363 To ensure locale-independent numbers formatting")
- [x] Code changes are covered by tests
- [x] If this PR adds or changes user-facing behaviour, `docs/` has been updated

Closes #363 