### PR TITLE
#355 dive: theme and visual hierarchy

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -63,6 +63,11 @@ Before starting new work, check whether a corresponding GitHub issue exists. If 
 Commit messages must begin with the GitHub issue key (e.g. `#90 Include file name in all exceptions raised during reading`). This applies to every commit, including fixups and amendments.
 Focus the body on **why**, not **what** — the diff already shows the what. A short paragraph is usually enough; do not restate the change as a bullet list. See [CONTRIBUTING.md](CONTRIBUTING.md#commit-messages).
 
+# Dive TUI
+
+When changing visual styling in the `hardwood dive` TUI (any code under `cli/src/main/java/dev/hardwood/cli/dive/`), follow the visual-hierarchy decision tree in [_designs/DIVE_THEME.md](_designs/DIVE_THEME.md). Style spans through one of `Theme.primary()` / `Theme.accent()` / `Theme.selection()` / `Theme.dim()`, or leave them at default fg via `Style.EMPTY`. Direct use of `Color.*` constants or literal `Style.EMPTY.bold()` / `Style.EMPTY.fg(...)` outside `Theme.java` is a smell — review against the decision tree before introducing any.
+
 # Code Reviews
 
 When reviewing a pull request, make sure the principles described here are applied.
+When asked to review a PR, write the findings to a Markdown file with a `[ ]` checkbox in front of each actionable item. When subsequently asked to address those review remarks, check the items off (`[x]`) as they are resolved.

--- a/_designs/DIVE_THEME.md
+++ b/_designs/DIVE_THEME.md
@@ -1,0 +1,237 @@
+# Design: `dive` theme and visual hierarchy (#355)
+
+**Status: Implemented.**
+
+## Goal
+
+Visual rules for the `hardwood dive` TUI that are consistent across
+screens and render correctly on the terminal palettes dive ships
+against — Solarized Dark, Solarized Light, macOS Terminal, and any
+terminal that honours either truecolor escapes or named ANSI. One
+theme; no per-mode palette; no startup probe.
+
+The rest of this document describes the rule set in five tiers and
+the decision tree authors should follow when adding new content.
+
+## Tiers
+
+| # | Tier | Method | Visual |
+|---|---|---|---|
+| 1 | Selection | `Theme.selection()` | bold yellow |
+| 2 | Structural caption | `Theme.accent().bold()` | bold blue |
+| 3 | Label / "you-are-here" | `Theme.primary()` | bold default fg |
+| 4 | Body content | `Style.EMPTY` (no method call) | terminal default fg |
+| 5 | Persistent chrome | `Theme.dim()` | faint default fg |
+
+Concrete styling on the four `Theme` methods:
+
+| Method | Truecolor terminals | Named-ANSI terminals |
+|---|---|---|
+| `primary()` | `Style.EMPTY.bold()` | (same) |
+| `accent()` | `Style.EMPTY.fg(rgb(38, 139, 210))` | `Style.EMPTY.fg(Color.BLUE)` |
+| `selection()` | `Style.EMPTY.bold().fg(rgb(181, 137, 0))` | `Style.EMPTY.bold().fg(Color.YELLOW)` |
+| `dim()` | `Style.EMPTY.dim()` | (same — uses ANSI faint attribute) |
+
+Truecolor support is detected once at class-load via `$COLORTERM`
+(`truecolor` or `24bit`). The boolean is fixed for the JVM lifetime;
+`Theme` is otherwise stateless.
+
+`accent()` and `selection()` use truecolor RGB pinned to Solarized's
+accent slots when available so that iTerm2's "Use bright colors for
+bold text" setting cannot remap them. `Color.BLUE` and `Color.YELLOW`
+serve as the fallback when truecolor is unavailable; on those
+terminals the bold-bright remap either does not occur or maps to
+something readable.
+
+`dim()` uses the ANSI faint attribute rather than a specific grey
+colour. This avoids Solarized's named-grey traps (`Color.GRAY` →
+`base2` cream, brighter than fg; `Color.DARK_GRAY` → `base03`, the
+Solarized Dark background). Terminals that do not honour the faint
+attribute render the text at default fg unchanged.
+
+## Decision tree
+
+When adding new content to a dive screen, walk these in order. The
+first match wins.
+
+1. **Is it the active row in a navigable list?** (table-row highlight,
+   selected drill-into menu row, selected schema name, footer active
+   anchor, modal cursor.) → `Theme.selection()`.
+
+2. **Is it a structural caption?** (section heading inside a pane,
+   table column header, app brand " hardwood dive ".) →
+   `Theme.accent().bold()`.
+
+3. **Is it a label, breadcrumb leaf, drill-into menu label (enabled,
+   not selected), or interactive prompt?** (`/ ` search prompt, kv
+   pane label, "you-are-here" indicator.) → `Theme.primary()`.
+
+4. **Is it persistent chrome?** (keybar, modal hint bar, breadcrumb
+   non-head segment, ` › ` separator, empty-state message,
+   search-result count, parenthetical advisory, unfocused pane
+   border.) → `Theme.dim()`.
+
+5. **Else** — body content the user came to read (kv values, schema
+   row name / type / logical / repetition / col-suffix, top-bar facts
+   like filename and size, menu hint values, table data rows). →
+   `Style.EMPTY` (no `Theme` call).
+
+The decision tree is exhaustive. Any new dive content falls into
+exactly one tier.
+
+## Pane borders
+
+Borders follow the same active / ambient distinction as text content
+but use `borderStyle` rather than `borderColor`:
+
+- **Active pane** (focused half of a multi-pane screen, or the only
+  pane on a single-pane screen): no `borderStyle` set on the `Block`
+  builder. Border lines render in the terminal's default fg.
+- **Unfocused pane** in a multi-pane focus-tracking screen
+  (`OverviewScreen`, `RowGroupDetailScreen`, `ColumnChunkDetailScreen`):
+  `Block.builder()....borderStyle(Theme.dim())`. Faint default fg.
+
+Pane borders deliberately do not use `accent()`. Bold blue is
+reserved for textual structural anchors (section titles, table
+headers, brand) so the eye reads it as "this is a heading-like
+thing" rather than "this is decoration."
+
+## Modal dimming
+
+When a modal is open (help overlay, kv-meta detail, page-header
+detail, record detail, dictionary value, min/max), the body behind
+the modal is faded so the modal stands out and to signal that the
+background is non-interactive.
+
+Implementation: each modal-render path calls
+`buffer.setStyle(area, Style.EMPTY.dim())` on the body area
+immediately before the modal renders. `Buffer.setStyle` invokes
+`Cell.patchStyle` per cell, which adds the faint modifier on top of
+existing styling without overwriting the cell content or its other
+modifiers. The modal's own `Clear.INSTANCE.render(modalArea, buffer)`
+then fully replaces the cells inside the modal area, restoring full
+intensity for the modal contents.
+
+Chrome (top bar, breadcrumb, keybar) stays at full intensity. Only
+the body region — the screen's main pane area passed to `render` —
+is dimmed.
+
+```java
+// in a screen's render method, after the body is painted:
+if (state.modalOpen()) {
+    buffer.setStyle(area, Style.EMPTY.dim());
+    renderXxxModal(buffer, area, ...);
+}
+```
+
+A new modal added to dive should follow this pattern: paint the body
+first, dim the body area, render the modal last. Skipping the dim
+call leaves the background at full intensity behind the modal —
+visually inconsistent with every other modal in the app.
+
+## Convention recipes
+
+### KV panes (label / value rows)
+
+```java
+new Span(padRight(label, width), Theme.primary()),
+new Span(value, Style.EMPTY)
+```
+
+### Tables (Tamboui `Table` widget)
+
+```java
+Row header = Row.from(...).style(Theme.accent().bold());
+Table.builder()
+    .header(header)
+    .highlightStyle(Theme.selection())
+    ...
+```
+
+### Drill-into menu rows
+
+| Row state | Cursor | Label | Hint |
+|---|---|---|---|
+| Enabled, not selected | `  ` | `Theme.primary()` | per screen |
+| Enabled, selected | `▶ ` | `Theme.selection()` | per screen |
+| Disabled | `  ` | `Theme.primary()` | hint shows `n/a` / `—` |
+
+Hint styling depends on what the hint says:
+- If the hint carries a fact (e.g. `4 pages`, `present`, `n/a` in
+  `ColumnChunkDetailScreen`'s menu): default fg, treated as body
+  content.
+- If the hint has both a fact value and an annotation (e.g. `4 columns
+  · browse by column` in `OverviewScreen`'s menu): split — value at
+  default fg, ` · browse by …` suffix at `Theme.dim()`.
+
+Disabled rows are signalled by the hint content (`n/a` / `—`), not by
+a separate visual style. The cursor skips them on selection.
+
+### Schema tree
+
+- Header row (`Name`, `Type`, `Logical`, `Repetition`):
+  `Theme.accent().bold()`.
+- Body rows: name / type / logical / repetition / `[col N]` columns
+  all at default fg.
+- Selected name: `Theme.selection()`.
+- Expand / collapse marker (`▼` / `▶`): `Theme.accent()` (no bold).
+
+### Section delimiters within a pane
+
+```java
+new Span(" Compression ", Theme.accent().bold())
+```
+
+Used by `RowGroupDetailScreen` (Compression / Encoding mix / Page
+indexes), `FooterScreen` (File layout / Encodings / Codecs / Page
+indexes / Dictionary / Aggregate), `PagesScreen` modal (Inline
+statistics), `OverviewScreen` ("key/value meta (N)"), and the help
+overlay's section labels.
+
+## `Theme` API
+
+```java
+public final class Theme {
+    public static Style primary();
+    public static Style accent();
+    public static Style selection();
+    public static Style dim();
+}
+```
+
+All four return `Style`. Selection sites compose `.bold()` onto
+`accent()` directly. The rare site that needs a `Color` (currently
+none) extracts it via `.fg().orElseThrow()`.
+
+There is no `init()` and no `--theme` flag. The truecolor probe runs
+in a static initialiser; the values are immutable for the JVM's
+lifetime.
+
+## Testing
+
+- `ThemeTest` pins each tone's structure (modifier presence, fg
+  colour identity) so an accidental retargeting shows up in review.
+- Manual verification on at least: iTerm2 + Solarized Dark, iTerm2
+  + Solarized Light, macOS Terminal, one generic xterm-style
+  terminal. Truecolor / named-ANSI behaviour is exercised by
+  setting / unsetting `$COLORTERM`.
+
+## Maintaining consistency
+
+When adding new dive content:
+
+- Style spans through one of the four `Theme` methods or leave them
+  unstyled (`Style.EMPTY`). Direct use of `Color.*` constants or
+  literal `Style.EMPTY.bold()` / `Style.EMPTY.fg(...)` etc. outside
+  `Theme.java` is a smell — review against the decision tree before
+  introducing any.
+- Walk the [decision tree](#decision-tree) in order; the first match
+  is the correct tier.
+- New table widgets follow the [tables recipe](#tables-tamboui-table-widget).
+  New kv blocks follow the [kv recipe](#kv-panes-label--value-rows).
+  New panes that participate in focus tracking follow the [pane
+  borders](#pane-borders) rule.
+- `dim()` is for chrome; do not use it for content the user came to
+  read. Conversely, body content (values, schema rows, top-bar
+  facts) must not use `Theme.primary()` — primary is for labels and
+  "you-are-here" markers, not for emphasising data.

--- a/cli/src/main/java/dev/hardwood/cli/dive/DiveApp.java
+++ b/cli/src/main/java/dev/hardwood/cli/dive/DiveApp.java
@@ -27,6 +27,7 @@ import dev.hardwood.cli.dive.internal.RowGroupDetailScreen;
 import dev.hardwood.cli.dive.internal.RowGroupIndexesScreen;
 import dev.hardwood.cli.dive.internal.RowGroupsScreen;
 import dev.hardwood.cli.dive.internal.SchemaScreen;
+import dev.hardwood.cli.dive.internal.Theme;
 import dev.tamboui.buffer.Buffer;
 import dev.tamboui.layout.Rect;
 import dev.tamboui.terminal.Frame;
@@ -176,6 +177,10 @@ public final class DiveApp {
         Chrome.renderKeybar(buffer, regions.keybar(), screenKeys, globalKeys);
 
         if (helpOpen) {
+            // Faint the body so the modal pops; the modal's own
+            // Clear+paint restores full intensity inside its area.
+            // Chrome (top bar, breadcrumb, keybar) stays unchanged.
+            buffer.setStyle(regions.body(), Theme.dim());
             HelpOverlay.render(buffer, area);
         }
     }

--- a/cli/src/main/java/dev/hardwood/cli/dive/internal/Chrome.java
+++ b/cli/src/main/java/dev/hardwood/cli/dive/internal/Chrome.java
@@ -67,11 +67,11 @@ public final class Chrome {
     }
 
     public static void renderTopBar(Buffer buffer, Rect area, ParquetModel model) {
-        Style bold = Style.EMPTY.bold();
-        Style dim = Style.EMPTY.fg(Theme.DIM);
+        Style brand = Theme.accent().bold();
+        Style dim = Theme.dim();
         ParquetModel.Facts f = model.facts();
         List<Span> spans = new ArrayList<>();
-        spans.add(new Span(" hardwood dive ", bold.fg(Theme.ACCENT)));
+        spans.add(new Span(" hardwood dive ", brand));
         spans.add(new Span("│ ", dim));
         spans.add(Span.raw(basename(model.displayPath())));
         spans.add(new Span(" │ ", dim));
@@ -113,17 +113,20 @@ public final class Chrome {
                 haveRgInPath = true;
             }
         }
+        Style dim = Theme.dim();
         for (int i = 0; i < frames.size(); i++) {
             if (i > 0) {
-                spans.add(new Span(" › ", Style.EMPTY.fg(Theme.DIM)));
+                spans.add(new Span(" › ", dim));
             }
             boolean last = i == frames.size() - 1;
-            Style style = last ? Style.EMPTY.bold() : Style.EMPTY.fg(Theme.DIM);
             String label = breadcrumbLabel(frames.get(i), model);
             if (last) {
                 label += leafContextSuffix(frames.get(i), model, haveRgInPath, haveColInPath);
+                spans.add(new Span(label, Theme.primary()));
             }
-            spans.add(new Span(label, style));
+            else {
+                spans.add(new Span(label, dim));
+            }
         }
         Paragraph.builder().text(convert(Line.from(spans))).left().build().render(area, buffer);
     }
@@ -163,12 +166,12 @@ public final class Chrome {
     }
 
     public static void renderKeybar(Buffer buffer, Rect area, String screenKeys, String globalKeys) {
-        Style dim = Style.EMPTY.fg(Theme.DIM);
+        Style style = Theme.dim();
         Line line = Line.from(
                 Span.raw(" "),
-                new Span(screenKeys, dim),
-                new Span(KEYBAR_SEP, dim),
-                new Span(globalKeys, dim));
+                new Span(screenKeys, style),
+                new Span(KEYBAR_SEP, style),
+                new Span(globalKeys, style));
         Paragraph.builder()
                 .text(convert(line))
                 .left()

--- a/cli/src/main/java/dev/hardwood/cli/dive/internal/ColumnAcrossRowGroupsScreen.java
+++ b/cli/src/main/java/dev/hardwood/cli/dive/internal/ColumnAcrossRowGroupsScreen.java
@@ -24,7 +24,6 @@ import dev.hardwood.schema.ColumnSchema;
 import dev.tamboui.buffer.Buffer;
 import dev.tamboui.layout.Constraint;
 import dev.tamboui.layout.Rect;
-import dev.tamboui.style.Style;
 import dev.tamboui.tui.event.KeyEvent;
 import dev.tamboui.widgets.block.Block;
 import dev.tamboui.widgets.block.BorderType;
@@ -129,7 +128,7 @@ public final class ColumnAcrossRowGroupsScreen {
                     max));
         }
         Row header = Row.from("RG", "Rows", "Pages", "Comp", "Ratio", "Dict", "CI", "Nulls", "Min", "Max")
-                .style(Style.EMPTY.bold());
+                .style(Theme.accent().bold());
         String typeMode = state.logicalTypes() ? "" : " · physical";
         Block block = Block.builder()
                 .title(" " + truncateLeft(col.fieldPath().toString(), 40)
@@ -139,7 +138,6 @@ public final class ColumnAcrossRowGroupsScreen {
                         + typeMode + " ")
                 .borders(Borders.ALL)
                 .borderType(BorderType.ROUNDED)
-                .borderColor(Theme.ACCENT)
                 .build();
         Table table = Table.builder()
                 .header(header)
@@ -157,7 +155,7 @@ public final class ColumnAcrossRowGroupsScreen {
                 .columnSpacing(1)
                 .block(block)
                 .highlightSymbol("▶ ")
-                .highlightStyle(Style.EMPTY.bold())
+                .highlightStyle(Theme.selection())
                 .build();
         TableState tableState = new TableState();
         tableState.select(state.selection());

--- a/cli/src/main/java/dev/hardwood/cli/dive/internal/ColumnChunkDetailScreen.java
+++ b/cli/src/main/java/dev/hardwood/cli/dive/internal/ColumnChunkDetailScreen.java
@@ -268,10 +268,10 @@ public final class ColumnChunkDetailScreen {
             boolean selected = focused && i == effectiveSelection && enabled;
             String cursor = selected ? "▶ " : "  ";
             String hint = menuHint(item, model, state);
-            Style labelStyle = !enabled
-                    ? Style.EMPTY.fg(Theme.DIM)
-                    : selected ? Style.EMPTY.bold().fg(Theme.ACCENT) : Style.EMPTY;
-            Style hintStyle = Style.EMPTY.fg(Theme.DIM);
+            Style labelStyle = selected
+                    ? Theme.selection()
+                    : Theme.primary();
+            Style hintStyle = Style.EMPTY;
             lines.add(Line.from(
                     new Span(cursor, labelStyle),
                     new Span(padRight(item.label, 16), labelStyle),
@@ -295,18 +295,20 @@ public final class ColumnChunkDetailScreen {
     }
 
     private static Block paneBlock(String title, boolean focused) {
-        return Block.builder()
+        Block.Builder b = Block.builder()
                 .title(title)
                 .borders(Borders.ALL)
-                .borderType(BorderType.ROUNDED)
-                .borderColor(focused ? Theme.ACCENT : Theme.DIM)
-                .build();
+                .borderType(BorderType.ROUNDED);
+        if (!focused) {
+            b.borderStyle(Theme.dim());
+        }
+        return b.build();
     }
 
     private static Line fact(String key, String value) {
         return Line.from(
-                new Span(" " + padRight(key, 22), Style.EMPTY),
-                new Span(value, Style.EMPTY.bold()));
+                new Span(" " + padRight(key, 22), Theme.primary()),
+                new Span(value, Style.EMPTY));
     }
 
     /// Special-case the Path row: when the path is short, a single "Path  value"
@@ -319,8 +321,8 @@ public final class ColumnChunkDetailScreen {
             return List.of(fact("Path", path));
         }
         return List.of(
-                Line.from(new Span(" " + padRight("Path", 22), Style.EMPTY)),
-                Line.from(new Span("   " + path, Style.EMPTY.bold())));
+                Line.from(new Span(" " + padRight("Path", 22), Theme.primary())),
+                Line.from(new Span("   " + path, Style.EMPTY)));
     }
 
     private static String formatStatValue(byte[] bytes, ColumnSchema col, boolean useLogicalType) {

--- a/cli/src/main/java/dev/hardwood/cli/dive/internal/ColumnChunksScreen.java
+++ b/cli/src/main/java/dev/hardwood/cli/dive/internal/ColumnChunksScreen.java
@@ -21,7 +21,6 @@ import dev.hardwood.metadata.RowGroup;
 import dev.tamboui.buffer.Buffer;
 import dev.tamboui.layout.Constraint;
 import dev.tamboui.layout.Rect;
-import dev.tamboui.style.Style;
 import dev.tamboui.tui.event.KeyEvent;
 import dev.tamboui.widgets.block.Block;
 import dev.tamboui.widgets.block.BorderType;
@@ -96,7 +95,7 @@ public final class ColumnChunksScreen {
                     cmd.dictionaryPageOffset() != null ? "yes" : "no"));
         }
         Row header = Row.from("#", "Column", "Type", "Logical", "Codec", "Compressed", "Ratio", "Dict")
-                .style(Style.EMPTY.bold());
+                .style(Theme.accent().bold());
         Block block = Block.builder()
                 .title(" RG #" + state.rowGroupIndex() + " column chunks "
                         + Plurals.rangeOf(state.selection(),
@@ -104,7 +103,6 @@ public final class ColumnChunksScreen {
                                 Keys.viewportStride()) + " ")
                 .borders(Borders.ALL)
                 .borderType(BorderType.ROUNDED)
-                .borderColor(Theme.ACCENT)
                 .build();
         Table table = Table.builder()
                 .header(header)
@@ -120,7 +118,7 @@ public final class ColumnChunksScreen {
                 .columnSpacing(2)
                 .block(block)
                 .highlightSymbol("▶ ")
-                .highlightStyle(Style.EMPTY.bold())
+                .highlightStyle(Theme.selection())
                 .build();
         TableState tableState = new TableState();
         tableState.select(state.selection());

--- a/cli/src/main/java/dev/hardwood/cli/dive/internal/ColumnIndexScreen.java
+++ b/cli/src/main/java/dev/hardwood/cli/dive/internal/ColumnIndexScreen.java
@@ -21,7 +21,6 @@ import dev.tamboui.buffer.Buffer;
 import dev.tamboui.layout.Constraint;
 import dev.tamboui.layout.Layout;
 import dev.tamboui.layout.Rect;
-import dev.tamboui.style.Style;
 import dev.tamboui.text.Line;
 import dev.tamboui.text.Span;
 import dev.tamboui.text.Text;
@@ -175,8 +174,8 @@ public final class ColumnIndexScreen {
 
         Paragraph.builder()
                 .text(Text.from(Line.from(
-                        new Span(" Boundary order: ", Style.EMPTY.fg(Theme.DIM)),
-                        new Span(ci.boundaryOrder().name(), Style.EMPTY.bold()))))
+                        new Span(" Boundary order: ", Theme.primary()),
+                        Span.raw(ci.boundaryOrder().name()))))
                 .left()
                 .build()
                 .render(split.get(0), buffer);
@@ -195,7 +194,7 @@ public final class ColumnIndexScreen {
                     formatStat(ci.minValues().get(idx), col, state.logicalTypes()),
                     formatStat(ci.maxValues().get(idx), col, state.logicalTypes())));
         }
-        Row header = Row.from("#", "Null page", "Nulls", "Min", "Max").style(Style.EMPTY.bold());
+        Row header = Row.from("#", "Null page", "Nulls", "Min", "Max").style(Theme.accent().bold());
         String typeMode = state.logicalTypes() ? "" : " · physical";
         Block block = Block.builder()
                 .title(" Column index "
@@ -206,7 +205,6 @@ public final class ColumnIndexScreen {
                         + typeMode + " ")
                 .borders(Borders.ALL)
                 .borderType(BorderType.ROUNDED)
-                .borderColor(Theme.ACCENT)
                 .build();
         Table table = Table.builder()
                 .header(header)
@@ -219,7 +217,7 @@ public final class ColumnIndexScreen {
                 .columnSpacing(2)
                 .block(block)
                 .highlightSymbol("▶ ")
-                .highlightStyle(Style.EMPTY.bold())
+                .highlightStyle(Theme.selection())
                 .build();
         TableState tableState = new TableState();
         if (!filtered.isEmpty()) {
@@ -229,6 +227,7 @@ public final class ColumnIndexScreen {
 
         if (state.modalOpen() && !filtered.isEmpty()) {
             int idx = filtered.get(Math.min(state.selection(), filtered.size() - 1));
+            buffer.setStyle(area, Theme.dim());
             renderMinMaxModal(buffer, area, idx,
                     ci.minValues().get(idx), ci.maxValues().get(idx),
                     col, state.logicalTypes());
@@ -250,17 +249,16 @@ public final class ColumnIndexScreen {
         dev.tamboui.widgets.Clear.INSTANCE.render(modal, buffer);
 
         List<Line> lines = new ArrayList<>();
-        lines.add(Line.from(new Span(" Min ", Style.EMPTY.bold()), Span.raw(min)));
-        lines.add(Line.from(new Span(" Max ", Style.EMPTY.bold()), Span.raw(max)));
+        lines.add(Line.from(new Span(" Min ", Theme.primary()), Span.raw(min)));
+        lines.add(Line.from(new Span(" Max ", Theme.primary()), Span.raw(max)));
         lines.add(Line.empty());
         boolean hasLogical = col.logicalType() != null;
         String hint = " Esc / Enter close" + (hasLogical ? " · t logical types" : "");
-        lines.add(Line.from(new Span(hint, Style.EMPTY.fg(Theme.DIM))));
+        lines.add(Line.from(new Span(hint, Theme.dim())));
         Block block = Block.builder()
                 .title(" Page #" + pageIndex + " min / max ")
                 .borders(Borders.ALL)
                 .borderType(BorderType.ROUNDED)
-                .borderColor(Theme.ACCENT)
                 .build();
         Paragraph.builder().block(block).text(Text.from(lines)).left().build().render(modal, buffer);
     }
@@ -321,7 +319,7 @@ public final class ColumnIndexScreen {
                     .text(Text.from(Line.from(new Span(
                             " " + Plurals.format(totalPages, "page", "pages")
                                     + ". Press / to filter by min/max.",
-                            Style.EMPTY.fg(Theme.DIM)))))
+                            Theme.dim()))))
                     .left()
                     .build()
                     .render(area, buffer);
@@ -329,10 +327,10 @@ public final class ColumnIndexScreen {
         }
         String cursor = state.searching() ? "█" : "";
         Line line = Line.from(
-                new Span(" / ", Style.EMPTY.fg(Theme.ACCENT).bold()),
-                new Span(state.filter() + cursor, Style.EMPTY.bold()),
+                new Span(" / ", Theme.primary()),
+                new Span(state.filter() + cursor, Theme.primary()),
                 new Span("  (" + Fmt.fmt("%,d", matchCount) + " / "
-                        + Plurals.format(totalPages, "page", "pages") + ")", Style.EMPTY.fg(Theme.DIM)));
+                        + Plurals.format(totalPages, "page", "pages") + ")", Theme.dim()));
         Paragraph.builder().text(Text.from(line)).left().build().render(area, buffer);
     }
 
@@ -369,11 +367,10 @@ public final class ColumnIndexScreen {
                 .title(" Column index ")
                 .borders(Borders.ALL)
                 .borderType(BorderType.ROUNDED)
-                .borderColor(Theme.DIM)
                 .build();
         Paragraph.builder()
                 .block(block)
-                .text(Text.from(Line.from(new Span(" " + message, Style.EMPTY.fg(Theme.DIM)))))
+                .text(Text.from(Line.from(new Span(" " + message, Theme.dim()))))
                 .left()
                 .build()
                 .render(area, buffer);

--- a/cli/src/main/java/dev/hardwood/cli/dive/internal/DataPreviewScreen.java
+++ b/cli/src/main/java/dev/hardwood/cli/dive/internal/DataPreviewScreen.java
@@ -222,7 +222,7 @@ public final class DataPreviewScreen {
             }
             rows.add(Row.from(truncated));
         }
-        Row header = Row.from(visible.toArray(new String[0])).style(Style.EMPTY.bold());
+        Row header = Row.from(visible.toArray(new String[0])).style(Theme.accent().bold());
 
         long total = model.facts().totalRows();
         long lastRow = state.firstRow() + state.rows().size();
@@ -235,7 +235,6 @@ public final class DataPreviewScreen {
                 .title(title)
                 .borders(Borders.ALL)
                 .borderType(BorderType.ROUNDED)
-                .borderColor(Theme.ACCENT)
                 .build();
         List<Constraint> widths = new ArrayList<>();
         for (int i = 0; i < visible.size(); i++) {
@@ -248,7 +247,7 @@ public final class DataPreviewScreen {
                 .columnSpacing(2)
                 .block(block)
                 .highlightSymbol("▶ ")
-                .highlightStyle(Style.EMPTY.bold())
+                .highlightStyle(Theme.selection())
                 .build();
         TableState tableState = new TableState();
         if (!state.rows().isEmpty()) {
@@ -256,6 +255,7 @@ public final class DataPreviewScreen {
         }
         table.render(area, buffer, tableState);
         if (state.modalRow() >= 0 && state.modalRow() < state.rows().size()) {
+            buffer.setStyle(area, Theme.dim());
             renderRecordModal(buffer, area, model, state);
         }
     }
@@ -297,7 +297,7 @@ public final class DataPreviewScreen {
                     wrapped.add("");
                 }
                 all.add(Line.from(
-                        new Span(" " + name + pad + " : ", Style.EMPTY.bold()),
+                        new Span(" " + name + pad + " : ", Theme.primary()),
                         Span.raw(wrapped.get(0))));
                 for (int k = 1; k < wrapped.size(); k++) {
                     all.add(Line.from(Span.raw(continuationIndent + wrapped.get(k))));
@@ -305,7 +305,7 @@ public final class DataPreviewScreen {
             }
             else {
                 all.add(Line.from(
-                        new Span(" " + name + pad + " : ", Style.EMPTY.bold()),
+                        new Span(" " + name + pad + " : ", Theme.primary()),
                         Span.raw(truncate(value, valueBudget))));
             }
         }
@@ -332,7 +332,7 @@ public final class DataPreviewScreen {
             String pad = " ".repeat(maxKeyWidth - name.length());
             boolean isExpanded = state.expandedColumns().contains(fieldIdx);
             String value = fieldIdx < values.size() ? values.get(fieldIdx) : "";
-            Style accent = Style.EMPTY.bold().fg(Theme.ACCENT);
+            Style selectionStyle = Theme.selection();
             if (cursorLine == fieldFirstLine) {
                 String shown;
                 if (isExpanded) {
@@ -344,15 +344,15 @@ public final class DataPreviewScreen {
                     shown = truncate(value, valueBudget);
                 }
                 all.set(cursorLine, Line.from(
-                        new Span("▶" + name + pad + " : ", accent),
-                        new Span(shown, accent)));
+                        new Span("▶" + name + pad + " : ", selectionStyle),
+                        new Span(shown, selectionStyle)));
             }
             else if (isExpanded) {
                 String fullValue = fieldIdx < expanded.size() ? expanded.get(fieldIdx) : value;
                 List<String> wrapped = wrapValue(fullValue, valueBudget);
                 int contIdx = cursorLine - fieldFirstLine;
                 String text = contIdx < wrapped.size() ? wrapped.get(contIdx) : "";
-                all.set(cursorLine, Line.from(new Span(continuationIndent + text, accent)));
+                all.set(cursorLine, Line.from(new Span(continuationIndent + text, selectionStyle)));
             }
         }
 
@@ -400,14 +400,13 @@ public final class DataPreviewScreen {
         if (!hint.startsWith(" ")) {
             hint = " " + hint;
         }
-        lines.add(Line.from(new Span(hint, Style.EMPTY.fg(Theme.DIM))));
+        lines.add(Line.from(new Span(hint, Theme.dim())));
 
         long absRow = state.firstRow() + state.modalRow();
         Block block = Block.builder()
                 .title(Fmt.fmt(" Row %,d ", absRow + 1))
                 .borders(Borders.ALL)
                 .borderType(BorderType.ROUNDED)
-                .borderColor(Theme.ACCENT)
                 .build();
         Paragraph.builder()
                 .block(block)

--- a/cli/src/main/java/dev/hardwood/cli/dive/internal/DictionaryScreen.java
+++ b/cli/src/main/java/dev/hardwood/cli/dive/internal/DictionaryScreen.java
@@ -21,7 +21,6 @@ import dev.tamboui.buffer.Buffer;
 import dev.tamboui.layout.Constraint;
 import dev.tamboui.layout.Layout;
 import dev.tamboui.layout.Rect;
-import dev.tamboui.style.Style;
 import dev.tamboui.text.Line;
 import dev.tamboui.text.Span;
 import dev.tamboui.text.Text;
@@ -199,7 +198,7 @@ public final class DictionaryScreen {
                     "[" + idx + "]",
                     formatValue(dict, idx, col, VALUE_PREVIEW_MAX, state.logicalTypes())));
         }
-        Row header = Row.from("#", "Value").style(Style.EMPTY.bold());
+        Row header = Row.from("#", "Value").style(Theme.accent().bold());
         String typeMode = state.logicalTypes() ? "" : " · physical";
         Block block = Block.builder()
                 .title(" Dictionary entries "
@@ -210,7 +209,6 @@ public final class DictionaryScreen {
                         + typeMode + " ")
                 .borders(Borders.ALL)
                 .borderType(BorderType.ROUNDED)
-                .borderColor(Theme.ACCENT)
                 .build();
         Table table = Table.builder()
                 .header(header)
@@ -219,7 +217,7 @@ public final class DictionaryScreen {
                 .columnSpacing(2)
                 .block(block)
                 .highlightSymbol("▶ ")
-                .highlightStyle(Style.EMPTY.bold())
+                .highlightStyle(Theme.selection())
                 .build();
         TableState tableState = new TableState();
         if (!filtered.isEmpty()) {
@@ -229,6 +227,7 @@ public final class DictionaryScreen {
 
         if (state.modalOpen() && !filtered.isEmpty()) {
             int dictIdx = filtered.get(Math.min(state.selection(), filtered.size() - 1));
+            buffer.setStyle(area, Theme.dim());
             renderValueModal(buffer, area, dict, col, dictIdx, state.logicalTypes());
         }
     }
@@ -262,7 +261,7 @@ public final class DictionaryScreen {
             Paragraph.builder()
                     .text(Text.from(Line.from(new Span(
                             " " + Plurals.format(totalSize, "entry", "entries") + ". Press / to filter.",
-                            Style.EMPTY.fg(Theme.DIM)))))
+                            Theme.dim()))))
                     .left()
                     .build()
                     .render(area, buffer);
@@ -270,10 +269,10 @@ public final class DictionaryScreen {
         }
         String cursor = state.searching() ? "█" : "";
         Line line = Line.from(
-                new Span(" / ", Style.EMPTY.fg(Theme.ACCENT).bold()),
-                new Span(state.filter() + cursor, Style.EMPTY.bold()),
+                new Span(" / ", Theme.primary()),
+                new Span(state.filter() + cursor, Theme.primary()),
                 new Span("  (" + Fmt.fmt("%,d", filteredSize) + " / "
-                        + Plurals.format(totalSize, "entry", "entries") + ")", Style.EMPTY.fg(Theme.DIM)));
+                        + Plurals.format(totalSize, "entry", "entries") + ")", Theme.dim()));
         Paragraph.builder().text(Text.from(line)).left().build().render(area, buffer);
     }
 
@@ -368,12 +367,11 @@ public final class DictionaryScreen {
         lines.add(Line.empty());
         lines.add(Line.from(new Span(
                 " (raise the cap with --max-dict-bytes on the next launch)",
-                Style.EMPTY.fg(Theme.DIM))));
+                Theme.dim())));
         Block block = Block.builder()
                 .title(" Dictionary — load confirmation ")
                 .borders(Borders.ALL)
                 .borderType(BorderType.ROUNDED)
-                .borderColor(Theme.ACCENT)
                 .build();
         Paragraph.builder().block(block).text(Text.from(lines)).left().build().render(area, buffer);
     }
@@ -383,13 +381,12 @@ public final class DictionaryScreen {
                 .title(" Dictionary ")
                 .borders(Borders.ALL)
                 .borderType(BorderType.ROUNDED)
-                .borderColor(Theme.DIM)
                 .build();
         Paragraph.builder()
                 .block(block)
                 .text(Text.from(Line.from(new Span(
                         " This chunk is not dictionary-encoded.",
-                        Style.EMPTY.fg(Theme.DIM)))))
+                        Theme.dim()))))
                 .left()
                 .build()
                 .render(area, buffer);
@@ -411,13 +408,12 @@ public final class DictionaryScreen {
         lines.add(Line.empty());
         boolean hasLogical = col.logicalType() != null;
         String hint = " Esc / Enter close" + (hasLogical ? " · t logical types" : "");
-        lines.add(Line.from(new Span(hint, Style.EMPTY.fg(Theme.DIM))));
+        lines.add(Line.from(new Span(hint, Theme.dim())));
 
         Block block = Block.builder()
                 .title(" Entry #" + index + " ")
                 .borders(Borders.ALL)
                 .borderType(BorderType.ROUNDED)
-                .borderColor(Theme.ACCENT)
                 .build();
         Paragraph.builder().block(block).text(Text.from(lines)).left().build().render(area, buffer);
     }

--- a/cli/src/main/java/dev/hardwood/cli/dive/internal/FileIndexesScreen.java
+++ b/cli/src/main/java/dev/hardwood/cli/dive/internal/FileIndexesScreen.java
@@ -21,7 +21,6 @@ import dev.hardwood.metadata.RowGroup;
 import dev.tamboui.buffer.Buffer;
 import dev.tamboui.layout.Constraint;
 import dev.tamboui.layout.Rect;
-import dev.tamboui.style.Style;
 import dev.tamboui.text.Line;
 import dev.tamboui.text.Span;
 import dev.tamboui.text.Text;
@@ -111,12 +110,11 @@ public final class FileIndexesScreen {
                     .title(title)
                     .borders(Borders.ALL)
                     .borderType(BorderType.ROUNDED)
-                    .borderColor(Theme.DIM)
                     .build();
             Paragraph.builder()
                     .block(emptyBlock)
                     .text(Text.from(Line.from(
-                            new Span(" " + message, Style.EMPTY.fg(Theme.DIM)))))
+                            new Span(" " + message, Theme.dim()))))
                     .left()
                     .build()
                     .render(area, buffer);
@@ -152,10 +150,10 @@ public final class FileIndexesScreen {
             }
         }
         Row header = switch (state.kind()) {
-            case COLUMN -> Row.from("RG", "Column", "CI offset", "CI bytes").style(Style.EMPTY.bold());
-            case OFFSET -> Row.from("RG", "Column", "OI offset", "OI bytes").style(Style.EMPTY.bold());
+            case COLUMN -> Row.from("RG", "Column", "CI offset", "CI bytes").style(Theme.accent().bold());
+            case OFFSET -> Row.from("RG", "Column", "OI offset", "OI bytes").style(Theme.accent().bold());
             case DICTIONARY -> Row.from("RG", "Column", "Dict offset", "Data offset", "Dict span")
-                    .style(Style.EMPTY.bold());
+                    .style(Theme.accent().bold());
         };
         List<Constraint> widths = switch (state.kind()) {
             case COLUMN, OFFSET -> List.of(
@@ -180,7 +178,6 @@ public final class FileIndexesScreen {
                 .title(title)
                 .borders(Borders.ALL)
                 .borderType(BorderType.ROUNDED)
-                .borderColor(Theme.ACCENT)
                 .build();
         Table table = Table.builder()
                 .header(header)
@@ -189,7 +186,7 @@ public final class FileIndexesScreen {
                 .columnSpacing(2)
                 .block(block)
                 .highlightSymbol("▶ ")
-                .highlightStyle(Style.EMPTY.bold())
+                .highlightStyle(Theme.selection())
                 .build();
         TableState tableState = new TableState();
         if (!entries.isEmpty()) {

--- a/cli/src/main/java/dev/hardwood/cli/dive/internal/FooterScreen.java
+++ b/cli/src/main/java/dev/hardwood/cli/dive/internal/FooterScreen.java
@@ -171,7 +171,6 @@ public final class FooterScreen {
                 .title(" Footer & indexes ")
                 .borders(Borders.ALL)
                 .borderType(BorderType.ROUNDED)
-                .borderColor(Theme.ACCENT)
                 .build();
         Paragraph.builder().block(block).text(Text.from(lines)).left().build().render(area, buffer);
     }
@@ -189,8 +188,8 @@ public final class FooterScreen {
         String marker = enabled ? "▶" : " ";
         String shown = text.startsWith(" ") ? marker + text.substring(1) : marker + text;
         Style style = enabled
-                ? Style.EMPTY.bold().fg(Theme.ACCENT)
-                : Style.EMPTY.bold();
+                ? Theme.selection()
+                : Theme.primary();
         visible.set(offset, Line.from(new Span(shown, style)));
     }
 
@@ -286,7 +285,7 @@ public final class FooterScreen {
 
         List<Line> lines = new ArrayList<>();
 
-        lines.add(Line.from(new Span(" File layout ", Style.EMPTY.bold())));
+        lines.add(Line.from(new Span(" File layout ", Theme.accent().bold())));
         lines.add(fact("  File size", Sizes.dualFormat(fileSize)));
         lines.add(fact("  Format version", String.valueOf(model.metadata().version())));
         lines.add(fact("  Created by",
@@ -303,14 +302,14 @@ public final class FooterScreen {
         }
 
         lines.add(Line.empty());
-        lines.add(Line.from(new Span(" Encodings ", Style.EMPTY.bold())));
+        lines.add(Line.from(new Span(" Encodings ", Theme.accent().bold())));
         for (Map.Entry<Encoding, Integer> e : stats.encodingHistogram().entrySet()) {
             lines.add(fact("  " + e.getKey().name(),
                     Plurals.format(e.getValue(), "chunk", "chunks")));
         }
 
         lines.add(Line.empty());
-        lines.add(Line.from(new Span(" Codecs ", Style.EMPTY.bold())));
+        lines.add(Line.from(new Span(" Codecs ", Theme.accent().bold())));
         for (Map.Entry<CompressionCodec, Integer> e : stats.codecHistogram().entrySet()) {
             int pct = stats.totalChunks() == 0 ? 0
                     : (int) Math.round(100.0 * e.getValue() / stats.totalChunks());
@@ -319,7 +318,7 @@ public final class FooterScreen {
         }
 
         lines.add(Line.empty());
-        lines.add(Line.from(new Span(" Page indexes ", Style.EMPTY.bold())));
+        lines.add(Line.from(new Span(" Page indexes ", Theme.accent().bold())));
         lines.add(fact("  Column indexes",
                 Sizes.dualFormat(stats.columnIndexBytes()) + "  ("
                         + coverage(stats.columnIndexCount(), stats.totalChunks()) + ")"));
@@ -328,12 +327,12 @@ public final class FooterScreen {
                         + coverage(stats.offsetIndexCount(), stats.totalChunks()) + ")"));
 
         lines.add(Line.empty());
-        lines.add(Line.from(new Span(" Dictionary ", Style.EMPTY.bold())));
+        lines.add(Line.from(new Span(" Dictionary ", Theme.accent().bold())));
         lines.add(fact("  With dictionary",
                 coverage(stats.dictionaryCount(), stats.totalChunks())));
 
         lines.add(Line.empty());
-        lines.add(Line.from(new Span(" Aggregate ", Style.EMPTY.bold())));
+        lines.add(Line.from(new Span(" Aggregate ", Theme.accent().bold())));
         lines.add(fact("  Compressed data", Sizes.dualFormat(model.facts().compressedBytes())));
         lines.add(fact("  Uncompressed data", Sizes.dualFormat(model.facts().uncompressedBytes())));
         lines.add(fact("  Compression ratio",
@@ -473,8 +472,8 @@ public final class FooterScreen {
 
     private static Line fact(String key, String value) {
         return Line.from(
-                new Span(" " + padRight(key, 26), Style.EMPTY),
-                new Span(value, Style.EMPTY.bold()));
+                new Span(" " + padRight(key, 26), Theme.primary()),
+                new Span(value, Style.EMPTY));
     }
 
     private static String padRight(String s, int width) {

--- a/cli/src/main/java/dev/hardwood/cli/dive/internal/HelpOverlay.java
+++ b/cli/src/main/java/dev/hardwood/cli/dive/internal/HelpOverlay.java
@@ -38,7 +38,7 @@ public final class HelpOverlay {
         dev.tamboui.widgets.Clear.INSTANCE.render(area, buffer);
 
         List<Line> lines = List.of(
-                Line.from(new Span("Navigation", Style.EMPTY.bold())),
+                Line.from(new Span("Navigation", Theme.accent().bold())),
                 kv("↑ / ↓", "move selection"),
                 kv("g / G", "jump to first / last row"),
                 kv("Enter", "drill into selected item"),
@@ -46,32 +46,31 @@ public final class HelpOverlay {
                 kv("Tab / Shift-Tab", "switch focused pane"),
                 kv("o", "return to Overview"),
                 Line.empty(),
-                Line.from(new Span("Schema tree", Style.EMPTY.bold())),
+                Line.from(new Span("Schema tree", Theme.accent().bold())),
                 kv("→ / Enter", "expand group · drill leaf"),
                 kv("←", "collapse group"),
                 kv("e / c", "expand / collapse all groups"),
                 Line.empty(),
-                Line.from(new Span("Inline search", Style.EMPTY.bold())),
+                Line.from(new Span("Inline search", Theme.accent().bold())),
                 kv("/", "enter filter mode (Schema, Column index, Dictionary)"),
                 kv("Enter", "commit filter"),
                 kv("Esc", "clear filter"),
                 Line.empty(),
-                Line.from(new Span("Global", Style.EMPTY.bold())),
+                Line.from(new Span("Global", Theme.accent().bold())),
                 kv("?", "toggle this help"),
                 kv("q / Ctrl-C", "quit"),
                 Line.empty(),
-                Line.from(new Span("Data preview", Style.EMPTY.bold())),
+                Line.from(new Span("Data preview", Theme.accent().bold())),
                 kv("PgDn / PgUp", "page forward / back (Shift+↓/↑ on macOS)"),
                 kv("← / →", "scroll visible columns"),
                 kv("g / G", "jump to first / last row of file"),
                 Line.empty(),
-                Line.from(new Span("Press ? or Esc to close", Style.EMPTY.fg(Theme.DIM))));
+                Line.from(new Span("Press ? or Esc to close", Theme.dim())));
 
         Block block = Block.builder()
                 .title(" hardwood dive — help ")
                 .borders(Borders.ALL)
                 .borderType(BorderType.ROUNDED)
-                .borderColor(Theme.ACCENT)
                 .build();
         Paragraph.builder().block(block).text(Text.from(lines)).left().build().render(area, buffer);
     }
@@ -79,7 +78,7 @@ public final class HelpOverlay {
     private static Line kv(String key, String description) {
         return Line.from(
                 Span.raw("  "),
-                new Span(padRight(key, 18), Style.EMPTY.fg(Theme.ACCENT)),
+                new Span(padRight(key, 18), Theme.primary()),
                 new Span(description, Style.EMPTY));
     }
 

--- a/cli/src/main/java/dev/hardwood/cli/dive/internal/OffsetIndexScreen.java
+++ b/cli/src/main/java/dev/hardwood/cli/dive/internal/OffsetIndexScreen.java
@@ -20,7 +20,6 @@ import dev.hardwood.metadata.PageLocation;
 import dev.tamboui.buffer.Buffer;
 import dev.tamboui.layout.Constraint;
 import dev.tamboui.layout.Rect;
-import dev.tamboui.style.Style;
 import dev.tamboui.text.Line;
 import dev.tamboui.text.Span;
 import dev.tamboui.text.Text;
@@ -89,12 +88,11 @@ public final class OffsetIndexScreen {
                     .title(" Offset index ")
                     .borders(Borders.ALL)
                     .borderType(BorderType.ROUNDED)
-                    .borderColor(Theme.DIM)
                     .build();
             Paragraph.builder()
                     .block(emptyBlock)
                     .text(Text.from(Line.from(
-                            new Span(" No offset index for this chunk.", Style.EMPTY.fg(Theme.DIM)))))
+                            new Span(" No offset index for this chunk.", Theme.dim()))))
                     .left()
                     .build()
                     .render(area, buffer);
@@ -110,14 +108,13 @@ public final class OffsetIndexScreen {
                     Sizes.format(loc.compressedPageSize()),
                     Fmt.fmt("%,d", loc.firstRowIndex())));
         }
-        Row header = Row.from("#", "Offset", "Size", "First row").style(Style.EMPTY.bold());
+        Row header = Row.from("#", "Offset", "Size", "First row").style(Theme.accent().bold());
         Block block = Block.builder()
                 .title(" Offset index "
                         + Plurals.rangeOf(state.selection(), locations.size(), Keys.viewportStride())
                         + " ")
                 .borders(Borders.ALL)
                 .borderType(BorderType.ROUNDED)
-                .borderColor(Theme.ACCENT)
                 .build();
         Table table = Table.builder()
                 .header(header)
@@ -129,7 +126,7 @@ public final class OffsetIndexScreen {
                 .columnSpacing(2)
                 .block(block)
                 .highlightSymbol("▶ ")
-                .highlightStyle(Style.EMPTY.bold())
+                .highlightStyle(Theme.selection())
                 .build();
         TableState tableState = new TableState();
         if (!locations.isEmpty()) {

--- a/cli/src/main/java/dev/hardwood/cli/dive/internal/OverviewScreen.java
+++ b/cli/src/main/java/dev/hardwood/cli/dive/internal/OverviewScreen.java
@@ -183,6 +183,7 @@ public final class OverviewScreen {
         renderFactsPane(buffer, cols.get(0), model, state);
         renderMenuPane(buffer, cols.get(1), model, state);
         if (state.kvModalOpen()) {
+            buffer.setStyle(area, Theme.dim());
             renderKvModal(buffer, area, model, state);
         }
     }
@@ -215,16 +216,18 @@ public final class OverviewScreen {
         List<Map.Entry<String, String>> kv = f.keyValueMetadata();
         if (!kv.isEmpty()) {
             lines.add(Line.empty());
-            lines.add(Line.from(new Span("key/value meta (" + kv.size() + ")", Style.EMPTY.bold())));
+            lines.add(Line.from(new Span("key/value meta (" + kv.size() + ")", Theme.accent().bold())));
             for (int i = 0; i < kv.size(); i++) {
                 Map.Entry<String, String> entry = kv.get(i);
                 boolean selected = focused && i == state.kvSelection();
                 String marker = selected ? "▶ " : "  ";
-                Style keyStyle = selected ? Style.EMPTY.bold().fg(Theme.ACCENT) : Style.EMPTY;
+                Style rowStyle = selected ? Theme.selection() : null;
+                Style keyStyle = rowStyle != null ? rowStyle : Theme.primary();
+                Style valueStyle = rowStyle != null ? rowStyle : Style.EMPTY;
                 lines.add(Line.from(
                         new Span(marker, keyStyle),
                         new Span(padRight(entry.getKey(), 16), keyStyle),
-                        new Span(trim(entry.getValue(), 32), keyStyle)));
+                        new Span(trim(entry.getValue(), 32), valueStyle)));
             }
         }
         renderParagraph(buffer, area, block, Text.from(lines));
@@ -265,12 +268,11 @@ public final class OverviewScreen {
                 : (scroll > 0
                         ? " ↑ " + scroll + " lines above · Esc / Enter close · ↑↓ scroll · Shift+↑↓ page"
                         : " Press Esc or Enter to close");
-        lines.add(Line.from(new Span(hint, Style.EMPTY.fg(Theme.DIM))));
+        lines.add(Line.from(new Span(hint, Theme.dim())));
         Block block = Block.builder()
                 .title(" " + entry.getKey() + " ")
                 .borders(Borders.ALL)
                 .borderType(BorderType.ROUNDED)
-                .borderColor(Theme.ACCENT)
                 .build();
         Paragraph.builder().block(block).text(Text.from(lines)).left().build().render(area, buffer);
     }
@@ -284,25 +286,41 @@ public final class OverviewScreen {
             MenuItem item = items[i];
             boolean selected = focused && i == state.menuSelection();
             String cursor = selected ? "▶ " : "  ";
-            String hint = menuHint(item, model);
-            Style labelStyle = selected ? Style.EMPTY.bold().fg(Theme.ACCENT) : Style.EMPTY;
-            Style hintStyle = Style.EMPTY.fg(Theme.DIM);
+            MenuHint hint = menuHint(item, model);
+            Style labelStyle = selected
+                    ? Theme.selection()
+                    : Theme.primary();
             lines.add(Line.from(
                     new Span(cursor, labelStyle),
                     new Span(padRight(item.label, 20), labelStyle),
-                    new Span(hint, hintStyle)));
+                    new Span(hint.value(), Style.EMPTY),
+                    new Span(hint.suffix(), Theme.dim())));
         }
         renderParagraph(buffer, area, block, Text.from(lines));
     }
 
-    private static String menuHint(MenuItem item, ParquetModel model) {
+    /// Right-column annotation for a drill-into menu row: the count
+    /// `value` (rendered in default fg, e.g. "4 columns"), and an
+    /// optional dim `suffix` (e.g. " · browse by column"). Built so
+    /// the count reads as a fact while the descriptor sits behind it
+    /// at a quieter weight.
+    private record MenuHint(String value, String suffix) {
+    }
+
+    private static MenuHint menuHint(MenuItem item, ParquetModel model) {
         return switch (item) {
-            case SCHEMA -> padRight(Plurals.format(model.columnCount(), "column", "columns"),
-                    AXIS_HINT_WIDTH) + " · browse by column";
-            case ROW_GROUPS -> padRight(Plurals.format(model.rowGroupCount(), "group", "groups"),
-                    AXIS_HINT_WIDTH) + " · browse by row group";
-            case FOOTER -> Sizes.format(FooterScreen.footerAndIndexBytes(model));
-            case DATA_PREVIEW -> Plurals.format(model.facts().totalRows(), "row", "rows");
+            case SCHEMA -> new MenuHint(
+                    padRight(Plurals.format(model.columnCount(), "column", "columns"), AXIS_HINT_WIDTH),
+                    " · browse by column");
+            case ROW_GROUPS -> new MenuHint(
+                    padRight(Plurals.format(model.rowGroupCount(), "group", "groups"), AXIS_HINT_WIDTH),
+                    " · browse by row group");
+            case FOOTER -> new MenuHint(
+                    Sizes.format(FooterScreen.footerAndIndexBytes(model)),
+                    "");
+            case DATA_PREVIEW -> new MenuHint(
+                    Plurals.format(model.facts().totalRows(), "row", "rows"),
+                    "");
         };
     }
 
@@ -313,7 +331,7 @@ public final class OverviewScreen {
 
     private static Line factsLine(String key, String value) {
         return Line.from(
-                new Span(padRight(key, 16), Style.EMPTY),
+                new Span(padRight(key, 16), Theme.primary()),
                 new Span(value, Style.EMPTY));
     }
 
@@ -322,11 +340,8 @@ public final class OverviewScreen {
                 .title(" " + title + " ")
                 .borders(Borders.ALL)
                 .borderType(BorderType.ROUNDED);
-        if (focused) {
-            b.borderColor(Theme.ACCENT);
-        }
-        else {
-            b.borderColor(Theme.DIM);
+        if (!focused) {
+            b.borderStyle(Theme.dim());
         }
         return b.build();
     }

--- a/cli/src/main/java/dev/hardwood/cli/dive/internal/PagesScreen.java
+++ b/cli/src/main/java/dev/hardwood/cli/dive/internal/PagesScreen.java
@@ -201,9 +201,9 @@ public final class PagesScreen {
         }
         Row header = hasAnyStats
                 ? Row.from("#", "Type", "First row", "Values", "Encoding", "Comp", "Uncomp", "Nulls", "Min", "Max")
-                        .style(Style.EMPTY.bold())
+                        .style(Theme.accent().bold())
                 : Row.from("#", "Type", "First row", "Values", "Encoding", "Comp", "Uncomp", "Nulls")
-                        .style(Style.EMPTY.bold());
+                        .style(Theme.accent().bold());
         String titleSuffix = hasAnyStats ? "" : " (no column index)";
         String typeMode = state.logicalTypes() ? "" : " · physical";
         Block block = Block.builder()
@@ -212,7 +212,6 @@ public final class PagesScreen {
                         + titleSuffix + typeMode + " ")
                 .borders(Borders.ALL)
                 .borderType(BorderType.ROUNDED)
-                .borderColor(Theme.ACCENT)
                 .build();
         List<Constraint> widths = new ArrayList<>();
         widths.add(new Constraint.Length(4));   // #
@@ -239,7 +238,7 @@ public final class PagesScreen {
                 .columnSpacing(1)
                 .block(block)
                 .highlightSymbol("▶ ")
-                .highlightStyle(Style.EMPTY.bold())
+                .highlightStyle(Theme.selection())
                 .build();
         TableState tableState = new TableState();
         if (!headers.isEmpty()) {
@@ -248,6 +247,7 @@ public final class PagesScreen {
         table.render(area, buffer, tableState);
 
         if (state.modalOpen() && !headers.isEmpty()) {
+            buffer.setStyle(area, Theme.dim());
             renderHeaderModal(buffer, area, headers.get(state.selection()), state.selection(), col,
                     state.logicalTypes());
         }
@@ -372,7 +372,7 @@ public final class PagesScreen {
         Statistics inline = inlineStats(header);
         if (inline != null) {
             lines.add(Line.empty());
-            lines.add(Line.from(new Span(" Inline statistics ", Style.EMPTY.bold())));
+            lines.add(Line.from(new Span(" Inline statistics ", Theme.accent().bold())));
             lines.add(kv("  Min", formatStatFull(inline.minValue(), col, logical)));
             lines.add(kv("  Max", formatStatFull(inline.maxValue(), col, logical)));
             if (inline.nullCount() != null) {
@@ -385,13 +385,12 @@ public final class PagesScreen {
         boolean onDataPage = header.type() != PageHeader.PageType.DICTIONARY_PAGE;
         boolean hasLogical = col.logicalType() != null && onDataPage;
         String hint = " Esc / Enter close" + (hasLogical ? " · t logical types" : "");
-        lines.add(Line.from(new Span(hint, Style.EMPTY.fg(Theme.DIM))));
+        lines.add(Line.from(new Span(hint, Theme.dim())));
 
         Block block = Block.builder()
                 .title(" Page #" + index + " header ")
                 .borders(Borders.ALL)
                 .borderType(BorderType.ROUNDED)
-                .borderColor(Theme.ACCENT)
                 .build();
         Paragraph.builder().block(block).text(Text.from(lines)).left().build().render(area, buffer);
     }
@@ -411,8 +410,8 @@ public final class PagesScreen {
     private static Line kv(String key, String value) {
         return Line.from(
                 Span.raw(" "),
-                new Span(padRight(key, 20), Style.EMPTY),
-                new Span(value, Style.EMPTY.bold()));
+                new Span(padRight(key, 20), Theme.primary()),
+                new Span(value, Style.EMPTY));
     }
 
     private static String padRight(String s, int width) {

--- a/cli/src/main/java/dev/hardwood/cli/dive/internal/RowGroupDetailScreen.java
+++ b/cli/src/main/java/dev/hardwood/cli/dive/internal/RowGroupDetailScreen.java
@@ -148,16 +148,16 @@ public final class RowGroupDetailScreen {
         lines.add(fact("Column chunks", String.valueOf(chunkCount)));
         lines.add(fact("Total byte size", Sizes.dualFormat(rg.totalByteSize())));
         lines.add(Line.empty());
-        lines.add(Line.from(new Span(" Compression ", Style.EMPTY.bold())));
+        lines.add(Line.from(new Span(" Compression ", Theme.accent().bold())));
         lines.add(fact("  Compressed", Sizes.dualFormat(compressed)));
         lines.add(fact("  Uncompressed", Sizes.dualFormat(uncompressed)));
         lines.add(fact("  Ratio", Fmt.fmt("%.2f×", ratio)));
         lines.add(Line.empty());
-        lines.add(Line.from(new Span(" Encoding mix ", Style.EMPTY.bold())));
+        lines.add(Line.from(new Span(" Encoding mix ", Theme.accent().bold())));
         lines.add(fact("  Encodings", mix(encodingCounts)));
         lines.add(fact("  Codecs", mix(codecCounts)));
         lines.add(Line.empty());
-        lines.add(Line.from(new Span(" Page indexes ", Style.EMPTY.bold())));
+        lines.add(Line.from(new Span(" Page indexes ", Theme.accent().bold())));
         lines.add(fact("  Column indexes", Sizes.dualFormat(ciBytes)
                 + "  (" + ciCount + "/" + chunkCount + " chunks)"));
         lines.add(fact("  Offset indexes", Sizes.dualFormat(oiBytes)
@@ -177,7 +177,9 @@ public final class RowGroupDetailScreen {
             MenuItem item = items[i];
             boolean selected = focused && i == state.menuSelection();
             String cursor = selected ? "▶ " : "  ";
-            Style labelStyle = selected ? Style.EMPTY.bold().fg(Theme.ACCENT) : Style.EMPTY;
+            Style labelStyle = selected
+                    ? Theme.selection()
+                    : Theme.primary();
             lines.add(Line.from(
                     new Span(cursor, labelStyle),
                     new Span(item.label, labelStyle)));
@@ -195,18 +197,20 @@ public final class RowGroupDetailScreen {
     }
 
     private static Block paneBlock(String title, boolean focused) {
-        return Block.builder()
+        Block.Builder b = Block.builder()
                 .title(title)
                 .borders(Borders.ALL)
-                .borderType(BorderType.ROUNDED)
-                .borderColor(focused ? Theme.ACCENT : Theme.DIM)
-                .build();
+                .borderType(BorderType.ROUNDED);
+        if (!focused) {
+            b.borderStyle(Theme.dim());
+        }
+        return b.build();
     }
 
     private static Line fact(String key, String value) {
         return Line.from(
-                new Span(" " + padRight(key, 22), Style.EMPTY),
-                new Span(value, Style.EMPTY.bold()));
+                new Span(" " + padRight(key, 22), Theme.primary()),
+                new Span(value, Style.EMPTY));
     }
 
     private static String padRight(String s, int width) {

--- a/cli/src/main/java/dev/hardwood/cli/dive/internal/RowGroupIndexesScreen.java
+++ b/cli/src/main/java/dev/hardwood/cli/dive/internal/RowGroupIndexesScreen.java
@@ -20,7 +20,6 @@ import dev.hardwood.metadata.RowGroup;
 import dev.tamboui.buffer.Buffer;
 import dev.tamboui.layout.Constraint;
 import dev.tamboui.layout.Rect;
-import dev.tamboui.style.Style;
 import dev.tamboui.text.Line;
 import dev.tamboui.text.Span;
 import dev.tamboui.text.Text;
@@ -119,13 +118,12 @@ public final class RowGroupIndexesScreen {
                     .title(" RG #" + state.rowGroupIndex() + " index regions ")
                     .borders(Borders.ALL)
                     .borderType(BorderType.ROUNDED)
-                    .borderColor(Theme.DIM)
                     .build();
             Paragraph.builder()
                     .block(emptyBlock)
                     .text(Text.from(Line.from(
                             new Span(" This row group has no column or offset indexes.",
-                                    Style.EMPTY.fg(Theme.DIM)))))
+                                    Theme.dim()))))
                     .left()
                     .build()
                     .render(area, buffer);
@@ -140,14 +138,13 @@ public final class RowGroupIndexesScreen {
                     Sizes.format(e.size())));
         }
         Row header = Row.from("Column", "Index type", "Offset", "Size")
-                .style(Style.EMPTY.bold());
+                .style(Theme.accent().bold());
         Block block = Block.builder()
                 .title(" RG #" + state.rowGroupIndex() + " index regions "
                         + Plurals.rangeOf(state.selection(), entries.size(),
                                 Keys.viewportStride()) + " ")
                 .borders(Borders.ALL)
                 .borderType(BorderType.ROUNDED)
-                .borderColor(Theme.ACCENT)
                 .build();
         Table table = Table.builder()
                 .header(header)
@@ -159,7 +156,7 @@ public final class RowGroupIndexesScreen {
                 .columnSpacing(2)
                 .block(block)
                 .highlightSymbol("▶ ")
-                .highlightStyle(Style.EMPTY.bold())
+                .highlightStyle(Theme.selection())
                 .build();
         TableState tableState = new TableState();
         if (!entries.isEmpty()) {

--- a/cli/src/main/java/dev/hardwood/cli/dive/internal/RowGroupsScreen.java
+++ b/cli/src/main/java/dev/hardwood/cli/dive/internal/RowGroupsScreen.java
@@ -21,7 +21,6 @@ import dev.hardwood.metadata.RowGroup;
 import dev.tamboui.buffer.Buffer;
 import dev.tamboui.layout.Constraint;
 import dev.tamboui.layout.Rect;
-import dev.tamboui.style.Style;
 import dev.tamboui.tui.event.KeyEvent;
 import dev.tamboui.widgets.block.Block;
 import dev.tamboui.widgets.block.BorderType;
@@ -106,13 +105,12 @@ public final class RowGroupsScreen {
                     oiCount + "/" + chunkCount));
         }
         Row header = Row.from("#", "Rows", "Uncompressed", "Compressed", "Ratio", "CI", "OI")
-                .style(Style.EMPTY.bold());
+                .style(Theme.accent().bold());
         Block block = Block.builder()
                 .title(" Row groups " + Plurals.rangeOf(state.selection(),
                         model.rowGroupCount(), Keys.viewportStride()) + " ")
                 .borders(Borders.ALL)
                 .borderType(BorderType.ROUNDED)
-                .borderColor(Theme.ACCENT)
                 .build();
         Table table = Table.builder()
                 .header(header)
@@ -127,7 +125,7 @@ public final class RowGroupsScreen {
                 .columnSpacing(2)
                 .block(block)
                 .highlightSymbol("▶ ")
-                .highlightStyle(Style.EMPTY.bold())
+                .highlightStyle(Theme.selection())
                 .build();
         TableState tableState = new TableState();
         tableState.select(state.selection());

--- a/cli/src/main/java/dev/hardwood/cli/dive/internal/SchemaScreen.java
+++ b/cli/src/main/java/dev/hardwood/cli/dive/internal/SchemaScreen.java
@@ -188,10 +188,10 @@ public final class SchemaScreen {
         // Pre-compute the longest width per aligned column so every row's
         // type / logical / repetition fields line up vertically. Name column
         // = indent + marker + name in tree mode, path in filtered mode.
-        int maxName = 0;
-        int maxType = 0;
-        int maxLogical = 0;
-        int maxRepetition = 0;
+        int maxName = "Name".length();
+        int maxType = "Type".length();
+        int maxLogical = "Logical".length();
+        int maxRepetition = "Repetition".length();
         TypeParts[] parts = new TypeParts[rows.size()];
         for (int i = 0; i < rows.size(); i++) {
             Row row = rows.get(i);
@@ -204,11 +204,18 @@ public final class SchemaScreen {
             maxLogical = Math.max(maxLogical, parts[i].logical().length());
             maxRepetition = Math.max(maxRepetition, parts[i].repetition().length());
         }
+        Style headerStyle = Theme.accent().bold();
+        lines.add(Line.from(
+                Span.raw("  "),
+                new Span(padRight("Name", maxName), headerStyle),
+                new Span("  " + padRight("Type", maxType), headerStyle),
+                new Span("  " + padRight("Logical", maxLogical), headerStyle),
+                new Span("  " + padRight("Repetition", maxRepetition), headerStyle)));
         for (int i = 0; i < rows.size(); i++) {
             Row row = rows.get(i);
             boolean selected = i == state.selection();
             String cursor = selected ? "▸ " : "  ";
-            Style nameStyle = selected ? Style.EMPTY.bold() : Style.EMPTY;
+            Style nameStyle = selected ? Theme.selection() : Style.EMPTY;
             TypeParts p = parts[i];
             String colSuffix = !row.isGroup() ? "[col " + row.columnIndex() + "]" : "";
             if (filtering) {
@@ -217,10 +224,10 @@ public final class SchemaScreen {
                         Span.raw(cursor),
                         new Span(row.path(), nameStyle),
                         Span.raw(pad),
-                        new Span("  " + padRight(p.type(), maxType), Style.EMPTY.fg(Theme.DIM)),
-                        new Span("  " + padRight(p.logical(), maxLogical), Style.EMPTY.fg(Theme.DIM)),
-                        new Span("  " + padRight(p.repetition(), maxRepetition), Style.EMPTY.fg(Theme.DIM)),
-                        new Span("  " + colSuffix, Style.EMPTY.fg(Theme.DIM))));
+                        new Span("  " + padRight(p.type(), maxType), Style.EMPTY),
+                        new Span("  " + padRight(p.logical(), maxLogical), Style.EMPTY),
+                        new Span("  " + padRight(p.repetition(), maxRepetition), Style.EMPTY),
+                        new Span("  " + colSuffix, Style.EMPTY)));
                 continue;
             }
             String indent = "  ".repeat(row.depth());
@@ -236,13 +243,13 @@ public final class SchemaScreen {
             lines.add(Line.from(
                     Span.raw(cursor),
                     Span.raw(indent),
-                    new Span(marker, Style.EMPTY.fg(Theme.ACCENT)),
+                    new Span(marker, Theme.accent()),
                     new Span(row.node().name(), nameStyle),
                     Span.raw(pad),
-                    new Span("  " + padRight(p.type(), maxType), Style.EMPTY.fg(Theme.DIM)),
-                    new Span("  " + padRight(p.logical(), maxLogical), Style.EMPTY.fg(Theme.DIM)),
-                    new Span("  " + padRight(p.repetition(), maxRepetition), Style.EMPTY.fg(Theme.DIM)),
-                    new Span("  " + colSuffix, Style.EMPTY.fg(Theme.DIM))));
+                    new Span("  " + padRight(p.type(), maxType), Style.EMPTY),
+                    new Span("  " + padRight(p.logical(), maxLogical), Style.EMPTY),
+                    new Span("  " + padRight(p.repetition(), maxRepetition), Style.EMPTY),
+                    new Span("  " + colSuffix, Style.EMPTY)));
         }
         Block block = Block.builder()
                 .title(" Schema "
@@ -255,7 +262,6 @@ public final class SchemaScreen {
                         + " ")
                 .borders(Borders.ALL)
                 .borderType(BorderType.ROUNDED)
-                .borderColor(Theme.ACCENT)
                 .build();
         Paragraph.builder().block(block).text(Text.from(lines)).left().build().render(split.get(1), buffer);
     }
@@ -286,7 +292,7 @@ public final class SchemaScreen {
                     .text(Text.from(Line.from(new Span(
                             " " + Plurals.format(totalColumns, "leaf column", "leaf columns")
                                     + ". Press / to filter by path.",
-                            Style.EMPTY.fg(Theme.DIM)))))
+                            Theme.dim()))))
                     .left()
                     .build()
                     .render(area, buffer);
@@ -294,10 +300,10 @@ public final class SchemaScreen {
         }
         String cursor = state.searching() ? "█" : "";
         Line line = Line.from(
-                new Span(" / ", Style.EMPTY.fg(Theme.ACCENT).bold()),
-                new Span(state.filter() + cursor, Style.EMPTY.bold()),
+                new Span(" / ", Theme.primary()),
+                new Span(state.filter() + cursor, Theme.primary()),
                 new Span("  (" + Fmt.fmt("%,d", matchCount) + " / "
-                        + Plurals.format(totalColumns, "leaf", "leaves") + ")", Style.EMPTY.fg(Theme.DIM)));
+                        + Plurals.format(totalColumns, "leaf", "leaves") + ")", Theme.dim()));
         Paragraph.builder().text(Text.from(line)).left().build().render(area, buffer);
     }
 

--- a/cli/src/main/java/dev/hardwood/cli/dive/internal/Theme.java
+++ b/cli/src/main/java/dev/hardwood/cli/dive/internal/Theme.java
@@ -8,22 +8,101 @@
 package dev.hardwood.cli.dive.internal;
 
 import dev.tamboui.style.Color;
+import dev.tamboui.style.Style;
 
-/// Centralised colour palette for the `dive` TUI. No visual change from the
-/// ad-hoc `Color.CYAN` / `Color.GRAY` screens used previously — this just
-/// puts the two colours behind named constants so a future retheme
-/// (light-terminal variant, `--no-color`, etc.) doesn't have to grep every
-/// screen.
+/// Centralised visual hierarchy for the `dive` TUI. Four roles named
+/// for what they mark rather than for a specific colour, so call
+/// sites stay stable when the implementations are retargeted.
+///
+/// - [#selection] — bold yellow. Active row in a navigable list:
+///   table-row highlight, selected drill-into menu row, selected
+///   schema name, footer active anchor, modal cursor.
+/// - [#accent] ± `.bold()` — blue. Structural captions: section
+///   headings, table column headers, app brand.
+/// - [#primary] — bold default fg. Labels, breadcrumb leaf, enabled
+///   drill-into menu labels, the `/` search prompt, "you-are-here"
+///   markers.
+/// - [#dim] — faint default fg. Persistent chrome: keybar, modal
+///   hint bars, breadcrumb non-head, ` › ` separators, empty-state
+///   messages, search-result counts, unfocused pane borders.
+///
+/// Body content (kv values, schema rows, top-bar facts, table data)
+/// uses `Style.EMPTY` and reads as the user's terminal default fg.
+///
+/// See `_designs/DIVE_THEME.md` for the full decision tree authors
+/// should follow when adding new content. Direct use of `Color.*`
+/// constants or literal modifier styles outside this class is
+/// reserved for `Theme` itself; everything else routes through one
+/// of the four methods or stays unstyled.
 public final class Theme {
 
-    /// Accent colour for focused borders, active titles, and `/` search
-    /// prompt. Renders as bright cyan on a dark terminal.
-    public static final Color ACCENT = Color.CYAN;
-
-    /// Dim colour for secondary text (breadcrumb non-head, keybar,
-    /// help-overlay trailer, absent-value markers) and unfocused borders.
-    public static final Color DIM = Color.GRAY;
-
     private Theme() {
+    }
+
+    /// Solarized's accent slots specified as truecolor RGB. Used
+    /// when the terminal advertises truecolor support via
+    /// `$COLORTERM`. Truecolor escapes bypass iTerm2's
+    /// "Use bright colors for bold text" remapping (which would
+    /// otherwise turn `bold + ANSI 4` into Solarized's `base0`,
+    /// the default body fg on Dark) and render the exact hex on
+    /// every variant.
+    private static final Color SOLARIZED_BLUE = Color.rgb(38, 139, 210);
+    private static final Color SOLARIZED_YELLOW = Color.rgb(181, 137, 0);
+
+    /// Whether the host terminal advertises 24-bit truecolor support
+    /// via `$COLORTERM`. Set by iTerm2, kitty, alacritty, WezTerm,
+    /// Ghostty, modern gnome-terminal / xterm, VS Code's terminal,
+    /// foot, and most other terminals released in the last decade
+    /// that support truecolor. Probed once at class-load time —
+    /// the value is fixed for the lifetime of the JVM.
+    private static final boolean TRUECOLOR =
+            "truecolor".equals(System.getenv("COLORTERM"))
+                    || "24bit".equals(System.getenv("COLORTERM"));
+
+    /// Bold default foreground — labels, breadcrumb leaf, enabled
+    /// drill-into menu labels, the `/` search prompt, and other
+    /// "you-are-here" markers. Adds visual weight without imposing
+    /// a hue, so the tone tracks the user's terminal palette.
+    public static Style primary() {
+        return Style.EMPTY.bold();
+    }
+
+    /// Auxiliary text — keybar, modal hint bars, breadcrumb
+    /// non-head, menu-row hints, empty-state messages, search-result
+    /// counts. Uses the ANSI faint attribute (`ESC [ 2 m`) so the
+    /// terminal renders the existing foreground colour in a fainter
+    /// shade rather than overriding it with a specific grey. Tracks
+    /// the user's terminal palette: faded `base0` on Solarized Dark,
+    /// faded `base00` on Solarized Light, faded whatever-fg-is on
+    /// every other palette. On terminals that don't honour the faint
+    /// attribute the text falls back to default fg unchanged — a
+    /// graceful degradation rather than the inversion / invisibility
+    /// the named-grey approaches would produce.
+    public static Style dim() {
+        return Style.EMPTY.dim();
+    }
+
+    /// Structural-caption tone — section headings, table column
+    /// headers, top-bar brand. Composed with `.bold()` at every
+    /// such call site (`Theme.accent().bold()`). The bare,
+    /// non-bold form is used for the schema tree's `▼` / `▶`
+    /// expand/collapse marker.
+    ///
+    /// On truecolor terminals this is Solarized blue (`#268bd2`)
+    /// pinned via RGB so iTerm2's "Use bright colors for bold
+    /// text" remapping cannot turn `bold + ANSI 4` into Solarized's
+    /// default body fg. On legacy terminals named `Color.BLUE`
+    /// (ANSI 4) is used.
+    public static Style accent() {
+        return Style.EMPTY.fg(TRUECOLOR ? SOLARIZED_BLUE : Color.BLUE);
+    }
+
+    /// Active-row indicator for navigable tables and menus —
+    /// distinct from [#accent] so that selected rows don't blur
+    /// with section titles or focused borders. Bold yellow on
+    /// truecolor terminals (Solarized yellow `#b58900`); bold
+    /// named `Color.YELLOW` otherwise.
+    public static Style selection() {
+        return Style.EMPTY.bold().fg(TRUECOLOR ? SOLARIZED_YELLOW : Color.YELLOW);
     }
 }

--- a/cli/src/test/java/dev/hardwood/cli/dive/internal/ThemeTest.java
+++ b/cli/src/test/java/dev/hardwood/cli/dive/internal/ThemeTest.java
@@ -1,0 +1,53 @@
+/*
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Copyright The original authors
+ *
+ *  Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package dev.hardwood.cli.dive.internal;
+
+import org.junit.jupiter.api.Test;
+
+import dev.tamboui.style.Color;
+import dev.tamboui.style.Modifier;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/// Pins each tone to its current implementation so an accidental
+/// rebinding shows up in review. The roles ([Theme#primary],
+/// [Theme#dim], [Theme#accent]) define the visual hierarchy; the
+/// concrete style/colour each returns is an implementation choice
+/// that this test guards.
+class ThemeTest {
+
+    @Test
+    void primaryIsBoldDefaultFg() {
+        assertThat(Theme.primary().effectiveModifiers()).contains(Modifier.BOLD);
+        assertThat(Theme.primary().fg()).isEmpty();
+    }
+
+    @Test
+    void dimIsFaintDefaultFg() {
+        assertThat(Theme.dim().effectiveModifiers()).contains(Modifier.DIM);
+        assertThat(Theme.dim().fg()).isEmpty();
+    }
+
+    /// Accent's foreground depends on the host terminal's truecolor
+    /// capability (probed via `$COLORTERM`). Truecolor terminals get
+    /// Solarized blue pinned via RGB; others fall back to named
+    /// `Color.BLUE`.
+    @Test
+    void accentIsBlue() {
+        assertThat(Theme.accent().effectiveModifiers()).doesNotContain(Modifier.BOLD);
+        Color fg = Theme.accent().fg().orElseThrow();
+        boolean truecolor = "truecolor".equals(System.getenv("COLORTERM"))
+                || "24bit".equals(System.getenv("COLORTERM"));
+        if (truecolor) {
+            assertThat(fg).isEqualTo(Color.rgb(38, 139, 210));
+        }
+        else {
+            assertThat(fg).isSameAs(Color.BLUE);
+        }
+    }
+}


### PR DESCRIPTION
The original `Theme.DIM = Color.GRAY` resolved to ANSI 37, which on Solarized Dark renders as `base2` cream — brighter than default fg — and on Solarized Light sits very close to the bg. The dim/bright relationship was inverted on Dark and lost on Light. The screens also disagreed on which column of a kv pane carried which weight, on what `bold()` meant, and on how active rows should render.

The fix is a five-tier visual hierarchy routed through four `Theme` methods plus default fg, with the rule set captured in `_designs/DIVE_THEME.md`:

- `selection()` — bold yellow for active rows in navigable lists (table highlights, drill-into selection, schema selected name, footer active anchor, modal cursor).
- `accent()` — blue for structural captions (section titles, table column headers, brand). Compose with `.bold()` at call sites.
- `primary()` — bold default fg for labels, breadcrumb leaf, enabled drill-into menu labels, search prompt.
- `dim()` — ANSI faint attribute for persistent chrome (keybar, modal hint bars, breadcrumb non-head, empty-state messages, search-result counts, unfocused pane borders).
- Body content (kv values, schema rows, top-bar facts, table data) uses `Style.EMPTY` and reads as terminal default fg.

`accent()` and `selection()` use truecolor RGB pinned to Solarized's accent slots when `$COLORTERM` advertises truecolor, named ANSI fallback otherwise. Truecolor bypasses iTerm2's "Use bright colors for bold text" remap that would otherwise turn bold + named ANSI 4 into Solarized's default body fg. `dim()` uses `Style.EMPTY.dim()` (the faint attribute) rather than a specific grey colour, which side-steps Solarized's named-grey traps and tracks the user's terminal palette automatically.

Pane borders follow the same active / ambient distinction: unfocused panes in multi-pane screens use `borderStyle(Theme.dim())`, all other panes use the default border colour (terminal default fg). Modal-bearing screens dim the body area while a modal is open (`buffer.setStyle(area, Style.EMPTY.dim())` is additive — it patches existing styles rather than overwriting them; the modal's `Clear.INSTANCE.render(modalArea, buffer)` then restores full intensity for the modal contents).

Tests pin each tone's structure (`ThemeTest`). Direct `Color.*` use or literal modifier styles outside `Theme.java` are reserved for the Theme implementation itself; everything else routes through one of the four methods or stays unstyled. CLAUDE.md references the design doc so future dive UI work follows the decision tree.