### PR TITLE
#350 CLI Support of Interval logical type

### DIFF
--- a/cli/src/main/java/dev/hardwood/cli/internal/IndexValueFormatter.java
+++ b/cli/src/main/java/dev/hardwood/cli/internal/IndexValueFormatter.java
@@ -10,6 +10,7 @@ package dev.hardwood.cli.internal;
 import java.math.BigDecimal;
 import java.math.BigInteger;
 import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
 import java.nio.charset.StandardCharsets;
 import java.time.Instant;
 import java.time.LocalDate;
@@ -185,6 +186,10 @@ public final class IndexValueFormatter {
         if (lt instanceof LogicalType.UuidType && bytes.length == 16) {
             ByteBuffer bb = ByteBuffer.wrap(bytes);
             return new UUID(bb.getLong(), bb.getLong()).toString();
+        }
+        if (lt instanceof LogicalType.IntervalType && bytes.length == 12) {
+            ByteBuffer bb = ByteBuffer.wrap(bytes).order(ByteOrder.LITTLE_ENDIAN);
+            return RowValueFormatter.formatInterval(bb.getInt(0), bb.getInt(4), bb.getInt(8));
         }
         String hex = HexFormat.of().formatHex(bytes);
         return truncate ? truncate(hex) : hex;

--- a/cli/src/main/java/dev/hardwood/cli/internal/RowValueFormatter.java
+++ b/cli/src/main/java/dev/hardwood/cli/internal/RowValueFormatter.java
@@ -10,6 +10,7 @@ package dev.hardwood.cli.internal;
 import java.math.BigDecimal;
 import java.math.BigInteger;
 import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
 import java.nio.charset.StandardCharsets;
 import java.time.Instant;
 import java.time.LocalDate;
@@ -19,6 +20,7 @@ import java.util.UUID;
 
 import dev.hardwood.metadata.LogicalType;
 import dev.hardwood.reader.RowReader;
+import dev.hardwood.row.PqInterval;
 import dev.hardwood.row.PqList;
 import dev.hardwood.row.PqMap;
 import dev.hardwood.row.PqStruct;
@@ -106,6 +108,9 @@ public final class RowValueFormatter {
                 default -> ((Number) reader.getValue(fieldIndex)).longValue();
             };
             return Long.toUnsignedString(raw);
+        }
+        if (lt instanceof LogicalType.IntervalType) {
+            return formatInterval(reader.getInterval(fieldIndex));
         }
         // BYTE_ARRAY / FIXED_LEN_BYTE_ARRAY / INT96 with no string-like logical
         // type fall through here. `getValue` returns the raw byte[]; the default
@@ -350,7 +355,44 @@ public final class RowValueFormatter {
             ByteBuffer bb = ByteBuffer.wrap(raw);
             return new UUID(bb.getLong(), bb.getLong()).toString();
         }
+        if (lt instanceof LogicalType.IntervalType && raw.length == 12) {
+            ByteBuffer bb = ByteBuffer.wrap(raw).order(ByteOrder.LITTLE_ENDIAN);
+            return formatInterval(bb.getInt(0), bb.getInt(4), bb.getInt(8));
+        }
         return formatRawBytes(raw);
+    }
+
+    public static String formatInterval(PqInterval interval) {
+        if (interval == null) {
+            return "null";
+        }
+        return formatInterval(interval.months(), interval.days(), interval.milliseconds());
+    }
+
+    public static String formatInterval(int months, int days, int milliseconds) {
+        long m = Integer.toUnsignedLong(months);
+        long d = Integer.toUnsignedLong(days);
+        long ms = Integer.toUnsignedLong(milliseconds);
+        if (m == 0 && d == 0 && ms == 0) {
+            return "0ms";
+        }
+        StringBuilder sb = new StringBuilder();
+        if (m != 0) {
+            sb.append(m).append("mo");
+        }
+        if (d != 0) {
+            if (!sb.isEmpty()) {
+                sb.append(' ');
+            }
+            sb.append(d).append('d');
+        }
+        if (ms != 0) {
+            if (!sb.isEmpty()) {
+                sb.append(' ');
+            }
+            sb.append(ms).append("ms");
+        }
+        return sb.toString();
     }
 
     /// Renders a raw byte array as either UTF-8 text (when the bytes are

--- a/cli/src/main/java/dev/hardwood/cli/internal/table/RowTable.java
+++ b/cli/src/main/java/dev/hardwood/cli/internal/table/RowTable.java
@@ -10,6 +10,7 @@ package dev.hardwood.cli.internal.table;
 import java.math.BigDecimal;
 import java.math.BigInteger;
 import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
 import java.nio.charset.CharacterCodingException;
 import java.nio.charset.CharsetDecoder;
 import java.nio.charset.CodingErrorAction;
@@ -21,6 +22,7 @@ import java.util.List;
 import java.util.Set;
 import java.util.UUID;
 
+import dev.hardwood.cli.internal.RowValueFormatter;
 import dev.hardwood.internal.conversion.LogicalTypeConverter;
 import dev.hardwood.metadata.LogicalType;
 import dev.hardwood.metadata.PhysicalType;
@@ -153,6 +155,10 @@ public final class RowTable {
         }
         if (lt instanceof LogicalType.DecimalType dt) {
             return new BigDecimal(new BigInteger(bytes), dt.scale()).toPlainString();
+        }
+        if (lt instanceof LogicalType.IntervalType && bytes.length == 12) {
+            ByteBuffer bb = ByteBuffer.wrap(bytes).order(ByteOrder.LITTLE_ENDIAN);
+            return RowValueFormatter.formatInterval(bb.getInt(0), bb.getInt(4), bb.getInt(8));
         }
         return switch (pn.type()) {
             case INT96 -> decodeInt96Timestamp(bytes);

--- a/cli/src/test/java/dev/hardwood/cli/internal/IndexValueFormatterTest.java
+++ b/cli/src/test/java/dev/hardwood/cli/internal/IndexValueFormatterTest.java
@@ -7,6 +7,8 @@
  */
 package dev.hardwood.cli.internal;
 
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
 import java.nio.charset.StandardCharsets;
 
 import org.junit.jupiter.api.Test;
@@ -98,6 +100,32 @@ class IndexValueFormatterTest {
         int day = 20202;
         byte[] bytes = new byte[]{(byte) day, (byte) (day >> 8), (byte) (day >> 16), (byte) (day >> 24)};
         assertThat(IndexValueFormatter.format(bytes, col)).isEqualTo("2025-04-24");
+    }
+
+    @Test
+    void rendersIntervalLogically() {
+        ColumnSchema col = new ColumnSchema(FieldPath.of("iv"), PhysicalType.FIXED_LEN_BYTE_ARRAY,
+                RepetitionType.OPTIONAL, null, 0, 1, 0, new LogicalType.IntervalType());
+        // 1 month, 15 days, 3_600_000 ms — little-endian unsigned 32-bit
+        byte[] bytes = new byte[12];
+        ByteBuffer bb = ByteBuffer.wrap(bytes).order(ByteOrder.LITTLE_ENDIAN);
+        bb.putInt(1);
+        bb.putInt(15);
+        bb.putInt(3_600_000);
+        assertThat(IndexValueFormatter.format(bytes, col)).isEqualTo("1mo 15d 3600000ms");
+    }
+
+    @Test
+    void intervalPhysicalModeRendersAsHex() {
+        ColumnSchema col = new ColumnSchema(FieldPath.of("iv"), PhysicalType.FIXED_LEN_BYTE_ARRAY,
+                RepetitionType.OPTIONAL, null, 0, 1, 0, new LogicalType.IntervalType());
+        byte[] bytes = new byte[12];
+        ByteBuffer bb = ByteBuffer.wrap(bytes).order(ByteOrder.LITTLE_ENDIAN);
+        bb.putInt(1);
+        bb.putInt(15);
+        bb.putInt(3_600_000);
+        assertThat(IndexValueFormatter.format(bytes, col, false, false))
+                .isEqualTo(java.util.HexFormat.of().formatHex(bytes));
     }
 
     private static ColumnSchema stringColumn() {

--- a/cli/src/test/java/dev/hardwood/cli/internal/RowValueFormatterIntervalTest.java
+++ b/cli/src/test/java/dev/hardwood/cli/internal/RowValueFormatterIntervalTest.java
@@ -1,0 +1,89 @@
+/*
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Copyright The original authors
+ *
+ *  Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package dev.hardwood.cli.internal;
+
+import java.io.IOException;
+import java.nio.file.Path;
+
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+
+import dev.hardwood.InputFile;
+import dev.hardwood.reader.ParquetFileReader;
+import dev.hardwood.reader.RowReader;
+import dev.hardwood.schema.FileSchema;
+import dev.hardwood.schema.SchemaNode;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/// Verifies [RowValueFormatter] renders INTERVAL fields correctly when called
+/// through the live `RowReader` path — both single-line and expanded forms.
+/// Complements [RowValueFormatterTest], which only tests the dictionary entry
+/// path with synthetic byte arrays.
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+class RowValueFormatterIntervalTest {
+
+    // Row 0: 1 month, 15 days, 1 hour (3_600_000 ms)
+    // Row 1: 0 months, 30 days, 0 ms
+    // Row 2: null
+
+    private SchemaNode durationField;
+    private int durationIdx;
+    private String row0Formatted;
+    private String row1Formatted;
+    private String row2Formatted;
+    private String row0Expanded;
+    private String row1Expanded;
+    private String row2Expanded;
+
+    @BeforeAll
+    void readAll() throws IOException {
+        Path file = Path.of(getClass().getResource("/interval_logical_type_test.parquet").getPath());
+        try (ParquetFileReader fileReader = ParquetFileReader.open(InputFile.of(file));
+             RowReader rowReader = fileReader.createRowReader()) {
+            FileSchema schema = fileReader.getFileSchema();
+            durationField = schema.getField("duration");
+            durationIdx = schema.getColumn("duration").columnIndex();
+
+            rowReader.next();
+            row0Formatted = RowValueFormatter.format(rowReader, durationIdx, durationField);
+            row0Expanded = RowValueFormatter.formatExpanded(rowReader, durationIdx, durationField, true);
+
+            rowReader.next();
+            row1Formatted = RowValueFormatter.format(rowReader, durationIdx, durationField);
+            row1Expanded = RowValueFormatter.formatExpanded(rowReader, durationIdx, durationField, true);
+
+            rowReader.next();
+            row2Formatted = RowValueFormatter.format(rowReader, durationIdx, durationField);
+            row2Expanded = RowValueFormatter.formatExpanded(rowReader, durationIdx, durationField, true);
+        }
+    }
+
+    @Test
+    void formatRendersAllComponents() {
+        assertThat(row0Formatted).isEqualTo("1mo 15d 3600000ms");
+    }
+
+    @Test
+    void formatOmitsZeroComponents() {
+        assertThat(row1Formatted).isEqualTo("30d");
+    }
+
+    @Test
+    void formatRendersNullAsNull() {
+        assertThat(row2Formatted).isEqualTo("null");
+    }
+
+    @Test
+    void formatExpandedMatchesFormatForPrimitiveLeaf() {
+        assertThat(row0Expanded).isEqualTo(row0Formatted);
+        assertThat(row1Expanded).isEqualTo(row1Formatted);
+        assertThat(row2Expanded).isEqualTo(row2Formatted);
+    }
+}

--- a/cli/src/test/java/dev/hardwood/cli/internal/RowValueFormatterTest.java
+++ b/cli/src/test/java/dev/hardwood/cli/internal/RowValueFormatterTest.java
@@ -7,12 +7,16 @@
  */
 package dev.hardwood.cli.internal;
 
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
+
 import org.junit.jupiter.api.Test;
 
 import dev.hardwood.metadata.FieldPath;
 import dev.hardwood.metadata.LogicalType;
 import dev.hardwood.metadata.PhysicalType;
 import dev.hardwood.metadata.RepetitionType;
+import dev.hardwood.row.PqInterval;
 import dev.hardwood.schema.ColumnSchema;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -96,6 +100,45 @@ class RowValueFormatterTest {
         byte[] bytes = "hello".getBytes(java.nio.charset.StandardCharsets.UTF_8);
         assertThat(RowValueFormatter.formatDictionaryValue(bytes, col))
                 .isEqualTo("hello");
+    }
+
+    @Test
+    void intervalRendersAsReadableComponents() {
+        // Row 0 from interval_logical_type_test.parquet: 1 month, 15 days, 1 hour (3_600_000 ms)
+        assertThat(RowValueFormatter.formatInterval(new PqInterval(1, 15, 3_600_000)))
+                .isEqualTo("1mo 15d 3600000ms");
+    }
+
+    @Test
+    void intervalWithZeroComponentsOmitsThem() {
+        assertThat(RowValueFormatter.formatInterval(new PqInterval(0, 30, 0)))
+                .isEqualTo("30d");
+    }
+
+    @Test
+    void intervalAllZeroRendersAsZeroMs() {
+        assertThat(RowValueFormatter.formatInterval(new PqInterval(0, 0, 0)))
+                .isEqualTo("0ms");
+    }
+
+    @Test
+    void intervalAboveMaxValueUsesUnsignedRendering() {
+        // 0xFFFFFFFF = 4294967295 as unsigned, -1 as signed int
+        assertThat(RowValueFormatter.formatInterval(new PqInterval(-1, -1, -1)))
+                .isEqualTo("4294967295mo 4294967295d 4294967295ms");
+    }
+
+    @Test
+    void intervalDictionaryBytesRenderAsComponents() {
+        ColumnSchema col = column(PhysicalType.FIXED_LEN_BYTE_ARRAY, new LogicalType.IntervalType());
+        // 1 month, 15 days, 3_600_000 ms — little-endian unsigned 32-bit
+        byte[] bytes = new byte[12];
+        ByteBuffer bb = ByteBuffer.wrap(bytes).order(ByteOrder.LITTLE_ENDIAN);
+        bb.putInt(1);
+        bb.putInt(15);
+        bb.putInt(3_600_000);
+        assertThat(RowValueFormatter.formatDictionaryValue(bytes, col))
+                .isEqualTo("1mo 15d 3600000ms");
     }
 
     private static ColumnSchema column(PhysicalType type, LogicalType logical) {


### PR DESCRIPTION
Hello, this PR resolves #350 to render Interval columns correctly 

## Checklist

- [x] Build via `./mvnw clean verify` passes
- [x] The commit message is prefixed with the issue key ("#123 Adding support for...")
- [x] Code changes are covered by tests
- [ ] If this PR adds or changes user-facing behaviour, `docs/` has been updated
