### PR TITLE
#366 Using Long for PqInterval components

### DIFF
--- a/core/src/main/java/dev/hardwood/internal/conversion/LogicalTypeConverter.java
+++ b/core/src/main/java/dev/hardwood/internal/conversion/LogicalTypeConverter.java
@@ -98,7 +98,11 @@ public class LogicalTypeConverter {
                     "INTERVAL requires exactly 12 bytes, got " + bytes.length);
         }
         ByteBuffer buffer = ByteBuffer.wrap(bytes).order(ByteOrder.LITTLE_ENDIAN);
-        return new PqInterval(buffer.getInt(0), buffer.getInt(4), buffer.getInt(8));
+        long months = Integer.toUnsignedLong(buffer.getInt(0));
+        long days = Integer.toUnsignedLong(buffer.getInt(4));
+        long millis = Integer.toUnsignedLong(buffer.getInt(8));
+
+        return new PqInterval(months, days, millis);
     }
 
     /// Julian day number of the Unix epoch (1970-01-01).

--- a/core/src/main/java/dev/hardwood/row/PqInterval.java
+++ b/core/src/main/java/dev/hardwood/row/PqInterval.java
@@ -15,12 +15,10 @@ package dev.hardwood.row;
 /// FIXED_LEN_BYTE_ARRAY: three little-endian **unsigned** 32-bit integers in
 /// the order `months`, `days`, `milliseconds`.
 ///
-/// **Unsigned semantics:** Java has no unsigned `int` type, so values greater
-/// than `Integer.MAX_VALUE` will appear negative when read directly. To recover
-/// the unsigned value, use `Integer.toUnsignedLong(interval.months())` (and the
-/// same for `days()` / `milliseconds()`).
+/// Each component is exposed as a `long` holding its unsigned 32-bit value,
+/// so all values are in the range `[0, 4_294_967_295]`.
 ///
-/// @param months       number of months (unsigned 32-bit)
-/// @param days         number of days (unsigned 32-bit)
-/// @param milliseconds number of milliseconds (unsigned 32-bit)
-public record PqInterval(int months, int days, int milliseconds) {}
+/// @param months       number of months (unsigned 32-bit, range 0–4,294,967,295)
+/// @param days         number of days (unsigned 32-bit, range 0–4,294,967,295)
+/// @param milliseconds number of milliseconds (unsigned 32-bit, range 0–4,294,967,295)
+public record PqInterval(long months, long days, long milliseconds) {}

--- a/core/src/test/java/dev/hardwood/IntervalLogicalTypeTest.java
+++ b/core/src/test/java/dev/hardwood/IntervalLogicalTypeTest.java
@@ -8,6 +8,8 @@
 package dev.hardwood;
 
 import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 
@@ -87,6 +89,20 @@ class IntervalLogicalTypeTest {
     @Test
     void testNullFieldReturnsNull() {
         assertThat(row2).isNull();
+    }
+
+    @Test
+    void testUnsignedValuesAboveIntegerMaxValueAreReturnedAsPositiveLongs() {
+        // 0xFFFFFFFF = 4_294_967_295 — max unsigned 32-bit value, would be -1 as signed int
+        long maxUint32 = 0xFFFFFFFFL;
+        ByteBuffer buf = ByteBuffer.allocate(12).order(ByteOrder.LITTLE_ENDIAN);
+        buf.putInt((int) maxUint32);
+        buf.putInt((int) maxUint32);
+        buf.putInt((int) maxUint32);
+        PqInterval interval = LogicalTypeConverter.convertToInterval(buf.array(), PhysicalType.FIXED_LEN_BYTE_ARRAY);
+        assertThat(interval.months()).isEqualTo(maxUint32);
+        assertThat(interval.days()).isEqualTo(maxUint32);
+        assertThat(interval.milliseconds()).isEqualTo(maxUint32);
     }
 
     @Test

--- a/docs/content/usage.md
+++ b/docs/content/usage.md
@@ -156,7 +156,7 @@ All accessor methods are available in two forms:
 
 All methods are available as both `method(name)` and `method(index)`, except `getStruct`, `getList`, `getMap`, and `getVariant` which are name-based only.
 
-**INTERVAL columns:** `PqInterval` is a plain record with three int properties — `months()`, `days()`, and `milliseconds()`. The components are independent and not normalized, and the on-disk encoding stores each as an unsigned 32-bit integer; if values may exceed `Integer.MAX_VALUE`, recover the unsigned value via `Integer.toUnsignedLong(interval.months())`. Files written by older parquet-mr / Spark / Hive writers that set only the legacy `converted_type=INTERVAL` annotation are handled transparently — no caller-side opt-in is required.
+**INTERVAL columns:** `PqInterval` is a plain record with three `long` properties — `months()`, `days()`, and `milliseconds()`. Each holds an unsigned 32-bit value in the range `[0, 4_294_967_295]`, so no additional conversion is needed. The components are independent and not normalized. Files written by older parquet-mr / Spark / Hive writers that set only the legacy `converted_type=INTERVAL` annotation are handled transparently — no caller-side opt-in is required.
 
 **Bare `BYTE_ARRAY` columns:** `BYTE_ARRAY` columns without a `STRING` logical type annotation may hold arbitrary binary payloads (Protobuf, WKB, custom encodings). Generic accessors such as `PqList.get` and `PqList.iterator` surface these as `byte[]` rather than silently UTF-8 decoding them — invalid byte sequences would otherwise be replaced with `U+FFFD`. Call `getString` explicitly when the column is known to contain UTF-8 text from an older writer that omitted the `STRING` annotation.
 


### PR DESCRIPTION
Using long for PqInterval components

## Checklist

- [x] Build via `./mvnw clean verify` passes
- [x] The commit message is prefixed with the issue key ("#123 Adding support for...")
- [x] Code changes are covered by tests
- [ ] If this PR adds or changes user-facing behaviour, `docs/` has been updated
