### PR TITLE
#408 display version info (tag + commit sha) in the cli

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -11,6 +11,7 @@ Run ./mvnw verify to build the project.
 When doing changes in hardwood-core, install that module before running the performance tests or any other module.
 When running Maven commands, always apply a timeout of 180 seconds to detect deadlocks early on.
 Enable -Pperformance-test to run performance tests.
+All plugin versions must be declared in the parent `pom.xml`'s `<pluginManagement>`. Module POMs reference plugins by `groupId`/`artifactId` only, never with a `<version>` of their own.
 
 # Design
 

--- a/cli/pom.xml
+++ b/cli/pom.xml
@@ -567,7 +567,6 @@
       <plugin>
         <groupId>org.codehaus.mojo</groupId>
         <artifactId>buildnumber-maven-plugin</artifactId>
-        <version>3.3.0</version>
         <executions>
           <execution>
             <phase>initialize</phase>
@@ -587,7 +586,6 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-jar-plugin</artifactId>
-        <version>3.3.0</version>
         <configuration>
           <archive>
             <manifestEntries>

--- a/cli/pom.xml
+++ b/cli/pom.xml
@@ -564,6 +564,40 @@
           </execution>
         </executions>
       </plugin>
+      <plugin>
+        <groupId>org.codehaus.mojo</groupId>
+        <artifactId>buildnumber-maven-plugin</artifactId>
+        <version>3.3.0</version>
+        <executions>
+          <execution>
+            <phase>initialize</phase>
+            <goals>
+              <goal>create</goal>
+            </goals>
+          </execution>
+        </executions>
+        <configuration>
+          <doCheck>true</doCheck> <!-- Required to detect 'dirty' state -->
+          <failTheBuild>false</failTheBuild>
+          <getRevisionOnlyOnce>true</getRevisionOnlyOnce>
+          <shortRevisionLength>7</shortRevisionLength>
+          <buildNumberPropertiesFileLocation>${project.build.directory}/buildNumber.properties</buildNumberPropertiesFileLocation>
+        </configuration>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-jar-plugin</artifactId>
+        <version>3.3.0</version>
+        <configuration>
+          <archive>
+            <manifestEntries>
+              <Implementation-Title>${project.name}</Implementation-Title>
+              <Implementation-Version>${project.version}</Implementation-Version>
+              <Implementation-Build>${buildNumber}</Implementation-Build>
+            </manifestEntries>
+          </archive>
+        </configuration>
+      </plugin>
     </plugins>
   </build>
 </project>

--- a/cli/src/main/java/dev/hardwood/cli/command/HardwoodCommand.java
+++ b/cli/src/main/java/dev/hardwood/cli/command/HardwoodCommand.java
@@ -42,7 +42,6 @@ class VersionProviderWithConfigProvider implements IVersionProvider {
     public String[] getVersion() {
         String applicationName = "hardwood";
         String applicationVersion = Version.getVersion();
-
         return new String[]{ Fmt.fmt("%s %s", applicationName, applicationVersion) };
     }
 }

--- a/cli/src/main/java/dev/hardwood/cli/command/HardwoodCommand.java
+++ b/cli/src/main/java/dev/hardwood/cli/command/HardwoodCommand.java
@@ -7,9 +7,8 @@
  */
 package dev.hardwood.cli.command;
 
-import org.eclipse.microprofile.config.ConfigProvider;
-
 import dev.hardwood.cli.internal.Fmt;
+import dev.hardwood.cli.internal.Version;
 import io.quarkus.picocli.runtime.PicocliCommandLineFactory;
 import io.quarkus.picocli.runtime.annotations.TopCommand;
 import jakarta.enterprise.inject.Produces;
@@ -42,12 +41,8 @@ class VersionProviderWithConfigProvider implements IVersionProvider {
     @Override
     public String[] getVersion() {
         String applicationName = "hardwood";
-        String applicationVersion = ConfigProvider.getConfig().getValue("project.version", String.class);
-        String applicationRevision = ConfigProvider.getConfig().getValue("project.revision", String.class);
-        String dirtyStatus = ConfigProvider.getConfig().getValue("project.revision.dirty", String.class);
+        String applicationVersion = Version.getVersion();
 
-        String dirtyMark = "tainted".equalsIgnoreCase(dirtyStatus) ? "-dirty" : "";
-
-        return new String[]{ Fmt.fmt("%s %s (%s%s)", applicationName, applicationVersion, applicationRevision, dirtyMark) };
+        return new String[]{ Fmt.fmt("%s %s", applicationName, applicationVersion) };
     }
 }

--- a/cli/src/main/java/dev/hardwood/cli/command/HardwoodCommand.java
+++ b/cli/src/main/java/dev/hardwood/cli/command/HardwoodCommand.java
@@ -43,6 +43,11 @@ class VersionProviderWithConfigProvider implements IVersionProvider {
     public String[] getVersion() {
         String applicationName = "hardwood";
         String applicationVersion = ConfigProvider.getConfig().getValue("project.version", String.class);
-        return new String[]{ Fmt.fmt("%s %s", applicationName, applicationVersion) };
+        String applicationRevision = ConfigProvider.getConfig().getValue("project.revision", String.class);
+        String dirtyStatus = ConfigProvider.getConfig().getValue("project.revision.dirty", String.class);
+
+        String dirtyMark = "tainted".equalsIgnoreCase(dirtyStatus) ? "-dirty" : "";
+
+        return new String[]{ Fmt.fmt("%s %s (%s%s)", applicationName, applicationVersion, applicationRevision, dirtyMark) };
     }
 }

--- a/cli/src/main/java/dev/hardwood/cli/dive/internal/HelpOverlay.java
+++ b/cli/src/main/java/dev/hardwood/cli/dive/internal/HelpOverlay.java
@@ -30,7 +30,7 @@ public final class HelpOverlay {
 
     public static void render(Buffer buffer, Rect screenArea) {
         int width = Math.min(60, screenArea.width() - 4);
-        int height = Math.min(22, screenArea.height() - 2);
+        int height = Math.min(31, screenArea.height() - 2);
         int x = screenArea.left() + (screenArea.width() - width) / 2;
         int y = screenArea.top() + (screenArea.height() - height) / 2;
         Rect area = new Rect(x, y, width, height);
@@ -39,8 +39,6 @@ public final class HelpOverlay {
         dev.tamboui.widgets.Clear.INSTANCE.render(area, buffer);
 
         List<Line> lines = List.of(
-                Line.from(new Span("Version: " + Version.getVersion(), Theme.primary())),
-                Line.empty(),
                 Line.from(new Span("Navigation", Theme.accent().bold())),
                 kv("↑ / ↓", "move selection"),
                 kv("g / G", "jump to first / last row"),
@@ -68,6 +66,7 @@ public final class HelpOverlay {
                 kv("← / →", "scroll visible columns"),
                 kv("g / G", "jump to first / last row of file"),
                 Line.empty(),
+                Line.from(new Span("Version: " + Version.getVersion(), Theme.dim())),
                 Line.from(new Span("Press ? or Esc to close", Theme.dim())));
 
         Block block = Block.builder()

--- a/cli/src/main/java/dev/hardwood/cli/dive/internal/HelpOverlay.java
+++ b/cli/src/main/java/dev/hardwood/cli/dive/internal/HelpOverlay.java
@@ -9,6 +9,7 @@ package dev.hardwood.cli.dive.internal;
 
 import java.util.List;
 
+import dev.hardwood.cli.internal.Version;
 import dev.tamboui.buffer.Buffer;
 import dev.tamboui.layout.Rect;
 import dev.tamboui.style.Style;
@@ -38,6 +39,8 @@ public final class HelpOverlay {
         dev.tamboui.widgets.Clear.INSTANCE.render(area, buffer);
 
         List<Line> lines = List.of(
+                Line.from(new Span("Version: " + Version.getVersion(), Theme.primary())),
+                Line.empty(),
                 Line.from(new Span("Navigation", Theme.accent().bold())),
                 kv("↑ / ↓", "move selection"),
                 kv("g / G", "jump to first / last row"),

--- a/cli/src/main/java/dev/hardwood/cli/internal/Version.java
+++ b/cli/src/main/java/dev/hardwood/cli/internal/Version.java
@@ -1,0 +1,19 @@
+package dev.hardwood.cli.internal;
+
+import org.eclipse.microprofile.config.ConfigProvider;
+
+public class Version {
+
+    private Version() {
+    }
+
+    public static String getVersion() {
+        String applicationVersion = ConfigProvider.getConfig().getValue("project.version", String.class);
+        String applicationRevision = ConfigProvider.getConfig().getValue("project.revision", String.class);
+        String dirtyStatus = ConfigProvider.getConfig().getValue("project.revision.dirty", String.class);
+
+        String dirtyMark = "tainted".equalsIgnoreCase(dirtyStatus) ? "-dirty" : "";
+        return Fmt.fmt("%s (%s%s)", applicationVersion, applicationRevision, dirtyMark);
+    }
+
+}

--- a/cli/src/main/java/dev/hardwood/cli/internal/Version.java
+++ b/cli/src/main/java/dev/hardwood/cli/internal/Version.java
@@ -1,19 +1,32 @@
+/*
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Copyright The original authors
+ *
+ *  Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
 package dev.hardwood.cli.internal;
 
 import org.eclipse.microprofile.config.ConfigProvider;
 
 public class Version {
 
-    private Version() {
-    }
+    private static final String VERSION = initVersion();
 
-    public static String getVersion() {
+    private static String initVersion() {
         String applicationVersion = ConfigProvider.getConfig().getValue("project.version", String.class);
         String applicationRevision = ConfigProvider.getConfig().getValue("project.revision", String.class);
         String dirtyStatus = ConfigProvider.getConfig().getValue("project.revision.dirty", String.class);
 
         String dirtyMark = "tainted".equalsIgnoreCase(dirtyStatus) ? "-dirty" : "";
         return Fmt.fmt("%s (%s%s)", applicationVersion, applicationRevision, dirtyMark);
+    }
+
+    private Version() {
+    }
+
+    public static String getVersion() {
+        return VERSION;
     }
 
 }

--- a/cli/src/main/java/dev/hardwood/cli/internal/Version.java
+++ b/cli/src/main/java/dev/hardwood/cli/internal/Version.java
@@ -7,26 +7,36 @@
  */
 package dev.hardwood.cli.internal;
 
+import org.eclipse.microprofile.config.Config;
 import org.eclipse.microprofile.config.ConfigProvider;
 
-public class Version {
+/// Resolves the human-readable version string for the CLI and TUI.
+public final class Version {
+
+    /// Value of `project.revision.dirty` produced by `buildnumber-maven-plugin`'s
+    /// `doCheck` when the working tree has uncommitted changes (the alternative is `ok`).
+    private static final String DIRTY_MARKER = "tainted";
 
     private static final String VERSION = initVersion();
 
-    private static String initVersion() {
-        String applicationVersion = ConfigProvider.getConfig().getValue("project.version", String.class);
-        String applicationRevision = ConfigProvider.getConfig().getValue("project.revision", String.class);
-        String dirtyStatus = ConfigProvider.getConfig().getValue("project.revision.dirty", String.class);
-
-        String dirtyMark = "tainted".equalsIgnoreCase(dirtyStatus) ? "-dirty" : "";
-        return Fmt.fmt("%s (%s%s)", applicationVersion, applicationRevision, dirtyMark);
+    private Version() {
     }
 
-    private Version() {
+    /// Returns the version in the form `<project-version> (<short-sha>[-dirty])`,
+    /// e.g. `1.0.0-SNAPSHOT (a093aab-dirty)`. Values come from the filtered
+    /// `application.properties` populated at build time by `buildnumber-maven-plugin`.
+
+    private static String initVersion() {
+        Config config = ConfigProvider.getConfig();
+        String applicationVersion = config.getValue("project.version", String.class);
+        String applicationRevision = config.getValue("project.revision", String.class);
+        String dirtyStatus = config.getValue("project.revision.dirty", String.class);
+
+        String dirtyMark = DIRTY_MARKER.equalsIgnoreCase(dirtyStatus) ? "-dirty" : "";
+        return Fmt.fmt("%s (%s%s)", applicationVersion, applicationRevision, dirtyMark);
     }
 
     public static String getVersion() {
         return VERSION;
     }
-
 }

--- a/cli/src/main/resources/application.properties
+++ b/cli/src/main/resources/application.properties
@@ -7,6 +7,8 @@
 #
 
 project.version=${project.version}
+project.revision=${buildNumber}
+project.revision.dirty=${buildIsTainted}
 quarkus.banner.enabled=false
 quarkus.package.output-name=hardwood
 quarkus.package.runner-suffix=-cli

--- a/pom.xml
+++ b/pom.xml
@@ -221,6 +221,18 @@
         </plugin>
         <plugin>
           <groupId>org.codehaus.mojo</groupId>
+          <artifactId>buildnumber-maven-plugin</artifactId>
+          <version>3.3.0</version>
+          <dependencies>
+            <dependency>
+              <groupId>org.apache.maven.scm</groupId>
+              <artifactId>maven-scm-provider-gitexe</artifactId>
+              <version>2.0.1</version>
+            </dependency>
+          </dependencies>
+        </plugin>
+        <plugin>
+          <groupId>org.codehaus.mojo</groupId>
           <artifactId>exec-maven-plugin</artifactId>
           <version>3.5.0</version>
         </plugin>


### PR DESCRIPTION
closes #408 
Display version info (tag + commit SHA) in the CLI via --version and display version information from inside the hardwood dive TUI help model

> hardwood --version
hardwood 1.0.0-SNAPSHOT (fe218a0)

when there are changes not commit yet, `-dirty` is added to sha
> hardwood 1.0.0-SNAPSHOT (a093aab-dirty)

#### TUI help model
<img width="494" height="198" alt="Screenshot from 2026-05-04 06-19-12" src="https://github.com/user-attachments/assets/f118fddf-cdd4-4859-88c5-2906a26d1125" />



also, Inject Project info into the Manifest for official record-keeping.

## Checklist

- [x] Build via `./mvnw clean verify` passes
- [x] The commit message is prefixed with the issue key ("#408")
- [x] Code changes are covered by tests
- [x] If this PR adds or changes user-facing behaviour, `docs/` has been updated
