### PR TITLE
#401 Make dive list-screen navigation O(viewport) instead of O(collection size)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -67,6 +67,8 @@ Focus the body on **why**, not **what** — the diff already shows the what. A s
 
 When changing visual styling in the `hardwood dive` TUI (any code under `cli/src/main/java/dev/hardwood/cli/dive/`), follow the visual-hierarchy decision tree in [_designs/DIVE_THEME.md](_designs/DIVE_THEME.md). Style spans through one of `Theme.primary()` / `Theme.accent()` / `Theme.selection()` / `Theme.dim()`, or leave them at default fg via `Style.EMPTY`. Direct use of `Color.*` constants or literal `Style.EMPTY.bold()` / `Style.EMPTY.fg(...)` outside `Theme.java` is a smell — review against the decision tree before introducing any.
 
+List-shaped screens must build `Row` objects only for the visible viewport, never for the whole collection. Use `RowWindow.bottomPinned(selection, total, viewport)` to derive the slice and pass `window.selectionInWindow()` to `TableState.select(...)`. Building rows for the entire list is invisible on small inputs but turns navigation O(N) on dictionaries with hundreds of thousands of entries, page lists with thousands of pages, or wide-schema files. See [_designs/DIVE_LIST_VIEWPORT_VIRTUALIZATION.md](_designs/DIVE_LIST_VIEWPORT_VIRTUALIZATION.md).
+
 # Code Reviews
 
 When reviewing a pull request, make sure the principles described here are applied.

--- a/_designs/DIVE_LIST_VIEWPORT_VIRTUALIZATION.md
+++ b/_designs/DIVE_LIST_VIEWPORT_VIRTUALIZATION.md
@@ -1,0 +1,113 @@
+# Design: dive list-screen viewport virtualization
+
+**Status: Implemented.** Tracking issue: #401.
+
+## Goal
+
+Make Up/Down navigation on every list-shaped dive screen feel instant
+regardless of how large the underlying collection is. Per-keystroke work
+must scale with the visible viewport, not with the total row count, so a
+file with hundreds of thousands of dictionary entries, thousands of
+pages, or tens of thousands of file-wide index entries navigates as
+smoothly as a small file does.
+
+## Behaviour
+
+Each list screen's `render` constructs `Row` objects only for the rows
+the table will actually paint, derived from the current selection and
+the available viewport height. The visible window is bottom-pinned on
+the selection, matching what `TableState.scrollToSelected` would
+produce when the state is constructed fresh each frame:
+
+```
+viewport = max(1, area.height() - <chrome>)   // chrome varies per screen
+sel      = clamp(selection, 0, total - 1)
+start    = sel >= viewport ? sel - viewport + 1 : 0
+end      = min(total, start + viewport)
+```
+
+The math lives in a shared helper, [`RowWindow.bottomPinned(selection,
+total, viewport)`](../cli/src/main/java/dev/hardwood/cli/dive/internal/RowWindow.java),
+which returns the `[start, end)` range plus `selectionInWindow` (the
+slice-relative selection index). Each screen builds rows for that range
+only, then sets `TableState.select(window.selectionInWindow())` so the
+table draws the cursor at the right row of the slice. The underlying
+widget keeps its existing rendering behaviour and never sees the rest
+of the collection.
+
+The user-visible behaviour is unchanged: range header
+(`Plurals.rangeOf`), search bar (where present), modal, and key bar
+all still operate against the full row count.
+
+## Affected screens
+
+Applied to every list-shaped screen that previously built a `Row` per
+collection item:
+
+| Screen | Row source | Realistic worst N |
+|---|---|---|
+| `DictionaryScreen` | filtered dictionary entries | hundreds of thousands |
+| `PagesScreen` | pages in a column chunk | thousands |
+| `ColumnIndexScreen` | pages with stats | thousands |
+| `OffsetIndexScreen` | page locations | thousands |
+| `FileIndexesScreen` | row groups × columns × index types | tens of thousands |
+| `ColumnChunksScreen` | columns in a row group | thousands on wide schemas |
+| `ColumnAcrossRowGroupsScreen` | row groups for one column | hundreds–thousands |
+| `RowGroupIndexesScreen` | columns × index types per RG | thousands on wide schemas |
+| `RowGroupsScreen` | row groups | hundreds–thousands |
+
+`DataPreviewScreen` is intentionally not on the list. It already solves
+the problem one layer up: its `state.rows()` is the page-sized slice
+returned from `PreviewWindow.slice(model, firstRow, pageSize, …)`,
+sized to the viewport. Iterating it is already O(viewport), and the
+selection is already slice-relative.
+
+`PagesScreen` carries one extra detail: per-data-page stats (offset
+index, column index, inline statistics) are addressed by a sequential
+`dataPageIdx` that advances only on non-dictionary pages. After
+slicing, the screen recovers `dataPageIdx` at `window.start()` by
+counting non-dictionary pages in the skipped prefix — a cheap O(start)
+header-type scan, not formatting work.
+
+## Why not just keep memoising
+
+The Dictionary screen already memoised its filter result so the *filter
+predicate* did not re-run on every keystroke. That cache helped when
+the filter was non-trivial, but it did not reduce the dominant
+per-frame cost: building N `Row`/`Cell` objects and formatting N
+values. The Table widget walks the full row list to compute its
+visible window via cumulative `Row.totalHeight()`, so even off-screen
+rows were constructed. Other screens did not even have a filter cache.
+
+Slicing the rows up front fixes both at every screen: less allocation,
+and the table no longer iterates the full list.
+
+## Filter cache representation (Dictionary screen only)
+
+The Dictionary screen still memoises its filter result, but with a
+representation chosen so the empty-filter cache-hit allocates nothing.
+The cache uses an `int[]` instead of `List<Integer>`, with a `null`
+sentinel for the empty-filter (and "every entry matches") case
+representing the identity mapping `[0, size)`. The cache key holds the
+`Dictionary` via `WeakReference` so an entry evicted from the model's
+bounded `dictionaryCache` is not pinned by this static slot for the
+JVM lifetime.
+
+Callers go through a small `FilterIndex` helper:
+
+```java
+private record FilterIndex(int size, int[] indices) {
+    boolean isEmpty() { return size == 0; }
+    int at(int i) { return indices == null ? i : indices[i]; }
+}
+```
+
+This optimisation is Dictionary-specific and does not transfer — the
+other list screens have no `/`-style filter.
+
+## Convention
+
+`CLAUDE.md` carries the rule in its Dive TUI section: list-shaped
+screens must build `Row` objects only for the visible viewport, using
+`RowWindow.bottomPinned(...)`. New list screens inherit this from the
+start.

--- a/cli/src/main/java/dev/hardwood/cli/dive/internal/ColumnAcrossRowGroupsScreen.java
+++ b/cli/src/main/java/dev/hardwood/cli/dive/internal/ColumnAcrossRowGroupsScreen.java
@@ -91,8 +91,10 @@ public final class ColumnAcrossRowGroupsScreen {
     public static void render(Buffer buffer, Rect area, ParquetModel model, ScreenState.ColumnAcrossRowGroups state) {
         Keys.observeViewport(area.height() - 3);
         ColumnSchema col = model.schema().getColumn(state.columnIndex());
-        List<Row> rows = new ArrayList<>();
-        for (int i = 0; i < model.rowGroupCount(); i++) {
+        // Build Row objects only for the visible window — see RowWindow.
+        RowWindow window = RowWindow.bottomPinned(state.selection(), model.rowGroupCount(), area.height() - 3);
+        List<Row> rows = new ArrayList<>(window.size());
+        for (int i = window.start(); i < window.end(); i++) {
             RowGroup rg = model.rowGroup(i);
             ColumnChunk cc = rg.columns().get(state.columnIndex());
             ColumnMetaData cmd = cc.metaData();
@@ -158,7 +160,7 @@ public final class ColumnAcrossRowGroupsScreen {
                 .highlightStyle(Theme.selection())
                 .build();
         TableState tableState = new TableState();
-        tableState.select(state.selection());
+        tableState.select(window.selectionInWindow());
         table.render(area, buffer, tableState);
     }
 

--- a/cli/src/main/java/dev/hardwood/cli/dive/internal/ColumnChunksScreen.java
+++ b/cli/src/main/java/dev/hardwood/cli/dive/internal/ColumnChunksScreen.java
@@ -76,8 +76,10 @@ public final class ColumnChunksScreen {
     public static void render(Buffer buffer, Rect area, ParquetModel model, ScreenState.ColumnChunks state) {
         Keys.observeViewport(area.height() - 3);
         RowGroup rg = model.rowGroup(state.rowGroupIndex());
-        List<Row> rows = new ArrayList<>();
-        for (int i = 0; i < rg.columns().size(); i++) {
+        // Build Row objects only for the visible window — see RowWindow.
+        RowWindow window = RowWindow.bottomPinned(state.selection(), rg.columns().size(), area.height() - 3);
+        List<Row> rows = new ArrayList<>(window.size());
+        for (int i = window.start(); i < window.end(); i++) {
             ColumnChunk cc = rg.columns().get(i);
             ColumnMetaData cmd = cc.metaData();
             double ratio = cmd.totalCompressedSize() == 0
@@ -121,7 +123,7 @@ public final class ColumnChunksScreen {
                 .highlightStyle(Theme.selection())
                 .build();
         TableState tableState = new TableState();
-        tableState.select(state.selection());
+        tableState.select(window.selectionInWindow());
         table.render(area, buffer, tableState);
     }
 

--- a/cli/src/main/java/dev/hardwood/cli/dive/internal/ColumnIndexScreen.java
+++ b/cli/src/main/java/dev/hardwood/cli/dive/internal/ColumnIndexScreen.java
@@ -183,8 +183,11 @@ public final class ColumnIndexScreen {
 
         renderSearchBar(buffer, split.get(1), state, ci.getPageCount(), filtered.size());
 
-        List<Row> rows = new ArrayList<>();
-        for (int idx : filtered) {
+        // Build Row objects only for the visible window — see RowWindow.
+        RowWindow window = RowWindow.bottomPinned(state.selection(), filtered.size(), area.height() - 5);
+        List<Row> rows = new ArrayList<>(window.size());
+        for (int i = window.start(); i < window.end(); i++) {
+            int idx = filtered.get(i);
             String nulls = ci.nullCounts() != null && idx < ci.nullCounts().size()
                     ? Fmt.fmt("%,d", ci.nullCounts().get(idx))
                     : "—";
@@ -222,7 +225,7 @@ public final class ColumnIndexScreen {
                 .build();
         TableState tableState = new TableState();
         if (!filtered.isEmpty()) {
-            tableState.select(Math.min(state.selection(), filtered.size() - 1));
+            tableState.select(window.selectionInWindow());
         }
         table.render(split.get(2), buffer, tableState);
 

--- a/cli/src/main/java/dev/hardwood/cli/dive/internal/DictionaryScreen.java
+++ b/cli/src/main/java/dev/hardwood/cli/dive/internal/DictionaryScreen.java
@@ -7,7 +7,9 @@
  */
 package dev.hardwood.cli.dive.internal;
 
+import java.lang.ref.WeakReference;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 import java.util.Locale;
 
@@ -49,11 +51,28 @@ public final class DictionaryScreen {
     /// thousands of entries re-filters twice per navigation keystroke (once in
     /// handle, once in render); caching the most recent (dict, filter) result
     /// turns navigation into O(1) lookups while still invalidating when the
-    /// user types / deletes a character.
-    private static Dictionary cachedDict;
+    /// user types / deletes a character. The dictionary is held via
+    /// `WeakReference` so an evicted entry from the model's bounded
+    /// `dictionaryCache` is not pinned for the lifetime of the JVM.
+    private static WeakReference<Dictionary> cachedDictRef;
     private static String cachedFilter;
     private static boolean cachedLogical;
-    private static List<Integer> cachedFiltered;
+    private static int cachedSize;
+    private static int[] cachedFiltered;
+
+    /// Result of filtering a dictionary by the user's `/ filter` string. When
+    /// `indices == null` the view is the identity mapping `[0, size)` — used
+    /// for the (very common) empty-filter case so the cache hit path
+    /// allocates nothing per entry. Otherwise `indices[i]` is the dictionary
+    /// index of the `i`-th visible entry.
+    private record FilterIndex(int size, int[] indices) {
+        boolean isEmpty() {
+            return size == 0;
+        }
+        int at(int i) {
+            return indices == null ? i : indices[i];
+        }
+    }
 
     private DictionaryScreen() {
     }
@@ -99,7 +118,7 @@ public final class DictionaryScreen {
         }
         Dictionary dict = loadDictionary(model, state);
         ColumnSchema col = model.schema().getColumn(state.columnIndex());
-        List<Integer> filtered = filteredIndices(dict, col, state.filter(), state.logicalTypes());
+        FilterIndex filtered = filteredIndices(dict, col, state.filter(), state.logicalTypes());
         // Plain Up/Down step one entry; PgDn/PgUp (and the Shift+↓/↑ Mac
         // chord since most macOS laptops have no dedicated PgDn/PgUp keys)
         // move Keys.viewportStride() entries via the shared helper.
@@ -136,7 +155,7 @@ public final class DictionaryScreen {
             // For numeric dictionaries like VendorID=1, the row already shows the
             // full value, so a modal would just redraw the same character in a
             // bigger frame.
-            int idx = filtered.get(Math.min(state.selection(), filtered.size() - 1));
+            int idx = filtered.at(Math.min(state.selection(), filtered.size() - 1));
             String full = fullValue(dict, idx, col, state.logicalTypes());
             if (full.length() <= VALUE_PREVIEW_MAX) {
                 return false;
@@ -186,15 +205,20 @@ public final class DictionaryScreen {
         }
 
         ColumnSchema col = model.schema().getColumn(state.columnIndex());
-        List<Integer> filtered = filteredIndices(dict, col, state.filter(), state.logicalTypes());
+        FilterIndex filtered = filteredIndices(dict, col, state.filter(), state.logicalTypes());
         List<Rect> split = Layout.vertical()
                 .constraints(new Constraint.Length(1), new Constraint.Fill(1))
                 .split(area);
 
         renderSearchBar(buffer, split.get(0), state, dict.size(), filtered.size());
 
-        List<Row> rows = new ArrayList<>();
-        for (int idx : filtered) {
+        // Build Row objects only for the visible window — see RowWindow for
+        // why list screens must do this.
+        int total = filtered.size();
+        RowWindow window = RowWindow.bottomPinned(state.selection(), total, area.height() - 4);
+        List<Row> rows = new ArrayList<>(window.size());
+        for (int i = window.start(); i < window.end(); i++) {
+            int idx = filtered.at(i);
             rows.add(Row.from(
                     "[" + idx + "]",
                     formatValue(dict, idx, col, VALUE_PREVIEW_MAX, state.logicalTypes())));
@@ -203,7 +227,7 @@ public final class DictionaryScreen {
         String typeMode = state.logicalTypes() ? "" : " · physical";
         Block block = Block.builder()
                 .title(" Dictionary entries "
-                        + Plurals.rangeOf(state.selection(), filtered.size(), Keys.viewportStride())
+                        + Plurals.rangeOf(state.selection(), total, Keys.viewportStride())
                         + (state.filter().isEmpty()
                                 ? ""
                                 : " · " + Plurals.format(dict.size(), "entry", "entries") + " total")
@@ -221,13 +245,13 @@ public final class DictionaryScreen {
                 .highlightStyle(Theme.selection())
                 .build();
         TableState tableState = new TableState();
-        if (!filtered.isEmpty()) {
-            tableState.select(Math.min(state.selection(), filtered.size() - 1));
+        if (total > 0) {
+            tableState.select(window.selectionInWindow());
         }
         table.render(split.get(1), buffer, tableState);
 
         if (state.modalOpen() && !filtered.isEmpty()) {
-            int dictIdx = filtered.get(Math.min(state.selection(), filtered.size() - 1));
+            int dictIdx = filtered.at(Math.min(state.selection(), filtered.size() - 1));
             buffer.setStyle(area, Theme.dim());
             renderValueModal(buffer, area, dict, col, dictIdx, state.logicalTypes());
         }
@@ -236,12 +260,12 @@ public final class DictionaryScreen {
     public static String keybarKeys(ScreenState.DictionaryView state, ParquetModel model) {
         Dictionary dict = needsConfirmation(model, state) ? null : loadDictionary(model, state);
         ColumnSchema col = model.schema().getColumn(state.columnIndex());
-        java.util.List<Integer> filtered = dict == null ? java.util.List.of()
+        FilterIndex filtered = dict == null ? new FilterIndex(0, null)
                 : filteredIndices(dict, col, state.filter(), state.logicalTypes());
         int count = filtered.size();
         boolean canExpand = false;
         if (dict != null && count > 0) {
-            int idx = filtered.get(Math.min(state.selection(), count - 1));
+            int idx = filtered.at(Math.min(state.selection(), count - 1));
             canExpand = fullValue(dict, idx, col, state.logicalTypes()).length() > VALUE_PREVIEW_MAX;
         }
         boolean hasLogical = col.logicalType() != null;
@@ -277,27 +301,39 @@ public final class DictionaryScreen {
         Paragraph.builder().text(Text.from(line)).left().build().render(area, buffer);
     }
 
-    private static List<Integer> filteredIndices(Dictionary dict, ColumnSchema col, String filter,
+    private static FilterIndex filteredIndices(Dictionary dict, ColumnSchema col, String filter,
                                                   boolean useLogicalType) {
         if (dict == null) {
-            return List.of();
+            return new FilterIndex(0, null);
         }
-        if (dict == cachedDict && filter.equals(cachedFilter) && useLogicalType == cachedLogical) {
-            return cachedFiltered;
+        Dictionary cached = cachedDictRef == null ? null : cachedDictRef.get();
+        if (dict == cached && filter.equals(cachedFilter) && useLogicalType == cachedLogical) {
+            return new FilterIndex(cachedSize, cachedFiltered);
         }
-        List<Integer> out = new ArrayList<>();
-        String needle = filter.toLowerCase(Locale.ROOT);
-        for (int i = 0; i < dict.size(); i++) {
-            if (needle.isEmpty() || fullValue(dict, i, col, useLogicalType).toLowerCase(Locale.ROOT).contains(needle)) {
-                out.add(i);
+        int n = dict.size();
+        int size;
+        int[] indices;
+        if (filter.isEmpty()) {
+            size = n;
+            indices = null;
+        } else {
+            String needle = filter.toLowerCase(Locale.ROOT);
+            int[] tmp = new int[n];
+            int k = 0;
+            for (int i = 0; i < n; i++) {
+                if (fullValue(dict, i, col, useLogicalType).toLowerCase(Locale.ROOT).contains(needle)) {
+                    tmp[k++] = i;
+                }
             }
+            size = k;
+            indices = (k == n) ? null : Arrays.copyOf(tmp, k);
         }
-        List<Integer> result = List.copyOf(out);
-        cachedDict = dict;
+        cachedDictRef = new WeakReference<>(dict);
         cachedFilter = filter;
         cachedLogical = useLogicalType;
-        cachedFiltered = result;
-        return result;
+        cachedSize = size;
+        cachedFiltered = indices;
+        return new FilterIndex(size, indices);
     }
 
     private static ScreenState.DictionaryView with(ScreenState.DictionaryView state,

--- a/cli/src/main/java/dev/hardwood/cli/dive/internal/FileIndexesScreen.java
+++ b/cli/src/main/java/dev/hardwood/cli/dive/internal/FileIndexesScreen.java
@@ -120,8 +120,11 @@ public final class FileIndexesScreen {
                     .render(area, buffer);
             return;
         }
-        List<Row> rows = new ArrayList<>();
-        for (Entry e : entries) {
+        // Build Row objects only for the visible window — see RowWindow.
+        RowWindow window = RowWindow.bottomPinned(state.selection(), entries.size(), area.height() - 3);
+        List<Row> rows = new ArrayList<>(window.size());
+        for (int i = window.start(); i < window.end(); i++) {
+            Entry e = entries.get(i);
             ColumnChunk cc = e.chunk();
             ColumnMetaData cmd = cc.metaData();
             String columnPath = Sizes.columnPath(cmd);
@@ -190,7 +193,7 @@ public final class FileIndexesScreen {
                 .build();
         TableState tableState = new TableState();
         if (!entries.isEmpty()) {
-            tableState.select(Math.min(state.selection(), entries.size() - 1));
+            tableState.select(window.selectionInWindow());
         }
         table.render(area, buffer, tableState);
     }

--- a/cli/src/main/java/dev/hardwood/cli/dive/internal/OffsetIndexScreen.java
+++ b/cli/src/main/java/dev/hardwood/cli/dive/internal/OffsetIndexScreen.java
@@ -98,9 +98,11 @@ public final class OffsetIndexScreen {
                     .render(area, buffer);
             return;
         }
-        List<Row> rows = new ArrayList<>();
         List<PageLocation> locations = oi.pageLocations();
-        for (int i = 0; i < locations.size(); i++) {
+        // Build Row objects only for the visible window — see RowWindow.
+        RowWindow window = RowWindow.bottomPinned(state.selection(), locations.size(), area.height() - 3);
+        List<Row> rows = new ArrayList<>(window.size());
+        for (int i = window.start(); i < window.end(); i++) {
             PageLocation loc = locations.get(i);
             rows.add(Row.from(
                     String.valueOf(i),
@@ -130,7 +132,7 @@ public final class OffsetIndexScreen {
                 .build();
         TableState tableState = new TableState();
         if (!locations.isEmpty()) {
-            tableState.select(state.selection());
+            tableState.select(window.selectionInWindow());
         }
         table.render(area, buffer, tableState);
     }

--- a/cli/src/main/java/dev/hardwood/cli/dive/internal/PagesScreen.java
+++ b/cli/src/main/java/dev/hardwood/cli/dive/internal/PagesScreen.java
@@ -129,14 +129,24 @@ public final class PagesScreen {
         OffsetIndex offsetIndex = model.offsetIndex(state.rowGroupIndex(), state.columnIndex());
         ColumnSchema col = model.schema().getColumn(state.columnIndex());
 
-        List<Row> rows = new ArrayList<>();
         // Hide Min / Max columns entirely when no page-level stats are available
         // anywhere (no ColumnIndex AND no inline statistics on any page). Every
         // row would be "—" otherwise, pure visual noise.
         boolean hasAnyStats = columnIndex != null || headers.stream()
                 .anyMatch(h -> h.type() != PageHeader.PageType.DICTIONARY_PAGE && inlineStats(h) != null);
+        // Build Row objects only for the visible window — see RowWindow.
+        RowWindow window = RowWindow.bottomPinned(state.selection(), headers.size(), area.height() - 3);
+        // Per-data-page stats are addressed by `dataPageIdx`, which advances
+        // only on non-dictionary pages. Recover its value at window.start()
+        // by counting non-dict pages in the skipped prefix.
         int dataPageIdx = 0;
-        for (int i = 0; i < headers.size(); i++) {
+        for (int i = 0; i < window.start(); i++) {
+            if (headers.get(i).type() != PageHeader.PageType.DICTIONARY_PAGE) {
+                dataPageIdx++;
+            }
+        }
+        List<Row> rows = new ArrayList<>(window.size());
+        for (int i = window.start(); i < window.end(); i++) {
             PageHeader h = headers.get(i);
             String firstRow = "—";
             String min = "—";
@@ -242,7 +252,7 @@ public final class PagesScreen {
                 .build();
         TableState tableState = new TableState();
         if (!headers.isEmpty()) {
-            tableState.select(state.selection());
+            tableState.select(window.selectionInWindow());
         }
         table.render(area, buffer, tableState);
 

--- a/cli/src/main/java/dev/hardwood/cli/dive/internal/RowGroupIndexesScreen.java
+++ b/cli/src/main/java/dev/hardwood/cli/dive/internal/RowGroupIndexesScreen.java
@@ -129,8 +129,11 @@ public final class RowGroupIndexesScreen {
                     .render(area, buffer);
             return;
         }
-        List<Row> rows = new ArrayList<>();
-        for (Entry e : entries) {
+        // Build Row objects only for the visible window — see RowWindow.
+        RowWindow window = RowWindow.bottomPinned(state.selection(), entries.size(), area.height() - 3);
+        List<Row> rows = new ArrayList<>(window.size());
+        for (int i = window.start(); i < window.end(); i++) {
+            Entry e = entries.get(i);
             rows.add(Row.from(
                     Sizes.columnPath(e.chunk().metaData()),
                     e.typeLabel(),
@@ -160,7 +163,7 @@ public final class RowGroupIndexesScreen {
                 .build();
         TableState tableState = new TableState();
         if (!entries.isEmpty()) {
-            tableState.select(Math.min(state.selection(), entries.size() - 1));
+            tableState.select(window.selectionInWindow());
         }
         table.render(area, buffer, tableState);
     }

--- a/cli/src/main/java/dev/hardwood/cli/dive/internal/RowGroupsScreen.java
+++ b/cli/src/main/java/dev/hardwood/cli/dive/internal/RowGroupsScreen.java
@@ -75,8 +75,10 @@ public final class RowGroupsScreen {
 
     public static void render(Buffer buffer, Rect area, ParquetModel model, ScreenState.RowGroups state) {
         Keys.observeViewport(area.height() - 3);
-        List<Row> rows = new ArrayList<>();
-        for (int i = 0; i < model.rowGroupCount(); i++) {
+        // Build Row objects only for the visible window — see RowWindow.
+        RowWindow window = RowWindow.bottomPinned(state.selection(), model.rowGroupCount(), area.height() - 3);
+        List<Row> rows = new ArrayList<>(window.size());
+        for (int i = window.start(); i < window.end(); i++) {
             RowGroup rg = model.rowGroup(i);
             long compressed = 0;
             long uncompressed = 0;
@@ -128,7 +130,7 @@ public final class RowGroupsScreen {
                 .highlightStyle(Theme.selection())
                 .build();
         TableState tableState = new TableState();
-        tableState.select(state.selection());
+        tableState.select(window.selectionInWindow());
         table.render(area, buffer, tableState);
     }
 

--- a/cli/src/main/java/dev/hardwood/cli/dive/internal/RowWindow.java
+++ b/cli/src/main/java/dev/hardwood/cli/dive/internal/RowWindow.java
@@ -1,0 +1,50 @@
+/*
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Copyright The original authors
+ *
+ *  Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package dev.hardwood.cli.dive.internal;
+
+/// Visible row window for a list-shaped dive screen. List screens that build
+/// a `Row` per item must build only the visible slice each frame, otherwise
+/// per-keystroke navigation is O(N) in formatting + Row/Cell allocation —
+/// which is invisible on small files but becomes the dominant cost on
+/// dictionaries with hundreds of thousands of entries, page lists with
+/// thousands of pages, or wide-schema files.
+///
+/// The window is bottom-pinned on the selection: when the cursor sits at or
+/// past the bottom of the viewport, the window scrolls so the cursor stays
+/// on the last row. This mirrors what `TableState.scrollToSelected` produces
+/// when the state is constructed fresh each frame, so swapping in the slice
+/// gives the same on-screen result.
+///
+/// `selectionInWindow` is the selection's row index relative to the slice
+/// (i.e. `selection - start`), suitable for `TableState.select(...)` after
+/// the slice is handed to the Table widget.
+public record RowWindow(int start, int end, int selectionInWindow) {
+
+    public int size() {
+        return end - start;
+    }
+
+    public boolean isEmpty() {
+        return start >= end;
+    }
+
+    /// Compute the visible window for a list of `total` rows, bottom-pinned
+    /// on `selection`, given the viewport's row capacity. `viewport` may be
+    /// non-positive (very narrow terminals): callers get a single-row
+    /// window in that case so the table still draws the cursor.
+    public static RowWindow bottomPinned(int selection, int total, int viewport) {
+        if (total <= 0) {
+            return new RowWindow(0, 0, 0);
+        }
+        int v = Math.max(1, viewport);
+        int sel = Math.min(Math.max(0, selection), total - 1);
+        int start = sel >= v ? sel - v + 1 : 0;
+        int end = Math.min(total, start + v);
+        return new RowWindow(start, end, sel - start);
+    }
+}


### PR DESCRIPTION
Holding Up/Down on dive list screens felt sluggish whenever the underlying collection was large: column chunks with hundreds of thousands of dictionary entries, chunks with thousands of pages, file-wide index views on wide files, and per-row-group / per-column screens on wide schemas. Each screen rebuilt a Row covering the entire collection on every keystroke, and the Table widget walked that full row list (via cumulative `totalHeight`) to find the visible window even though it only painted a viewport-sized slice. Row construction and per-row formatting (page-stat min/max decoding in particular) was the dominant cost and scaled with N rather than the viewport.

The fix is a small `RowWindow` helper that returns the bottom-pinned `[start, end)` window plus the slice-relative selection, mirroring what `TableState.scrollToSelected` produces for a fresh state. Each list screen now builds Rows only for that range and tells the table the slice-relative selection. `PagesScreen` also recovers its data-page counter at `window.start()` by counting non-dictionary pages in the skipped prefix. `DataPreviewScreen` is intentionally untouched: its `state.rows()` is already viewport-sized via `PreviewWindow`.

Affected screens: `DictionaryScreen`, `PagesScreen`, `ColumnIndexScreen`, `OffsetIndexScreen`, `FileIndexesScreen`, `ColumnChunksScreen`, `ColumnAcrossRowGroupsScreen`, `RowGroupIndexesScreen`, `RowGroupsScreen`.

The `DictionaryScreen` filter cache also moves from `List<Integer>` + `List.copyOf` to `int[]` with a `null` sentinel for the empty-filter identity case, so the common navigation path on a cache hit allocates nothing per entry, and the cached `Dictionary` is held via `WeakReference` so it is not pinned for the JVM lifetime.

`CLAUDE.md` gains a note in the dive section so future list screens use the helper from the start. See `_designs/DIVE_LIST_VIEWPORT_VIRTUALIZATION.md`.

Closes #401. Closes #338 (duplicate, narrower Dictionary-only framing of the same problem).