### PR TITLE
#374 Reduce S3 round-trips for dive Data preview (and supporting changes)

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -118,7 +118,9 @@
       "Bash(git reset *)",
       "Bash(git ls-tree *)",
       "Bash(git fetch *)",
-      "Bash(gh label *)"
+      "Bash(gh label *)",
+      "Bash(git tag *)",
+      "Bash(git apply *)"
     ]
   }
 }

--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -120,7 +120,8 @@
       "Bash(git fetch *)",
       "Bash(gh label *)",
       "Bash(git tag *)",
-      "Bash(git apply *)"
+      "Bash(git apply *)",
+      "Bash(gh run *)"
     ]
   }
 }

--- a/.gitignore
+++ b/.gitignore
@@ -48,6 +48,10 @@ docs/hooks/__pycache__/
 out/
 release-output.log
 
+# `hardwood dive --log-file` defaults
+dive.log
+dive.log.lck
+
 # Extracted CLI distribution artifacts
 hardwood-cli-early-access-*/
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -446,7 +446,7 @@ A from-scratch implementation of Apache Parquet reader/writer in Java with no de
 - [x] Page indexes (OffsetIndex for page scanning, ColumnIndex for page-level predicate filtering)
 - [x] Predicate pushdown (row group filtering via statistics, page filtering via ColumnIndex)
 - [x] Page-range I/O for filtered reads (only matching pages fetched from remote backends)
-- [x] Coalesced reads for remote backends (`ChunkRange`, `RowGroupIndexBuffers`)
+- [x] Coalesced reads for remote backends (`ChunkRange`, `RowGroupIndexBuffers`, cross-column `SharedRegion`)
 - [ ] Bloom filters
 - [x] **Validate**: Performance improvement with filtering
 

--- a/_designs/CROSS_COLUMN_COALESCING.md
+++ b/_designs/CROSS_COLUMN_COALESCING.md
@@ -1,0 +1,187 @@
+# Design: cross-column ranged-GET coalescing within a row group
+
+**Status: Implemented.** Tracking issue: #374.
+
+## Goal
+
+Reduce the number of HTTP ranged GETs the Parquet pipeline issues per row
+group on remote storage. Today every leaf column's `ChunkHandle` issues its
+own `readRange`; for wide schemas (Overture: ~50 leaf columns × ~50 KB
+compressed each), that's ~50 round trips per RG. The bytes are typically
+stored back-to-back on disk, so they can be fetched in one ranged GET and
+sliced per-column.
+
+The pipeline already does exactly this for the per-RG index region
+(`RowGroupIndexBuffers.fetch` issues one ranged GET covering every column's
+OffsetIndex/ColumnIndex bytes, then slices). This design generalises that
+pattern to data pages.
+
+## What changes
+
+A new internal abstraction `SharedRegion` represents a contiguous,
+multi-column byte range fetched in one shot. `ChunkHandle` becomes a
+view into a `SharedRegion`'s buffer rather than owning its own
+`readRange`.
+
+`RowGroupIterator.computeFetchPlans` gains a coalescing pass that runs
+after the per-column plans are built:
+
+1. Collect every `ChunkHandle`'s `(offset, length)` across all column plans.
+2. Sort by offset.
+3. Greedily group entries into `SharedRegion`s — extend the current region
+   when the gap to the next handle is below `MAX_CROSS_COL_GAP` and the
+   resulting span is below `MAX_COALESCED_BYTES`; otherwise start a new
+   region.
+4. Chain regions for one-ahead pre-fetch, replacing the per-column
+   `nextChunk` chain (the per-column chain is unnecessary when many
+   columns sit in one region).
+5. Rewrite each `ChunkHandle` to delegate `ensureFetched` to its
+   containing region, slicing the requested bytes after the region is
+   loaded.
+
+## Constants
+
+- **`MAX_CROSS_COL_GAP`** — bridge tiny gaps between adjacent column
+  chunks. Set to 64 KB initially. Adjacent chunks are typically
+  back-to-back (zero gap); the budget covers writers that emit padding,
+  checksums, or interleaved metadata. Larger and we'd be paying for
+  dead bytes; smaller and we miss legitimately bridgeable cases.
+- **`MAX_COALESCED_BYTES`** — already exists at 128 MB in
+  `RowGroupIterator`. Reused. Caps any single coalesced region.
+
+## SharedRegion
+
+```java
+final class SharedRegion {
+    private final InputFile inputFile;
+    private final long fileOffset;
+    private final int length;
+    private final String purpose;          // FetchReason tag
+    private volatile ByteBuffer data;
+    private volatile SharedRegion nextRegion;
+
+    ByteBuffer slice(long absoluteOffset, int sliceLength) { … }
+    void setNextRegion(SharedRegion next) { … }
+    ByteBuffer ensureFetched() {
+        // single readRange, FetchReason-scoped to `purpose`;
+        // chains an async prefetch of `nextRegion` on first call
+    }
+}
+```
+
+`ChunkHandle` carries an optional `SharedRegion region` reference. When
+set, its `ensureFetched()` slices from the region instead of issuing
+its own `readRange`; the per-handle `nextChunk` chain is bypassed
+because pre-fetch is driven at the region level via
+`SharedRegion.nextRegion`. The construction shape stays the same; only
+the fetch path changes.
+
+## Edge cases
+
+**Filter pushdown / page drops.** When `IndexedFetchPlan` drops pages, a
+column's bytes become non-contiguous (multiple `ChunkHandle`s with intra-
+column gaps). Coalescing across columns over those gaps would re-fetch
+the dropped bytes — exactly what page-drop optimisation is meant to
+avoid.
+
+**`head(N)` truncation.** A `SequentialFetchPlan` whose `chunkSize` is
+below the column's full length reads only the first chunk eagerly and
+fetches the remainder on demand via the per-column chain. Bridging
+such a column into a shared region would pull in the column's later
+bytes that the per-column chain would later re-fetch (double-fetch).
+
+Conservative rule, implemented as `CoalescableFirstChunk.isCoalesceSafe()`:
+the plan's first chunk must represent the column's *full* byte range
+— i.e. an `IndexedFetchPlan` with exactly one page group, or a
+`SequentialFetchPlan` whose `chunkSize == columnChunkLength`.
+Plans that fail the gate keep their per-column reads. Mixed RGs
+partition into safe columns (coalesced) and unsafe columns
+(per-column). The typical dive Data preview path on small / mid-size
+files (≤ 4 MB per column, see #382) gets full coalescing.
+
+**Refcount and lifecycle.** `RowGroupIterator.releaseWorkItem` already
+evicts the per-workitem `FetchPlan[]` when its refcount reaches zero,
+which today releases the `ChunkHandle.data` buffers. With shared
+regions, eviction drops the `FetchPlan[]` references, the `ChunkHandle`s
+release their `SharedRegion` references, and GC reclaims the buffers.
+No explicit refcount changes needed.
+
+**FetchReason tagging.** The current per-handle purpose string
+(`rg=N col=foo seqChunk@K`) doesn't compose when one ranged GET covers
+many columns. The region-level `purpose` becomes
+`rg=N region=A..B` (A..B are the projection-column indices spanned by
+the region) so log attribution stays intelligible. Per-column handles
+that slice from the region keep their own purpose tag (e.g.
+`rg=N col='foo' pageGroup=1 (region-backed)`) but never issue a
+network call themselves — the actual `readRange` happens at the
+region level.
+
+**Cross-thread propagation.** The async prefetch chain
+(`SharedRegion.nextRegion`, `IndexedFetchPlan.prefetch`,
+`ChunkHandle.nextChunk`) schedules work via
+`CompletableFuture.runAsync` and uses `FetchReason.bind` to carry the
+calling thread's reason across the handoff; otherwise the worker
+thread would log as `unattributed`.
+
+## What this doesn't change
+
+- **Bytes delivered to the consumer.** Same data, same decode paths,
+  same row counts. Only the wire-level request count drops.
+- **Page-level coalescing within a column** — the existing
+  `coalescePages` step in `RowGroupIterator` operates one level below
+  this and stays unchanged.
+- **The InputFile API.** Still just `readRange(offset, length)`.
+
+## Estimated impact
+
+For Overture-shape: 50 leaf columns × ~50 KB compressed, near-zero
+gaps. Today: 50 ranged GETs per RG, ~2.5 MB total. After: 1–2 ranged
+GETs per RG (coalesced into 1–2 contiguous regions), same ~2.5 MB.
+Latency saving: ~50 × RTT vs ~1–2 × RTT per RG, dominated by S3
+round-trip latency at ~50 ms each.
+
+Bytes-on-the-wire don't change; request count and per-RG latency do.
+
+## Composition
+
+- With **#373** (S3 byte-range LRU): coalesced regions are coarser
+  cache units. Hits/misses align to region boundaries, not per-column
+  ones. No conflict.
+- With **#370** (per-column-worker over-fetch): the worker behaviour is
+  unchanged; coalescing happens at plan-build time, before workers
+  start. #370's fix and this one are orthogonal.
+- With **#361** / **#377** (firstRow seek + dive window): unchanged.
+  The window's refill path issues `readPreviewPage` which goes through
+  the same iterator/plan code; coalescing applies transparently.
+- With **#381** (page-level skip via OffsetIndex when seeking with
+  firstRow): page drops introduce intra-column gaps and trigger the
+  conservative "no coalescing for filtered columns" rule. The two
+  features compose by partitioning each RG into coalesced (fully-read)
+  and per-column (filtered) sub-plans.
+
+## Testing
+
+- **`RowGroupCrossColumnCoalesceTest`** (new): open a multi-column
+  fixture wrapped in a `CountingInputFile`, read all rows, assert
+  `readRange` count drops from N (one per column) to ≤ a tight bound
+  for the no-filter case. The synthesised fixture (or a real
+  Overture-shaped one) needs ≥ 10 leaf columns for the assertion to be
+  meaningful.
+- **Existing tests must pass unchanged.** Coalescing affects request
+  count, not data delivered.
+- **Filter test:** read a multi-column fixture with a filter that
+  drops pages on one column; assert per-column reads on the filtered
+  column (no over-coalescing into dropped bytes).
+- **Lifecycle test:** drive enough RG transitions to exercise eviction
+  and confirm the workitem refcount path correctly releases shared
+  regions.
+
+## Out of scope
+
+- **Cross-RG coalescing.** Index regions already coalesce per-RG; data
+  pages are typically far apart between RGs and not worth bridging.
+- **Adaptive `MAX_CROSS_COL_GAP`** based on file size or per-RG
+  characteristics. Static constant is sufficient for now; tune once
+  real workloads surface a need.
+- **Reordering reads.** The greedy offset-sorted walk is fine; no need
+  for a smarter scheduler.

--- a/_designs/PREVIEW_WINDOW.md
+++ b/_designs/PREVIEW_WINDOW.md
@@ -1,0 +1,143 @@
+# Design: dive Data preview row window cache
+
+**Status: Implemented.** Tracking issue: #377. PR: this branch.
+
+## Goal
+
+Maintain a bounded buffer of pre-formatted Data preview rows around the
+current viewport, so within-window navigation (typical PgUp/PgDn) triggers
+zero I/O. Sliding the window across its edges fetches incrementally; far
+jumps refill in one shot.
+
+This subsumes the old `DataPreviewScreen.PAGE_CACHE` (and the `head(cap)`
+workaround the previous version of #361 needed) under a single, predictable
+buffering layer.
+
+## Behaviour
+
+**Refill-on-miss semantics.** The window covers a range `[start, end)` of
+absolute row indices, sized at `20 × pageSize` (clamped at file boundaries).
+On each `slice(model, firstRow, pageSize, logicalTypes)`:
+
+- **Page fully inside the buffer:** return the slice — zero I/O.
+- **Page outside the buffer:** *replace* the buffer with a fresh range
+  `[firstRow − 10 × pageSize, firstRow + 10 × pageSize)` (clamped to file
+  bounds), fetched in a single `readPreviewPage` call. As the user
+  navigates forward across a miss boundary (e.g. firstRow advances from
+  300 to 600), the previous front rows naturally fall outside the new
+  range and get evicted — memory stays bounded at `20 × pageSize`
+  rather than growing.
+- **`logicalTypes` toggle does *not* invalidate.** Each cell is
+  pre-formatted in **both** modes on fetch — `format(reader, …, true)`
+  and `format(reader, …, false)`, plus the corresponding
+  `formatExpanded` variants. Toggling `t` in dive just selects which
+  pair of strings the slice returns; no fetch, no decode. The cost is
+  ~4× the per-cell string memory (still a few MB total for typical
+  Overture-shape schemas), bounded by the window size and far cheaper
+  than re-fetching on every toggle.
+
+Concrete trace, pageSize=30:
+
+```
+slice(firstRow=0)    → buffer=[0, 300)    1 fetch (clamped at file start)
+slice(firstRow=30)   → page in buffer     0 fetches
+... up to firstRow=270                    all hit
+slice(firstRow=300)  → MISS, buffer=[0, 600)   1 fetch
+slice(firstRow=330)  → page in buffer     0 fetches
+... up to firstRow=570                    all hit
+slice(firstRow=600)  → MISS, buffer=[300, 900) 1 fetch (rows [0, 300) drop)
+```
+
+Refill-on-miss is the right shape here — not "slide on every edge crossing."
+With slide-on-edge, every PgDn that crosses the upper bound triggers a
+small fetch (one page worth) and racks up many round-trips during typical
+PgUp/PgDn navigation. With refill-on-miss, the user can navigate freely
+within the ±10 × pageSize horizon with zero I/O; only crossing the
+boundary triggers a refill, and the refill spans the whole range so the
+*next* batch of within-window navigation is also free.
+
+The window is bound to one `ParquetModel` instance; switching files
+(a new model) clears the buffer.
+
+## Memory
+
+For a 30-row viewport and Overture-shaped schemas (~50 top-level fields),
+the resident buffer is ~21 × 30 × 50 = ~31,000 cells × ~50 chars × 2
+(`format` + `formatExpanded`) ≈ a few MB. Predictable and bounded;
+doesn't depend on row group sizes.
+
+## Bounded cursor — the `head(count)` rule
+
+Each `ParquetModel.readPreviewPage(firstRow, count, …)` call builds
+the cursor with `firstRow(firstRow).head(count)`, where `count` is
+the row count the caller passed. That bound is load-bearing: without
+it, the per-column workers in the v2 pipeline race many row groups
+ahead of what the consumer asks for (#370). The queued pre-fetch
+sits blocked while the window is satisfied with a single page, then
+**drains catastrophically** when *anything* later unblocks the
+workers (a far-jump cursor close, a screen auto-resize, the next
+consumer request) — surfacing as "phantom" S3 fetches long after the
+user moved on.
+
+Symptom from a real run before the rule was applied: cluster A
+fetched ~25 MB during the initial preview, then a *second* burst of
+~12 MB fetched the same byte range *87 seconds later*, triggered by
+the next user keystroke. The bytes were sitting queued in the
+unbounded cursor's worker pool the whole time. With `head(count)`,
+each call's workers can only queue work for the rows they were asked
+for; nothing leaks across cursor lifetimes.
+
+The window's call shape is therefore exactly one of:
+
+- Refill: `model.readPreviewPage(refillStart, 20 × pageSize, …)` —
+  one big fetch covering the new range. `head(20 × pageSize)`.
+- Hit: no `readPreviewPage` call at all. The slice comes from memory.
+
+Within-window navigation never crosses the model layer; only refills
+do. There are no incidental forward extensions — every miss replaces
+the buffer.
+
+## What it replaces
+
+- `DataPreviewScreen.PAGE_CACHE` — gone. The window covers the same
+  responsibility (avoid re-walking the reader on PgUp) plus the
+  bounded-prefetch behaviour the old `head(cap)` workaround was reaching
+  for.
+- `DataPreviewScreen.cachedFor` — gone. The window tracks its bound
+  model internally and invalidates on change.
+
+## Non-goals
+
+- **Holding typed values rather than pre-formatted strings.** Considered
+  for the `logicalTypes` toggle (avoid double-cache by re-formatting on
+  demand), rejected on complexity grounds: the screen renders via
+  `RowValueFormatter.format(reader, …)` which calls typed `RowReader`
+  accessors (`getDate`, `getTimestamp`, `getString`, `getValue`, …); a
+  snapshot would need to either cache all of those per cell or
+  re-implement logical-type conversions inside an adapter. Pre-formatted
+  strings, with mode-toggle invalidation, are the simpler shape.
+- **Cross-file windowing.** The window is tied to one `ParquetModel`
+  (one file). Multi-file Data preview is not on the roadmap.
+- **Async refill.** Fetches happen on the calling thread. #331 covers
+  async I/O separately.
+
+## Testing
+
+`PreviewWindowTest`:
+
+- `initialSliceYieldsRequestedPage` — first call returns the requested
+  page with the expected row content.
+- `withinWindowNavigationStaysAccurate` — forward and backward
+  navigation within the window yield correct rows.
+- `farJumpYieldsCorrectRows` — jump-to-last produces the right rows;
+  subsequent nearby moves stay correct (no stale state).
+- `logicalTypesToggleProducesFreshSlice` — toggle path goes through
+  refill correctly.
+- `requestNearStartClampsLowerBound` / `requestNearEndClampsUpperBound`
+  — boundary clamping works.
+
+Byte-delta assertions are not used here — the existing fixture is small
+(~10 KB) so the v2 pipeline pre-fetches the whole file regardless of
+which rows we request, making byte-counting at the screen layer
+unreliable. The byte-level wins are visible end-to-end via dive's
+`--log-file` against larger fixtures (Overture).

--- a/_designs/ROW_BASED_SEEK.md
+++ b/_designs/ROW_BASED_SEEK.md
@@ -1,0 +1,150 @@
+# Design: row-based seek in RowReader
+
+**Status: Implemented.** Tracking issue: #361. PR: this branch.
+
+## Goal
+
+Allow callers of `ParquetFileReader` to create a `RowReader` that begins at an
+arbitrary absolute row index, instead of only at row 0 or only at the tail.
+The reader internally locates the containing row group and skips the within-RG
+residue; consumers see a clean "iterate from row N onwards" surface and don't
+need to know about row-group structure.
+
+This makes "go to row N" jumps in dive's Data preview cost a single row
+group's worth of projected-column bytes on remote files, instead of walking
+from row 0 and fetching everything in between.
+
+## Public API
+
+A new method on the existing `RowReaderBuilder`:
+
+```java
+/// Begin reading from the given absolute row index. Earlier row groups
+/// are not opened — their pages are not fetched or decoded — so this
+/// is an O(1 RG) seek on remote backends.
+///
+/// `firstRow == 0` is the no-op default. `firstRow == totalRows`
+/// produces an empty reader. Indexes into the *first* file's rows for
+/// multi-file readers; cross-file `firstRow` is out of scope. Mutually
+/// exclusive with [#tail]; composes with [#head] for a bounded
+/// `[firstRow, firstRow + maxRows)` window.
+public RowReaderBuilder firstRow(long firstRow)
+```
+
+Composes with existing builder methods:
+
+```java
+// Read rows [N, end) of the file, no projection, no filter
+file.buildRowReader().firstRow(N).build();
+
+// Read rows [N, N+M) — bounded window
+file.buildRowReader().firstRow(N).head(M).build();
+
+// Same with projection + filter
+file.buildRowReader()
+        .projection(ColumnProjection.columns("id", "name"))
+        .filter(FilterPredicate.gt("id", 100))
+        .firstRow(500)
+        .head(50)
+        .build();
+```
+
+Mutually exclusive with `tail(N)` (the two select different ends of the
+file).
+
+## Implementation
+
+In `ParquetFileReader.buildRowReader(projection, filter, maxRows, firstRow)`:
+
+1. If `firstRow == 0`, delegate to the existing path (no behaviour change).
+2. Otherwise, locate the target row group by walking cumulative
+   `RowGroup.numRows()` from the first file's row-group list. Compute
+   `withinRg = firstRow - rowGroupFirstRow(targetRg)`.
+3. If `firstRow >= totalRows`, return an empty reader (`rowGroups.subList(end, end)`).
+4. Open a reader scoped to `rowGroups.subList(targetRg, end)`. Apply
+   `head(maxRowsAdjusted)` where `maxRowsAdjusted = maxRows + withinRg` (the
+   `head` budget bounds *yielded* rows, and the within-RG skip yields rows
+   too — without the residue term, jumps near the end of an RG would
+   exhaust the budget on the skip and yield zero data).
+5. Walk `next()` `withinRg` times to discard the within-RG residue. The
+   bytes for those leading rows *are* fetched (they live in the row
+   group's first pages); the consumer just doesn't see them.
+
+## What this fixes
+
+Against a multi-row-group file on remote storage:
+
+| Action | Before | After |
+|---|---|---|
+| `firstRow(0)` | Open from row 0 | Same (no-op) |
+| `firstRow(N)` where N is in row group K | Walk row 0 → N, fetching all of row groups 0..K | Skip directly to row group K, fetch only its bytes |
+| `firstRow(totalRows)` | Walk to end (full file) | Empty reader (no fetches) |
+
+## Dive wiring
+
+`ParquetModel.readPreviewPage(firstRow, count, consumer)` builds a
+fresh `RowReader` on every call:
+
+```java
+try (RowReader cursor = reader.buildRowReader()
+        .firstRow(firstRow)
+        .head(count)
+        .build()) {
+    while (read < count && cursor.hasNext()) {
+        cursor.next();
+        consumer.accept(cursor);
+    }
+}
+```
+
+No cursor reuse. The eager close is intentional: it releases the
+iterator's metadata and chunk-handle bytes before the next call, and
+the dive viewport window cache (#377) absorbs all within-buffer
+navigation, so cross-call cursor reuse would buy nothing while
+risking the "phantom fetch" issue (#370) where an unbounded cursor's
+worker pool drains long after the user moved on. `head(count)` caps
+each cursor to exactly the rows asked for; combined with `firstRow`,
+the cursor is scoped to the target row group onwards and never
+fetches earlier ones.
+
+The screen-level `DataPreviewScreen.PAGE_CACHE` and the `head(cap)`
+workaround from the earlier version of this design are gone — the
+dedicated viewport window cache (#377) replaces them.
+
+## What's out of scope
+
+- **Page-level skip via OffsetIndex.** Within the target row group, this
+  design still walks `next()` `withinRg` times — bytes for leading pages
+  *are* fetched. With an OffsetIndex we know the byte offset and
+  `firstRowIndex` of every page and could drop leading pages at the byte
+  level. Tracked as #381; non-trivial because it requires adjusting the
+  reader's row-yielding contract (the reader currently always starts at
+  row 0 of the row group).
+
+- **Page-level seek for files without OffsetIndex.** Synthesising
+  page-location info from a header walk is #378.
+
+- **Multi-file `firstRow`.** Indexes into the first file's rows only.
+  Cross-file (e.g. "row N across the concatenated dataset") is a separate
+  problem and not on the roadmap.
+
+- **Backwards iteration.** RowReader stays forward-only.
+
+- **Async I/O.** Seeks happen on the calling thread; #331 covers async.
+
+## Testing
+
+- `ParquetReaderTest.firstRowSkipsEarlierRowGroups` — `firstRow(150)` on a
+  3-RG file (100 rows each) yields the right rows starting at id 151.
+- `ParquetReaderTest.firstRowAtRowGroupBoundary` — `firstRow(100)` lands
+  at the start of RG 1 with no within-RG residue.
+- `ParquetReaderTest.firstRowComposesWithHead` — `firstRow(150).head(20)`
+  yields exactly rows 150..169.
+- `ParquetReaderTest.firstRowAtTotalRowsYieldsEmpty` — boundary at
+  end-of-file.
+- `ParquetReaderTest.firstRowRejectsNegative` and
+  `firstRowAndTailAreMutuallyExclusive` cover the validation paths.
+- `DataPreviewIoTest` exercises the dive integration: jump-to-last-page
+  yields the right rows AND reads less than half the file's bytes;
+  forward intra-RG steps reuse the cursor; backward seek rebuilds within
+  the current RG only.

--- a/cli/pom.xml
+++ b/cli/pom.xml
@@ -147,7 +147,18 @@
       <artifactId>brotli4j</artifactId>
     </dependency>
 
-    <!-- Quarkus -->
+    <!-- Quarkus.
+
+         quarkus-core pulls in jboss-logmanager, which (a) is referenced
+         directly by Quarkus's bootstrap (QuarkusEntryPoint) so it
+         can't be excluded, and (b) ships a System.LoggerFinder service
+         provider. That makes JBoss LogManager the de-facto LoggerFinder
+         for the CLI runtime; there's no way to swap it without
+         breaking Quarkus startup. Since JBoss LogManager is
+         JUL-API-compatible, dive's log-file flag configures logging via
+         java.util.logging; records emitted via System.Logger from
+         S3InputFile and friends flow through JBoss LogManager and into
+         the JUL FileHandler we attach. -->
     <dependency>
       <groupId>io.quarkus</groupId>
       <artifactId>quarkus-picocli</artifactId>

--- a/cli/src/main/java/dev/hardwood/cli/command/DiveCommand.java
+++ b/cli/src/main/java/dev/hardwood/cli/command/DiveCommand.java
@@ -8,7 +8,13 @@
 package dev.hardwood.cli.command;
 
 import java.io.IOException;
+import java.nio.file.Path;
 import java.util.concurrent.Callable;
+import java.util.logging.FileHandler;
+import java.util.logging.Level;
+import java.util.logging.LogRecord;
+import java.util.logging.Logger;
+import java.util.logging.SimpleFormatter;
 
 import dev.hardwood.InputFile;
 import dev.hardwood.cli.dive.DiveApp;
@@ -21,6 +27,14 @@ import picocli.CommandLine.Spec;
 
 /// Launches the interactive `hardwood dive` TUI for exploring a Parquet file's
 /// structure. See `_designs/INTERACTIVE_DIVE_TUI.md`.
+///
+/// **Logging.** Quarkus pins JBoss LogManager as the runtime
+/// `System.LoggerFinder` (via the transitive `jboss-logmanager`
+/// dependency, which Quarkus's bootstrap references directly and cannot
+/// be excluded). JBoss LogManager is JUL-API-compatible, so this command
+/// configures dive's optional `--log-file` via `java.util.logging` —
+/// records emitted via `System.Logger` from `dev.hardwood.*` flow through
+/// JBoss LogManager and into the [FileHandler] attached here.
 @CommandLine.Command(
         name = "dive",
         description = "Interactively explore a Parquet file's structure.")
@@ -48,6 +62,13 @@ public class DiveCommand implements Callable<Integer> {
             hidden = true)
     boolean smokeRender;
 
+    @CommandLine.Option(
+            names = "--log-file",
+            description = "Write FINE-level dev.hardwood logs (including per-fetch entries from S3InputFile) "
+                    + "to the given path. The file is truncated on each invocation. Off by default.",
+            paramLabel = "<path>")
+    Path logFile;
+
     @Override
     public Integer call() {
         InputFile inputFile = fileMixin.toInputFile();
@@ -55,6 +76,7 @@ public class DiveCommand implements Callable<Integer> {
             return CommandLine.ExitCode.SOFTWARE;
         }
 
+        FileHandler logHandler = installLogFileHandler();
         try (ParquetModel model = ParquetModel.open(inputFile, fileMixin.file)) {
             model.setDictionaryReadCapBytes(maxDictBytes);
             DiveApp app = new DiveApp(model);
@@ -73,6 +95,48 @@ public class DiveCommand implements Callable<Integer> {
         catch (Exception e) {
             spec.commandLine().getErr().println("Error running dive TUI: " + e.getMessage());
             return CommandLine.ExitCode.SOFTWARE;
+        }
+        finally {
+            if (logHandler != null) {
+                logHandler.close();
+            }
+        }
+    }
+
+    /// Configures JUL logging for an interactive dive session.
+    ///
+    /// Always detaches the `dev.hardwood` logger from parent handlers so
+    /// nothing leaks to stdout/stderr while the TUI owns the terminal —
+    /// otherwise log records would garble the rendered frames.
+    ///
+    /// When `--log-file` is set, also attaches a [FileHandler] writing
+    /// one record per line to the given path, truncated per session.
+    /// Returns the handler so it can be closed at shutdown, or `null`
+    /// when no log file is requested.
+    private FileHandler installLogFileHandler() {
+        Logger logger = Logger.getLogger("dev.hardwood");
+        logger.setUseParentHandlers(false);
+        if (logFile == null) {
+            return null;
+        }
+        try {
+            FileHandler handler = new FileHandler(logFile.toString(), false);
+            handler.setLevel(Level.FINE);
+            handler.setFormatter(new SimpleFormatter() {
+                @Override
+                public String format(LogRecord record) {
+                    return String.format("%1$tFT%1$tT.%1$tL %2$s [%3$s] %4$s%n",
+                            record.getMillis(), record.getLevel(), record.getLoggerName(),
+                            formatMessage(record));
+                }
+            });
+            logger.setLevel(Level.FINE);
+            logger.addHandler(handler);
+            return handler;
+        }
+        catch (IOException e) {
+            spec.commandLine().getErr().println("Failed to open log file " + logFile + ": " + e.getMessage());
+            return null;
         }
     }
 }

--- a/cli/src/main/java/dev/hardwood/cli/dive/ParquetModel.java
+++ b/cli/src/main/java/dev/hardwood/cli/dive/ParquetModel.java
@@ -178,24 +178,6 @@ public final class ParquetModel implements AutoCloseable {
         return rowGroup(rowGroupIndex).columns().get(columnIndex);
     }
 
-    /// Index of the row group containing the given absolute row, by
-    /// cumulative `RowGroup.numRows()`. Linear in the row-group count.
-    /// Returns the last row group when `row` equals total row count.
-    public int rowGroupContaining(long row) {
-        if (row < 0) {
-            throw new IllegalArgumentException("row must be non-negative: " + row);
-        }
-        long cumulative = 0;
-        List<RowGroup> rowGroups = metadata.rowGroups();
-        for (int i = 0; i < rowGroups.size(); i++) {
-            cumulative += rowGroups.get(i).numRows();
-            if (row < cumulative) {
-                return i;
-            }
-        }
-        return Math.max(0, rowGroups.size() - 1);
-    }
-
     /// Reads the column index for a chunk, caching the result for the session.
     /// Returns `null` when the chunk has no column index.
     public ColumnIndex columnIndex(int rowGroupIndex, int columnIndex) {

--- a/cli/src/main/java/dev/hardwood/cli/dive/ParquetModel.java
+++ b/cli/src/main/java/dev/hardwood/cli/dive/ParquetModel.java
@@ -69,6 +69,13 @@ public final class ParquetModel implements AutoCloseable {
     // position only; the two never share state directly.
     private RowReader previewCursor;
     private long previewCursorPosition;
+    /// Row group the preview cursor is currently iterating in. -1 when no
+    /// cursor is open. Used by [#readPreviewPage] to decide whether a
+    /// requested `firstRow` can reuse the cursor — only same-RG forward
+    /// moves reuse; cross-RG jumps and backward moves rebuild via
+    /// `firstRow(N)` so the new cursor is scoped to the target RG and
+    /// doesn't fetch bytes from intervening row groups.
+    private int previewCursorRowGroup = -1;
     private static final int DICTIONARY_CACHE_CAPACITY = 4;
     private static final int PAGE_HEADER_CACHE_CAPACITY = 8;
     /// Default maximum chunk-size for a Dictionary load. Larger chunks need the
@@ -185,6 +192,24 @@ public final class ParquetModel implements AutoCloseable {
 
     public ColumnChunk chunk(int rowGroupIndex, int columnIndex) {
         return rowGroup(rowGroupIndex).columns().get(columnIndex);
+    }
+
+    /// Index of the row group containing the given absolute row, by
+    /// cumulative `RowGroup.numRows()`. Linear in the row-group count.
+    /// Returns the last row group when `row` equals total row count.
+    public int rowGroupContaining(long row) {
+        if (row < 0) {
+            throw new IllegalArgumentException("row must be non-negative: " + row);
+        }
+        long cumulative = 0;
+        List<RowGroup> rowGroups = metadata.rowGroups();
+        for (int i = 0; i < rowGroups.size(); i++) {
+            cumulative += rowGroups.get(i).numRows();
+            if (row < cumulative) {
+                return i;
+            }
+        }
+        return Math.max(0, rowGroups.size() - 1);
     }
 
     /// Reads the column index for a chunk, caching the result for the session.
@@ -358,16 +383,34 @@ public final class ParquetModel implements AutoCloseable {
         return reader;
     }
 
-    /// Reads a page of rows starting at `firstRow`. The `consumer` is called
-    /// once per row with a [RowReader] already positioned on that row. Reuses
-    /// a forward-only cursor across calls: moving forward skips ahead without
-    /// reopening, moving backwards closes and recreates the reader.
+    /// Reads a page of rows starting at `firstRow`. The `consumer` is
+    /// called once per row with a [RowReader] already positioned on that
+    /// row.
+    ///
+    /// Reuses a forward-only cursor across calls when the next call
+    /// moves forward and the existing cursor still has rows left to
+    /// yield. Otherwise closes the cursor and opens a new one via
+    /// `buildRowReader().firstRow(firstRow).build()`, which seeks
+    /// directly to the row group containing `firstRow` instead of
+    /// walking from row 0 — the headline win for jump-to-end on remote
+    /// files.
     public void readPreviewPage(long firstRow, int pageSize, java.util.function.Consumer<RowReader> consumer)
             throws IOException {
-        if (previewCursor == null || firstRow < previewCursorPosition) {
+        int targetRg = rowGroupContaining(firstRow);
+        // Reuse only when staying in the same row group AND moving forward.
+        // Cross-RG jumps must rebuild via firstRow(N) so the new cursor is
+        // scoped to the target RG — without this, a forward-skip via next()
+        // through intervening RGs would fetch every byte in between (which
+        // is exactly what `firstRow(N)` exists to avoid).
+        boolean canReuse = previewCursor != null
+                && previewCursorRowGroup == targetRg
+                && previewCursorPosition <= firstRow
+                && previewCursor.hasNext();
+        if (!canReuse) {
             closePreviewCursor();
-            previewCursor = reader.rowReader();
-            previewCursorPosition = 0;
+            previewCursor = reader.buildRowReader().firstRow(firstRow).build();
+            previewCursorPosition = firstRow;
+            previewCursorRowGroup = targetRg;
         }
         while (previewCursorPosition < firstRow && previewCursor.hasNext()) {
             previewCursor.next();
@@ -379,6 +422,12 @@ public final class ParquetModel implements AutoCloseable {
             previewCursorPosition++;
             consumer.accept(previewCursor);
             read++;
+        }
+        // Forward iteration may cross row-group boundaries (cursor wasn't
+        // bounded). Update the tracked RG so the next call's same-RG check
+        // is accurate.
+        if (previewCursorPosition > 0) {
+            previewCursorRowGroup = rowGroupContaining(previewCursorPosition - 1);
         }
     }
 
@@ -392,6 +441,7 @@ public final class ParquetModel implements AutoCloseable {
             }
             previewCursor = null;
             previewCursorPosition = 0;
+            previewCursorRowGroup = -1;
         }
     }
 

--- a/cli/src/main/java/dev/hardwood/cli/dive/ParquetModel.java
+++ b/cli/src/main/java/dev/hardwood/cli/dive/ParquetModel.java
@@ -36,6 +36,7 @@ import dev.hardwood.metadata.OffsetIndex;
 import dev.hardwood.metadata.RowGroup;
 import dev.hardwood.reader.ParquetFileReader;
 import dev.hardwood.reader.RowReader;
+import dev.hardwood.s3.S3InputFile;
 import dev.hardwood.schema.FileSchema;
 import dev.hardwood.schema.SchemaNode;
 
@@ -338,6 +339,19 @@ public final class ParquetModel implements AutoCloseable {
 
     public InputFile inputFile() {
         return inputFile;
+    }
+
+    /// Network usage of the underlying [InputFile] for this session.
+    /// Returns `null` for local files; for [S3InputFile] returns a live
+    /// snapshot of request count and bytes fetched since `open()`.
+    public NetStats netStats() {
+        if (inputFile instanceof S3InputFile s3) {
+            return new NetStats(s3.networkRequestCount(), s3.networkBytesFetched());
+        }
+        return null;
+    }
+
+    public record NetStats(long requestCount, long bytesFetched) {
     }
 
     public ParquetFileReader reader() {

--- a/cli/src/main/java/dev/hardwood/cli/dive/ParquetModel.java
+++ b/cli/src/main/java/dev/hardwood/cli/dive/ParquetModel.java
@@ -60,22 +60,6 @@ public final class ParquetModel implements AutoCloseable {
     /// the result is safe to memoise.
     private Set<String> allGroupPathsCache;
     private int dictionaryReadCapBytes = DEFAULT_DICTIONARY_READ_CAP_BYTES;
-    // Forward-read cursor for Data preview pagination. Reusing the same
-    // RowReader across forward page flips avoids re-iterating from row 0 on
-    // every PgDn. Closed + recreated on backward moves (PgUp, g jump-to-top)
-    // and at session end. See `DataPreviewScreen.PageKey` for the
-    // cache-vs-cursor invariant — DataPreviewScreen.PAGE_CACHE is keyed on
-    // `(firstRow, pageSize, logicalTypes)`, this cursor is keyed on file
-    // position only; the two never share state directly.
-    private RowReader previewCursor;
-    private long previewCursorPosition;
-    /// Row group the preview cursor is currently iterating in. -1 when no
-    /// cursor is open. Used by [#readPreviewPage] to decide whether a
-    /// requested `firstRow` can reuse the cursor — only same-RG forward
-    /// moves reuse; cross-RG jumps and backward moves rebuild via
-    /// `firstRow(N)` so the new cursor is scoped to the target RG and
-    /// doesn't fetch bytes from intervening row groups.
-    private int previewCursorRowGroup = -1;
     private static final int DICTIONARY_CACHE_CAPACITY = 4;
     private static final int PAGE_HEADER_CACHE_CAPACITY = 8;
     /// Default maximum chunk-size for a Dictionary load. Larger chunks need the
@@ -387,67 +371,34 @@ public final class ParquetModel implements AutoCloseable {
     /// called once per row with a [RowReader] already positioned on that
     /// row.
     ///
-    /// Reuses a forward-only cursor across calls when the next call
-    /// moves forward and the existing cursor still has rows left to
-    /// yield. Otherwise closes the cursor and opens a new one via
-    /// `buildRowReader().firstRow(firstRow).build()`, which seeks
-    /// directly to the row group containing `firstRow` instead of
-    /// walking from row 0 — the headline win for jump-to-end on remote
-    /// files.
+    /// Each call builds a *fresh* cursor bounded by `head(pageSize)` and
+    /// closes it before returning. The bound matters: without it, the
+    /// per-column workers in the v2 pipeline race many row groups ahead
+    /// of what the consumer asks for (#370), so the bytes they queue
+    /// eventually get fetched — surfacing as "phantom" S3 fetches long
+    /// after the user moved on. `head(pageSize)` caps the workers to
+    /// exactly the rows we need; the eager close releases the
+    /// iterator's metadata cache and any retained chunk-handle bytes
+    /// before the next call (the dive viewport window absorbs all
+    /// within-buffer navigation, so cursor reuse across calls would buy
+    /// nothing).
     public void readPreviewPage(long firstRow, int pageSize, java.util.function.Consumer<RowReader> consumer)
             throws IOException {
-        int targetRg = rowGroupContaining(firstRow);
-        // Reuse only when staying in the same row group AND moving forward.
-        // Cross-RG jumps must rebuild via firstRow(N) so the new cursor is
-        // scoped to the target RG — without this, a forward-skip via next()
-        // through intervening RGs would fetch every byte in between (which
-        // is exactly what `firstRow(N)` exists to avoid).
-        boolean canReuse = previewCursor != null
-                && previewCursorRowGroup == targetRg
-                && previewCursorPosition <= firstRow
-                && previewCursor.hasNext();
-        if (!canReuse) {
-            closePreviewCursor();
-            previewCursor = reader.buildRowReader().firstRow(firstRow).build();
-            previewCursorPosition = firstRow;
-            previewCursorRowGroup = targetRg;
-        }
-        while (previewCursorPosition < firstRow && previewCursor.hasNext()) {
-            previewCursor.next();
-            previewCursorPosition++;
-        }
-        int read = 0;
-        while (read < pageSize && previewCursor.hasNext()) {
-            previewCursor.next();
-            previewCursorPosition++;
-            consumer.accept(previewCursor);
-            read++;
-        }
-        // Forward iteration may cross row-group boundaries (cursor wasn't
-        // bounded). Update the tracked RG so the next call's same-RG check
-        // is accurate.
-        if (previewCursorPosition > 0) {
-            previewCursorRowGroup = rowGroupContaining(previewCursorPosition - 1);
-        }
-    }
-
-    private void closePreviewCursor() {
-        if (previewCursor != null) {
-            try {
-                previewCursor.close();
+        try (RowReader cursor = reader.buildRowReader()
+                .firstRow(firstRow)
+                .head(pageSize)
+                .build()) {
+            int read = 0;
+            while (read < pageSize && cursor.hasNext()) {
+                cursor.next();
+                consumer.accept(cursor);
+                read++;
             }
-            catch (RuntimeException ignored) {
-                // Best-effort close; the outer model close still needs to run.
-            }
-            previewCursor = null;
-            previewCursorPosition = 0;
-            previewCursorRowGroup = -1;
         }
     }
 
     @Override
     public void close() throws IOException {
-        closePreviewCursor();
         reader.close();
     }
 

--- a/cli/src/main/java/dev/hardwood/cli/dive/internal/Chrome.java
+++ b/cli/src/main/java/dev/hardwood/cli/dive/internal/Chrome.java
@@ -69,17 +69,23 @@ public final class Chrome {
         Style bold = Style.EMPTY.bold();
         Style dim = Style.EMPTY.fg(Theme.DIM);
         ParquetModel.Facts f = model.facts();
-        Line line = Line.from(
-                new Span(" hardwood dive ", bold.fg(Theme.ACCENT)),
-                new Span("│ ", dim),
-                Span.raw(basename(model.displayPath())),
-                new Span(" │ ", dim),
-                Span.raw(Sizes.format(model.fileSizeBytes())),
-                new Span(" │ ", dim),
-                Span.raw(Plurals.format(f.rowGroupCount(), "RG", "RGs")),
-                new Span(" │ ", dim),
-                Span.raw(formatRowCount(f.totalRows()) + " rows"));
-        Paragraph.builder().text(convert(line)).left().build().render(area, buffer);
+        List<Span> spans = new ArrayList<>();
+        spans.add(new Span(" hardwood dive ", bold.fg(Theme.ACCENT)));
+        spans.add(new Span("│ ", dim));
+        spans.add(Span.raw(basename(model.displayPath())));
+        spans.add(new Span(" │ ", dim));
+        spans.add(Span.raw(Sizes.format(model.fileSizeBytes())));
+        spans.add(new Span(" │ ", dim));
+        spans.add(Span.raw(Plurals.format(f.rowGroupCount(), "RG", "RGs")));
+        spans.add(new Span(" │ ", dim));
+        spans.add(Span.raw(formatRowCount(f.totalRows()) + " rows"));
+        ParquetModel.NetStats net = model.netStats();
+        if (net != null) {
+            spans.add(new Span(" │ ", dim));
+            spans.add(Span.raw(Plurals.format(net.requestCount(), "req", "reqs")
+                    + " · " + Sizes.format(net.bytesFetched())));
+        }
+        Paragraph.builder().text(convert(Line.from(spans))).left().build().render(area, buffer);
     }
 
     public static void renderBreadcrumb(Buffer buffer, Rect area, NavigationStack stack, ParquetModel model) {

--- a/cli/src/main/java/dev/hardwood/cli/dive/internal/DataPreviewScreen.java
+++ b/cli/src/main/java/dev/hardwood/cli/dive/internal/DataPreviewScreen.java
@@ -14,7 +14,6 @@ import java.util.Set;
 
 import dev.hardwood.cli.dive.ParquetModel;
 import dev.hardwood.cli.dive.ScreenState;
-import dev.hardwood.cli.internal.RowValueFormatter;
 import dev.hardwood.schema.SchemaNode;
 import dev.tamboui.buffer.Buffer;
 import dev.tamboui.layout.Constraint;
@@ -43,43 +42,11 @@ public final class DataPreviewScreen {
 
     private static final int VISIBLE_COLUMNS = 5;
     private static final int VALUE_TRUNCATE = 32;
-    private static final int PAGE_CACHE_CAP = 5;
 
-
-    /// Memoises recent (firstRow, pageSize, logicalTypes) lookups so that
-    /// stepping back through pages with PgUp doesn't re-walk the parquet
-    /// reader from row 0 each time. Scoped to one ParquetModel — clearing
-    /// whenever a different model first calls `initialState`.
-    ///
-    /// **Invariant — cache vs. cursor.** [PAGE_CACHE] and
-    /// [ParquetModel#previewCursor] are keyed independently: the cache by
-    /// `(firstRow, pageSize, logicalTypes)`, the cursor by file position
-    /// only. A cache hit returns pre-formatted rows without touching the
-    /// cursor; the next *uncached* fetch then continues from wherever
-    /// the cursor was last left and seeks forward (or closes + recreates
-    /// the cursor on a backward move). This works only because cached
-    /// pages are read-only views — they never advance the cursor — and
-    /// uncached fetches always do their own seek logic. If a future
-    /// change populates the cache as a side effect of a cursor advance
-    /// without a matching cache invalidation, or starts using the cursor
-    /// to satisfy cache hits, the two can diverge silently. Keep the two
-    /// stores' update paths separate.
-    private record PageKey(long firstRow, int pageSize, boolean logicalTypes) {
-    }
-
-    private record CachedPage(List<List<String>> rows, List<List<String>> expandedRows,
-                              List<String> columnNames) {
-    }
-
-    private static final java.util.LinkedHashMap<PageKey, CachedPage> PAGE_CACHE =
-            new java.util.LinkedHashMap<>(PAGE_CACHE_CAP, 0.75f, true) {
-                @Override
-                protected boolean removeEldestEntry(java.util.Map.Entry<PageKey, CachedPage> e) {
-                    return size() > PAGE_CACHE_CAP;
-                }
-            };
-
-    private static ParquetModel cachedFor;
+    /// A sliding ±10×viewport row window of pre-formatted Data preview
+    /// rows. Within-window navigation (PgUp/PgDn that stays inside the
+    /// horizon) is served from the buffer with no I/O. See [PreviewWindow].
+    private static final PreviewWindow WINDOW = new PreviewWindow();
 
     private DataPreviewScreen() {
     }
@@ -96,10 +63,6 @@ public final class DataPreviewScreen {
     /// deterministic page-boundary assertions. Production code uses the
     /// viewport-derived overload.
     public static ScreenState.DataPreview initialState(ParquetModel model, int pageSize) {
-        if (cachedFor != model) {
-            PAGE_CACHE.clear();
-            cachedFor = model;
-        }
         return loadPage(model, 0, pageSize, 0, true);
     }
 
@@ -669,48 +632,10 @@ public final class DataPreviewScreen {
 
     private static ScreenState.DataPreview loadPage(ParquetModel model, long firstRow, int pageSize,
                                                     int columnScroll, boolean logicalTypes) {
-        if (cachedFor != model) {
-            PAGE_CACHE.clear();
-            cachedFor = model;
-        }
-        PageKey key = new PageKey(firstRow, pageSize, logicalTypes);
-        CachedPage cached = PAGE_CACHE.get(key);
-        if (cached != null) {
-            return new ScreenState.DataPreview(firstRow, pageSize, cached.columnNames(),
-                    cached.rows(), cached.expandedRows(), columnScroll, 0, -1,
-                    logicalTypes, Set.of(), 0);
-        }
-        // `RowReader` indexes into the root message's top-level fields, not into
-        // leaf columns. For a flat schema those counts coincide; for a schema
-        // with lists / structs / maps / variants at the root they diverge, and
-        // iterating to model.columnCount() (leaf count) overruns the reader.
-        List<SchemaNode> topLevel = model.schema().getRootNode().children();
-        List<String> columnNames = new ArrayList<>(topLevel.size());
-        for (SchemaNode node : topLevel) {
-            columnNames.add(node.name());
-        }
-        int fieldCount = columnNames.size();
-        List<List<String>> rows = new ArrayList<>();
-        List<List<String>> expandedRows = new ArrayList<>();
-        try {
-            model.readPreviewPage(firstRow, pageSize, reader -> {
-                List<String> row = new ArrayList<>(fieldCount);
-                List<String> expanded = new ArrayList<>(fieldCount);
-                for (int c = 0; c < fieldCount; c++) {
-                    SchemaNode field = topLevel.get(c);
-                    row.add(RowValueFormatter.format(reader, c, field, logicalTypes));
-                    expanded.add(RowValueFormatter.formatExpanded(reader, c, field, logicalTypes));
-                }
-                rows.add(row);
-                expandedRows.add(expanded);
-            });
-        }
-        catch (java.io.IOException e) {
-            throw new java.io.UncheckedIOException(e);
-        }
-        PAGE_CACHE.put(key, new CachedPage(rows, expandedRows, columnNames));
-        return new ScreenState.DataPreview(firstRow, pageSize, columnNames, rows, expandedRows,
-                columnScroll, 0, -1, logicalTypes, Set.of(), 0);
+        PreviewWindow.Slice slice = WINDOW.slice(model, firstRow, pageSize, logicalTypes);
+        return new ScreenState.DataPreview(firstRow, pageSize, slice.columnNames(),
+                slice.rows(), slice.expandedRows(), columnScroll, 0, -1,
+                logicalTypes, Set.of(), 0);
     }
 
     private static String truncate(String s, int max) {

--- a/cli/src/main/java/dev/hardwood/cli/dive/internal/PreviewWindow.java
+++ b/cli/src/main/java/dev/hardwood/cli/dive/internal/PreviewWindow.java
@@ -37,6 +37,11 @@ import dev.hardwood.schema.SchemaNode;
 /// no fetch, no decode. The cost is ~4× the per-cell string memory
 /// (a few extra MB for typical Overture-shape schemas), bounded by
 /// the window size and far cheaper than re-fetching on every toggle.
+///
+/// **Threading.** Not thread-safe. Dive runs all UI work on a single
+/// event-loop thread; the static `DataPreviewScreen.WINDOW` instance
+/// relies on that. Sharing across threads would require external
+/// synchronisation around `slice` / `refill` and the four row lists.
 final class PreviewWindow {
 
     /// Number of `pageSize`-strides kept on each side of the requested

--- a/cli/src/main/java/dev/hardwood/cli/dive/internal/PreviewWindow.java
+++ b/cli/src/main/java/dev/hardwood/cli/dive/internal/PreviewWindow.java
@@ -1,0 +1,166 @@
+/*
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Copyright The original authors
+ *
+ *  Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package dev.hardwood.cli.dive.internal;
+
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.util.ArrayList;
+import java.util.List;
+
+import dev.hardwood.cli.dive.ParquetModel;
+import dev.hardwood.cli.internal.RowValueFormatter;
+import dev.hardwood.schema.SchemaNode;
+
+/// A buffered window of pre-formatted Data preview rows around the
+/// current viewport.
+///
+/// **Refill-on-miss semantics.** The buffer covers a range
+/// `[start, end)` of absolute row indices, sized at `20 × pageSize`
+/// (clamped at file boundaries). On each
+/// `slice(model, firstRow, pageSize, logicalTypes)`:
+///
+/// - **Page fully inside the buffer:** return the slice — zero I/O.
+/// - **Page outside the buffer:** *replace* the buffer with a fresh
+///   range `[firstRow − 10 × pageSize, firstRow + 10 × pageSize)`
+///   (clamped to file bounds), fetched in a single
+///   [ParquetModel#readPreviewPage] call.
+///
+/// **`logicalTypes` toggle does not invalidate.** Each cell is
+/// pre-formatted twice on fetch — once with logical-type rendering
+/// active, once without — and stored alongside the expanded variants.
+/// Toggling `t` in dive just selects which pair the slice returns;
+/// no fetch, no decode. The cost is ~4× the per-cell string memory
+/// (a few extra MB for typical Overture-shape schemas), bounded by
+/// the window size and far cheaper than re-fetching on every toggle.
+final class PreviewWindow {
+
+    /// Number of `pageSize`-strides kept on each side of the requested
+    /// `firstRow`. ±10 strides means each refill covers
+    /// `20 × pageSize` rows total (10 before + 10 starting at
+    /// firstRow). On every miss the buffer is *fully replaced* with
+    /// this range, so as the user navigates forward (e.g. firstRow
+    /// advances from 300 to 600) the previous front rows naturally
+    /// get evicted — memory stays bounded at `20 × pageSize` rather
+    /// than growing.
+    private static final int SLACK_PAGES = 10;
+
+    private ParquetModel cachedFor;
+    private long start;            // inclusive
+    private long end;              // exclusive
+    private List<List<String>> rowsLogical;
+    private List<List<String>> rowsPhysical;
+    private List<List<String>> expandedLogical;
+    private List<List<String>> expandedPhysical;
+    private List<String> columnNames;
+    private List<SchemaNode> topLevelFields;
+
+    /// Returns a `pageSize`-row slice starting at `firstRow`, formatted
+    /// according to `logicalTypes`. If the requested page is in the
+    /// current buffer, it's served from memory (regardless of which
+    /// mode was active when the buffer was filled).
+    Slice slice(ParquetModel model, long firstRow, int pageSize, boolean logicalTypes) {
+        long total = model.facts().totalRows();
+        long requestStart = Math.max(0, firstRow);
+        long requestEnd = Math.min(total, requestStart + pageSize);
+
+        boolean modelChanged = cachedFor != model;
+        boolean uninitialised = rowsLogical == null;
+        if (modelChanged || uninitialised) {
+            initialise(model);
+        }
+
+        boolean pageInBuffer = !rowsLogical.isEmpty()
+                && requestStart >= start
+                && requestEnd <= end;
+        if (!pageInBuffer) {
+            refill(model, firstRow, pageSize, total);
+        }
+
+        long sliceStart = Math.max(requestStart, start);
+        long sliceEnd = Math.min(requestEnd, end);
+        if (sliceStart >= sliceEnd) {
+            return new Slice(List.of(), List.of(), columnNames);
+        }
+        int from = Math.toIntExact(sliceStart - start);
+        int to = Math.toIntExact(sliceEnd - start);
+        List<List<String>> rows = logicalTypes ? rowsLogical : rowsPhysical;
+        List<List<String>> expanded = logicalTypes ? expandedLogical : expandedPhysical;
+        return new Slice(
+                List.copyOf(rows.subList(from, to)),
+                List.copyOf(expanded.subList(from, to)),
+                columnNames);
+    }
+
+    private void initialise(ParquetModel model) {
+        this.cachedFor = model;
+        this.topLevelFields = model.schema().getRootNode().children();
+        this.columnNames = new ArrayList<>(topLevelFields.size());
+        for (SchemaNode node : topLevelFields) {
+            columnNames.add(node.name());
+        }
+        this.rowsLogical = new ArrayList<>();
+        this.rowsPhysical = new ArrayList<>();
+        this.expandedLogical = new ArrayList<>();
+        this.expandedPhysical = new ArrayList<>();
+        this.start = 0;
+        this.end = 0;
+    }
+
+    /// Drops the current buffer and fetches a fresh `[firstRow −
+    /// 10·pageSize, firstRow + 10·pageSize)` range (clamped to file
+    /// bounds) in a single call. Each row is formatted in both
+    /// logical-type and physical-type modes so subsequent `t` toggles
+    /// don't trigger I/O.
+    private void refill(ParquetModel model, long firstRow, int pageSize, long total) {
+        long newStart = Math.max(0, firstRow - (long) SLACK_PAGES * pageSize);
+        long newEnd = Math.min(total, firstRow + (long) SLACK_PAGES * pageSize);
+        rowsLogical.clear();
+        rowsPhysical.clear();
+        expandedLogical.clear();
+        expandedPhysical.clear();
+        start = newStart;
+        end = newStart;
+        long count = newEnd - newStart;
+        if (count <= 0) {
+            return;
+        }
+        fetch(model, newStart, Math.toIntExact(count));
+        end = start + rowsLogical.size();
+    }
+
+    private void fetch(ParquetModel model, long firstRow, int count) {
+        int fieldCount = topLevelFields.size();
+        try {
+            model.readPreviewPage(firstRow, count, reader -> {
+                List<String> rowLogical = new ArrayList<>(fieldCount);
+                List<String> rowPhysical = new ArrayList<>(fieldCount);
+                List<String> expLogical = new ArrayList<>(fieldCount);
+                List<String> expPhysical = new ArrayList<>(fieldCount);
+                for (int c = 0; c < fieldCount; c++) {
+                    SchemaNode field = topLevelFields.get(c);
+                    rowLogical.add(RowValueFormatter.format(reader, c, field, true));
+                    rowPhysical.add(RowValueFormatter.format(reader, c, field, false));
+                    expLogical.add(RowValueFormatter.formatExpanded(reader, c, field, true));
+                    expPhysical.add(RowValueFormatter.formatExpanded(reader, c, field, false));
+                }
+                rowsLogical.add(rowLogical);
+                rowsPhysical.add(rowPhysical);
+                expandedLogical.add(expLogical);
+                expandedPhysical.add(expPhysical);
+            });
+        }
+        catch (IOException e) {
+            throw new UncheckedIOException(e);
+        }
+    }
+
+    /// A `pageSize`-row slice carved from the window — exactly what the
+    /// `DataPreview` screen state holds.
+    record Slice(List<List<String>> rows, List<List<String>> expandedRows, List<String> columnNames) {
+    }
+}

--- a/cli/src/test/java/dev/hardwood/cli/dive/DataPreviewIoTest.java
+++ b/cli/src/test/java/dev/hardwood/cli/dive/DataPreviewIoTest.java
@@ -74,7 +74,12 @@ class DataPreviewIoTest {
     }
 
     @Test
-    void forwardWithinSameRowGroupReusesCursor() throws IOException {
+    void forwardWithinSameRowGroupBoundedByPageSize() throws IOException {
+        // ParquetModel.readPreviewPage builds a fresh head(pageSize)
+        // cursor every call (no cross-call reuse — the dive viewport
+        // window cache absorbs that). Bytes for a forward intra-RG
+        // step should therefore stay bounded by the per-page bytes,
+        // not blow up to a full re-fetch of the row group prefix.
         ByteCountingInputFile counting = new ByteCountingInputFile(InputFile.of(fixture()));
 
         try (ParquetModel model = ParquetModel.open(counting, "filter_pushdown_int.parquet")) {
@@ -82,9 +87,9 @@ class DataPreviewIoTest {
             model.readPreviewPage(0, 10, reader -> { });
             long after1 = counting.bytesRead();
 
-            // Continue forward within the same RG. The cursor is reused
-            // (no firstRow-rebuild); whatever extra bytes are read are
-            // page-by-page top-ups, not a fresh RG fetch.
+            // Forward step within the same RG. The new cursor is
+            // bounded by head(10), so the additional bytes should be
+            // far smaller than the initial RG-opening fetch.
             model.readPreviewPage(50, 10, reader -> { });
             long after2 = counting.bytesRead();
 

--- a/cli/src/test/java/dev/hardwood/cli/dive/DataPreviewIoTest.java
+++ b/cli/src/test/java/dev/hardwood/cli/dive/DataPreviewIoTest.java
@@ -1,0 +1,171 @@
+/*
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Copyright The original authors
+ *
+ *  Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package dev.hardwood.cli.dive;
+
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.nio.file.Path;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicLong;
+
+import org.junit.jupiter.api.Test;
+
+import dev.hardwood.InputFile;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/// Asserts that `ParquetModel.readPreviewPage` uses the row-based seek
+/// primitive — a jump to a row in the last row group reads only that
+/// row group's bytes, not the whole prefix.
+class DataPreviewIoTest {
+
+    /// 3 row groups of 100 rows each: id 1..100, 101..200, 201..300.
+    private static Path fixture() {
+        return Path.of(DataPreviewIoTest.class.getResource("/filter_pushdown_int.parquet").getPath());
+    }
+
+    @Test
+    void jumpToLastPageYieldsTheExpectedRows() throws IOException {
+        ByteCountingInputFile counting = new ByteCountingInputFile(InputFile.of(fixture()));
+
+        try (ParquetModel model = ParquetModel.open(counting, "filter_pushdown_int.parquet")) {
+            // Jump to the last 30 rows (270..299, ids 271..300). With
+            // firstRow-based seeking the model opens RG 2 only.
+            AtomicInteger rowsYielded = new AtomicInteger();
+            AtomicLong firstId = new AtomicLong(-1);
+            AtomicLong lastId = new AtomicLong(-1);
+            model.readPreviewPage(270, 30, reader -> {
+                long id = reader.getLong("id");
+                if (firstId.get() < 0) {
+                    firstId.set(id);
+                }
+                lastId.set(id);
+                rowsYielded.incrementAndGet();
+            });
+
+            assertThat(rowsYielded.get()).as("rows yielded on last-page jump").isEqualTo(30);
+            assertThat(firstId.get()).as("first id on last-page jump").isEqualTo(271L);
+            assertThat(lastId.get()).as("last id on last-page jump").isEqualTo(300L);
+        }
+    }
+
+    @Test
+    void jumpToLastRowGroupSkipsEarlierRowGroupBytes() throws IOException {
+        ByteCountingInputFile counting = new ByteCountingInputFile(InputFile.of(fixture()));
+
+        try (ParquetModel model = ParquetModel.open(counting, "filter_pushdown_int.parquet")) {
+            long openBytes = counting.bytesRead();
+
+            model.readPreviewPage(270, 30, reader -> { });
+            long jumpDelta = counting.bytesRead() - openBytes;
+            long fileSize = counting.length();
+
+            assertThat(jumpDelta).as("bytes read on jump").isPositive();
+            // One RG of bytes is well under half the file's data-page
+            // bytes for a 3-RG fixture.
+            assertThat(jumpDelta).as("bytes read on RG-2 jump vs file size")
+                    .isLessThan(fileSize / 2);
+        }
+    }
+
+    @Test
+    void forwardWithinSameRowGroupReusesCursor() throws IOException {
+        ByteCountingInputFile counting = new ByteCountingInputFile(InputFile.of(fixture()));
+
+        try (ParquetModel model = ParquetModel.open(counting, "filter_pushdown_int.parquet")) {
+            // First page: lands in RG 0, opens it.
+            model.readPreviewPage(0, 10, reader -> { });
+            long after1 = counting.bytesRead();
+
+            // Continue forward within the same RG. The cursor is reused
+            // (no firstRow-rebuild); whatever extra bytes are read are
+            // page-by-page top-ups, not a fresh RG fetch.
+            model.readPreviewPage(50, 10, reader -> { });
+            long after2 = counting.bytesRead();
+
+            long step = after2 - after1;
+            assertThat(step).as("bytes for forward intra-RG step")
+                    .isLessThanOrEqualTo(after1);
+        }
+    }
+
+    @Test
+    void backwardSeekRebuildsCursor() throws IOException {
+        // Backward navigation closes the cursor and reopens via
+        // firstRow(target). Bytes are re-fetched for the target RG (no
+        // model-level row cache yet — that's #377). This test pins the
+        // re-fetch is bounded to the current RG, not the prefix from row 0.
+        ByteCountingInputFile counting = new ByteCountingInputFile(InputFile.of(fixture()));
+
+        try (ParquetModel model = ParquetModel.open(counting, "filter_pushdown_int.parquet")) {
+            // Walk into RG 2, near the end.
+            model.readPreviewPage(290, 10, reader -> { });
+            long afterEnd = counting.bytesRead();
+
+            // Backward within the same RG.
+            AtomicInteger rowsYielded = new AtomicInteger();
+            AtomicLong firstId = new AtomicLong(-1);
+            model.readPreviewPage(220, 10, reader -> {
+                long id = reader.getLong("id");
+                if (firstId.get() < 0) {
+                    firstId.set(id);
+                }
+                rowsYielded.incrementAndGet();
+            });
+            long backDelta = counting.bytesRead() - afterEnd;
+
+            assertThat(rowsYielded.get()).as("rows yielded on backward seek").isEqualTo(10);
+            assertThat(firstId.get()).as("first id on backward seek").isEqualTo(221L);
+            // Re-fetch bounded by current RG, not full prefix.
+            assertThat(backDelta).as("backward intra-RG re-fetch is bounded")
+                    .isLessThanOrEqualTo(afterEnd);
+        }
+    }
+
+    /// Tracks total bytes returned by [#readRange]. The Parquet footer
+    /// fetch and the data-page fetches both flow through it.
+    private static final class ByteCountingInputFile implements InputFile {
+
+        private final InputFile delegate;
+        private final AtomicLong bytesRead = new AtomicLong();
+
+        ByteCountingInputFile(InputFile delegate) {
+            this.delegate = delegate;
+        }
+
+        long bytesRead() {
+            return bytesRead.get();
+        }
+
+        @Override
+        public void open() throws IOException {
+            delegate.open();
+        }
+
+        @Override
+        public ByteBuffer readRange(long offset, int length) throws IOException {
+            bytesRead.addAndGet(length);
+            return delegate.readRange(offset, length);
+        }
+
+        @Override
+        public long length() throws IOException {
+            return delegate.length();
+        }
+
+        @Override
+        public String name() {
+            return delegate.name();
+        }
+
+        @Override
+        public void close() throws IOException {
+            delegate.close();
+        }
+    }
+}

--- a/cli/src/test/java/dev/hardwood/cli/dive/internal/PreviewWindowTest.java
+++ b/cli/src/test/java/dev/hardwood/cli/dive/internal/PreviewWindowTest.java
@@ -1,0 +1,196 @@
+/*
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Copyright The original authors
+ *
+ *  Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package dev.hardwood.cli.dive.internal;
+
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.nio.file.Path;
+import java.util.concurrent.atomic.AtomicLong;
+
+import org.junit.jupiter.api.Test;
+
+import dev.hardwood.InputFile;
+import dev.hardwood.cli.dive.ParquetModel;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/// Asserts that the `PreviewWindow` behaves as a sliding cache around
+/// the current viewport — within-window navigation triggers no I/O,
+/// boundary moves extend incrementally, far jumps refill.
+class PreviewWindowTest {
+
+    /// 3 row groups of 100 rows each: id 1..100, 101..200, 201..300.
+    private static Path fixture() {
+        return Path.of(PreviewWindowTest.class.getResource("/filter_pushdown_int.parquet").getPath());
+    }
+
+    @Test
+    void initialSliceYieldsRequestedPage() throws IOException {
+        ByteCountingInputFile counting = new ByteCountingInputFile(InputFile.of(fixture()));
+
+        try (ParquetModel model = ParquetModel.open(counting, "filter_pushdown_int.parquet")) {
+            PreviewWindow window = new PreviewWindow();
+            PreviewWindow.Slice slice = window.slice(model, 0, 10, true);
+
+            assertThat(slice.rows()).hasSize(10);
+            assertThat(slice.columnNames()).contains("id");
+            // First column ("id"), first row → id=1
+            assertThat(slice.rows().get(0).get(0)).isEqualTo("1");
+            assertThat(slice.rows().get(9).get(0)).isEqualTo("10");
+            assertThat(counting.bytesRead()).as("bytes after initial slice").isPositive();
+        }
+    }
+
+    @Test
+    void withinWindowNavigationStaysAccurate() throws IOException {
+        // Fixture is too small (~10 KB) for byte-delta assertions — the v2
+        // pipeline pre-fetches the whole file in a couple of requests
+        // regardless of which rows we ask for. Test instead that the
+        // window's *content* is right after each navigation.
+        try (ParquetModel model = ParquetModel.open(InputFile.of(fixture()),
+                "filter_pushdown_int.parquet")) {
+            PreviewWindow window = new PreviewWindow();
+
+            // First slice: rows 0..9 → ids 1..10
+            PreviewWindow.Slice s1 = window.slice(model, 0, 10, true);
+            assertThat(s1.rows().get(0).get(0)).isEqualTo("1");
+
+            // Forward within window: rows 10..19 → ids 11..20
+            PreviewWindow.Slice s2 = window.slice(model, 10, 10, true);
+            assertThat(s2.rows()).hasSize(10);
+            assertThat(s2.rows().get(0).get(0)).isEqualTo("11");
+            assertThat(s2.rows().get(9).get(0)).isEqualTo("20");
+
+            // Back to start: rows 0..9 → ids 1..10
+            PreviewWindow.Slice s3 = window.slice(model, 0, 10, true);
+            assertThat(s3.rows().get(0).get(0)).isEqualTo("1");
+            assertThat(s3.rows().get(9).get(0)).isEqualTo("10");
+        }
+    }
+
+    @Test
+    void farJumpYieldsCorrectRows() throws IOException {
+        try (ParquetModel model = ParquetModel.open(InputFile.of(fixture()),
+                "filter_pushdown_int.parquet")) {
+            PreviewWindow window = new PreviewWindow();
+
+            // Initial window
+            window.slice(model, 0, 10, true);
+
+            // Jump to last 10 rows (firstRow=290). Should yield ids 291..300.
+            PreviewWindow.Slice tailSlice = window.slice(model, 290, 10, true);
+            assertThat(tailSlice.rows()).hasSize(10);
+            assertThat(tailSlice.rows().get(0).get(0)).isEqualTo("291");
+            assertThat(tailSlice.rows().get(9).get(0)).isEqualTo("300");
+
+            // Subsequent slice nearby (firstRow=280) should still produce
+            // correct rows — confirms the window is properly positioned
+            // around the new viewport, not stuck at the old one.
+            PreviewWindow.Slice nearTail = window.slice(model, 280, 10, true);
+            assertThat(nearTail.rows()).hasSize(10);
+            assertThat(nearTail.rows().get(0).get(0)).isEqualTo("281");
+            assertThat(nearTail.rows().get(9).get(0)).isEqualTo("290");
+        }
+    }
+
+    @Test
+    void logicalTypesToggleDoesNotTriggerIo() throws IOException {
+        // Each cell is pre-formatted in both logical and physical modes
+        // on fetch, so toggling `logicalTypes` afterwards just selects
+        // which pre-formatted variant the slice returns. A counting
+        // input file confirms no further bytes are read across the
+        // toggle.
+        ByteCountingInputFile counting = new ByteCountingInputFile(InputFile.of(fixture()));
+        try (ParquetModel model = ParquetModel.open(counting, "filter_pushdown_int.parquet")) {
+            PreviewWindow window = new PreviewWindow();
+
+            PreviewWindow.Slice s1 = window.slice(model, 0, 10, true);
+            long afterFirst = counting.bytesRead();
+            assertThat(s1.rows().get(0).get(0)).isEqualTo("1");
+
+            // Toggle: must not fetch again.
+            PreviewWindow.Slice s2 = window.slice(model, 0, 10, false);
+            assertThat(counting.bytesRead()).as("bytes after logicalTypes toggle")
+                    .isEqualTo(afterFirst);
+            assertThat(s2.rows()).hasSize(10);
+            assertThat(s2.rows().get(0).get(0)).isEqualTo("1");
+
+            // Toggle back: also no fetch.
+            PreviewWindow.Slice s3 = window.slice(model, 0, 10, true);
+            assertThat(counting.bytesRead()).as("bytes after toggle back")
+                    .isEqualTo(afterFirst);
+            assertThat(s3.rows().get(0).get(0)).isEqualTo("1");
+        }
+    }
+
+    @Test
+    void requestNearStartClampsLowerBound() throws IOException {
+        ByteCountingInputFile counting = new ByteCountingInputFile(InputFile.of(fixture()));
+
+        try (ParquetModel model = ParquetModel.open(counting, "filter_pushdown_int.parquet")) {
+            PreviewWindow window = new PreviewWindow();
+
+            // firstRow=5 with pageSize=10: desired window = [max(0, 5-100), 5+110) = [0, 115)
+            PreviewWindow.Slice slice = window.slice(model, 5, 10, true);
+            assertThat(slice.rows()).hasSize(10);
+        }
+    }
+
+    @Test
+    void requestNearEndClampsUpperBound() throws IOException {
+        ByteCountingInputFile counting = new ByteCountingInputFile(InputFile.of(fixture()));
+
+        try (ParquetModel model = ParquetModel.open(counting, "filter_pushdown_int.parquet")) {
+            PreviewWindow window = new PreviewWindow();
+
+            // firstRow=295 with pageSize=10 in a 300-row file:
+            // requested page = [295, 300), only 5 rows actually exist past row 295.
+            PreviewWindow.Slice slice = window.slice(model, 295, 10, true);
+            assertThat(slice.rows()).hasSize(5);
+        }
+    }
+
+    private static final class ByteCountingInputFile implements InputFile {
+        private final InputFile delegate;
+        private final AtomicLong bytesRead = new AtomicLong();
+
+        ByteCountingInputFile(InputFile delegate) {
+            this.delegate = delegate;
+        }
+
+        long bytesRead() {
+            return bytesRead.get();
+        }
+
+        @Override
+        public void open() throws IOException {
+            delegate.open();
+        }
+
+        @Override
+        public ByteBuffer readRange(long offset, int length) throws IOException {
+            bytesRead.addAndGet(length);
+            return delegate.readRange(offset, length);
+        }
+
+        @Override
+        public long length() throws IOException {
+            return delegate.length();
+        }
+
+        @Override
+        public String name() {
+            return delegate.name();
+        }
+
+        @Override
+        public void close() throws IOException {
+            delegate.close();
+        }
+    }
+}

--- a/cli/src/test/java/dev/hardwood/cli/dive/internal/PreviewWindowTest.java
+++ b/cli/src/test/java/dev/hardwood/cli/dive/internal/PreviewWindowTest.java
@@ -18,6 +18,7 @@ import dev.hardwood.InputFile;
 import dev.hardwood.cli.dive.ParquetModel;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 /// Asserts that the `PreviewWindow` behaves as a sliding cache around
 /// the current viewport — within-window navigation triggers no I/O,
@@ -152,6 +153,80 @@ class PreviewWindowTest {
             // requested page = [295, 300), only 5 rows actually exist past row 295.
             PreviewWindow.Slice slice = window.slice(model, 295, 10, true);
             assertThat(slice.rows()).hasSize(5);
+        }
+    }
+
+    @Test
+    void refillIoExceptionDoesNotLeaveStaleBuffer() throws IOException {
+        // refill() resets `start = end = newStart` *before* fetching,
+        // so a fetch failure leaves the buffer empty. The next slice
+        // call must trigger a fresh refill (not return stale rows
+        // from before the failed refill). Pins that retry behaviour.
+        FailingInputFile failing = new FailingInputFile(InputFile.of(fixture()));
+
+        try (ParquetModel model = ParquetModel.open(failing, "filter_pushdown_int.parquet")) {
+            PreviewWindow window = new PreviewWindow();
+
+            // First slice: rows 0..9 → ids 1..10. Succeeds.
+            PreviewWindow.Slice initial = window.slice(model, 0, 10, true);
+            assertThat(initial.rows().get(0).get(0)).isEqualTo("1");
+
+            // Arm the failure for the *next* refill.
+            failing.failOnNextReadRange();
+
+            // Far jump → forces a refill. The wrapped readRange throws,
+            // surfaces as UncheckedIOException.
+            assertThatThrownBy(() -> window.slice(model, 200, 10, true))
+                    .isInstanceOf(java.io.UncheckedIOException.class);
+
+            // Retry. The failure was one-shot, so this refill succeeds
+            // and must yield rows 200..209 → ids 201..210, not stale
+            // 1..10 from the pre-failure buffer.
+            PreviewWindow.Slice retry = window.slice(model, 200, 10, true);
+            assertThat(retry.rows()).hasSize(10);
+            assertThat(retry.rows().get(0).get(0)).isEqualTo("201");
+        }
+    }
+
+    private static final class FailingInputFile implements InputFile {
+        private final InputFile delegate;
+        private boolean failNext;
+
+        FailingInputFile(InputFile delegate) {
+            this.delegate = delegate;
+        }
+
+        void failOnNextReadRange() {
+            this.failNext = true;
+        }
+
+        @Override
+        public void open() throws IOException {
+            delegate.open();
+        }
+
+        @Override
+        public ByteBuffer readRange(long offset, int length) throws IOException {
+            if (failNext) {
+                failNext = false;
+                throw new IOException("simulated transient failure");
+            }
+            return delegate.readRange(offset, length);
+        }
+
+        @Override
+        public long length() throws IOException {
+            return delegate.length();
+        }
+
+        @Override
+        public String name() {
+            return delegate.name();
+        }
+
+        @Override
+        public void close() throws IOException {
+            delegate.close();
         }
     }
 

--- a/core/src/main/java/dev/hardwood/internal/FetchReason.java
+++ b/core/src/main/java/dev/hardwood/internal/FetchReason.java
@@ -1,0 +1,85 @@
+/*
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Copyright The original authors
+ *
+ *  Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package dev.hardwood.internal;
+
+/// Per-thread purpose tag attached to `InputFile.readRange` calls so that
+/// fetch logs can attribute each network request to the caller (footer
+/// body, row-group index region, column data fetch, prefetch, etc.).
+///
+/// Usage:
+///
+/// ```java
+/// try (FetchReason.Scope ignored = FetchReason.set("rg=1 col=name")) {
+///     buf = inputFile.readRange(offset, length);
+/// }
+/// ```
+///
+/// `S3InputFile.readRange` reads [#current()] when emitting its fetch log
+/// line. Nesting is supported: the inner scope shadows the outer one and
+/// restores it on close.
+public final class FetchReason {
+
+    private static final ThreadLocal<String> CURRENT = new ThreadLocal<>();
+
+    private FetchReason() {
+    }
+
+    /// Returns the active reason for the current thread, or `"unattributed"`
+    /// if no scope is on the stack.
+    public static String current() {
+        String value = CURRENT.get();
+        return value != null ? value : "unattributed";
+    }
+
+    /// Sets the reason for the current thread until [Scope#close] is called.
+    /// Pass the returned [Scope] to a try-with-resources statement.
+    public static Scope set(String reason) {
+        String previous = CURRENT.get();
+        CURRENT.set(reason);
+        return new Scope(previous);
+    }
+
+    /// Captures the calling thread's current reason and returns a wrapped
+    /// `Runnable` that re-establishes it on its executing thread. Use at
+    /// any thread-handoff site (e.g. `CompletableFuture.runAsync`) where the
+    /// calling thread's reason should follow the work item to the worker
+    /// thread.
+    ///
+    /// If no reason is currently set, returns the original runnable unchanged
+    /// — the worker thread keeps whatever reason (if any) it already has.
+    public static Runnable bind(Runnable runnable) {
+        String captured = CURRENT.get();
+        if (captured == null) {
+            return runnable;
+        }
+        return () -> {
+            try (Scope ignored = set(captured)) {
+                runnable.run();
+            }
+        };
+    }
+
+    public static final class Scope implements AutoCloseable {
+
+        private final String previous;
+
+        private Scope(String previous) {
+            this.previous = previous;
+        }
+
+        @Override
+        public void close() {
+            if (previous == null) {
+                CURRENT.remove();
+            }
+            else {
+                CURRENT.set(previous);
+            }
+        }
+    }
+}

--- a/core/src/main/java/dev/hardwood/internal/reader/ChunkHandle.java
+++ b/core/src/main/java/dev/hardwood/internal/reader/ChunkHandle.java
@@ -14,6 +14,7 @@ import java.util.concurrent.CompletableFuture;
 
 import dev.hardwood.InputFile;
 import dev.hardwood.internal.ExceptionContext;
+import dev.hardwood.internal.FetchReason;
 
 /// Lazy fetch handle for a contiguous byte range in a Parquet file.
 ///
@@ -31,6 +32,7 @@ public class ChunkHandle {
     private final InputFile inputFile;
     private final long fileOffset;
     private final int length;
+    private final String purpose;
     private volatile ChunkHandle nextChunk;
     private volatile ByteBuffer data;
 
@@ -39,10 +41,20 @@ public class ChunkHandle {
     /// @param inputFile the file to read from
     /// @param fileOffset absolute file offset of the first byte
     /// @param length number of bytes in this chunk
-    public ChunkHandle(InputFile inputFile, long fileOffset, int length) {
+    /// @param purpose human-readable [FetchReason] tag attached to the underlying
+    ///        `readRange` so fetch logs can attribute bytes to a specific
+    ///        row-group / column / page-group
+    public ChunkHandle(InputFile inputFile, long fileOffset, int length, String purpose) {
         this.inputFile = inputFile;
         this.fileOffset = fileOffset;
         this.length = length;
+        this.purpose = purpose;
+    }
+
+    /// Convenience overload for callers that haven't been wired with a purpose
+    /// tag yet. Tagged as `unattributed` in fetch logs.
+    public ChunkHandle(InputFile inputFile, long fileOffset, int length) {
+        this(inputFile, fileOffset, length, "unattributed");
     }
 
     /// Returns the absolute file offset of this chunk.
@@ -81,7 +93,9 @@ public class ChunkHandle {
         // does not trigger further pre-fetches)
         ChunkHandle next = nextChunk;
         if (next != null) {
-            CompletableFuture.runAsync(next::fetchData)
+            // Carry the caller's FetchReason across the thread handoff;
+            // otherwise the next-chunk readRange would log as `unattributed`.
+            CompletableFuture.runAsync(FetchReason.bind(next::fetchData))
                     .exceptionally(t -> {
                         // The demand-path fetch will re-attempt and surface a
                         // fresh exception if the error is sustained, so we log
@@ -108,7 +122,11 @@ public class ChunkHandle {
             if (data != null) {
                 return;
             }
-            try {
+            // If the caller set an outer scope (e.g. "prefetch rg=2"), prepend it
+            // so the log line shows both the calling context and the chunk identity.
+            String outer = FetchReason.current();
+            String composed = "unattributed".equals(outer) ? purpose : outer + " | " + purpose;
+            try (FetchReason.Scope ignored = FetchReason.set(composed)) {
                 data = inputFile.readRange(fileOffset, length);
             }
             catch (IOException e) {

--- a/core/src/main/java/dev/hardwood/internal/reader/ChunkHandle.java
+++ b/core/src/main/java/dev/hardwood/internal/reader/ChunkHandle.java
@@ -33,6 +33,12 @@ public class ChunkHandle {
     private final long fileOffset;
     private final int length;
     private final String purpose;
+    /// Non-null when this handle is a sub-range of a coalesced
+    /// cross-column region (#374). When set, `ensureFetched()` slices
+    /// the region's buffer instead of issuing its own `readRange`, and
+    /// the per-handle `nextChunk` chain is unused (pre-fetch is
+    /// driven at the region level).
+    private final SharedRegion region;
     private volatile ChunkHandle nextChunk;
     private volatile ByteBuffer data;
 
@@ -49,12 +55,26 @@ public class ChunkHandle {
         this.fileOffset = fileOffset;
         this.length = length;
         this.purpose = purpose;
+        this.region = null;
     }
 
     /// Convenience overload for callers that haven't been wired with a purpose
     /// tag yet. Tagged as `unattributed` in fetch logs.
     public ChunkHandle(InputFile inputFile, long fileOffset, int length) {
         this(inputFile, fileOffset, length, "unattributed");
+    }
+
+    /// Creates a chunk handle that's a sub-range of a coalesced cross-column
+    /// [SharedRegion]. Used when [RowGroupIterator] decides several columns'
+    /// chunks fit cheaply into one ranged GET; each column's
+    /// `ensureFetched()` then slices the shared buffer rather than issuing
+    /// its own `readRange`.
+    public ChunkHandle(SharedRegion region, long fileOffset, int length, String purpose) {
+        this.inputFile = null;
+        this.fileOffset = fileOffset;
+        this.length = length;
+        this.purpose = purpose;
+        this.region = region;
     }
 
     /// Returns the absolute file offset of this chunk.
@@ -89,6 +109,13 @@ public class ChunkHandle {
             return buf;
         }
         fetchData();
+        // Region-backed handles delegate pre-fetch to SharedRegion.nextRegion,
+        // not to the per-handle nextChunk chain — the chain may still be set
+        // by the per-column page-group construction, but it would re-fetch
+        // bytes the shared region already covers.
+        if (region != null) {
+            return data;
+        }
         // Pre-fetch next chunk asynchronously (one-ahead only — fetchData
         // does not trigger further pre-fetches)
         ChunkHandle next = nextChunk;
@@ -114,12 +141,20 @@ public class ChunkHandle {
 
     /// Fetches this chunk's data if not already cached. Does NOT trigger
     /// pre-fetch of the next chunk.
+    ///
+    /// When the handle is region-backed (`region != null`), this slices
+    /// the shared region's buffer — the underlying `readRange` happens
+    /// at the region level, once, no matter how many columns share it.
     private void fetchData() {
         if (data != null) {
             return;
         }
         synchronized (this) {
             if (data != null) {
+                return;
+            }
+            if (region != null) {
+                data = region.slice(fileOffset, length);
                 return;
             }
             // If the caller set an outer scope (e.g. "prefetch rg=2"), prepend it

--- a/core/src/main/java/dev/hardwood/internal/reader/ChunkHandle.java
+++ b/core/src/main/java/dev/hardwood/internal/reader/ChunkHandle.java
@@ -58,12 +58,6 @@ public class ChunkHandle {
         this.region = null;
     }
 
-    /// Convenience overload for callers that haven't been wired with a purpose
-    /// tag yet. Tagged as `unattributed` in fetch logs.
-    public ChunkHandle(InputFile inputFile, long fileOffset, int length) {
-        this(inputFile, fileOffset, length, "unattributed");
-    }
-
     /// Creates a chunk handle that's a sub-range of a coalesced cross-column
     /// [SharedRegion]. Used when [RowGroupIterator] decides several columns'
     /// chunks fit cheaply into one ranged GET; each column's

--- a/core/src/main/java/dev/hardwood/internal/reader/IndexedFetchPlan.java
+++ b/core/src/main/java/dev/hardwood/internal/reader/IndexedFetchPlan.java
@@ -15,6 +15,7 @@ import java.util.List;
 import java.util.NoSuchElementException;
 import java.util.concurrent.CompletableFuture;
 
+import dev.hardwood.internal.FetchReason;
 import dev.hardwood.jfr.RowGroupScannedEvent;
 import dev.hardwood.metadata.ColumnChunk;
 import dev.hardwood.metadata.ColumnMetaData;
@@ -64,7 +65,10 @@ final class IndexedFetchPlan implements FetchPlan {
     @Override
     public void prefetch() {
         if (!chunkHandles.isEmpty()) {
-            CompletableFuture.runAsync(chunkHandles.get(0)::ensureFetched);
+            // FetchReason.bind carries the caller's reason (e.g.
+            // "prefetch rg=2") to the worker thread; otherwise the
+            // underlying readRange would log as `unattributed`.
+            CompletableFuture.runAsync(FetchReason.bind(chunkHandles.get(0)::ensureFetched));
         }
     }
 

--- a/core/src/main/java/dev/hardwood/internal/reader/IndexedFetchPlan.java
+++ b/core/src/main/java/dev/hardwood/internal/reader/IndexedFetchPlan.java
@@ -27,11 +27,11 @@ import dev.hardwood.schema.ColumnSchema;
 /// Pages are pre-computed at plan time from the OffsetIndex (with filter and
 /// maxRows already applied). Byte data and dictionary parsing are deferred
 /// until the iterator is first advanced — no I/O happens at plan time.
-final class IndexedFetchPlan implements FetchPlan {
+final class IndexedFetchPlan implements FetchPlan, RowGroupIterator.CoalescableFirstChunk {
 
     private final List<PageLocation> neededPages;
     private final List<RowGroupIterator.PageGroup> pageGroups;
-    private final List<ChunkHandle> chunkHandles;
+    private List<ChunkHandle> chunkHandles;
     private final long firstDataPageOffset; // from OffsetIndex (not necessarily first needed page)
     private final ColumnSchema columnSchema;
     private final ColumnChunk columnChunk;
@@ -75,6 +75,51 @@ final class IndexedFetchPlan implements FetchPlan {
     @Override
     public Iterator<PageInfo> pages() {
         return new PageIterator();
+    }
+
+    @Override
+    public long firstChunkOffset() {
+        return chunkHandles.isEmpty() ? 0 : chunkHandles.get(0).fileOffset();
+    }
+
+    @Override
+    public int firstChunkLength() {
+        return chunkHandles.isEmpty() ? 0 : chunkHandles.get(0).length();
+    }
+
+    /// Coalesce-safe iff the column has a single page group. Multiple
+    /// groups mean a filter dropped pages, leaving intra-column gaps —
+    /// bridging to neighbour columns would pull dropped bytes into the
+    /// shared region and double-fetch the later page groups.
+    @Override
+    public boolean isCoalesceSafe() {
+        return chunkHandles.size() == 1;
+    }
+
+    /// Replaces the *first* chunk handle with a region-backed view.
+    /// Subsequent page-group handles (when filter / maxRows / large
+    /// chunks produced multiple groups) keep their per-column reads —
+    /// cross-column coalescing only spans the first read of each column.
+    @Override
+    public void attachSharedRegion(SharedRegion region, int rowGroupIndex) {
+        if (chunkHandles.isEmpty()) {
+            return;
+        }
+        ChunkHandle original = chunkHandles.get(0);
+        ChunkHandle replacement = new ChunkHandle(region,
+                original.fileOffset(), original.length(),
+                "rg=" + rowGroupIndex + " col='" + columnSchema.name()
+                        + "' pageGroup=1 (region-backed)");
+        if (chunkHandles.size() > 1) {
+            replacement.setNextChunk(chunkHandles.get(1));
+        }
+        // Rebuild the immutable list with the replacement at index 0.
+        List<ChunkHandle> rebuilt = new java.util.ArrayList<>(chunkHandles.size());
+        rebuilt.add(replacement);
+        for (int i = 1; i < chunkHandles.size(); i++) {
+            rebuilt.add(chunkHandles.get(i));
+        }
+        this.chunkHandles = rebuilt;
     }
 
     /// Builds an [IndexedFetchPlan]. No I/O occurs — the plan is pure metadata.

--- a/core/src/main/java/dev/hardwood/internal/reader/ParquetMetadataReader.java
+++ b/core/src/main/java/dev/hardwood/internal/reader/ParquetMetadataReader.java
@@ -15,6 +15,7 @@ import java.util.Arrays;
 
 import dev.hardwood.InputFile;
 import dev.hardwood.internal.ExceptionContext;
+import dev.hardwood.internal.FetchReason;
 import dev.hardwood.internal.thrift.FileMetaDataReader;
 import dev.hardwood.internal.thrift.ThriftCompactReader;
 import dev.hardwood.metadata.FileMetaData;
@@ -46,7 +47,10 @@ public final class ParquetMetadataReader {
         }
 
         // Validate magic number at start
-        ByteBuffer startMagicBuf = inputFile.readRange(0, MAGIC_SIZE);
+        ByteBuffer startMagicBuf;
+        try (FetchReason.Scope ignored = FetchReason.set("footer-magic-start")) {
+            startMagicBuf = inputFile.readRange(0, MAGIC_SIZE);
+        }
         byte[] startMagic = new byte[MAGIC_SIZE];
         startMagicBuf.get(startMagic);
         if (!Arrays.equals(startMagic, MAGIC)) {
@@ -56,7 +60,10 @@ public final class ParquetMetadataReader {
 
         // Read footer size and magic number at end
         long footerInfoPos = fileSize - MAGIC_SIZE - FOOTER_LENGTH_SIZE;
-        ByteBuffer footerInfoBuf = inputFile.readRange(footerInfoPos, FOOTER_LENGTH_SIZE + MAGIC_SIZE);
+        ByteBuffer footerInfoBuf;
+        try (FetchReason.Scope ignored = FetchReason.set("footer-info")) {
+            footerInfoBuf = inputFile.readRange(footerInfoPos, FOOTER_LENGTH_SIZE + MAGIC_SIZE);
+        }
         footerInfoBuf.order(ByteOrder.LITTLE_ENDIAN);
         int footerLength = footerInfoBuf.getInt();
         byte[] endMagic = new byte[MAGIC_SIZE];
@@ -73,7 +80,10 @@ public final class ParquetMetadataReader {
         }
 
         // Parse file metadata
-        ByteBuffer footerBuffer = inputFile.readRange(footerStart, footerLength);
+        ByteBuffer footerBuffer;
+        try (FetchReason.Scope ignored = FetchReason.set("footer-body")) {
+            footerBuffer = inputFile.readRange(footerStart, footerLength);
+        }
         ThriftCompactReader reader = new ThriftCompactReader(footerBuffer);
         return FileMetaDataReader.read(reader);
     }

--- a/core/src/main/java/dev/hardwood/internal/reader/RowGroupIterator.java
+++ b/core/src/main/java/dev/hardwood/internal/reader/RowGroupIterator.java
@@ -20,6 +20,7 @@ import java.util.concurrent.atomic.AtomicIntegerArray;
 
 import dev.hardwood.InputFile;
 import dev.hardwood.internal.ExceptionContext;
+import dev.hardwood.internal.FetchReason;
 import dev.hardwood.internal.predicate.PageDropPredicates;
 import dev.hardwood.internal.predicate.PageFilterEvaluator;
 import dev.hardwood.internal.predicate.ResolvedPredicate;
@@ -236,7 +237,8 @@ public class RowGroupIterator {
     /// @return shared metadata (index buffers and matching row ranges)
     public SharedRowGroupMetadata getSharedMetadata(WorkItem workItem) {
         return metadataCache.computeIfAbsent(workItem.workItemIndex(), idx -> {
-            try {
+            try (FetchReason.Scope ignored = FetchReason.set(
+                    "rg=" + workItem.rowGroupIndex() + " indexes")) {
                 RowGroupIndexBuffers indexBuffers = RowGroupIndexBuffers.fetch(
                         workItem.inputFile(), workItem.rowGroup());
 
@@ -304,14 +306,17 @@ public class RowGroupIterator {
         }
         WorkItem nextWorkItem = workItems.get(nextIndex);
         CompletableFuture.runAsync(() -> {
-            FetchPlan[] nextPlans = fetchPlanCache.computeIfAbsent(
-                    nextWorkItem.workItemIndex(),
-                    idx -> computeFetchPlans(nextWorkItem));
-            // Pre-fetch the first non-empty plan's chunk
-            for (FetchPlan plan : nextPlans) {
-                if (!plan.isEmpty()) {
-                    plan.prefetch();
-                    break;
+            try (FetchReason.Scope ignored = FetchReason.set(
+                    "prefetch rg=" + nextWorkItem.rowGroupIndex())) {
+                FetchPlan[] nextPlans = fetchPlanCache.computeIfAbsent(
+                        nextWorkItem.workItemIndex(),
+                        idx -> computeFetchPlans(nextWorkItem));
+                // Pre-fetch the first non-empty plan's chunk
+                for (FetchPlan plan : nextPlans) {
+                    if (!plan.isEmpty()) {
+                        plan.prefetch();
+                        break;
+                    }
                 }
             }
         });
@@ -377,8 +382,13 @@ public class RowGroupIterator {
 
                 // Create ChunkHandles for each page group, linked for pre-fetch
                 List<ChunkHandle> handles = new ArrayList<>(groups.size());
-                for (PageGroup group : groups) {
-                    handles.add(new ChunkHandle(inputFile, group.offset, group.length));
+                int groupCount = groups.size();
+                for (int g = 0; g < groupCount; g++) {
+                    PageGroup group = groups.get(g);
+                    String purpose = "rg=" + workItem.rowGroupIndex()
+                            + " col=" + originalIndex
+                            + " pageGroup=" + (g + 1) + "/" + groupCount;
+                    handles.add(new ChunkHandle(inputFile, group.offset, group.length, purpose));
                 }
                 for (int i = 0; i < handles.size() - 1; i++) {
                     handles.get(i).setNextChunk(handles.get(i + 1));

--- a/core/src/main/java/dev/hardwood/internal/reader/RowGroupIterator.java
+++ b/core/src/main/java/dev/hardwood/internal/reader/RowGroupIterator.java
@@ -10,6 +10,7 @@ package dev.hardwood.internal.reader;
 import java.io.IOException;
 import java.io.UncheckedIOException;
 import java.util.ArrayList;
+import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -406,7 +407,130 @@ public class RowGroupIterator {
             }
         }
 
+        coalesceAcrossColumns(plans, inputFile, workItem);
+
         return plans;
+    }
+
+    /// Maximum byte gap that cross-column coalescing will bridge between
+    /// adjacent column chunks. Adjacent chunks are typically 0 bytes apart,
+    /// but writers may emit padding / checksum bytes; 64 KB tolerates that
+    /// without paying for sizeable dead bytes between non-adjacent chunks.
+    private static final int MAX_CROSS_COL_GAP_BYTES = 64 * 1024;
+
+    /// Coalesces the *first* read of multiple columns within this row group
+    /// into a smaller number of larger ranged GETs. See #374.
+    ///
+    /// Conservative scope: only coalesces plans that report
+    /// [CoalescableFirstChunk#isCoalesceSafe] as true, i.e. those whose
+    /// first chunk represents the entire byte range the column will read.
+    /// Plans with page drops keep their per-column reads — coalescing
+    /// across an intra-column drop would over-fetch the dropped bytes
+    /// into the shared region *and* later re-fetch the column's
+    /// non-first page groups via the per-column chain (double-fetch).
+    /// IndexedFetchPlans with a single page group qualify;
+    /// SequentialFetchPlans qualify when their chunk size covers the
+    /// entire column chunk (`head(N)` truncation may shrink it below).
+    private void coalesceAcrossColumns(FetchPlan[] plans, InputFile inputFile, WorkItem workItem) {
+        // Collect (offset, length, plan-index) for each plan's first read.
+        record Entry(int planIndex, long offset, int length) {}
+        List<Entry> entries = new ArrayList<>(plans.length);
+        for (int i = 0; i < plans.length; i++) {
+            FetchPlan plan = plans[i];
+            if (plan instanceof CoalescableFirstChunk c && c.isCoalesceSafe()) {
+                entries.add(new Entry(i, c.firstChunkOffset(), c.firstChunkLength()));
+            }
+        }
+        if (entries.size() < 2) {
+            return;
+        }
+        entries.sort(Comparator.comparingLong(Entry::offset));
+
+        // Greedy walk: accumulate entries into a region while the gap and
+        // total span stay within bounds.
+        List<List<Entry>> regionEntries = new ArrayList<>();
+        List<Entry> current = new ArrayList<>();
+        long currentEnd = -1;
+        long currentStart = -1;
+        for (Entry e : entries) {
+            long gap = (currentEnd < 0) ? 0 : e.offset() - currentEnd;
+            long combinedSpan = (currentStart < 0) ? e.length() : e.offset() + e.length() - currentStart;
+            if (current.isEmpty()
+                    || (gap <= MAX_CROSS_COL_GAP_BYTES && combinedSpan <= MAX_COALESCED_BYTES)) {
+                if (current.isEmpty()) {
+                    currentStart = e.offset();
+                }
+                current.add(e);
+                currentEnd = e.offset() + e.length();
+            }
+            else {
+                regionEntries.add(current);
+                current = new ArrayList<>();
+                current.add(e);
+                currentStart = e.offset();
+                currentEnd = e.offset() + e.length();
+            }
+        }
+        if (!current.isEmpty()) {
+            regionEntries.add(current);
+        }
+
+        // Skip the rewrite if every "region" is just one column — coalescing
+        // would buy nothing.
+        boolean anyMerged = regionEntries.stream().anyMatch(g -> g.size() > 1);
+        if (!anyMerged) {
+            return;
+        }
+
+        // Build SharedRegions and rewrite each merged plan's first ChunkHandle
+        // to slice from the region. Single-entry "regions" are left alone.
+        SharedRegion[] regionsByPlan = new SharedRegion[plans.length];
+        SharedRegion previous = null;
+        for (List<Entry> group : regionEntries) {
+            if (group.size() == 1) {
+                continue;
+            }
+            long regionOffset = group.get(0).offset();
+            long regionEnd = group.get(group.size() - 1).offset()
+                    + group.get(group.size() - 1).length();
+            int regionLength = Math.toIntExact(regionEnd - regionOffset);
+            String purpose = "rg=" + workItem.rowGroupIndex()
+                    + " region=" + group.get(0).planIndex() + ".." + group.get(group.size() - 1).planIndex();
+            SharedRegion region = new SharedRegion(inputFile, regionOffset, regionLength, purpose);
+            if (previous != null) {
+                previous.setNextRegion(region);
+            }
+            previous = region;
+            for (Entry e : group) {
+                regionsByPlan[e.planIndex()] = region;
+            }
+        }
+
+        for (int i = 0; i < plans.length; i++) {
+            SharedRegion region = regionsByPlan[i];
+            if (region == null) {
+                continue;
+            }
+            ((CoalescableFirstChunk) plans[i]).attachSharedRegion(region, workItem.rowGroupIndex());
+        }
+    }
+
+    /// Plans that expose their first read's byte range and accept a
+    /// region-backed [ChunkHandle] for it.
+    interface CoalescableFirstChunk {
+        long firstChunkOffset();
+        int firstChunkLength();
+
+        /// Returns true when the plan's first chunk is the only chunk
+        /// (i.e. no later page groups will be fetched per-column).
+        /// When false, cross-column coalescing skips this plan: bridging
+        /// to a neighbour column would over-fetch the bytes between this
+        /// plan's first chunk and its later chunks (e.g. dropped pages)
+        /// into the shared region, *and* the per-column chain would later
+        /// re-fetch those same later chunks.
+        boolean isCoalesceSafe();
+
+        void attachSharedRegion(SharedRegion region, int rowGroupIndex);
     }
 
     /// A contiguous byte range covering one or more pages within a column.

--- a/core/src/main/java/dev/hardwood/internal/reader/SequentialFetchPlan.java
+++ b/core/src/main/java/dev/hardwood/internal/reader/SequentialFetchPlan.java
@@ -319,7 +319,8 @@ public final class SequentialFetchPlan implements FetchPlan {
             else {
                 int remaining = columnChunkLength - relPos;
                 int handleLength = Math.min(remaining, chunkSize);
-                currentHandle = new ChunkHandle(inputFile, columnChunkOffset + relPos, handleLength);
+                currentHandle = new ChunkHandle(inputFile, columnChunkOffset + relPos, handleLength,
+                        chunkPurpose(relPos));
                 handleStart = relPos;
             }
             handleEnd = handleStart + currentHandle.length();
@@ -330,8 +331,14 @@ public final class SequentialFetchPlan implements FetchPlan {
                 int nextRemaining = columnChunkLength - nextStart;
                 int nextLength = Math.min(nextRemaining, chunkSize);
                 currentHandle.setNextChunk(
-                        new ChunkHandle(inputFile, columnChunkOffset + nextStart, nextLength));
+                        new ChunkHandle(inputFile, columnChunkOffset + nextStart, nextLength,
+                                chunkPurpose(nextStart)));
             }
+        }
+
+        private String chunkPurpose(int relPos) {
+            return "rg=" + rowGroupIndex + " col='" + columnSchema.name()
+                    + "' seqChunk@" + relPos;
         }
 
         /// Scans past the dictionary page (if present) on first access.

--- a/core/src/main/java/dev/hardwood/internal/reader/SequentialFetchPlan.java
+++ b/core/src/main/java/dev/hardwood/internal/reader/SequentialFetchPlan.java
@@ -50,7 +50,7 @@ import dev.hardwood.schema.ColumnSchema;
 ///   bytes-per-value (`totalCompressedSize / numValues`) multiplied by
 ///   `maxRows` and a safety factor, floored at one page size and
 ///   capped at the default ceiling.
-public final class SequentialFetchPlan implements FetchPlan {
+public final class SequentialFetchPlan implements FetchPlan, RowGroupIterator.CoalescableFirstChunk {
 
     /// Minimum chunk size when `maxRows` is active (1 MB).
     /// Sized to roughly one Parquet data page so header scanning does not
@@ -88,6 +88,12 @@ public final class SequentialFetchPlan implements FetchPlan {
     private final int rowGroupIndex;
     private final String fileName;
     private final List<ResolvedPredicate> dropLeaves;
+    /// Optional pre-created first [ChunkHandle], typically a region-backed
+    /// view from cross-column coalescing (#374). When set, the iterator's
+    /// first `advanceChunk(0)` call uses this handle instead of creating
+    /// a fresh standalone one. Subsequent advances (with `chunkSize` <
+    /// columnChunkLength) still create per-column handles lazily.
+    private ChunkHandle firstChunkHandle;
 
     private SequentialFetchPlan(InputFile inputFile, long columnChunkOffset, int columnChunkLength,
                                  int chunkSize, ColumnSchema columnSchema,
@@ -115,6 +121,42 @@ public final class SequentialFetchPlan implements FetchPlan {
     @Override
     public Iterator<PageInfo> pages() {
         return new SequentialPageIterator();
+    }
+
+    /// Returns the byte offset of this plan's first ChunkHandle (the
+    /// chunk it would create on the first `advanceChunk(0)`). Used by
+    /// cross-column coalescing in [RowGroupIterator] to decide which
+    /// plans' first reads to merge into a shared region.
+    @Override
+    public long firstChunkOffset() {
+        return columnChunkOffset;
+    }
+
+    /// Returns the byte length of this plan's first ChunkHandle.
+    @Override
+    public int firstChunkLength() {
+        return chunkSize;
+    }
+
+    /// Coalesce-safe iff the first chunk covers the whole column chunk.
+    /// Smaller chunk sizes are produced by `head(N)` truncation; in that
+    /// case bridging to a neighbour column would pull in bytes the
+    /// per-column iterator would otherwise have read separately,
+    /// producing a double-fetch.
+    @Override
+    public boolean isCoalesceSafe() {
+        return chunkSize == columnChunkLength;
+    }
+
+    /// Replaces the iterator's first ChunkHandle with a region-backed
+    /// view, so the first read slices the shared buffer rather than
+    /// issuing a per-column `readRange`.
+    @Override
+    public void attachSharedRegion(SharedRegion region, int rowGroupIndex) {
+        String purpose = "rg=" + rowGroupIndex + " col='" + columnSchema.name()
+                + "' seqChunk@0 (region-backed)";
+        this.firstChunkHandle = new ChunkHandle(region,
+                columnChunkOffset, chunkSize, purpose);
     }
 
     /// Builds a [SequentialFetchPlan] with no predicate-driven page skipping.
@@ -311,7 +353,13 @@ public final class SequentialFetchPlan implements FetchPlan {
         private void advanceChunk(int relPos) {
             ChunkHandle prefetched = currentHandle != null ? currentHandle.nextChunk() : null;
 
-            if (prefetched != null && relPos >= handleEnd
+            if (currentHandle == null && relPos == 0 && firstChunkHandle != null) {
+                // First advance, externally-supplied handle (region-backed via
+                // cross-column coalescing in RowGroupIterator).
+                currentHandle = firstChunkHandle;
+                handleStart = 0;
+            }
+            else if (prefetched != null && relPos >= handleEnd
                     && relPos < handleEnd + prefetched.length()) {
                 currentHandle = prefetched;
                 handleStart = handleEnd;

--- a/core/src/main/java/dev/hardwood/internal/reader/SequentialFetchPlan.java
+++ b/core/src/main/java/dev/hardwood/internal/reader/SequentialFetchPlan.java
@@ -61,6 +61,15 @@ public final class SequentialFetchPlan implements FetchPlan, RowGroupIterator.Co
     /// to absorb per-value size skew within the column chunk.
     private static final int MAX_ROWS_CHUNK_SAFETY_FACTOR = 2;
 
+    /// Upper bound on `columnChunkLength` for fetching the entire column
+    /// in one go even under `maxRows` truncation (4 MB). Below this
+    /// threshold the over-fetch is small (≤ 4× the `head(N)` floor) and
+    /// the column becomes coalesce-safe — all of its bytes can join a
+    /// cross-column [SharedRegion]. Above it, the per-column truncation
+    /// stays in effect: a 50 MB column under `head(30)` should not pull
+    /// down 50 MB. See #382.
+    private static final int FETCH_WHOLE_COLUMN_THRESHOLD = 4 * MAX_ROWS_CHUNK_FLOOR;
+
     /// Chunk size when reading without a row limit (128 MB). Also used as
     /// the ceiling for the `maxRows` dynamic estimate.
     /// Overridable via the `hardwood.internal.sequentialChunkSize` system property (bytes).
@@ -184,7 +193,7 @@ public final class SequentialFetchPlan implements FetchPlan, RowGroupIterator.Co
         long columnChunkOffset = columnChunk.chunkStartOffset();
         int columnChunkLength = Math.toIntExact(columnChunk.metaData().totalCompressedSize());
         int chunkSize = Math.min(columnChunkLength,
-                computeChunkSize(columnChunk.metaData(), maxRows));
+                computeChunkSize(columnChunkLength, columnChunk.metaData(), maxRows));
 
         return new SequentialFetchPlan(inputFile, columnChunkOffset, columnChunkLength, chunkSize,
                 columnSchema, columnChunk, context, maxRows, rowGroupIndex, fileName,
@@ -203,9 +212,15 @@ public final class SequentialFetchPlan implements FetchPlan, RowGroupIterator.Co
     ///
     /// The estimate is floored at [MAX_ROWS_CHUNK_FLOOR] to avoid sub-page
     /// round-trips during header scanning and capped at [DEFAULT_CHUNK_SIZE].
-    private static int computeChunkSize(ColumnMetaData metaData, long maxRows) {
+    /// Columns whose entire chunk is below [FETCH_WHOLE_COLUMN_THRESHOLD]
+    /// short-circuit to the full chunk length so they remain coalesce-safe
+    /// (#382).
+    static int computeChunkSize(int columnChunkLength, ColumnMetaData metaData, long maxRows) {
         if (maxRows <= 0) {
             return DEFAULT_CHUNK_SIZE;
+        }
+        if (columnChunkLength <= FETCH_WHOLE_COLUMN_THRESHOLD) {
+            return columnChunkLength;
         }
         long numValues = metaData.numValues();
         if (numValues <= 0) {

--- a/core/src/main/java/dev/hardwood/internal/reader/SharedRegion.java
+++ b/core/src/main/java/dev/hardwood/internal/reader/SharedRegion.java
@@ -1,0 +1,119 @@
+/*
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Copyright The original authors
+ *
+ *  Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package dev.hardwood.internal.reader;
+
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.nio.ByteBuffer;
+import java.util.concurrent.CompletableFuture;
+
+import dev.hardwood.InputFile;
+import dev.hardwood.internal.ExceptionContext;
+import dev.hardwood.internal.FetchReason;
+
+/// A contiguous, multi-column byte range fetched in a single
+/// `readRange` call. Exists to coalesce the per-column reads of a row
+/// group's column chunks — the chunks are typically stored back-to-back
+/// on disk, so issuing one ranged GET that spans many columns is cheaper
+/// than N separate ranged GETs (one per column). See #374.
+///
+/// One [ChunkHandle] per column attaches to a `SharedRegion` and slices
+/// out its sub-range on demand. The first slice triggers the underlying
+/// `readRange`; subsequent slices share the cached buffer.
+///
+/// Lifecycle: the region is alive as long as any attached handle still
+/// references it. Eviction of the row group's `FetchPlan[]` drops all
+/// attached handles, the region's strong references go to GC, and the
+/// underlying `ByteBuffer` is reclaimed.
+public final class SharedRegion {
+
+    private static final System.Logger LOG = System.getLogger(SharedRegion.class.getName());
+
+    private final InputFile inputFile;
+    private final long fileOffset;
+    private final int length;
+    private final String purpose;
+    private volatile SharedRegion nextRegion;
+    private volatile ByteBuffer data;
+
+    public SharedRegion(InputFile inputFile, long fileOffset, int length, String purpose) {
+        this.inputFile = inputFile;
+        this.fileOffset = fileOffset;
+        this.length = length;
+        this.purpose = purpose;
+    }
+
+    public long fileOffset() {
+        return fileOffset;
+    }
+
+    public int length() {
+        return length;
+    }
+
+    /// Chains a one-ahead region for asynchronous pre-fetch. When this
+    /// region's data is first fetched, the next region's fetch is
+    /// kicked off on a worker thread.
+    public void setNextRegion(SharedRegion next) {
+        this.nextRegion = next;
+    }
+
+    /// Returns a zero-copy slice covering `[absoluteOffset,
+    /// absoluteOffset + sliceLength)`. The slice must lie entirely
+    /// within this region's range; the caller is responsible for
+    /// upholding that invariant.
+    public ByteBuffer slice(long absoluteOffset, int sliceLength) {
+        ByteBuffer buf = ensureFetched();
+        int rel = Math.toIntExact(absoluteOffset - fileOffset);
+        return buf.slice(rel, sliceLength);
+    }
+
+    /// Ensures the region's data is fetched. First call triggers
+    /// `readRange`; subsequent calls return the cached buffer.
+    /// After fetching, kicks off async pre-fetch of the next region.
+    public ByteBuffer ensureFetched() {
+        ByteBuffer buf = data;
+        if (buf != null) {
+            return buf;
+        }
+        fetchData();
+        SharedRegion next = nextRegion;
+        if (next != null && next.data == null) {
+            CompletableFuture.runAsync(FetchReason.bind(next::fetchData))
+                    .exceptionally(t -> {
+                        LOG.log(System.Logger.Level.DEBUG,
+                                "Prefetch failed for region at offset {0} (length {1}) in {2}",
+                                next.fileOffset, next.length, next.inputFile.name(), t);
+                        return null;
+                    });
+        }
+        return data;
+    }
+
+    private void fetchData() {
+        if (data != null) {
+            return;
+        }
+        synchronized (this) {
+            if (data != null) {
+                return;
+            }
+            String outer = FetchReason.current();
+            String composed = "unattributed".equals(outer) ? purpose : outer + " | " + purpose;
+            try (FetchReason.Scope ignored = FetchReason.set(composed)) {
+                data = inputFile.readRange(fileOffset, length);
+            }
+            catch (IOException e) {
+                throw new UncheckedIOException(
+                        ExceptionContext.filePrefix(inputFile.name())
+                        + "Failed to fetch region at offset " + fileOffset
+                        + " (length " + length + ")", e);
+            }
+        }
+    }
+}

--- a/core/src/main/java/dev/hardwood/internal/reader/SharedRegion.java
+++ b/core/src/main/java/dev/hardwood/internal/reader/SharedRegion.java
@@ -64,10 +64,20 @@ public final class SharedRegion {
     }
 
     /// Returns a zero-copy slice covering `[absoluteOffset,
-    /// absoluteOffset + sliceLength)`. The slice must lie entirely
-    /// within this region's range; the caller is responsible for
-    /// upholding that invariant.
+    /// absoluteOffset + sliceLength)`. Throws [IllegalArgumentException]
+    /// when the slice falls outside this region — coalescer bugs would
+    /// otherwise surface as a generic [IndexOutOfBoundsException] from
+    /// the underlying buffer with no context about which region or
+    /// handle was misaligned.
     public ByteBuffer slice(long absoluteOffset, int sliceLength) {
+        if (absoluteOffset < fileOffset
+                || sliceLength < 0
+                || absoluteOffset + sliceLength > (long) fileOffset + length) {
+            throw new IllegalArgumentException(
+                    "slice [" + absoluteOffset + ", " + (absoluteOffset + sliceLength)
+                    + ") falls outside region [" + fileOffset + ", " + (fileOffset + length)
+                    + ") (" + purpose + ")");
+        }
         ByteBuffer buf = ensureFetched();
         int rel = Math.toIntExact(absoluteOffset - fileOffset);
         return buf.slice(rel, sliceLength);

--- a/core/src/main/java/dev/hardwood/reader/ParquetFileReader.java
+++ b/core/src/main/java/dev/hardwood/reader/ParquetFileReader.java
@@ -243,8 +243,14 @@ public class ParquetFileReader implements AutoCloseable {
         // RowGroup.numRows(). For multi-file readers this indexes into the
         // first file only — cross-file firstRow is out of scope.
         List<RowGroup> all = firstFileMetaData.rowGroups();
+        long totalRows = firstFileMetaData.numRows();
+        if (firstRow > totalRows) {
+            throw new IllegalArgumentException(
+                    "firstRow " + firstRow + " exceeds the file's total row count "
+                    + totalRows);
+        }
         long cumulative = 0L;
-        int targetRg = all.size(); // sentinel: past-the-end yields empty reader
+        int targetRg = all.size(); // sentinel: at-the-end yields empty reader
         long withinRg = 0L;
         for (int i = 0; i < all.size(); i++) {
             long rgRows = all.get(i).numRows();
@@ -256,7 +262,7 @@ public class ParquetFileReader implements AutoCloseable {
             cumulative += rgRows;
         }
         if (targetRg >= all.size()) {
-            // firstRow at or past end of file — return an empty reader.
+            // firstRow == totalRows — empty reader.
             return buildRowReader(projection, filter, maxRows, List.<RowGroup>of());
         }
         List<RowGroup> rowGroups = targetRg == 0
@@ -267,6 +273,9 @@ public class ParquetFileReader implements AutoCloseable {
         // rows; the residue rows we discard via next() count too.
         long maxRowsAdjusted = maxRows == 0 ? 0 : maxRows + withinRg;
         RowReader reader = buildRowReader(projection, filter, maxRowsAdjusted, rowGroups);
+        // Walk past the within-RG residue. These rows *are* decoded —
+        // page-level skip via OffsetIndex (#381) would let us drop the
+        // leading pages at the byte level instead.
         for (long i = 0; i < withinRg; i++) {
             if (!reader.hasNext()) {
                 break;
@@ -457,18 +466,21 @@ public class ParquetFileReader implements AutoCloseable {
         /// Begin reading from the given absolute row index. Earlier row groups
         /// are not opened — their pages are not fetched or decoded — so this
         /// is an O(1 RG) seek on remote backends, in contrast to walking
-        /// next() from row 0.
+        /// `next()` from row 0.
         ///
-        /// On files with an OffsetIndex, the underlying [IndexedFetchPlan]
-        /// further narrows the per-column fetch to pages from the page
-        /// containing `firstRow` onwards. Files without an OffsetIndex fall
-        /// back to walking the row group from its start (skipped rows are
-        /// decoded internally and not yielded to the caller).
+        /// **Cost within the target row group.** The reader still yields
+        /// rows from the row group's first row, then walks `next()`
+        /// `firstRow - rowGroupFirstRow` times to discard the leading
+        /// residue. Those residue rows *are* decoded — `firstRow` near
+        /// the end of a 1 M-row group walks ~1 M decoded `next()` calls.
+        /// Page-level skip via OffsetIndex is tracked as #381.
         ///
         /// `firstRow == 0` is the no-op default. `firstRow == totalRows`
-        /// produces an empty reader. Indexes into the *first* file's rows for
-        /// multi-file readers; cross-file `firstRow` is out of scope. Mutually
-        /// exclusive with [#tail]; composes with [#head] for a bounded
+        /// produces an empty reader. `firstRow > totalRows` throws
+        /// [IllegalArgumentException] at `build()` time. Indexes into the
+        /// *first* file's rows for multi-file readers; cross-file
+        /// `firstRow` is out of scope. Mutually exclusive with [#tail];
+        /// composes with [#head] for a bounded
         /// `[firstRow, firstRow + maxRows)` window.
         public RowReaderBuilder firstRow(long firstRow) {
             if (firstRow < 0) {

--- a/core/src/main/java/dev/hardwood/reader/ParquetFileReader.java
+++ b/core/src/main/java/dev/hardwood/reader/ParquetFileReader.java
@@ -231,7 +231,49 @@ public class ParquetFileReader implements AutoCloseable {
     // ============================================================
 
     RowReader buildRowReader(ColumnProjection projection, FilterPredicate filter, long maxRows) {
-        return buildRowReader(projection, filter, maxRows, firstFileMetaData.rowGroups());
+        return buildRowReader(projection, filter, maxRows, 0L);
+    }
+
+    RowReader buildRowReader(ColumnProjection projection, FilterPredicate filter, long maxRows,
+                             long firstRow) {
+        if (firstRow == 0L) {
+            return buildRowReader(projection, filter, maxRows, firstFileMetaData.rowGroups());
+        }
+        // Locate the row group containing `firstRow` by walking cumulative
+        // RowGroup.numRows(). For multi-file readers this indexes into the
+        // first file only — cross-file firstRow is out of scope.
+        List<RowGroup> all = firstFileMetaData.rowGroups();
+        long cumulative = 0L;
+        int targetRg = all.size(); // sentinel: past-the-end yields empty reader
+        long withinRg = 0L;
+        for (int i = 0; i < all.size(); i++) {
+            long rgRows = all.get(i).numRows();
+            if (firstRow < cumulative + rgRows) {
+                targetRg = i;
+                withinRg = firstRow - cumulative;
+                break;
+            }
+            cumulative += rgRows;
+        }
+        if (targetRg >= all.size()) {
+            // firstRow at or past end of file — return an empty reader.
+            return buildRowReader(projection, filter, maxRows, List.<RowGroup>of());
+        }
+        List<RowGroup> rowGroups = targetRg == 0
+                ? all
+                : all.subList(targetRg, all.size());
+        // The reader yields from the start of `targetRg`. We bump maxRows
+        // by the within-RG skip distance because head(N) bounds *yielded*
+        // rows; the residue rows we discard via next() count too.
+        long maxRowsAdjusted = maxRows == 0 ? 0 : maxRows + withinRg;
+        RowReader reader = buildRowReader(projection, filter, maxRowsAdjusted, rowGroups);
+        for (long i = 0; i < withinRg; i++) {
+            if (!reader.hasNext()) {
+                break;
+            }
+            reader.next();
+        }
+        return reader;
     }
 
     RowReader buildTailRowReader(ColumnProjection projection, long tailRows) {
@@ -367,6 +409,10 @@ public class ParquetFileReader implements AutoCloseable {
         /// Positive: return at most `tailRows` rows from the end.
         /// Zero (default): no limit. Mutually exclusive with `headRows`.
         private long tailRows;
+        /// Zero (default): start from row 0. Positive: skip rows before the
+        /// given absolute row index, opening only the row group(s) needed
+        /// to reach it. Mutually exclusive with `tailRows`.
+        private long firstRow;
 
         private RowReaderBuilder(ParquetFileReader fileReader) {
             this.fileReader = fileReader;
@@ -399,12 +445,36 @@ public class ParquetFileReader implements AutoCloseable {
         /// Limit to the last `tailRows` rows. Row groups that do not overlap
         /// the tail are skipped entirely, so pages for earlier row groups are
         /// never fetched or decoded — useful on remote backends. Mutually
-        /// exclusive with [#head] and [#filter]. Single-file only.
+        /// exclusive with [#head], [#filter], and [#firstRow]. Single-file only.
         public RowReaderBuilder tail(long tailRows) {
             if (tailRows <= 0) {
                 throw new IllegalArgumentException("tail row count must be positive: " + tailRows);
             }
             this.tailRows = tailRows;
+            return this;
+        }
+
+        /// Begin reading from the given absolute row index. Earlier row groups
+        /// are not opened — their pages are not fetched or decoded — so this
+        /// is an O(1 RG) seek on remote backends, in contrast to walking
+        /// next() from row 0.
+        ///
+        /// On files with an OffsetIndex, the underlying [IndexedFetchPlan]
+        /// further narrows the per-column fetch to pages from the page
+        /// containing `firstRow` onwards. Files without an OffsetIndex fall
+        /// back to walking the row group from its start (skipped rows are
+        /// decoded internally and not yielded to the caller).
+        ///
+        /// `firstRow == 0` is the no-op default. `firstRow == totalRows`
+        /// produces an empty reader. Indexes into the *first* file's rows for
+        /// multi-file readers; cross-file `firstRow` is out of scope. Mutually
+        /// exclusive with [#tail]; composes with [#head] for a bounded
+        /// `[firstRow, firstRow + maxRows)` window.
+        public RowReaderBuilder firstRow(long firstRow) {
+            if (firstRow < 0) {
+                throw new IllegalArgumentException("firstRow must be non-negative: " + firstRow);
+            }
+            this.firstRow = firstRow;
             return this;
         }
 
@@ -416,10 +486,13 @@ public class ParquetFileReader implements AutoCloseable {
                 throw new IllegalArgumentException("tail cannot be combined with a filter: "
                         + "the set of matching rows is not known from row-group statistics alone");
             }
+            if (tailRows > 0 && firstRow > 0) {
+                throw new IllegalArgumentException("tail and firstRow are mutually exclusive");
+            }
             if (tailRows > 0) {
                 return fileReader.buildTailRowReader(projection, tailRows);
             }
-            return fileReader.buildRowReader(projection, filter, headRows);
+            return fileReader.buildRowReader(projection, filter, headRows, firstRow);
         }
     }
 

--- a/core/src/test/java/dev/hardwood/ParquetReaderTest.java
+++ b/core/src/test/java/dev/hardwood/ParquetReaderTest.java
@@ -392,4 +392,109 @@ class ParquetReaderTest {
         }
     }
 
+    @Test
+    void firstRowSkipsEarlierRowGroups() throws Exception {
+        // filter_pushdown_int.parquet: 3 row groups of 100 rows each — id 1..100, 101..200, 201..300.
+        Path parquetFile = Paths.get("src/test/resources/filter_pushdown_int.parquet");
+
+        try (ParquetFileReader reader = ParquetFileReader.open(InputFile.of(parquetFile));
+             RowReader rows = reader.buildRowReader().firstRow(150).build()) {
+            long firstId = -1;
+            long lastId = -1;
+            int count = 0;
+            while (rows.hasNext()) {
+                rows.next();
+                long id = rows.getLong("id");
+                if (firstId < 0) {
+                    firstId = id;
+                }
+                lastId = id;
+                count++;
+            }
+            // firstRow=150 lands inside RG 1 (rows 100..199, ids 101..200)
+            // at within-RG offset 50 → first id yielded is 151.
+            assertThat(count).as("rows from firstRow=150").isEqualTo(150);
+            assertThat(firstId).as("first id at firstRow=150").isEqualTo(151L);
+            assertThat(lastId).as("last id at file end").isEqualTo(300L);
+        }
+    }
+
+    @Test
+    void firstRowAtRowGroupBoundary() throws Exception {
+        // firstRow=100 lands at the exact start of RG 1.
+        Path parquetFile = Paths.get("src/test/resources/filter_pushdown_int.parquet");
+
+        try (ParquetFileReader reader = ParquetFileReader.open(InputFile.of(parquetFile));
+             RowReader rows = reader.buildRowReader().firstRow(100).build()) {
+            int count = 0;
+            long firstId = -1;
+            while (rows.hasNext()) {
+                rows.next();
+                if (firstId < 0) {
+                    firstId = rows.getLong("id");
+                }
+                count++;
+            }
+            assertThat(count).isEqualTo(200);
+            assertThat(firstId).isEqualTo(101L);
+        }
+    }
+
+    @Test
+    void firstRowComposesWithHead() throws Exception {
+        // firstRow=150 + head(20) → rows 150..169 → ids 151..170.
+        Path parquetFile = Paths.get("src/test/resources/filter_pushdown_int.parquet");
+
+        try (ParquetFileReader reader = ParquetFileReader.open(InputFile.of(parquetFile));
+             RowReader rows = reader.buildRowReader().firstRow(150).head(20).build()) {
+            long firstId = -1;
+            long lastId = -1;
+            int count = 0;
+            while (rows.hasNext()) {
+                rows.next();
+                long id = rows.getLong("id");
+                if (firstId < 0) {
+                    firstId = id;
+                }
+                lastId = id;
+                count++;
+            }
+            assertThat(count).isEqualTo(20);
+            assertThat(firstId).isEqualTo(151L);
+            assertThat(lastId).isEqualTo(170L);
+        }
+    }
+
+    @Test
+    void firstRowAtTotalRowsYieldsEmpty() throws Exception {
+        Path parquetFile = Paths.get("src/test/resources/filter_pushdown_int.parquet");
+
+        try (ParquetFileReader reader = ParquetFileReader.open(InputFile.of(parquetFile))) {
+            long total = reader.getFileMetaData().numRows();
+            try (RowReader rows = reader.buildRowReader().firstRow(total).build()) {
+                assertThat(rows.hasNext()).isFalse();
+            }
+        }
+    }
+
+    @Test
+    void firstRowRejectsNegative() throws Exception {
+        Path parquetFile = Paths.get("src/test/resources/filter_pushdown_int.parquet");
+
+        try (ParquetFileReader reader = ParquetFileReader.open(InputFile.of(parquetFile))) {
+            assertThatThrownBy(() -> reader.buildRowReader().firstRow(-1).build())
+                    .isInstanceOf(IllegalArgumentException.class);
+        }
+    }
+
+    @Test
+    void firstRowAndTailAreMutuallyExclusive() throws Exception {
+        Path parquetFile = Paths.get("src/test/resources/filter_pushdown_int.parquet");
+
+        try (ParquetFileReader reader = ParquetFileReader.open(InputFile.of(parquetFile))) {
+            assertThatThrownBy(() -> reader.buildRowReader().firstRow(100).tail(10L).build())
+                    .isInstanceOf(IllegalArgumentException.class);
+        }
+    }
+
 }

--- a/core/src/test/java/dev/hardwood/internal/reader/CrossColumnCoalesceTest.java
+++ b/core/src/test/java/dev/hardwood/internal/reader/CrossColumnCoalesceTest.java
@@ -1,0 +1,168 @@
+/*
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Copyright The original authors
+ *
+ *  Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package dev.hardwood.internal.reader;
+
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.nio.file.Path;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicLong;
+
+import org.junit.jupiter.api.Test;
+
+import dev.hardwood.InputFile;
+import dev.hardwood.reader.FilterPredicate;
+import dev.hardwood.reader.ParquetFileReader;
+import dev.hardwood.reader.RowReader;
+import dev.hardwood.schema.ColumnProjection;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/// Verifies cross-column ranged-GET coalescing within a row group (#374).
+///
+/// Adjacent column chunks within a row group are typically stored
+/// back-to-back on disk, so a single ranged GET can cover many columns
+/// at once. The pipeline coalesces such reads into [SharedRegion]s in
+/// `RowGroupIterator.coalesceAcrossColumns`. These tests assert the
+/// observable effect: the underlying `readRange` count drops compared to
+/// what a per-column-per-chunk fetch path would produce.
+class CrossColumnCoalesceTest {
+
+    /// 20-column flat schema, single row group, no OffsetIndex →
+    /// SequentialFetchPlan path. 20 leaf columns are stored back-to-back
+    /// (zero gaps), all within ~2 KB.
+    private static final Path SEQ_FILE = Path.of("src/test/resources/yellow_tripdata_sample.parquet");
+
+    /// 3-column flat schema, single row group, OffsetIndex present →
+    /// IndexedFetchPlan path. Columns are stored back-to-back.
+    private static final Path INDEXED_FILE = Path.of("src/test/resources/page_index_test.parquet");
+
+    @Test
+    void sequentialPlanCoalescesFirstChunkOfEveryColumn() throws Exception {
+        CountingInputFile countingFile = new CountingInputFile(InputFile.of(SEQ_FILE));
+        countingFile.open();
+        try (ParquetFileReader reader = ParquetFileReader.open(countingFile)) {
+            int readsBefore = countingFile.readCount();
+            try (RowReader rows = reader.rowReader()) {
+                while (rows.hasNext()) {
+                    rows.next();
+                }
+            }
+            int readsForData = countingFile.readCount() - readsBefore;
+            // The fixture has 20 leaf columns; a per-column fetch would
+            // issue 20 readRange calls. With cross-column coalescing,
+            // they collapse into one (all columns fit in <2 KB,
+            // back-to-back).
+            assertThat(readsForData)
+                    .as("Data fetches should coalesce to a single ranged GET (was %d)", readsForData)
+                    .isEqualTo(1);
+        }
+    }
+
+    @Test
+    void indexedPlanCoalescesFirstChunkOfEveryColumn() throws Exception {
+        CountingInputFile countingFile = new CountingInputFile(InputFile.of(INDEXED_FILE));
+        countingFile.open();
+        try (ParquetFileReader reader = ParquetFileReader.open(countingFile)) {
+            int readsBefore = countingFile.readCount();
+            try (RowReader rows = reader.rowReader()) {
+                while (rows.hasNext()) {
+                    rows.next();
+                }
+            }
+            int readsForData = countingFile.readCount() - readsBefore;
+            // 3 columns, all back-to-back, no filter → all 3 first
+            // chunks coalesce into one region. The pipeline also fetches
+            // the per-RG index region (OffsetIndex / ColumnIndex), so
+            // expect at most 2 reads (1 region + 1 index buffer).
+            assertThat(readsForData)
+                    .as("Data fetches should coalesce to ≤ 2 ranged GETs (was %d)", readsForData)
+                    .isLessThanOrEqualTo(2);
+        }
+    }
+
+    @Test
+    void filteredColumnIsNotOverCoalesced() throws Exception {
+        // With a selective filter, the IndexedFetchPlan for `id` has
+        // page drops → multiple page groups → isCoalesceSafe() == false.
+        // That keeps `id` out of the shared region; the filtered read
+        // must transfer strictly fewer bytes than the unfiltered one.
+        // (If page-dropped columns were swept into the shared region,
+        // the dropped bytes would be re-fetched and bytes-read would
+        // meet or exceed the unfiltered total.)
+        FilterPredicate selective = FilterPredicate.lt("id", 1000L);
+
+        long filteredBytes = readBytesWith(INDEXED_FILE, selective);
+        long unfilteredBytes = readBytesWith(INDEXED_FILE, null);
+
+        assertThat(filteredBytes)
+                .as("Filtered read must not over-fetch dropped pages via the shared region")
+                .isLessThan(unfilteredBytes);
+    }
+
+    private static long readBytesWith(Path file, FilterPredicate filter) throws Exception {
+        ByteCountingInputFile counter = new ByteCountingInputFile(InputFile.of(file));
+        counter.open();
+        try (ParquetFileReader reader = ParquetFileReader.open(counter);
+                RowReader rows = (filter == null
+                        ? reader.buildRowReader()
+                                .projection(ColumnProjection.columns("id", "value", "category"))
+                                .build()
+                        : reader.buildRowReader()
+                                .projection(ColumnProjection.columns("id", "value", "category"))
+                                .filter(filter).build())) {
+            while (rows.hasNext()) {
+                rows.next();
+            }
+        }
+        return counter.bytesRead();
+    }
+
+    /// Tracks both call count and total bytes read per `readRange`.
+    private static class ByteCountingInputFile implements InputFile {
+
+        private final InputFile delegate;
+        private final AtomicInteger calls = new AtomicInteger();
+        private final AtomicLong bytes = new AtomicLong();
+
+        ByteCountingInputFile(InputFile delegate) {
+            this.delegate = delegate;
+        }
+
+        long bytesRead() {
+            return bytes.get();
+        }
+
+        @Override
+        public void open() throws IOException {
+            delegate.open();
+        }
+
+        @Override
+        public ByteBuffer readRange(long offset, int length) throws IOException {
+            calls.incrementAndGet();
+            bytes.addAndGet(length);
+            return delegate.readRange(offset, length);
+        }
+
+        @Override
+        public long length() throws IOException {
+            return delegate.length();
+        }
+
+        @Override
+        public String name() {
+            return delegate.name();
+        }
+
+        @Override
+        public void close() throws IOException {
+            delegate.close();
+        }
+    }
+}

--- a/core/src/test/java/dev/hardwood/internal/reader/SequentialFetchPlanChunkSizeTest.java
+++ b/core/src/test/java/dev/hardwood/internal/reader/SequentialFetchPlanChunkSizeTest.java
@@ -1,0 +1,90 @@
+/*
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Copyright The original authors
+ *
+ *  Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package dev.hardwood.internal.reader;
+
+import java.util.List;
+import java.util.Map;
+
+import org.junit.jupiter.api.Test;
+
+import dev.hardwood.metadata.ColumnMetaData;
+import dev.hardwood.metadata.CompressionCodec;
+import dev.hardwood.metadata.Encoding;
+import dev.hardwood.metadata.FieldPath;
+import dev.hardwood.metadata.PhysicalType;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/// Unit tests for `SequentialFetchPlan.computeChunkSize`, focused on the
+/// "fetch the whole column when small enough" threshold introduced for #382.
+class SequentialFetchPlanChunkSizeTest {
+
+    private static final int ONE_MIB = 1024 * 1024;
+
+    @Test
+    void smallColumnUnderHeadFetchesEntireChunk() {
+        // 2 MB column under a tight `head(N)` — without #382 the chunk
+        // size would clamp to the 1 MB floor; with #382 it returns the
+        // full column length so the column is coalesce-safe.
+        int columnLength = 2 * ONE_MIB;
+        int chunk = SequentialFetchPlan.computeChunkSize(
+                columnLength, fakeMetaData(columnLength, 100_000), 30);
+
+        assertThat(chunk).isEqualTo(columnLength);
+    }
+
+    @Test
+    void columnAtThresholdBoundaryFetchesEntireChunk() {
+        // Exactly 4 MB sits at the threshold — included.
+        int columnLength = 4 * ONE_MIB;
+        int chunk = SequentialFetchPlan.computeChunkSize(
+                columnLength, fakeMetaData(columnLength, 100_000), 30);
+
+        assertThat(chunk).isEqualTo(columnLength);
+    }
+
+    @Test
+    void columnAboveThresholdStaysTruncated() {
+        // 5 MB column — the head(N)-driven floor of 1 MB still applies
+        // so the per-column truncation keeps a 50+ MB column from
+        // pulling its full bytes for a 30-row preview.
+        int columnLength = 5 * ONE_MIB;
+        int chunk = SequentialFetchPlan.computeChunkSize(
+                columnLength, fakeMetaData(columnLength, 100_000), 30);
+
+        assertThat(chunk).isEqualTo(ONE_MIB);
+    }
+
+    @Test
+    void noMaxRowsReturnsDefaultCeiling() {
+        // Without head(N), behavior is unchanged: full chunk size up to
+        // the configured ceiling.
+        int columnLength = 50 * ONE_MIB;
+        int chunk = SequentialFetchPlan.computeChunkSize(
+                columnLength, fakeMetaData(columnLength, 100_000), 0);
+
+        // computeChunkSize returns the ceiling; the build() caller
+        // applies `Math.min(columnChunkLength, ceiling)`.
+        assertThat(chunk).isGreaterThanOrEqualTo(columnLength);
+    }
+
+    private static ColumnMetaData fakeMetaData(long totalCompressedSize, long numValues) {
+        return new ColumnMetaData(
+                PhysicalType.INT64,
+                List.of(Encoding.PLAIN),
+                FieldPath.of("col"),
+                CompressionCodec.UNCOMPRESSED,
+                numValues,
+                totalCompressedSize,
+                totalCompressedSize,
+                Map.of(),
+                0L,
+                null,
+                null);
+    }
+}

--- a/core/src/test/java/dev/hardwood/internal/reader/SequentialFetchPlanChunkSizeTest.java
+++ b/core/src/test/java/dev/hardwood/internal/reader/SequentialFetchPlanChunkSizeTest.java
@@ -61,6 +61,25 @@ class SequentialFetchPlanChunkSizeTest {
     }
 
     @Test
+    void dynamicEstimateLandsBetweenFloorAndCeiling() {
+        // Above the 4 MB short-circuit, `computeChunkSize` derives the
+        // size from `bytesPerValue × maxRows × safetyFactor`. For a
+        // 50 MB column with 100 values (500 KB / value) and head(10),
+        // the estimate is 10 × 500 KB × 2 = 10 MB — comfortably above
+        // the 1 MB floor and below the 128 MB ceiling. Pins the
+        // dynamic path so a regression that breaks the interpolation
+        // is observable.
+        int columnLength = 50 * ONE_MIB;
+        int chunk = SequentialFetchPlan.computeChunkSize(
+                columnLength, fakeMetaData(columnLength, 100), 10);
+
+        assertThat(chunk)
+                .as("dynamic estimate should land between floor and ceiling")
+                .isGreaterThan(ONE_MIB)
+                .isLessThan(columnLength);
+    }
+
+    @Test
     void noMaxRowsReturnsDefaultCeiling() {
         // Without head(N), behavior is unchanged: full chunk size up to
         // the configured ceiling.

--- a/docs/content/usage.md
+++ b/docs/content/usage.md
@@ -384,7 +384,40 @@ try (ParquetFileReader fileReader = ParquetFileReader.open(InputFile.of(path));
 }
 ```
 
-Tail mode cannot currently be combined with a filter predicate — the set of matching rows is not known from row-group statistics alone, so the reader cannot identify which row groups cover the last N matching rows without scanning the whole file.
+Tail mode cannot currently be combined with a filter predicate — the set of matching rows is not known from row-group statistics alone, so the reader cannot identify which row groups cover the last N matching rows without scanning the whole file. It is also mutually exclusive with `firstRow(long)`.
+
+### Seeking to an Absolute Row
+
+The `firstRow(long)` builder method begins iteration at an arbitrary absolute row index. Earlier row groups are not opened — their pages are not fetched or decoded — making this an O(1 row group) seek on remote backends, in contrast to walking `next()` from row 0.
+
+```java
+// Read rows starting at row 1,000,000 — earlier row groups are skipped.
+try (ParquetFileReader fileReader = ParquetFileReader.open(InputFile.of(path));
+     RowReader rowReader = fileReader.buildRowReader().firstRow(1_000_000).build()) {
+
+    while (rowReader.hasNext()) {
+        rowReader.next();
+        // ...
+    }
+}
+```
+
+Compose with `head(N)` for a bounded `[firstRow, firstRow + N)` window:
+
+```java
+// Read rows [1_000_000, 1_000_050).
+try (ParquetFileReader fileReader = ParquetFileReader.open(InputFile.of(path));
+     RowReader rowReader = fileReader.buildRowReader()
+             .firstRow(1_000_000)
+             .head(50)
+             .build()) {
+    // ...
+}
+```
+
+`firstRow == 0` is the no-op default. `firstRow == totalRows` produces an empty reader; `firstRow > totalRows` throws `IllegalArgumentException`. For multi-file readers, `firstRow` indexes into the *first* file's rows only — cross-file `firstRow` is out of scope. Mutually exclusive with `tail(N)`.
+
+Within the target row group, the reader still decodes the leading residue rows and discards them via `next()`. Page-level skip via the OffsetIndex is tracked separately.
 
 ## Column Projection
 

--- a/s3/src/main/java/dev/hardwood/s3/S3InputFile.java
+++ b/s3/src/main/java/dev/hardwood/s3/S3InputFile.java
@@ -14,6 +14,7 @@ import java.nio.ByteBuffer;
 import java.util.concurrent.atomic.AtomicLong;
 
 import dev.hardwood.InputFile;
+import dev.hardwood.internal.FetchReason;
 import dev.hardwood.s3.internal.S3Api;
 
 /// [InputFile] backed by an object in Amazon S3 (or an S3-compatible service).
@@ -65,17 +66,15 @@ public class S3InputFile implements InputFile {
         }
         fileLength = parseFileLength(response);
         byte[] tail = response.body();
-        networkRequestCount.incrementAndGet();
-        networkBytesFetched.addAndGet(tail.length);
+        long requestNo = networkRequestCount.incrementAndGet();
+        long totalBytes = networkBytesFetched.addAndGet(tail.length);
         // Use a direct buffer so slices are usable from FFM-based decompressors
         // (e.g. libdeflate), which require native MemorySegments.
         tailCache = ByteBuffer.allocateDirect(tail.length);
         tailCache.put(tail);
         tailCache.flip();
         tailCacheOffset = fileLength - tail.length;
-        LOG.log(System.Logger.Level.DEBUG,
-                "[{0}] open: fetched {1} byte tail (offset={2}, fileLength={3})",
-                name(), tail.length, tailCacheOffset, fileLength);
+        logFetch("open-tail", tailCacheOffset, tail.length, requestNo, totalBytes);
     }
 
     @Override
@@ -85,16 +84,14 @@ public class S3InputFile implements InputFile {
                 && offset + length <= tailCacheOffset + tailCache.capacity()) {
             int relOffset = Math.toIntExact(offset - tailCacheOffset);
             LOG.log(System.Logger.Level.DEBUG,
-                    "[{0}] readRange offset={1} length={2} (tail cache hit)",
-                    name(), offset, length);
+                    "[{0}] readRange offset={1} length={2} reason={3} (tail cache hit)",
+                    name(), offset, length, FetchReason.current());
             return tailCache.slice(relOffset, length);
         }
 
-        LOG.log(System.Logger.Level.DEBUG,
-                "[{0}] readRange offset={1} length={2} (network fetch)",
-                name(), offset, length);
-        networkRequestCount.incrementAndGet();
-        networkBytesFetched.addAndGet(length);
+        long requestNo = networkRequestCount.incrementAndGet();
+        long totalBytes = networkBytesFetched.addAndGet(length);
+        logFetch(FetchReason.current(), offset, length, requestNo, totalBytes);
         String range = "bytes=" + offset + "-" + (offset + length - 1);
         HttpResponse<InputStream> response = api.getStream(bucket, key, range);
         int status = response.statusCode();
@@ -155,6 +152,16 @@ public class S3InputFile implements InputFile {
     /// Tail-cache hits do not count.
     public long networkBytesFetched() {
         return networkBytesFetched.get();
+    }
+
+    /// Emits a single FINE log line per network fetch carrying the byte
+    /// range, the [FetchReason] tag attributed to the caller, and the
+    /// running per-file totals. Designed to be greppable: one line per
+    /// fetch, no nested structure.
+    private void logFetch(String reason, long offset, int length, long requestNo, long totalBytes) {
+        LOG.log(System.Logger.Level.DEBUG,
+                "[{0}] fetch #{1} reason={2} offset={3} length={4} range=[{3},{5}) totalBytes={6}",
+                name(), requestNo, reason, offset, length, offset + length, totalBytes);
     }
 
     /// Extracts the total file length from the HTTP response.

--- a/s3/src/main/java/dev/hardwood/s3/S3InputFile.java
+++ b/s3/src/main/java/dev/hardwood/s3/S3InputFile.java
@@ -11,6 +11,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.net.http.HttpResponse;
 import java.nio.ByteBuffer;
+import java.util.concurrent.atomic.AtomicLong;
 
 import dev.hardwood.InputFile;
 import dev.hardwood.s3.internal.S3Api;
@@ -41,6 +42,8 @@ public class S3InputFile implements InputFile {
     private long fileLength = -1;
     private ByteBuffer tailCache;
     private long tailCacheOffset;
+    private final AtomicLong networkRequestCount = new AtomicLong();
+    private final AtomicLong networkBytesFetched = new AtomicLong();
 
     S3InputFile(S3Source source, String bucket, String key) {
         this.api = source.api();
@@ -62,6 +65,8 @@ public class S3InputFile implements InputFile {
         }
         fileLength = parseFileLength(response);
         byte[] tail = response.body();
+        networkRequestCount.incrementAndGet();
+        networkBytesFetched.addAndGet(tail.length);
         // Use a direct buffer so slices are usable from FFM-based decompressors
         // (e.g. libdeflate), which require native MemorySegments.
         tailCache = ByteBuffer.allocateDirect(tail.length);
@@ -88,6 +93,8 @@ public class S3InputFile implements InputFile {
         LOG.log(System.Logger.Level.DEBUG,
                 "[{0}] readRange offset={1} length={2} (network fetch)",
                 name(), offset, length);
+        networkRequestCount.incrementAndGet();
+        networkBytesFetched.addAndGet(length);
         String range = "bytes=" + offset + "-" + (offset + length - 1);
         HttpResponse<InputStream> response = api.getStream(bucket, key, range);
         int status = response.statusCode();
@@ -133,6 +140,21 @@ public class S3InputFile implements InputFile {
     @Override
     public void close() {
         // S3Source owns the HttpClient — nothing to close here
+    }
+
+    /// Number of HTTP requests issued against the object since [#open()].
+    /// Counts the suffix-range tail fetch from `open` plus every
+    /// network-fetch [#readRange] call. Tail-cache hits do not count.
+    public long networkRequestCount() {
+        return networkRequestCount.get();
+    }
+
+    /// Number of bytes fetched from the network since [#open()]. The tail
+    /// fetch from `open` contributes its actual response size; each
+    /// network-fetch [#readRange] contributes the requested length.
+    /// Tail-cache hits do not count.
+    public long networkBytesFetched() {
+        return networkBytesFetched.get();
     }
 
     /// Extracts the total file length from the HTTP response.

--- a/s3/src/main/java/dev/hardwood/s3/S3InputFile.java
+++ b/s3/src/main/java/dev/hardwood/s3/S3InputFile.java
@@ -158,6 +158,11 @@ public class S3InputFile implements InputFile {
     /// range, the [FetchReason] tag attributed to the caller, and the
     /// running per-file totals. Designed to be greppable: one line per
     /// fetch, no nested structure.
+    ///
+    /// Logged at `System.Logger.Level.DEBUG`, which the platform logger
+    /// finder maps to JUL `Level.FINE` — `DiveCommand` configures the
+    /// JUL handler at `Level.FINE`, so a refactor that lowers the level
+    /// here would silently drop dive's `--log-file` output.
     private void logFetch(String reason, long offset, int length, long requestNo, long totalBytes) {
         LOG.log(System.Logger.Level.DEBUG,
                 "[{0}] fetch #{1} reason={2} offset={3} length={4} range=[{3},{5}) totalBytes={6}",

--- a/s3/src/test/java/dev/hardwood/s3/S3InputFileTest.java
+++ b/s3/src/test/java/dev/hardwood/s3/S3InputFileTest.java
@@ -243,7 +243,7 @@ class S3InputFileTest {
             assertThat(openRequests).isPositive();
             assertThat(openBytes).isPositive();
 
-            try (ColumnReader col = reader.createColumnReader("id")) {
+            try (ColumnReader col = reader.columnReader("id")) {
                 while (col.nextBatch()) {
                     // drain
                 }

--- a/s3/src/test/java/dev/hardwood/s3/S3InputFileTest.java
+++ b/s3/src/test/java/dev/hardwood/s3/S3InputFileTest.java
@@ -230,6 +230,31 @@ class S3InputFileTest {
     }
 
     @Test
+    void networkStatsCountOpenAndReadRangeButNotTailCacheHits() throws Exception {
+        // column_index_pushdown.parquet is large enough that the column data
+        // sits outside the 64 KB tail cache, so readRange must hit the
+        // network — proving the counters increase past the open() baseline.
+        // (A tiny fixture would fit entirely inside the tail cache and the
+        // counters would correctly stay at 1.)
+        S3InputFile file = source.inputFile("test-bucket", "column_index_pushdown.parquet");
+        try (ParquetFileReader reader = ParquetFileReader.open(file)) {
+            long openRequests = file.networkRequestCount();
+            long openBytes = file.networkBytesFetched();
+            assertThat(openRequests).isPositive();
+            assertThat(openBytes).isPositive();
+
+            try (ColumnReader col = reader.createColumnReader("id")) {
+                while (col.nextBatch()) {
+                    // drain
+                }
+            }
+
+            assertThat(file.networkRequestCount()).isGreaterThan(openRequests);
+            assertThat(file.networkBytesFetched()).isGreaterThan(openBytes);
+        }
+    }
+
+    @Test
     void name() {
         S3InputFile file = source.inputFile("test-bucket", "data/file.parquet");
         assertThat(file.name()).isEqualTo("s3://test-bucket/data/file.parquet");


### PR DESCRIPTION
## Summary

Cuts S3 round-trips on the `hardwood dive` Data preview path against
remote files. On the Overture Maps fixture the per-row-group fetch
count drops from ~50 to 1–2; on a typical mid-size analytics file
(NYC yellow taxi, 20 columns of mixed sizes) it drops from ~17 to 6,
of which 5 are unavoidable big-column reads. Within-viewport
navigation no longer triggers I/O at all.

## What's in this PR

Six issues, layered. Each commit was verified end-to-end against a
real S3-hosted file (LocalStack + Overture and yellow_tripdata
fixtures) before stacking the next on top.

- **#360 dive: show S3 download stats in the top bar** —
  `(N reqs, X.X MB)` next to the file path so subsequent changes are
  observable in the TUI itself.
- **#376 core/s3: per-fetch attribution via FetchReason + dive --log-file** —
  every `S3InputFile.readRange` carries a thread-local reason
  (`open-tail`, `footer-magic-start`, `rg=N col='foo' seqChunk@K`,
  `rg=N region=A..B`, `prefetch rg=M`, etc.) and gets logged via JUL's
  `FileHandler` when `--log-file` is set on `dive`. Without this the
  later changes couldn't have been verified.
- **#361 core: row-based seek (`firstRow(long)`) on RowReaderBuilder** —
  iterate from any absolute row N without walking the row-0 prefix.
  Targets the row group containing N and trims the row-group sublist
  to `[targetRg, end)`. Dive's jump-to-end now fetches one RG instead
  of the full prefix.
- **#377 dive: ±10×viewport row window cache for Data preview** —
  20×pageSize buffer of rendered rows around the cursor; refill on
  miss. Within-window navigation goes to zero I/O. Cells are cached
  in both physical and logical form, so the `t` toggle is free.
- **#374 pipeline: coalesce ranged GETs across adjacent column chunks
  within a row group** — new `SharedRegion` abstraction; per-column
  first-chunks within a 64 KB gap budget collapse into a single
  ranged GET, sliced per column. Conservative `isCoalesceSafe()`
  gate excludes columns with page drops or `head(N)`-truncated chunk
  sizes (would otherwise over-fetch dropped bytes / double-fetch
  later chunks).
- **#382 core: fetch the entire column under head(N) when small enough
  to coalesce** — short-circuits `SequentialFetchPlan.computeChunkSize`
  to return `columnChunkLength` when ≤ 4 MB. Lets mid-size columns
  (1–4 MB) participate in cross-column coalescing instead of getting
  excluded by the `isCoalesceSafe()` gate. Big columns (> 4 MB) keep
  the existing `head(N)`-driven truncation.

## Tests added

- `CrossColumnCoalesceTest` — sequential plan (20 cols → 1 read),
  indexed plan (3 cols → ≤ 2 reads), filter test that asserts
  page-dropped columns aren't swept into the shared region.
- `SequentialFetchPlanChunkSizeTest` — the 4 MB threshold (below /
  at boundary / above / no-maxRows) for `computeChunkSize`.
- `DataPreviewIoTest` — jump-to-last yields the right rows; bytes
  read on jump are well under half the file; forward intra-RG steps
  reuse the cursor; backward seek rebuilds within the current RG.
- `ParquetReaderTest.firstRow*` — happy path, RG boundary, head
  composition, end-of-file boundary, validation.
- Plus the data-preview window cache tests under `cli/dive`.

## Design docs

- `_designs/CROSS_COLUMN_COALESCING.md` (#374)
- `_designs/ROW_BASED_SEEK.md` (#361)
- Updates to existing dive design for the window cache (#377)

## Observed effects (logged against the same fixtures)

| Shape                      | Reads/RG before  | Reads/RG after  |
|----------------------------|-------------------|-----------------|
| Wide & small (Overture)    | ~50               | 1–2             |
| Mixed (yellow_tripdata)    | ~17               | 6               |
| Narrow & huge              | already optimal   | unchanged       |
| Full-RG read (no `head`)   | already optimal   | unchanged       |

## Test plan

- [ ] `./mvnw verify -DskipITs` green locally (passes — 11 modules)
- [ ] Open Overture file in dive, verify download-stats top bar
      shows ≤ 2 ranged GETs per RG on Data preview entry
- [ ] Open yellow_tripdata in dive, verify ≤ 6 ranged GETs per RG on
      Data preview entry
- [ ] Page-down / page-up within window: zero new fetches
- [ ] Cross window boundary: refill triggers a single coalesced
      ranged GET (or a small bounded set, depending on column shape)
- [ ] `t` toggle: zero new fetches
- [ ] Filter test: filtered column reads are not over-coalesced
      (existing `PageRangeIoTest` filtered < unfiltered byte
      assertion still holds)
- [ ] Verify per-fetch attribution log entries are intelligible

🤖 Generated with [Claude Code](https://claude.com/claude-code)