### PR TITLE
#278 add --rows/-n option to convert command

### DIFF
--- a/cli/src/main/java/dev/hardwood/cli/command/ConvertCommand.java
+++ b/cli/src/main/java/dev/hardwood/cli/command/ConvertCommand.java
@@ -30,8 +30,6 @@ import picocli.CommandLine.Spec;
 @CommandLine.Command(name = "convert", description = "Convert Parquet file to CSV or JSON.")
 public class ConvertCommand implements Callable<Integer> {
 
-    private static final String ALL = "ALL";
-
     enum Format {
         CSV,
         JSON
@@ -55,7 +53,7 @@ public class ConvertCommand implements Callable<Integer> {
     @CommandLine.Option(names = {"-c", "--columns"}, description = "Comma-separated list of columns to include. Supports nested fields via dot notation (e.g. 'account.id').")
     String columns;
 
-    @CommandLine.Option(names = {"-n", "--rows"}, defaultValue = ALL, description = "Number of rows to convert. Positive values convert the first N rows (head), negative values convert the last N rows (tail), 'ALL' converts every row.")
+    @CommandLine.Option(names = {"-n", "--rows"}, defaultValue = RowLimits.ALL, description = "Number of rows to convert. Positive values convert the first N rows (head), negative values convert the last N rows (tail), 'ALL' converts every row.")
     String n;
 
     @Override
@@ -65,7 +63,7 @@ public class ConvertCommand implements Callable<Integer> {
             return CommandLine.ExitCode.SOFTWARE;
         }
 
-        int rowLimit = parseRowLimit();
+        int rowLimit = RowLimits.parse(n, spec);
         ColumnProjection projection = parseColumnProjection();
 
         try (ParquetFileReader reader = ParquetFileReader.open(inputFile)) {
@@ -73,7 +71,7 @@ public class ConvertCommand implements Callable<Integer> {
             List<SchemaNode> fields = projectedFields(fileSchema, projection);
 
             PrintWriter out = openOutput();
-            try (RowReader rowReader = buildRowReader(reader, projection, rowLimit)) {
+            try (RowReader rowReader = RowLimits.buildRowReader(reader, projection, rowLimit)) {
                 switch (format) {
                     case CSV -> writeCsv(out, fields, rowReader);
                     case JSON -> writeJson(out, fields, rowReader);
@@ -125,29 +123,6 @@ public class ConvertCommand implements Callable<Integer> {
             return new PrintWriter(new FileWriter(outputFile));
         }
         return spec.commandLine().getOut();
-    }
-
-    private static RowReader buildRowReader(ParquetFileReader reader, ColumnProjection projection, int rowLimit) {
-        ParquetFileReader.RowReaderBuilder builder = reader.buildRowReader().projection(projection);
-        if (rowLimit > 0) {
-            builder.head(rowLimit);
-        }
-        else if (rowLimit < 0) {
-            builder.tail(-rowLimit);
-        }
-        return builder.build();
-    }
-
-    private int parseRowLimit() {
-        if (ALL.equalsIgnoreCase(n)) {
-            return 0;
-        }
-        try {
-            return Integer.parseInt(n);
-        } catch (NumberFormatException e) {
-            throw new CommandLine.ParameterException(spec.commandLine(),
-                    "Invalid value for option '-n': expected an integer or 'ALL', got '" + n + "'");
-        }
     }
 
     // ==================== CSV ====================

--- a/cli/src/main/java/dev/hardwood/cli/command/ConvertCommand.java
+++ b/cli/src/main/java/dev/hardwood/cli/command/ConvertCommand.java
@@ -30,6 +30,8 @@ import picocli.CommandLine.Spec;
 @CommandLine.Command(name = "convert", description = "Convert Parquet file to CSV or JSON.")
 public class ConvertCommand implements Callable<Integer> {
 
+    private static final String ALL = "ALL";
+
     enum Format {
         CSV,
         JSON
@@ -53,6 +55,9 @@ public class ConvertCommand implements Callable<Integer> {
     @CommandLine.Option(names = {"-c", "--columns"}, description = "Comma-separated list of columns to include. Supports nested fields via dot notation (e.g. 'account.id').")
     String columns;
 
+    @CommandLine.Option(names = {"-n", "--rows"}, defaultValue = ALL, description = "Number of rows to convert. Positive values convert the first N rows (head), negative values convert the last N rows (tail), 'ALL' converts every row.")
+    String n;
+
     @Override
     public Integer call() {
         InputFile inputFile = fileMixin.toInputFile();
@@ -60,6 +65,7 @@ public class ConvertCommand implements Callable<Integer> {
             return CommandLine.ExitCode.SOFTWARE;
         }
 
+        int rowLimit = parseRowLimit();
         ColumnProjection projection = parseColumnProjection();
 
         try (ParquetFileReader reader = ParquetFileReader.open(inputFile)) {
@@ -67,7 +73,7 @@ public class ConvertCommand implements Callable<Integer> {
             List<SchemaNode> fields = projectedFields(fileSchema, projection);
 
             PrintWriter out = openOutput();
-            try (RowReader rowReader = reader.buildRowReader().projection(projection).build()) {
+            try (RowReader rowReader = buildRowReader(reader, projection, rowLimit)) {
                 switch (format) {
                     case CSV -> writeCsv(out, fields, rowReader);
                     case JSON -> writeJson(out, fields, rowReader);
@@ -119,6 +125,29 @@ public class ConvertCommand implements Callable<Integer> {
             return new PrintWriter(new FileWriter(outputFile));
         }
         return spec.commandLine().getOut();
+    }
+
+    private static RowReader buildRowReader(ParquetFileReader reader, ColumnProjection projection, int rowLimit) {
+        ParquetFileReader.RowReaderBuilder builder = reader.buildRowReader().projection(projection);
+        if (rowLimit > 0) {
+            builder.head(rowLimit);
+        }
+        else if (rowLimit < 0) {
+            builder.tail(-rowLimit);
+        }
+        return builder.build();
+    }
+
+    private int parseRowLimit() {
+        if (ALL.equalsIgnoreCase(n)) {
+            return 0;
+        }
+        try {
+            return Integer.parseInt(n);
+        } catch (NumberFormatException e) {
+            throw new CommandLine.ParameterException(spec.commandLine(),
+                    "Invalid value for option '-n': expected an integer or 'ALL', got '" + n + "'");
+        }
     }
 
     // ==================== CSV ====================

--- a/cli/src/main/java/dev/hardwood/cli/command/PrintCommand.java
+++ b/cli/src/main/java/dev/hardwood/cli/command/PrintCommand.java
@@ -25,7 +25,6 @@ import dev.hardwood.InputFile;
 import dev.hardwood.cli.internal.table.RowTable;
 import dev.hardwood.cli.internal.table.StreamedTable;
 import dev.hardwood.reader.ParquetFileReader;
-import dev.hardwood.reader.ParquetFileReader.RowReaderBuilder;
 import dev.hardwood.reader.RowReader;
 import dev.hardwood.schema.ColumnProjection;
 import dev.hardwood.schema.FileSchema;
@@ -36,8 +35,6 @@ import picocli.CommandLine.Spec;
 
 @CommandLine.Command(name = "print", description = "Print all rows as an ASCII table.")
 public class PrintCommand implements Callable<Integer> {
-
-    private static final String ALL = "ALL";
 
     @CommandLine.Mixin
     HelpMixin help;
@@ -66,7 +63,7 @@ public class PrintCommand implements Callable<Integer> {
     @CommandLine.Option(names = {"-rd", "--row-delimiter"}, description = "Should a line separate rows, it is lighter without but less readable when it overlaps a single terminal line.")
     boolean rowDelimiter;
 
-    @CommandLine.Option(names = {"-n", "--rows"}, defaultValue = ALL, description = "Number of rows to display. Positive values show the first N rows (head), negative values show the last N rows (tail), 'ALL' shows every row.")
+    @CommandLine.Option(names = {"-n", "--rows"}, defaultValue = RowLimits.ALL, description = "Number of rows to display. Positive values show the first N rows (head), negative values show the last N rows (tail), 'ALL' shows every row.")
     String n;
 
     @CommandLine.Option(names = {"-c", "--columns"}, description = "Comma-separated list of columns to include. Supports nested fields via dot notation (e.g. 'account.id').")
@@ -79,12 +76,12 @@ public class PrintCommand implements Callable<Integer> {
             return CommandLine.ExitCode.SOFTWARE;
         }
 
-        int rowLimit = parseRowLimit();
+        int rowLimit = RowLimits.parse(n, spec);
         ColumnProjection projection = parseColumnProjection();
 
         try (ParquetFileReader reader = ParquetFileReader.open(inputFile)) {
             FileSchema fileSchema = reader.getFileSchema();
-            try (RowReader rowReader = buildRowReader(reader, projection, rowLimit)) {
+            try (RowReader rowReader = RowLimits.buildRowReader(reader, projection, rowLimit)) {
                 String[] headers = RowTable.topLevelFieldNames(fileSchema, projection);
                 List<SchemaNode> fields = projectedFields(fileSchema, projection);
                 AtomicLong rowIndex = addRowIndex ? new AtomicLong() : null;
@@ -131,30 +128,6 @@ public class PrintCommand implements Callable<Integer> {
                 maxWidth,
                 truncate,
                 rowDelimiter);
-    }
-
-    private static RowReader buildRowReader(ParquetFileReader reader, ColumnProjection projection, int rowLimit) {
-        RowReaderBuilder builder = reader.buildRowReader().projection(projection);
-        if (rowLimit > 0) {
-            builder.head(rowLimit);
-        }
-        else if (rowLimit < 0) {
-            builder.tail(-rowLimit);
-        }
-        return builder.build();
-    }
-
-    private int parseRowLimit() {
-        if (ALL.equalsIgnoreCase(n)) {
-            return 0;
-        }
-        try {
-            return Integer.parseInt(n);
-        }
-        catch (NumberFormatException e) {
-            throw new CommandLine.ParameterException(spec.commandLine(),
-                    "Invalid value for option '-n': expected an integer or 'ALL', got '" + n + "'");
-        }
     }
 
     private ColumnProjection parseColumnProjection() {

--- a/cli/src/main/java/dev/hardwood/cli/command/RowLimits.java
+++ b/cli/src/main/java/dev/hardwood/cli/command/RowLimits.java
@@ -1,0 +1,61 @@
+/*
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Copyright The original authors
+ *
+ *  Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package dev.hardwood.cli.command;
+
+import dev.hardwood.reader.ParquetFileReader;
+import dev.hardwood.reader.ParquetFileReader.RowReaderBuilder;
+import dev.hardwood.reader.RowReader;
+import dev.hardwood.schema.ColumnProjection;
+import picocli.CommandLine;
+import picocli.CommandLine.Model.CommandSpec;
+
+/// Shared `-n / --rows` parsing and application for CLI commands that
+/// support head / tail / ALL row limiting (`print`, `convert`, ...).
+final class RowLimits {
+
+    static final String ALL = "ALL";
+
+    private RowLimits() {
+    }
+
+    /// Parses the raw `-n` argument into a row-limit integer:
+    /// positive for head, negative for tail, `0` for no limit (`ALL`).
+    /// Throws [CommandLine.ParameterException] for invalid input, including
+    /// an explicit `0` (which would otherwise collide with the no-limit sentinel).
+    static int parse(String value, CommandSpec spec) {
+        if (ALL.equalsIgnoreCase(value)) {
+            return 0;
+        }
+        int parsed;
+        try {
+            parsed = Integer.parseInt(value);
+        }
+        catch (NumberFormatException e) {
+            throw new CommandLine.ParameterException(spec.commandLine(),
+                    "Invalid value for option '-n': expected a non-zero integer or 'ALL', got '" + value + "'");
+        }
+        if (parsed == 0) {
+            throw new CommandLine.ParameterException(spec.commandLine(),
+                    "Invalid value for option '-n': expected a non-zero integer or 'ALL', got '0'");
+        }
+        return parsed;
+    }
+
+    /// Builds a [RowReader] applying the parsed row limit:
+    /// positive → `head(limit)`, negative → `tail(-limit)`, zero → no limit.
+    static RowReader buildRowReader(ParquetFileReader reader, ColumnProjection projection, int rowLimit) {
+        RowReaderBuilder builder = reader.buildRowReader().projection(projection);
+        if (rowLimit > 0) {
+            builder.head(rowLimit);
+        }
+        else if (rowLimit < 0) {
+            builder.tail(-rowLimit);
+        }
+        return builder.build();
+    }
+}

--- a/cli/src/test/java/dev/hardwood/cli/command/ConvertCommandContract.java
+++ b/cli/src/test/java/dev/hardwood/cli/command/ConvertCommandContract.java
@@ -111,4 +111,37 @@ interface ConvertCommandContract {
 
         assertThat(result.exitCode()).isNotZero();
     }
+
+    @Test
+    default void explicitOneShowsFirstRow(){
+        Cli.Result result = Cli.launch("convert", "-f", plainFile(), "--format", "csv", "-n", "1");
+
+        assertThat(result.exitCode()).isZero();
+        assertThat(result.output()).isEqualTo("""
+                id,value
+                1,100""");
+    }
+
+    @Test
+    default void explicitNegativeOneShowsLastRow(){
+        Cli.Result result = Cli.launch("convert", "-f", plainFile(), "--format", "csv", "-n", "-1");
+
+        assertThat(result.exitCode()).isZero();
+        assertThat(result.output()).isEqualTo("""
+                id,value
+                3,300""");
+    }
+
+    @Test
+    default void explicitAllShowsEveryRow(){
+        Cli.Result result = Cli.launch("convert", "-f", plainFile(), "--format", "csv", "-n", "ALL");
+
+        assertThat(result.exitCode()).isZero();
+        assertThat(result.output()).isEqualTo("""
+                id,value
+                1,100
+                2,200
+                3,300""");
+    }
+
 }

--- a/cli/src/test/java/dev/hardwood/cli/command/ConvertCommandContract.java
+++ b/cli/src/test/java/dev/hardwood/cli/command/ConvertCommandContract.java
@@ -20,6 +20,8 @@ interface ConvertCommandContract {
 
     String listFile();
 
+    String multiRowGroupIntFile();
+
     String nonexistentFile();
 
     @Test
@@ -113,7 +115,7 @@ interface ConvertCommandContract {
     }
 
     @Test
-    default void explicitOneShowsFirstRow(){
+    default void head() {
         Cli.Result result = Cli.launch("convert", "-f", plainFile(), "--format", "csv", "-n", "1");
 
         assertThat(result.exitCode()).isZero();
@@ -123,7 +125,7 @@ interface ConvertCommandContract {
     }
 
     @Test
-    default void explicitNegativeOneShowsLastRow(){
+    default void tail() {
         Cli.Result result = Cli.launch("convert", "-f", plainFile(), "--format", "csv", "-n", "-1");
 
         assertThat(result.exitCode()).isZero();
@@ -133,7 +135,34 @@ interface ConvertCommandContract {
     }
 
     @Test
-    default void explicitAllShowsEveryRow(){
+    default void tailOnMultipleRowGroups() {
+        // filter_pushdown_int.parquet has three row groups of 100 rows each.
+        // The tail must reflect the last rows of the file regardless of the
+        // row-group layout; this also exercises the code path that skips
+        // row groups outside the tail.
+        Cli.Result result = Cli.launch("convert", "-f", multiRowGroupIntFile(), "--format", "csv", "-n", "-3");
+
+        assertThat(result.exitCode()).isZero();
+        assertThat(result.output()).isEqualTo("""
+                id,value,label
+                298,298,rg3_298
+                299,299,rg3_299
+                300,300,rg3_300""");
+    }
+
+    @Test
+    default void headJsonOutput() {
+        Cli.Result result = Cli.launch("convert", "-f", plainFile(), "--format", "json", "-n", "1");
+
+        assertThat(result.exitCode()).isZero();
+        assertThat(result.output()).isEqualTo("""
+                [
+                  {"id":"1","value":"100"}
+                ]""");
+    }
+
+    @Test
+    default void explicitAllConvertsEveryRow() {
         Cli.Result result = Cli.launch("convert", "-f", plainFile(), "--format", "csv", "-n", "ALL");
 
         assertThat(result.exitCode()).isZero();
@@ -142,6 +171,22 @@ interface ConvertCommandContract {
                 1,100
                 2,200
                 3,300""");
+    }
+
+    @Test
+    default void rejectsNonIntegerRowLimit() {
+        Cli.Result result = Cli.launch("convert", "-f", plainFile(), "--format", "csv", "-n", "abc");
+
+        assertThat(result.exitCode()).isNotZero();
+        assertThat(result.errorOutput()).contains("Invalid value for option '-n'");
+    }
+
+    @Test
+    default void rejectsZeroRowLimit() {
+        Cli.Result result = Cli.launch("convert", "-f", plainFile(), "--format", "csv", "-n", "0");
+
+        assertThat(result.exitCode()).isNotZero();
+        assertThat(result.errorOutput()).contains("Invalid value for option '-n'");
     }
 
 }

--- a/cli/src/test/java/dev/hardwood/cli/command/ConvertCommandTest.java
+++ b/cli/src/test/java/dev/hardwood/cli/command/ConvertCommandTest.java
@@ -40,6 +40,11 @@ class ConvertCommandTest implements ConvertCommandContract {
     }
 
     @Override
+    public String multiRowGroupIntFile() {
+        return getClass().getResource("/filter_pushdown_int.parquet").getPath();
+    }
+
+    @Override
     public String nonexistentFile() {
         return "nonexistent.parquet";
     }

--- a/cli/src/test/java/dev/hardwood/cli/command/ConvertS3CommandTest.java
+++ b/cli/src/test/java/dev/hardwood/cli/command/ConvertS3CommandTest.java
@@ -25,6 +25,11 @@ class ConvertS3CommandTest extends AbstractS3CommandTest implements ConvertComma
     }
 
     @Override
+    public String multiRowGroupIntFile() {
+        return S3_MULTI_ROW_GROUP_INT_FILE;
+    }
+
+    @Override
     public String nonexistentFile() {
         return S3_NONEXISTENT_FILE;
     }

--- a/docs/content/cli.md
+++ b/docs/content/cli.md
@@ -29,7 +29,7 @@ Pre-built native binaries for Linux, macOS, and Windows are available from the [
 | `hardwood info` | Display high-level file information |
 | `hardwood schema` | Print the file schema, including logical-type annotations such as `VARIANT(1)` on Variant groups |
 | `hardwood print` | Print rows as an ASCII table (head, tail, or all); Variant columns are decoded to JSON-like text |
-| `hardwood convert` | Convert a Parquet file to CSV or JSON; Variant columns are emitted as a JSON string in CSV and as a native JSON subtree in JSON |
+| `hardwood convert` | Convert a Parquet file to CSV or JSON (head, tail, or all); Variant columns are emitted as a JSON string in CSV and as a native JSON subtree in JSON |
 | `hardwood footer` | Print decoded footer length, offset, and file structure |
 | `hardwood inspect pages` | List data and dictionary pages per column chunk; includes per-page min/max when the file has a page index |
 | `hardwood inspect dictionary` | Print dictionary entries for a column |
@@ -64,6 +64,12 @@ hardwood inspect dictionary -f data.parquet -c category
 
 # Show all dictionary entries for a column
 hardwood inspect dictionary -f data.parquet -c category --limit 0
+
+# Convert first 100 rows to JSON
+hardwood convert -n 100 --format json -f data.parquet
+
+# Convert last 50 rows to CSV
+hardwood convert -n -50 --format csv -f data.parquet
 ```
 
 ## Interactive exploration (`dive`)


### PR DESCRIPTION
## Checklist

- [x] Build via `./mvnw clean verify` passes
- [x] The commit message is prefixed with the issue key #278 
- [x] Code changes are covered by tests
- [x] If this PR adds or changes user-facing behaviour, `docs/` has been updated
