### PR TITLE
#351 Adding UUID Filter Predicate and tighten SignedBinaryColumnPredicate

### DIFF
--- a/core/src/main/java/dev/hardwood/internal/predicate/BinaryComparator.java
+++ b/core/src/main/java/dev/hardwood/internal/predicate/BinaryComparator.java
@@ -7,6 +7,8 @@
  */
 package dev.hardwood.internal.predicate;
 
+import java.util.Arrays;
+
 /// Byte array comparison utilities for filter predicate evaluation.
 ///
 /// Provides unsigned lexicographic comparison (for BYTE_ARRAY) and signed
@@ -21,14 +23,7 @@ public final class BinaryComparator {
     ///
     /// @return negative if a < b, zero if equal, positive if a > b
     public static int compareUnsigned(byte[] a, byte[] b) {
-        int minLen = Math.min(a.length, b.length);
-        for (int i = 0; i < minLen; i++) {
-            int cmp = (a[i] & 0xFF) - (b[i] & 0xFF);
-            if (cmp != 0) {
-                return cmp;
-            }
-        }
-        return a.length - b.length;
+        return Arrays.compareUnsigned(a, b);
     }
 
     /// Compare two same-length byte arrays as big-endian two's complement signed values.
@@ -36,6 +31,7 @@ public final class BinaryComparator {
     ///
     /// @return negative if a < b, zero if equal, positive if a > b
     public static int compareSigned(byte[] a, byte[] b) {
+        int len = a.length;
         if (a.length != b.length) {
             throw new IllegalArgumentException(
                     "Signed binary comparison requires same-length arrays: " + a.length + " vs " + b.length);
@@ -49,12 +45,6 @@ public final class BinaryComparator {
             return cmp;
         }
         // Remaining bytes: compare as unsigned
-        for (int i = 1; i < a.length; i++) {
-            cmp = (a[i] & 0xFF) - (b[i] & 0xFF);
-            if (cmp != 0) {
-                return cmp;
-            }
-        }
-        return 0;
+        return Arrays.compareUnsigned(a, 1, len, b, 1, len);
     }
 }

--- a/core/src/main/java/dev/hardwood/internal/predicate/BinaryComparator.java
+++ b/core/src/main/java/dev/hardwood/internal/predicate/BinaryComparator.java
@@ -31,7 +31,6 @@ public final class BinaryComparator {
     ///
     /// @return negative if a < b, zero if equal, positive if a > b
     public static int compareSigned(byte[] a, byte[] b) {
-        int len = a.length;
         if (a.length != b.length) {
             throw new IllegalArgumentException(
                     "Signed binary comparison requires same-length arrays: " + a.length + " vs " + b.length);
@@ -45,6 +44,6 @@ public final class BinaryComparator {
             return cmp;
         }
         // Remaining bytes: compare as unsigned
-        return Arrays.compareUnsigned(a, 1, len, b, 1, len);
+        return Arrays.compareUnsigned(a, 1, a.length, b, 1, a.length);
     }
 }

--- a/core/src/main/java/dev/hardwood/internal/predicate/FilterPredicateResolver.java
+++ b/core/src/main/java/dev/hardwood/internal/predicate/FilterPredicateResolver.java
@@ -240,8 +240,8 @@ public class FilterPredicateResolver {
     }
 
     private static void validateLogicalType(String columnName,
-                                            Class<? extends LogicalType> expectedLogicalType,
-                                            ColumnSchema columnSchema) {
+            Class<? extends LogicalType> expectedLogicalType,
+            ColumnSchema columnSchema) {
         LogicalType logicalType = columnSchema.logicalType();
 
         if (!expectedLogicalType.isInstance(logicalType)) {

--- a/core/src/main/java/dev/hardwood/internal/predicate/FilterPredicateResolver.java
+++ b/core/src/main/java/dev/hardwood/internal/predicate/FilterPredicateResolver.java
@@ -142,7 +142,15 @@ public class FilterPredicateResolver {
                 ColumnSchema cs = resolveColumn(p.column(), schema);
                 rejectRepeated(p.column(), cs);
                 validateType(p.column(), PhysicalType.FIXED_LEN_BYTE_ARRAY, cs);
+                validateLogicalType(p.column(), LogicalType.DecimalType.class, cs);
                 yield new ResolvedPredicate.BinaryPredicate(cs.columnIndex(), p.op(), p.value(), true);
+            }
+            case FilterPredicate.UUIDColumnPredicate p -> {
+                ColumnSchema cs = resolveColumn(p.column(), schema);
+                rejectRepeated(p.column(), cs);
+                validateType(p.column(), PhysicalType.FIXED_LEN_BYTE_ARRAY, cs);
+                validateLogicalType(p.column(), LogicalType.UuidType.class, cs);
+                yield new ResolvedPredicate.BinaryPredicate(cs.columnIndex(), p.op(), p.value(), false);
             }
             case IntInPredicate p -> {
                 ColumnSchema cs = resolveColumn(p.column(), schema);
@@ -228,6 +236,19 @@ public class FilterPredicateResolver {
             throw new IllegalArgumentException(
                     "Column '" + columnName + "' has physical type " + actualType
                             + "; given filter predicate type " + expectedType + " is incompatible");
+        }
+    }
+
+    private static void validateLogicalType(String columnName,
+                                            Class<? extends LogicalType> expectedLogicalType,
+                                            ColumnSchema columnSchema) {
+        LogicalType logicalType = columnSchema.logicalType();
+
+        if (!expectedLogicalType.isInstance(logicalType)) {
+            throw new IllegalArgumentException(
+                    "Column '" + columnName + "' has logical type " + logicalType
+                            + "; given filter predicate logical type "
+                            + expectedLogicalType.getName() + " is incompatible");
         }
     }
 

--- a/core/src/main/java/dev/hardwood/internal/predicate/FilterPredicateResolver.java
+++ b/core/src/main/java/dev/hardwood/internal/predicate/FilterPredicateResolver.java
@@ -246,9 +246,8 @@ public class FilterPredicateResolver {
 
         if (!expectedLogicalType.isInstance(logicalType)) {
             throw new IllegalArgumentException(
-                    "Column '" + columnName + "' has logical type " + logicalType
-                            + "; given filter predicate logical type "
-                            + expectedLogicalType.getName() + " is incompatible");
+                    "Column '" + columnName + "' is not a " + expectedLogicalType.getSimpleName()
+                            + " column (logical type: " + logicalType + ")");
         }
     }
 

--- a/core/src/main/java/dev/hardwood/reader/FilterPredicate.java
+++ b/core/src/main/java/dev/hardwood/reader/FilterPredicate.java
@@ -66,6 +66,7 @@ public sealed interface FilterPredicate
                 FilterPredicate.BooleanColumnPredicate,
                 FilterPredicate.BinaryColumnPredicate,
                 FilterPredicate.SignedBinaryColumnPredicate,
+                FilterPredicate.UUIDColumnPredicate,
                 FilterPredicate.IntInPredicate,
                 FilterPredicate.LongInPredicate,
                 FilterPredicate.BinaryInPredicate,
@@ -400,35 +401,35 @@ public sealed interface FilterPredicate
 
     // ==================== UUID Predicates ====================
 
-    /// Creates an equals predicate for a [UUID] column (Parquet UUID logical type).
+    /// Creates an equal predicate for a [UUID] column (Parquet UUID logical type).
     /// The UUID is encoded as a 16-byte big-endian `FIXED_LEN_BYTE_ARRAY`.
     static FilterPredicate eq(String column, UUID value) {
-        return new BinaryColumnPredicate(column, Operator.EQ, uuidToBytes(value));
+        return new UUIDColumnPredicate(column, Operator.EQ, uuidToBytes(value));
     }
 
     /// Creates a not-equals predicate for a [UUID] column.
     static FilterPredicate notEq(String column, UUID value) {
-        return new BinaryColumnPredicate(column, Operator.NOT_EQ, uuidToBytes(value));
+        return new UUIDColumnPredicate(column, Operator.NOT_EQ, uuidToBytes(value));
     }
 
     /// Creates a less-than predicate for a [UUID] column.
     static FilterPredicate lt(String column, UUID value) {
-        return new BinaryColumnPredicate(column, Operator.LT, uuidToBytes(value));
+        return new UUIDColumnPredicate(column, Operator.LT, uuidToBytes(value));
     }
 
     /// Creates a less-than-or-equal predicate for a [UUID] column.
     static FilterPredicate ltEq(String column, UUID value) {
-        return new BinaryColumnPredicate(column, Operator.LT_EQ, uuidToBytes(value));
+        return new UUIDColumnPredicate(column, Operator.LT_EQ, uuidToBytes(value));
     }
 
     /// Creates a greater-than predicate for a [UUID] column.
     static FilterPredicate gt(String column, UUID value) {
-        return new BinaryColumnPredicate(column, Operator.GT, uuidToBytes(value));
+        return new UUIDColumnPredicate(column, Operator.GT, uuidToBytes(value));
     }
 
     /// Creates a greater-than-or-equal predicate for a [UUID] column.
     static FilterPredicate gtEq(String column, UUID value) {
-        return new BinaryColumnPredicate(column, Operator.GT_EQ, uuidToBytes(value));
+        return new UUIDColumnPredicate(column, Operator.GT_EQ, uuidToBytes(value));
     }
 
     // ==================== Conversion Helpers ====================
@@ -517,6 +518,23 @@ public sealed interface FilterPredicate
         public boolean equals(Object o) {
             if (this == o) return true;
             if (!(o instanceof SignedBinaryColumnPredicate that)) return false;
+            return column.equals(that.column) && op == that.op && Arrays.equals(value, that.value);
+        }
+
+        @Override
+        public int hashCode() {
+            int result = column.hashCode();
+            result = 31 * result + op.hashCode();
+            result = 31 * result + Arrays.hashCode(value);
+            return result;
+        }
+    }
+
+    record UUIDColumnPredicate(String column, Operator op, byte[] value) implements FilterPredicate {
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) return true;
+            if (!(o instanceof UUIDColumnPredicate that)) return false;
             return column.equals(that.column) && op == that.op && Arrays.equals(value, that.value);
         }
 

--- a/core/src/main/java/dev/hardwood/reader/FilterPredicate.java
+++ b/core/src/main/java/dev/hardwood/reader/FilterPredicate.java
@@ -401,7 +401,7 @@ public sealed interface FilterPredicate
 
     // ==================== UUID Predicates ====================
 
-    /// Creates an equal predicate for a [UUID] column (Parquet UUID logical type).
+    /// Creates an equals predicate for a [UUID] column (Parquet UUID logical type).
     /// The UUID is encoded as a 16-byte big-endian `FIXED_LEN_BYTE_ARRAY`.
     static FilterPredicate eq(String column, UUID value) {
         return new UUIDColumnPredicate(column, Operator.EQ, uuidToBytes(value));
@@ -510,8 +510,9 @@ public sealed interface FilterPredicate
         }
     }
 
-    /// Predicate for `FIXED_LEN_BYTE_ARRAY` columns that require signed (two's complement)
-    /// comparison, such as decimals. The value must be padded to the column's fixed length.
+    /// Predicate for decimal columns stored as `FIXED_LEN_BYTE_ARRAY`, which require signed
+    /// (two's complement) comparison. The column must carry a `DECIMAL` logical type and the
+    /// value must be padded to the column's fixed length.
     record SignedBinaryColumnPredicate(String column, Operator op, byte[] value) implements FilterPredicate {
 
         @Override

--- a/core/src/test/java/dev/hardwood/FilterPredicateTest.java
+++ b/core/src/test/java/dev/hardwood/FilterPredicateTest.java
@@ -32,6 +32,7 @@ import dev.hardwood.metadata.ColumnMetaData;
 import dev.hardwood.metadata.CompressionCodec;
 import dev.hardwood.metadata.Encoding;
 import dev.hardwood.metadata.FieldPath;
+import dev.hardwood.metadata.LogicalType;
 import dev.hardwood.metadata.PhysicalType;
 import dev.hardwood.metadata.RepetitionType;
 import dev.hardwood.metadata.RowGroup;
@@ -630,8 +631,8 @@ class FilterPredicateTest {
     void testUuidPredicateCreation() {
         UUID uuid = UUID.fromString("550e8400-e29b-41d4-a716-446655440000");
         FilterPredicate p = FilterPredicate.eq("request_id", uuid);
-        assertThat(p).isInstanceOf(FilterPredicate.BinaryColumnPredicate.class);
-        FilterPredicate.BinaryColumnPredicate bp = (FilterPredicate.BinaryColumnPredicate) p;
+        assertThat(p).isInstanceOf(FilterPredicate.UUIDColumnPredicate.class);
+        FilterPredicate.UUIDColumnPredicate bp = (FilterPredicate.UUIDColumnPredicate) p;
         assertThat(bp.column()).isEqualTo("request_id");
         assertThat(bp.op()).isEqualTo(FilterPredicate.Operator.EQ);
 
@@ -644,20 +645,55 @@ class FilterPredicateTest {
     @Test
     void testUuidAllOperators() {
         UUID uuid = UUID.fromString("00000000-0000-0000-0000-000000000001");
-        assertThat(((FilterPredicate.BinaryColumnPredicate) FilterPredicate.eq("u", uuid)).op()).isEqualTo(FilterPredicate.Operator.EQ);
-        assertThat(((FilterPredicate.BinaryColumnPredicate) FilterPredicate.notEq("u", uuid)).op()).isEqualTo(FilterPredicate.Operator.NOT_EQ);
-        assertThat(((FilterPredicate.BinaryColumnPredicate) FilterPredicate.lt("u", uuid)).op()).isEqualTo(FilterPredicate.Operator.LT);
-        assertThat(((FilterPredicate.BinaryColumnPredicate) FilterPredicate.ltEq("u", uuid)).op()).isEqualTo(FilterPredicate.Operator.LT_EQ);
-        assertThat(((FilterPredicate.BinaryColumnPredicate) FilterPredicate.gt("u", uuid)).op()).isEqualTo(FilterPredicate.Operator.GT);
-        assertThat(((FilterPredicate.BinaryColumnPredicate) FilterPredicate.gtEq("u", uuid)).op()).isEqualTo(FilterPredicate.Operator.GT_EQ);
+        assertThat(((FilterPredicate.UUIDColumnPredicate) FilterPredicate.eq("u", uuid)).op()).isEqualTo(FilterPredicate.Operator.EQ);
+        assertThat(((FilterPredicate.UUIDColumnPredicate) FilterPredicate.notEq("u", uuid)).op()).isEqualTo(FilterPredicate.Operator.NOT_EQ);
+        assertThat(((FilterPredicate.UUIDColumnPredicate) FilterPredicate.lt("u", uuid)).op()).isEqualTo(FilterPredicate.Operator.LT);
+        assertThat(((FilterPredicate.UUIDColumnPredicate) FilterPredicate.ltEq("u", uuid)).op()).isEqualTo(FilterPredicate.Operator.LT_EQ);
+        assertThat(((FilterPredicate.UUIDColumnPredicate) FilterPredicate.gt("u", uuid)).op()).isEqualTo(FilterPredicate.Operator.GT);
+        assertThat(((FilterPredicate.UUIDColumnPredicate) FilterPredicate.gtEq("u", uuid)).op()).isEqualTo(FilterPredicate.Operator.GT_EQ);
     }
 
     @Test
     void testUuidNilValue() {
         UUID nil = new UUID(0L, 0L);
-        FilterPredicate.BinaryColumnPredicate bp =
-                (FilterPredicate.BinaryColumnPredicate) FilterPredicate.eq("u", nil);
+        FilterPredicate.UUIDColumnPredicate bp =
+                (FilterPredicate.UUIDColumnPredicate) FilterPredicate.eq("u", nil);
         assertThat(bp.value()).isEqualTo(new byte[16]);
+    }
+
+    @Test
+    void uuidPredicateOnNonUuidColumnThrows() {
+        SchemaElement root = new SchemaElement("root", null, null, null, 1, null, null, null, null, null);
+        SchemaElement col = new SchemaElement("col", PhysicalType.FIXED_LEN_BYTE_ARRAY, 16,
+                RepetitionType.REQUIRED, null, null, null, null, null, null);
+        FileSchema schema = FileSchema.fromSchemaElements(List.of(root, col));
+
+        assertThatThrownBy(() -> FilterPredicateResolver.resolve(
+                FilterPredicate.eq("col", UUID.randomUUID()), schema))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("UuidType");
+    }
+
+    @Test
+    void testCanDropWithUuidPredicate() {
+        UUID low   = new UUID(0L, 1L);
+        UUID mid   = new UUID(0L, 50L);
+        UUID high  = new UUID(0L, 100L);
+        UUID above = new UUID(0L, 200L);
+
+        RowGroup rg = createUuidRowGroup(low, high);
+        FileSchema schema = createUuidSchema();
+
+        // EQ mid: in range → cannot drop
+        assertThat(canDropRowGroup(FilterPredicate.eq("col", mid), rg, schema)).isFalse();
+        // EQ above max → can drop
+        assertThat(canDropRowGroup(FilterPredicate.eq("col", above), rg, schema)).isTrue();
+        // GT high: max is high, none > high → can drop
+        assertThat(canDropRowGroup(FilterPredicate.gt("col", high), rg, schema)).isTrue();
+        // LT low: min is low, none < low → can drop
+        assertThat(canDropRowGroup(FilterPredicate.lt("col", low), rg, schema)).isTrue();
+        // GT_EQ low: max >= low → cannot drop
+        assertThat(canDropRowGroup(FilterPredicate.gtEq("col", low), rg, schema)).isFalse();
     }
 
     // ==================== Float/Double Edge Cases ====================
@@ -1105,6 +1141,18 @@ class FilterPredicateTest {
         return createRowGroupWithStats(PhysicalType.BYTE_ARRAY, min, max);
     }
 
+    private static RowGroup createUuidRowGroup(UUID min, UUID max) {
+        return createRowGroupWithStats(PhysicalType.FIXED_LEN_BYTE_ARRAY,
+                uuidBytes(min), uuidBytes(max));
+    }
+
+    private static byte[] uuidBytes(UUID uuid) {
+        ByteBuffer buf = ByteBuffer.allocate(16);
+        buf.putLong(uuid.getMostSignificantBits());
+        buf.putLong(uuid.getLeastSignificantBits());
+        return buf.array();
+    }
+
     private static RowGroup createRowGroupWithStats(PhysicalType type, byte[] min, byte[] max) {
         Statistics stats = new Statistics(min, max, 0L, null, false);
         ColumnMetaData cmd = new ColumnMetaData(
@@ -1153,6 +1201,13 @@ class FilterPredicateTest {
 
     private static FileSchema createBinarySchema() {
         return createSchemaForType(PhysicalType.BYTE_ARRAY);
+    }
+
+    private static FileSchema createUuidSchema() {
+        SchemaElement root = new SchemaElement("root", null, null, null, 1, null, null, null, null, null);
+        SchemaElement col = new SchemaElement("col", PhysicalType.FIXED_LEN_BYTE_ARRAY, 16,
+                RepetitionType.REQUIRED, null, null, null, null, null, new LogicalType.UuidType());
+        return FileSchema.fromSchemaElements(List.of(root, col));
     }
 
     private static FileSchema createSchemaForType(PhysicalType type) {

--- a/core/src/test/java/dev/hardwood/internal/predicate/FilterPredicateResolverTest.java
+++ b/core/src/test/java/dev/hardwood/internal/predicate/FilterPredicateResolverTest.java
@@ -12,6 +12,7 @@ import java.time.Instant;
 import java.time.LocalDate;
 import java.time.LocalTime;
 import java.util.List;
+import java.util.UUID;
 
 import org.junit.jupiter.api.Test;
 
@@ -197,6 +198,29 @@ class FilterPredicateResolverTest {
     }
 
     @Test
+    void resolveSignedBinaryOnDecimalColumn() {
+        FileSchema schema = schemaWithLogicalType("amount", PhysicalType.FIXED_LEN_BYTE_ARRAY, 8,
+                new LogicalType.DecimalType(2, 18));
+        byte[] value = new byte[8];
+        ResolvedPredicate resolved = FilterPredicateResolver.resolve(
+                new FilterPredicate.SignedBinaryColumnPredicate("amount", FilterPredicate.Operator.GT, value),
+                schema);
+        assertThat(resolved).isInstanceOf(ResolvedPredicate.BinaryPredicate.class);
+        assertThat(((ResolvedPredicate.BinaryPredicate) resolved).signed()).isTrue();
+    }
+
+    @Test
+    void resolveSignedBinaryOnNonDecimalColumnThrows() {
+        FileSchema schema = schemaWithLogicalType("data", PhysicalType.FIXED_LEN_BYTE_ARRAY, 8, null);
+        byte[] value = new byte[8];
+        assertThatThrownBy(() -> FilterPredicateResolver.resolve(
+                new FilterPredicate.SignedBinaryColumnPredicate("data", FilterPredicate.Operator.EQ, value),
+                schema))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("DecimalType");
+    }
+
+    @Test
     void resolveNegativeDecimalFixedLenByteArray() {
         FileSchema schema = schemaWithLogicalType("amount", PhysicalType.FIXED_LEN_BYTE_ARRAY, 8,
                 new LogicalType.DecimalType(2, 18));
@@ -211,6 +235,32 @@ class FilterPredicateResolverTest {
         assertThat(bp.value()).isEqualTo(expected);
         // First byte should be 0xFF (negative sign extension)
         assertThat(bp.value()[0]).isEqualTo((byte) 0xFF);
+    }
+
+    // ==================== UUID ====================
+
+    @Test
+    void resolveUuidToUnsignedBinary() {
+        FileSchema schema = schemaWithLogicalType("id", PhysicalType.FIXED_LEN_BYTE_ARRAY, 16,
+                new LogicalType.UuidType());
+        UUID uuid = UUID.fromString("550e8400-e29b-41d4-a716-446655440000");
+        ResolvedPredicate resolved = FilterPredicateResolver.resolve(
+                FilterPredicate.eq("id", uuid), schema);
+
+        assertThat(resolved).isInstanceOf(ResolvedPredicate.BinaryPredicate.class);
+        ResolvedPredicate.BinaryPredicate bp = (ResolvedPredicate.BinaryPredicate) resolved;
+        assertThat(bp.signed()).isFalse();
+        assertThat(bp.op()).isEqualTo(FilterPredicate.Operator.EQ);
+        assertThat(bp.columnIndex()).isEqualTo(0);
+    }
+
+    @Test
+    void resolveUuidOnNonUuidColumnThrows() {
+        FileSchema schema = schemaWithLogicalType("id", PhysicalType.FIXED_LEN_BYTE_ARRAY, 16, null);
+        assertThatThrownBy(() -> FilterPredicateResolver.resolve(
+                FilterPredicate.eq("id", UUID.randomUUID()), schema))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("UuidType");
     }
 
     // ==================== Combinators ====================

--- a/docs/content/usage.md
+++ b/docs/content/usage.md
@@ -309,10 +309,12 @@ FilterPredicate filter = FilterPredicate.lt("start_time", LocalTime.of(9, 0));
 // DECIMAL columns — scale and physical type are resolved from the column schema
 FilterPredicate filter = FilterPredicate.gtEq("amount", new BigDecimal("99.99"));
 
-// UUID columns
+// UUID columns — column must carry the UUID logical type
 FilterPredicate filter = FilterPredicate.eq("request_id",
     UUID.fromString("550e8400-e29b-41d4-a716-446655440000"));
 ```
+
+The logical-type factories validate the column's logical type at reader creation: `BigDecimal` predicates require a `DECIMAL` column and `UUID` predicates require a `UUID` column. Applying them to a plain `FIXED_LEN_BYTE_ARRAY` column without the corresponding logical-type annotation throws `IllegalArgumentException`.
 
 Raw physical-type predicates (`int`, `long`, etc.) remain available for columns without logical types or for filtering on the underlying physical value directly.
 


### PR DESCRIPTION
Hello, this PR resolves #351, adding a UUID Filter Predicate and tightening SignedBinaryColumnPredicate to logical type decimal, and a very slight performance improvement of the binary comparator 

## Checklist

- [x] Build via `./mvnw clean verify` passes
- [ x The commit message is prefixed with the issue key ("#123 Adding support for...")
- [x] Code changes are covered by tests
- [ ] If this PR adds or changes user-facing behaviour, `docs/` has been updated
