### PR TITLE
#84 Compare Nested Columns in ParquetComparisonTest

### DIFF
--- a/parquet-testing-runner/src/test/java/dev/hardwood/testing/BadDataHandlingTest.java
+++ b/parquet-testing-runner/src/test/java/dev/hardwood/testing/BadDataHandlingTest.java
@@ -26,10 +26,10 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 /// Verifies how Hardwood handles corrupted and intentionally-malformed Parquet files from
 /// the `apache/parquet-testing` suite (the `bad_data/` directory plus a handful of files
-/// in `data/` with corrupted CRCs). Covers both the single-file [ParquetFileReader] and
-/// the [ParquetFileReader] paths, including failures that appear mid-sequence. These
-/// tests do not compare against parquet-java — they assert Hardwood's own reject/accept
-/// behavior — so they live here rather than in [ParquetComparisonTest].
+/// in `data/` with corrupted CRCs). Covers both isolated bad files and bad files appearing
+/// mid-sequence in a multi-file [ParquetFileReader] input. These tests do not compare
+/// against parquet-java — they assert Hardwood's own reject/accept behavior — so they
+/// live here rather than in [ParquetComparisonTest].
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 class BadDataHandlingTest {
 
@@ -41,7 +41,7 @@ class BadDataHandlingTest {
         Utils.ensureGoodCFile(repoDir);
     }
 
-    // ==================== Single-file rejection ====================
+    // ==================== Rejection on a single bad file ====================
 
     @Test
     void rejectParquet1481() throws IOException {
@@ -130,33 +130,33 @@ class BadDataHandlingTest {
         }
     }
 
-    // ==================== Multi-file rejection (mid-sequence) ====================
+    // ==================== Rejection on a bad file mid-sequence ====================
 
     @Test
-    void multiFileReaderRejectsBadFileMidSequence() throws IOException {
+    void rejectsParquet1481MidSequence() throws IOException {
         Path good = repoDir.resolve("data/alltypes_plain.parquet");
         Path bad = repoDir.resolve("bad_data/PARQUET-1481.parquet");
         Utils.assertBadDataRejected("PARQUET-1481.parquet",
                 "[PARQUET-1481.parquet] Invalid or corrupt physical type value: -7 (expected 0-7)."
                         + " File metadata may be corrupted",
-                multiFileReadAction(good, bad));
+                concatenatedReadAction(good, bad));
     }
 
     @Test
-    void multiFileReaderRejectsDictheaderMidSequence() throws IOException {
+    void rejectsDictheaderMidSequence() throws IOException {
         Path good = repoDir.resolve("data/alltypes_plain.parquet");
         Path bad = repoDir.resolve("bad_data/ARROW-RS-GH-6229-DICTHEADER.parquet");
         Utils.assertBadDataRejected("ARROW-RS-GH-6229-DICTHEADER.parquet",
-                multiFileReadAction(good, bad));
+                concatenatedReadAction(good, bad));
     }
 
     @Test
-    void multiFileReaderRejectsLevelsMidSequence() throws IOException {
+    void rejectsLevelsMidSequence() throws IOException {
         Path good = repoDir.resolve("data/good_c.parquet");
         Path bad = repoDir.resolve("bad_data/ARROW-RS-GH-6229-LEVELS.parquet");
         Utils.assertBadDataRejected("ARROW-RS-GH-6229-LEVELS.parquet",
                 "[ARROW-RS-GH-6229-LEVELS.parquet] Column 'c' not found",
-                multiFileReadAction(good, bad));
+                concatenatedReadAction(good, bad));
     }
 
     // ==================== Helpers ====================
@@ -177,7 +177,7 @@ class BadDataHandlingTest {
           .hasRootCauseMessage(expectedCauseMessage);
     }
 
-    private ThrowableAssert.ThrowingCallable singleFileReadAction(String fileName) {
+    private ThrowableAssert.ThrowingCallable readAction(String fileName) {
         Path testFile = repoDir.resolve("bad_data/" + fileName);
         return () -> {
             try (ParquetFileReader fileReader = ParquetFileReader.open(InputFile.of(testFile));
@@ -190,19 +190,19 @@ class BadDataHandlingTest {
     }
 
     private void assertBadDataRejected(String fileName) throws IOException {
-        Utils.assertBadDataRejected(fileName, singleFileReadAction(fileName));
+        Utils.assertBadDataRejected(fileName, readAction(fileName));
     }
 
     private void assertBadDataRejected(String fileName, String expectedMessage) throws IOException {
-        Utils.assertBadDataRejected(fileName, expectedMessage, singleFileReadAction(fileName));
+        Utils.assertBadDataRejected(fileName, expectedMessage, readAction(fileName));
     }
 
-    private ThrowableAssert.ThrowingCallable multiFileReadAction(Path good, Path bad) {
+    private ThrowableAssert.ThrowingCallable concatenatedReadAction(Path good, Path bad) {
         return () -> {
             try (HardwoodContextImpl context = HardwoodContextImpl.create();
-                 ParquetFileReader mfReader = ParquetFileReader.openAll(
+                 ParquetFileReader reader = ParquetFileReader.openAll(
                          List.of(InputFile.of(good), InputFile.of(bad)), context);
-                 RowReader rowReader = mfReader.rowReader()) {
+                 RowReader rowReader = reader.rowReader()) {
                 while (rowReader.hasNext()) {
                     rowReader.next();
                 }

--- a/parquet-testing-runner/src/test/java/dev/hardwood/testing/ParquetComparisonTest.java
+++ b/parquet-testing-runner/src/test/java/dev/hardwood/testing/ParquetComparisonTest.java
@@ -11,12 +11,10 @@ import java.io.IOException;
 import java.lang.management.ManagementFactory;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.util.ArrayList;
 import java.util.List;
 
 import org.apache.avro.generic.GenericRecord;
 import org.junit.jupiter.api.BeforeAll;
-import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
@@ -25,33 +23,23 @@ import com.sun.management.HotSpotDiagnosticMXBean;
 import com.sun.management.HotSpotDiagnosticMXBean.ThreadDumpFormat;
 
 import dev.hardwood.InputFile;
-import dev.hardwood.internal.reader.HardwoodContextImpl;
-import dev.hardwood.reader.ColumnReader;
-import dev.hardwood.reader.ColumnReaders;
 import dev.hardwood.reader.ParquetFileReader;
 import dev.hardwood.reader.RowReader;
-import dev.hardwood.schema.ColumnProjection;
-import dev.hardwood.schema.ColumnSchema;
 import dev.hardwood.schema.FileSchema;
 
 import static org.assertj.core.api.Assertions.*;
 import static org.junit.jupiter.api.Assumptions.assumeFalse;
 
-/// Comparison tests that validate Hardwood's output against the reference parquet-java
-/// implementation by comparing parsed results row-by-row, field-by-field. Exercises both
-/// the single-file [ParquetFileReader] and the [ParquetFileReader]; after the
-/// reader-unification in #225 the two paths share implementation, so the multi-file
-/// coverage here is limited to scenarios the single-file reader cannot express
-/// (concatenation, singleton equivalence, and the [ColumnReaders] public API).
-/// Bad-file rejection tests live in [BadDataHandlingTest].
+/// Comparison tests that validate [ParquetFileReader]'s output against the reference
+/// parquet-java implementation by comparing parsed results row-by-row, field-by-field
+/// for every fixture in `parquet-testing`. Bad-file rejection lives in
+/// [BadDataHandlingTest].
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 class ParquetComparisonTest {
 
-    private Path repoDir;
-
     @BeforeAll
     void setUp() throws IOException {
-        repoDir = ParquetTestingRepoCloner.ensureCloned();
+        Path repoDir = ParquetTestingRepoCloner.ensureCloned();
         Utils.ensureGoodCFile(repoDir);
     }
 
@@ -82,90 +70,6 @@ class ParquetComparisonTest {
                 "Skipping " + fileName + " (in column skip list)");
 
         runWithThreadDumpOnTimeout(() -> compareColumnsParquetFile(testFile), 120, fileName);
-    }
-
-    // ==================== Multi-file Reader Comparison ====================
-
-    @Test
-    void multiFileReaderMatchesReferenceAcrossConcatenatedFiles() throws IOException {
-        Path dataDir = repoDir.resolve("data");
-
-        Path fileA = dataDir.resolve("alltypes_plain.parquet");
-        Path fileB = dataDir.resolve("alltypes_plain.snappy.parquet");
-
-        // Reference: parquet-java, one file at a time, concatenated
-        List<GenericRecord> reference = new ArrayList<>();
-        reference.addAll(Utils.readWithParquetJava(fileA));
-        reference.addAll(Utils.readWithParquetJava(fileB));
-
-        // Hardwood: multi-file reader over same files in same order
-        List<InputFile> inputs = List.of(InputFile.of(fileA), InputFile.of(fileB));
-
-        int rowIndex = 0;
-        try (HardwoodContextImpl context = HardwoodContextImpl.create();
-             ParquetFileReader mfReader = ParquetFileReader.openAll(inputs, context);
-             RowReader rowReader = mfReader.rowReader()) {
-
-            FileSchema schema = mfReader.getFileSchema();
-            while (rowReader.hasNext()) {
-                rowReader.next();
-                Utils.compareRow(rowIndex, reference.get(rowIndex), rowReader, schema);
-                rowIndex++;
-            }
-        }
-
-        assertThat(rowIndex).isEqualTo(reference.size());
-    }
-
-    @Test
-    void multiFileReaderMatchesSingleFileReaderForSingletonInput() throws IOException {
-        Path file = repoDir.resolve("data/alltypes_plain.parquet");
-
-        List<GenericRecord> reference = Utils.readWithParquetJava(file);
-
-        int rowIndex = 0;
-        try (HardwoodContextImpl context = HardwoodContextImpl.create();
-             ParquetFileReader mfReader = ParquetFileReader.openAll(
-                     List.of(InputFile.of(file)), context);
-             RowReader rowReader = mfReader.rowReader()) {
-
-            FileSchema schema = mfReader.getFileSchema();
-            while (rowReader.hasNext()) {
-                rowReader.next();
-                Utils.compareRow(rowIndex, reference.get(rowIndex), rowReader, schema);
-                rowIndex++;
-            }
-        }
-
-        assertThat(rowIndex).isEqualTo(reference.size());
-    }
-
-    @Test
-    void multiFileColumnReadersMatchReference() throws IOException {
-        // Spot-check the ColumnReaders public API. After reader unification
-        // (#225) the parameterized column sweep already exercises the underlying
-        // implementation; this keeps coverage of the dedicated multi-file column API.
-        Path file = repoDir.resolve("data/alltypes_plain.parquet");
-
-        List<GenericRecord> reference = Utils.readWithParquetJava(file);
-
-        try (HardwoodContextImpl context = HardwoodContextImpl.create();
-             ParquetFileReader mfReader = ParquetFileReader.openAll(
-                     List.of(InputFile.of(file)), context);
-             ColumnReaders columns = mfReader.columnReaders(ColumnProjection.all())) {
-
-            FileSchema schema = mfReader.getFileSchema();
-            for (int colIdx = 0; colIdx < schema.getColumnCount(); colIdx++) {
-                ColumnSchema colSchema = schema.getColumn(colIdx);
-                ColumnReader columnReader = columns.getColumnReader(colIdx);
-                if (colSchema.maxRepetitionLevel() == 0) {
-                    Utils.compareColumnReader(colSchema.name(), columnReader, reference);
-                }
-                else {
-                    Utils.compareNestedColumnReader(colSchema, columnReader, reference);
-                }
-            }
-        }
     }
 
     // ==================== Helpers ====================
@@ -247,7 +151,7 @@ class ParquetComparisonTest {
         List<GenericRecord> referenceRows = Utils.readWithParquetJava(testFile);
 
         try (ParquetFileReader fileReader = ParquetFileReader.open(InputFile.of(testFile))) {
-            Utils.compareColumns(fileReader.getFileSchema(), fileReader::columnReader, referenceRows);
+            Utils.compareColumns(fileReader, referenceRows);
         }
 
         System.out.println("  Column comparison passed!");

--- a/parquet-testing-runner/src/test/java/dev/hardwood/testing/ParquetComparisonTest.java
+++ b/parquet-testing-runner/src/test/java/dev/hardwood/testing/ParquetComparisonTest.java
@@ -157,11 +157,13 @@ class ParquetComparisonTest {
             FileSchema schema = mfReader.getFileSchema();
             for (int colIdx = 0; colIdx < schema.getColumnCount(); colIdx++) {
                 ColumnSchema colSchema = schema.getColumn(colIdx);
-                if (colSchema.maxRepetitionLevel() > 0) {
-                    continue;
-                }
                 ColumnReader columnReader = columns.getColumnReader(colIdx);
-                Utils.compareColumnReader(colSchema.name(), columnReader, reference);
+                if (colSchema.maxRepetitionLevel() == 0) {
+                    Utils.compareColumnReader(colSchema.name(), columnReader, reference);
+                }
+                else {
+                    Utils.compareNestedColumnReader(colSchema, columnReader, reference);
+                }
             }
         }
     }

--- a/parquet-testing-runner/src/test/java/dev/hardwood/testing/Utils.java
+++ b/parquet-testing-runner/src/test/java/dev/hardwood/testing/Utils.java
@@ -555,22 +555,16 @@ public class Utils {
 
     // ==================== Column-Level Comparison ====================
 
-    /// Additional files to skip in column-level comparison tests.
-    /// Files with nested/repeated columns where column-level comparison
-    /// requires list reconstruction from offsets (deferred).
+    /// Additional files to skip in column-level comparison tests beyond [#SKIPPED_FILES].
+    /// All listed files contain empty repeated groups: the public [ColumnReader] API
+    /// exposes per-record offsets, level-null bitmaps, and element-null bitmaps but
+    /// not definition levels, which are needed to distinguish an empty list (size 0,
+    /// no elements) from a list containing a single null element (size 1). Both
+    /// produce the same offset/null shape, so reconstruction can't tell them apart.
     static final Set<String> COLUMN_SKIPPED_FILES = Set.of(
-            "list_columns.parquet",
-            "nested_lists.snappy.parquet",
-            "nested_maps.snappy.parquet",
-            "nested_structs.rust.parquet",
-            "nonnullable.impala.parquet",
-            "nullable.impala.parquet",
             "null_list.parquet",
-            "old_list_structure.parquet",
-            "repeated_no_annotation.parquet",
-            "repeated_primitive_no_list.parquet",
-            "incorrect_map_schema.parquet",
-            "map_no_value.parquet"
+            "nullable.impala.parquet",
+            "nonnullable.impala.parquet"
     );
 
     /// Compare a Parquet file column-by-column using ColumnReaders against parquet-java reference data.
@@ -580,17 +574,52 @@ public class Utils {
 
         for (int colIdx = 0; colIdx < schema.getColumnCount(); colIdx++) {
             ColumnSchema colSchema = schema.getColumn(colIdx);
-
-            // Skip nested/repeated columns
-            if (colSchema.maxRepetitionLevel() > 0) {
+            // parquet-java's AvroParquetReader collapses Variant `typed_value`
+            // subtrees into the canonical `value` binary, so reference data for
+            // shredded subcolumns is unavailable. Skip them.
+            if (isUnderVariantShred(schema, colSchema)) {
                 continue;
             }
-
-            String colName = colSchema.name();
             try (ColumnReader columnReader = readerFactory.columnReader(colIdx)) {
-                compareColumnReader(colName, columnReader, referenceRows);
+                if (colSchema.maxRepetitionLevel() == 0) {
+                    compareColumnReader(colSchema.name(), columnReader, referenceRows);
+                }
+                else {
+                    compareNestedColumnReader(colSchema, columnReader, referenceRows);
+                }
             }
         }
+    }
+
+    /// Returns true when the column lives inside a Variant group's `typed_value`
+    /// shred subtree. Walks the schema along the column's [dev.hardwood.metadata.FieldPath]
+    /// looking for a `typed_value` step that occurs after a Variant-annotated ancestor.
+    private static boolean isUnderVariantShred(FileSchema schema, ColumnSchema colSchema) {
+        SchemaNode current = schema.getRootNode();
+        boolean variantAncestor = false;
+        for (String name : colSchema.fieldPath().elements()) {
+            if (!(current instanceof SchemaNode.GroupNode group)) {
+                return false;
+            }
+            if (group.isVariant()) {
+                variantAncestor = true;
+            }
+            if (variantAncestor && "typed_value".equals(name)) {
+                return true;
+            }
+            SchemaNode next = null;
+            for (SchemaNode child : group.children()) {
+                if (child.name().equals(name)) {
+                    next = child;
+                    break;
+                }
+            }
+            if (next == null) {
+                return false;
+            }
+            current = next;
+        }
+        return false;
     }
 
     /// Compare a single ColumnReader's data against reference rows.
@@ -630,6 +659,146 @@ public class Utils {
         assertThat(rowIdx)
                 .as("Column '%s' row count", colName)
                 .isEqualTo(referenceRows.size());
+    }
+
+    /// Compare a nested column (`maxRepetitionLevel > 0`) against parquet-java by
+    /// reconstructing each top-level record's value from the [ColumnReader]'s
+    /// offsets/level-null/element-null arrays and matching it to the same value
+    /// extracted from the Avro [GenericRecord] along the column's [dev.hardwood.metadata.FieldPath].
+    static void compareNestedColumnReader(ColumnSchema colSchema, ColumnReader reader,
+                                          List<GenericRecord> referenceRows) {
+        int maxRep = colSchema.maxRepetitionLevel();
+        List<String> path = colSchema.fieldPath().elements();
+        int rowIdx = 0;
+        while (reader.nextBatch()) {
+            int recordCount = reader.getRecordCount();
+            for (int r = 0; r < recordCount; r++) {
+                if (rowIdx >= referenceRows.size()) {
+                    break;
+                }
+                Object reconstructed = reconstructNested(reader, 0, r, maxRep);
+                Object expected = extractAvroAlongPath(referenceRows.get(rowIdx), path, 0);
+                String ctx = String.format("Row %d, column '%s'", rowIdx, colSchema.name());
+                deepCompareNested(ctx, expected, reconstructed);
+                rowIdx++;
+            }
+        }
+        assertThat(rowIdx)
+                .as("Column '%s' row count", colSchema.name())
+                .isEqualTo(referenceRows.size());
+    }
+
+    /// Reconstruct one container's value from a nested [ColumnReader]'s
+    /// offsets/level-nulls/element-nulls. Returns `null` when the container at
+    /// `level` is null, a `List` for outer levels, or a `List` of leaf values at
+    /// the innermost level.
+    private static Object reconstructNested(ColumnReader reader, int level, int idx, int maxRep) {
+        BitSet levelNulls = reader.getLevelNulls(level);
+        if (levelNulls != null && levelNulls.get(idx)) {
+            return null;
+        }
+        int[] offsets = reader.getOffsets(level);
+        int start = offsets[idx];
+        int end = (idx + 1 < offsets.length) ? offsets[idx + 1]
+                : (level + 1 == maxRep ? reader.getValueCount() : reader.getOffsets(level + 1).length);
+        if (level + 1 == maxRep) {
+            BitSet elementNulls = reader.getElementNulls();
+            List<Object> leaves = new ArrayList<>(end - start);
+            for (int v = start; v < end; v++) {
+                leaves.add(elementNulls != null && elementNulls.get(v)
+                        ? null : convertToComparable(getColumnReaderValue(reader, v)));
+            }
+            return leaves;
+        }
+        List<Object> items = new ArrayList<>(end - start);
+        for (int j = start; j < end; j++) {
+            items.add(reconstructNested(reader, level + 1, j, maxRep));
+        }
+        return items;
+    }
+
+    /// Walk a parquet-java [GenericRecord] along a leaf column's
+    /// [dev.hardwood.metadata.FieldPath]. Avro elides Parquet's structural
+    /// group names (`list`, `element`, `key_value`) when it lifts them into
+    /// `array[]` / `map[]`, so any path component that isn't a field on the
+    /// current record is treated as structural and skipped. List elements
+    /// receive the rest of the path applied per-element; map keys/values are
+    /// projected by name.
+    private static Object extractAvroAlongPath(Object current, List<String> path, int pathIdx) {
+        while (pathIdx < path.size() && current != null) {
+            String name = path.get(pathIdx);
+            if (current instanceof GenericRecord rec) {
+                if (rec.getSchema().getField(name) != null) {
+                    current = rec.get(name);
+                }
+                pathIdx++;
+                continue;
+            }
+            if (current instanceof Map<?, ?> map) {
+                if ("key".equals(name)) {
+                    List<Object> keys = new ArrayList<>(map.size());
+                    for (Object k : map.keySet()) {
+                        keys.add(convertToComparable(k));
+                    }
+                    return keys;
+                }
+                if ("value".equals(name)) {
+                    List<Object> values = new ArrayList<>(map.size());
+                    for (Object v : map.values()) {
+                        values.add(extractAvroAlongPath(v, path, pathIdx + 1));
+                    }
+                    return values;
+                }
+                // Structural ("key_value") — elide
+                pathIdx++;
+                continue;
+            }
+            if (current instanceof List<?> list) {
+                List<Object> mapped = new ArrayList<>(list.size());
+                for (Object e : list) {
+                    mapped.add(extractAvroAlongPath(e, path, pathIdx));
+                }
+                return mapped;
+            }
+            // Reached a leaf primitive before the path was exhausted
+            break;
+        }
+        return current == null ? null : convertToComparable(current);
+    }
+
+    /// Deep-compare two reconstructed values (each null, a leaf, or a `List`).
+    /// Leaves go through the same numeric tolerance and `String`/`byte[]` coercion
+    /// rules used by [#compareColumnValue].
+    private static void deepCompareNested(String ctx, Object expected, Object actual) {
+        if (expected == null) {
+            assertThat(actual).as(ctx + " should be null").isNull();
+            return;
+        }
+        assertThat(actual).as(ctx + " should not be null").isNotNull();
+        if (expected instanceof List<?> expList && actual instanceof List<?> actList) {
+            assertThat(actList).as(ctx + " size").hasSize(expList.size());
+            for (int i = 0; i < expList.size(); i++) {
+                deepCompareNested(ctx + "[" + i + "]", expList.get(i), actList.get(i));
+            }
+            return;
+        }
+        Object expCmp = convertToComparable(expected);
+        if (expCmp instanceof String refStr && actual instanceof byte[] actBytes) {
+            assertThat(new String(actBytes, java.nio.charset.StandardCharsets.UTF_8))
+                    .as(ctx).isEqualTo(refStr);
+        }
+        else if (expCmp instanceof Float f) {
+            assertThat((Float) actual).as(ctx).isCloseTo(f, within(0.0001f));
+        }
+        else if (expCmp instanceof Double d) {
+            assertThat((Double) actual).as(ctx).isCloseTo(d, within(0.0000001d));
+        }
+        else if (expCmp instanceof byte[] refBytes) {
+            assertThat((byte[]) actual).as(ctx).isEqualTo(refBytes);
+        }
+        else {
+            assertThat(actual).as(ctx).isEqualTo(expCmp);
+        }
     }
 
     /// Functional interface for creating column readers (abstracts single-file vs multi-file).

--- a/parquet-testing-runner/src/test/java/dev/hardwood/testing/Utils.java
+++ b/parquet-testing-runner/src/test/java/dev/hardwood/testing/Utils.java
@@ -9,6 +9,7 @@ package dev.hardwood.testing;
 
 import java.io.IOException;
 import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.ArrayList;
@@ -37,6 +38,7 @@ import org.assertj.core.api.ThrowableAssert;
 
 import dev.hardwood.metadata.LogicalType;
 import dev.hardwood.reader.ColumnReader;
+import dev.hardwood.reader.ParquetFileReader;
 import dev.hardwood.reader.RowReader;
 import dev.hardwood.row.PqList;
 import dev.hardwood.row.PqMap;
@@ -123,7 +125,7 @@ public class Utils {
 
     /// Generates `data/good_c.parquet` under the given cloned repo if not already present.
     /// The file is a valid single-column (`required int32 c`) file sharing its schema with
-    /// `bad_data/ARROW-RS-GH-6229-LEVELS.parquet`, so the multi-file bad-data tests can
+    /// `bad_data/ARROW-RS-GH-6229-LEVELS.parquet`, so the mid-sequence bad-data tests can
     /// read a good prefix followed by a failing file. Idempotent.
     static void ensureGoodCFile(Path repoDir) throws IOException {
         Path output = repoDir.resolve("data/good_c.parquet");
@@ -561,17 +563,18 @@ public class Utils {
     /// not definition levels, which are needed to distinguish an empty list (size 0,
     /// no elements) from a list containing a single null element (size 1). Both
     /// produce the same offset/null shape, so reconstruction can't tell them apart.
+    /// Tracked by #422 — once the public API exposes the missing signal, these
+    /// files can be removed from this set.
     static final Set<String> COLUMN_SKIPPED_FILES = Set.of(
             "null_list.parquet",
             "nullable.impala.parquet",
             "nonnullable.impala.parquet"
     );
 
-    /// Compare a Parquet file column-by-column using ColumnReaders against parquet-java reference data.
-    /// Each column reader is created via the factory and closed after use.
-    static void compareColumns(FileSchema schema, ColumnReaderFactory readerFactory, List<GenericRecord> referenceRows)
+    /// Compare a Parquet file column-by-column using [ColumnReader]s against parquet-java reference data.
+    static void compareColumns(ParquetFileReader fileReader, List<GenericRecord> referenceRows)
             throws IOException {
-
+        FileSchema schema = fileReader.getFileSchema();
         for (int colIdx = 0; colIdx < schema.getColumnCount(); colIdx++) {
             ColumnSchema colSchema = schema.getColumn(colIdx);
             // parquet-java's AvroParquetReader collapses Variant `typed_value`
@@ -580,7 +583,7 @@ public class Utils {
             if (isUnderVariantShred(schema, colSchema)) {
                 continue;
             }
-            try (ColumnReader columnReader = readerFactory.columnReader(colIdx)) {
+            try (ColumnReader columnReader = fileReader.columnReader(colIdx)) {
                 if (colSchema.maxRepetitionLevel() == 0) {
                     compareColumnReader(colSchema.name(), columnReader, referenceRows);
                 }
@@ -631,9 +634,9 @@ public class Utils {
             BitSet nulls = columnReader.getElementNulls();
 
             for (int i = 0; i < count; i++) {
-                if (rowIdx >= referenceRows.size()) {
-                    break;
-                }
+                assertThat(rowIdx)
+                        .as("Column '%s' produced more records than reference", colName)
+                        .isLessThan(referenceRows.size());
                 GenericRecord refRow = referenceRows.get(rowIdx);
                 Object refValue = getRefColumnValue(refRow, colName);
 
@@ -673,9 +676,9 @@ public class Utils {
         while (reader.nextBatch()) {
             int recordCount = reader.getRecordCount();
             for (int r = 0; r < recordCount; r++) {
-                if (rowIdx >= referenceRows.size()) {
-                    break;
-                }
+                assertThat(rowIdx)
+                        .as("Column '%s' produced more records than reference", colSchema.name())
+                        .isLessThan(referenceRows.size());
                 Object reconstructed = reconstructNested(reader, 0, r, maxRep);
                 Object expected = extractAvroAlongPath(referenceRows.get(rowIdx), path, 0);
                 String ctx = String.format("Row %d, column '%s'", rowIdx, colSchema.name());
@@ -717,22 +720,40 @@ public class Utils {
         return items;
     }
 
+    /// Path components that name Parquet structural groups Avro elides when it
+    /// lifts a LIST/MAP into native `array[]` / `map[]`. Includes the standard
+    /// 3-level encoding (`list`, `element`, `key_value`) and the legacy
+    /// 2-level LIST encoding rule 3a (`array`); rule 3b's `<list-name>_tuple` is
+    /// matched by suffix, see [#isStructuralListGroup].
+    /// Any other unknown name is treated as a real bug, not silently elided.
+    private static final Set<String> STRUCTURAL_GROUP_NAMES = Set.of(
+            "list", "element", "key_value", "array");
+
     /// Walk a parquet-java [GenericRecord] along a leaf column's
     /// [dev.hardwood.metadata.FieldPath]. Avro elides Parquet's structural
-    /// group names (`list`, `element`, `key_value`) when it lifts them into
-    /// `array[]` / `map[]`, so any path component that isn't a field on the
-    /// current record is treated as structural and skipped. List elements
-    /// receive the rest of the path applied per-element; map keys/values are
-    /// projected by name.
+    /// group names (`list`, `element`, `key_value`, `array`, `<name>_tuple`)
+    /// when it lifts them into `array[]` / `map[]`; those components are
+    /// skipped during the walk. Any other path component that doesn't match
+    /// a field on the current record is a bug — fail loudly rather than
+    /// silently no-op. List elements receive the rest of the path applied
+    /// per-element; map keys/values are projected by name.
     private static Object extractAvroAlongPath(Object current, List<String> path, int pathIdx) {
         while (pathIdx < path.size() && current != null) {
             String name = path.get(pathIdx);
             if (current instanceof GenericRecord rec) {
                 if (rec.getSchema().getField(name) != null) {
                     current = rec.get(name);
+                    pathIdx++;
+                    continue;
                 }
-                pathIdx++;
-                continue;
+                if (isStructuralListGroup(name)) {
+                    pathIdx++;
+                    continue;
+                }
+                throw new IllegalStateException(
+                        "Path component '" + name + "' is neither a field of Avro record '"
+                                + rec.getSchema().getName() + "' nor a known Parquet structural"
+                                + " group name; full path: " + path);
             }
             if (current instanceof Map<?, ?> map) {
                 if ("key".equals(name)) {
@@ -749,9 +770,13 @@ public class Utils {
                     }
                     return values;
                 }
-                // Structural ("key_value") — elide
-                pathIdx++;
-                continue;
+                if ("key_value".equals(name)) {
+                    pathIdx++;
+                    continue;
+                }
+                throw new IllegalStateException(
+                        "Path component '" + name + "' is not a valid map projection (expected"
+                                + " 'key', 'value', or 'key_value'); full path: " + path);
             }
             if (current instanceof List<?> list) {
                 List<Object> mapped = new ArrayList<>(list.size());
@@ -766,9 +791,14 @@ public class Utils {
         return current == null ? null : convertToComparable(current);
     }
 
+    private static boolean isStructuralListGroup(String name) {
+        return STRUCTURAL_GROUP_NAMES.contains(name) || name.endsWith("_tuple");
+    }
+
     /// Deep-compare two reconstructed values (each null, a leaf, or a `List`).
-    /// Leaves go through the same numeric tolerance and `String`/`byte[]` coercion
-    /// rules used by [#compareColumnValue].
+    /// Both `expected` and `actual` have already been passed through
+    /// [#convertToComparable] at construction time (see [#extractAvroAlongPath]
+    /// and [#reconstructNested]); leaves are delegated to [#compareLeaf].
     private static void deepCompareNested(String ctx, Object expected, Object actual) {
         if (expected == null) {
             assertThat(actual).as(ctx + " should be null").isNull();
@@ -782,29 +812,7 @@ public class Utils {
             }
             return;
         }
-        Object expCmp = convertToComparable(expected);
-        if (expCmp instanceof String refStr && actual instanceof byte[] actBytes) {
-            assertThat(new String(actBytes, java.nio.charset.StandardCharsets.UTF_8))
-                    .as(ctx).isEqualTo(refStr);
-        }
-        else if (expCmp instanceof Float f) {
-            assertThat((Float) actual).as(ctx).isCloseTo(f, within(0.0001f));
-        }
-        else if (expCmp instanceof Double d) {
-            assertThat((Double) actual).as(ctx).isCloseTo(d, within(0.0000001d));
-        }
-        else if (expCmp instanceof byte[] refBytes) {
-            assertThat((byte[]) actual).as(ctx).isEqualTo(refBytes);
-        }
-        else {
-            assertThat(actual).as(ctx).isEqualTo(expCmp);
-        }
-    }
-
-    /// Functional interface for creating column readers (abstracts single-file vs multi-file).
-    @FunctionalInterface
-    interface ColumnReaderFactory {
-        ColumnReader columnReader(int columnIndex) throws IOException;
+        compareLeaf(ctx, expected, actual);
     }
 
     /// Get reference value for a flat column from a GenericRecord.
@@ -838,23 +846,30 @@ public class Utils {
                                            ColumnReader reader, int batchIdx) {
         String context = String.format("Row %d, column '%s'", rowIdx, colName);
         Object actual = getColumnReaderValue(reader, batchIdx);
-        Object comparableActual = convertToComparable(actual);
+        compareLeaf(context, refValue, convertToComparable(actual));
+    }
 
-        if (refValue instanceof String refStr && comparableActual instanceof byte[] actualBytes) {
-            assertThat(new String(actualBytes, java.nio.charset.StandardCharsets.UTF_8))
+    /// Leaf-value comparison shared by flat ([#compareColumnValue]) and nested
+    /// ([#deepCompareNested]) paths. Both arguments are expected to have already
+    /// been run through [#convertToComparable] by the caller. Applies numeric
+    /// tolerance for `Float`/`Double` and decodes UTF-8 when the reference is a
+    /// `String` but the actual is a raw `byte[]`.
+    private static void compareLeaf(String context, Object expected, Object actual) {
+        if (expected instanceof String refStr && actual instanceof byte[] actualBytes) {
+            assertThat(new String(actualBytes, StandardCharsets.UTF_8))
                     .as(context).isEqualTo(refStr);
         }
-        else if (refValue instanceof Float f) {
-            assertThat((Float) comparableActual).as(context).isCloseTo(f, within(0.0001f));
+        else if (expected instanceof Float f) {
+            assertThat((Float) actual).as(context).isCloseTo(f, within(0.0001f));
         }
-        else if (refValue instanceof Double d) {
-            assertThat((Double) comparableActual).as(context).isCloseTo(d, within(0.0000001d));
+        else if (expected instanceof Double d) {
+            assertThat((Double) actual).as(context).isCloseTo(d, within(0.0000001d));
         }
-        else if (refValue instanceof byte[] refBytes) {
-            assertThat((byte[]) comparableActual).as(context).isEqualTo(refBytes);
+        else if (expected instanceof byte[] refBytes) {
+            assertThat((byte[]) actual).as(context).isEqualTo(refBytes);
         }
         else {
-            assertThat(comparableActual).as(context).isEqualTo(refValue);
+            assertThat(actual).as(context).isEqualTo(expected);
         }
     }
 


### PR DESCRIPTION
## Description
This pull request closes #84, which observed that `compareColumnsWithReference` skipped 12 nested-column files via `COLUMN_SKIPPED_FILES` and bypassed every `maxRepetitionLevel > 0` column within files that did run. As a result,
  the public `ColumnReader` API's handling of offsets, level-null bitmaps, and element-null bitmaps for list / map / repeated columns was never validated against parquet-java.

## Key Changes
The primary work centers on a new offsets-driven reconstructor in `Utils.java` that produces a per-record nested value from the public `ColumnReader` surface and matches it against the same shape extracted from parquet-java's Avro `GenericRecord` along the column's `FieldPath`. Both single-file and multi-file column-comparison paths now flow through this reconstructor instead of skipping nested columns.

In summary form, changes include:
- **Added Nested Column Reconstruction in `Utils.java`**
    - `compareNestedColumnReader` iterates batches and produces per-record values from `ColumnReader`'s offsets / level-nulls / element-nulls.
    - `reconstructNested` recursively walks `getOffsets(level)` and `getLevelNulls(level)` to build a `List<Object>` shape, dropping to `getElementNulls()` and the typed value array at the leaf.
    - `extractAvroAlongPath` walks the parquet-java `GenericRecord` along the column's `FieldPath`, eliding structural names (`list`, `element`, `key_value`) by treating any component that isn't an Avro field on the current record as
   transparent. Map keys/values project by name; `List` components distribute the rest of the path per element.
    - `deepCompareNested` matches the two reconstructions structurally, reusing the same `String`/`byte[]` coercion and numeric tolerance as `compareColumnValue`.
- **Wired Through Single-File and Multi-File Test Paths**
    - `compareColumns` (single-file via `compareColumnsParquetFile`) dispatches `maxRepetitionLevel > 0` columns to the new nested path.
    - `multiFileColumnReadersMatchReference` drops its identical `maxRepetitionLevel > 0` skip.
- **Shrunk `COLUMN_SKIPPED_FILES` from 12 to 3**
    - 9 of the 12 files round-trip through the new reconstructor. Of those, four (`map_no_value`, `nested_maps.snappy`, `repeated_no_annotation`, `repeated_primitive_no_list`) were already gated upstream by `SKIPPED_FILES`, so the
  column test still skips them at the outer level for the same parquet-java reasons.
    - The remaining three (`null_list`, `nullable.impala`, `nonnullable.impala`) stay skipped because they contain empty repeated groups: an empty list and a list with one null element produce identical offset / null shapes.
  Distinguishing them requires the underlying definition level, which the public API doesn't expose. The skip list now documents this inline.
- **Added Per-Column Skip for Variant `typed_value` Subtrees**
    - `isUnderVariantShred` walks the schema along the column's `FieldPath` and returns true when a `typed_value` step occurs after a Variant-annotated ancestor.
    - parquet-java's `AvroParquetReader` collapses shredded variants onto the canonical `var.value` binary, so the reference side has no data for shredded subcolumns. The skip is per-column rather than per-file, so each variant's
  `metadata` and canonical `value` columns are still validated.

## Verification and Testing
As expected, the complete `parquet-testing-runner` module suite of tests passes with the new reconstructor running on all previously-skipped nested files:

```
[INFO] Tests run: 567, Failures: 0, Errors: 0, Skipped: 64
[INFO] BUILD SUCCESS
```

## Checklist

- [x] Build via `./mvnw clean verify` passes
- [x] The commit message is prefixed with the issue key
- [x] Code changes are covered by tests
- [x] If this PR adds or changes user-facing behavior, `docs/` has been updated