### PR TITLE
#422 Distinguish Empty / Single Null Lists in ColumnReader API

### DIFF
--- a/core/src/main/java/dev/hardwood/internal/reader/NestedBatch.java
+++ b/core/src/main/java/dev/hardwood/internal/reader/NestedBatch.java
@@ -19,8 +19,8 @@ import java.util.BitSet;
 /// thread and published through a `BatchExchange<NestedBatch>`.
 ///
 /// The drain computes index structures (element nulls, multi-level offsets,
-/// level nulls) before publishing, so the consumer thread does not need to
-/// perform any expensive index computation.
+/// level nulls, empty-list markers) before publishing, so the consumer thread
+/// does not need to perform any expensive index computation.
 public final class NestedBatch {
     // Raw arrays (filled by drain assembly)
     public Object values;
@@ -37,4 +37,5 @@ public final class NestedBatch {
     public BitSet elementNulls;
     public int[][] multiLevelOffsets;
     public BitSet[] levelNulls;
+    public BitSet[] emptyListMarkers;
 }

--- a/core/src/main/java/dev/hardwood/internal/reader/NestedColumnWorker.java
+++ b/core/src/main/java/dev/hardwood/internal/reader/NestedColumnWorker.java
@@ -200,8 +200,8 @@ public class NestedColumnWorker extends ColumnWorker<NestedBatch> {
         nestedValueCount = 0;
     }
 
-    /// Computes index structures (element nulls, multi-level offsets, level nulls)
-    /// on the batch before it is published.
+    /// Computes index structures (element nulls, multi-level offsets, level nulls,
+    /// empty-list markers) on the batch before it is published.
     private void computeIndex(NestedBatch batch) {
         int[] defLevels = batch.definitionLevels;
         int valueCount = batch.valueCount;
@@ -212,13 +212,16 @@ public class NestedColumnWorker extends ColumnWorker<NestedBatch> {
         if (maxRepetitionLevel > 0 && batch.repetitionLevels != null && valueCount > 0) {
             batch.multiLevelOffsets = NestedLevelComputer.computeMultiLevelOffsets(
                     batch.repetitionLevels, valueCount, batch.recordCount, maxRepetitionLevel);
-            batch.levelNulls = NestedLevelComputer.computeLevelNulls(
+            NestedLevelComputer.LevelIndex levelIndex = NestedLevelComputer.computeLevelIndex(
                     defLevels, batch.repetitionLevels, valueCount,
                     maxRepetitionLevel, levelNullThresholds);
+            batch.levelNulls = levelIndex.levelNulls();
+            batch.emptyListMarkers = levelIndex.emptyListMarkers();
         }
         else {
             batch.multiLevelOffsets = null;
             batch.levelNulls = null;
+            batch.emptyListMarkers = null;
         }
     }
 

--- a/core/src/main/java/dev/hardwood/internal/reader/NestedColumnWorker.java
+++ b/core/src/main/java/dev/hardwood/internal/reader/NestedColumnWorker.java
@@ -212,11 +212,11 @@ public class NestedColumnWorker extends ColumnWorker<NestedBatch> {
         if (maxRepetitionLevel > 0 && batch.repetitionLevels != null && valueCount > 0) {
             batch.multiLevelOffsets = NestedLevelComputer.computeMultiLevelOffsets(
                     batch.repetitionLevels, valueCount, batch.recordCount, maxRepetitionLevel);
-            NestedLevelComputer.LevelIndex levelIndex = NestedLevelComputer.computeLevelIndex(
+            NestedLevelComputer.LevelBitmaps bitmaps = NestedLevelComputer.computeLevelBitmaps(
                     defLevels, batch.repetitionLevels, valueCount,
                     maxRepetitionLevel, levelNullThresholds);
-            batch.levelNulls = levelIndex.levelNulls();
-            batch.emptyListMarkers = levelIndex.emptyListMarkers();
+            batch.levelNulls = bitmaps.levelNulls();
+            batch.emptyListMarkers = bitmaps.emptyListMarkers();
         }
         else {
             batch.multiLevelOffsets = null;

--- a/core/src/main/java/dev/hardwood/internal/reader/NestedLevelComputer.java
+++ b/core/src/main/java/dev/hardwood/internal/reader/NestedLevelComputer.java
@@ -131,15 +131,15 @@ public final class NestedLevelComputer {
         };
     }
 
-    /// Computed per-level null and empty-list bitmaps, returned by [#computeLevelIndex].
+    /// Per-level null and empty-list bitmaps, returned by [#computeLevelBitmaps].
     ///
     /// `levelNulls[k]` flags items at level k whose enclosing container is null;
     /// `emptyListMarkers[k]` flags items whose container is present-but-empty
     /// (the def level reached the parent of the repeated group but not the
     /// repeated group itself). Both arrays are positionally aligned with the
     /// items at level k. A `null` entry at any index means "no bits set" at
-    /// that level.
-    public record LevelIndex(BitSet[] levelNulls, BitSet[] emptyListMarkers) {}
+    /// that level — callers should treat it the same as an all-zero BitSet.
+    public record LevelBitmaps(BitSet[] levelNulls, BitSet[] emptyListMarkers) {}
 
     /// Compute per-level null and empty-list bitmaps from definition and
     /// repetition levels in a single pass.
@@ -153,9 +153,9 @@ public final class NestedLevelComputer {
     ///
     /// @param levelNullThresholds per-level definition level thresholds from
     ///                            [#computeLevelNullThresholds]
-    public static LevelIndex computeLevelIndex(int[] defLevels, int[] repLevels,
-                                               int valueCount, int maxRepLevel,
-                                               int[] levelNullThresholds) {
+    public static LevelBitmaps computeLevelBitmaps(int[] defLevels, int[] repLevels,
+                                                   int valueCount, int maxRepLevel,
+                                                   int[] levelNullThresholds) {
         BitSet[] levelNulls = new BitSet[maxRepLevel];
         BitSet[] emptyListMarkers = new BitSet[maxRepLevel];
 
@@ -188,7 +188,7 @@ public final class NestedLevelComputer {
             emptyListMarkers[k] = emptyBits;
         }
 
-        return new LevelIndex(levelNulls, emptyListMarkers);
+        return new LevelBitmaps(levelNulls, emptyListMarkers);
     }
 
     /// Compute leaf-level null bitmap.

--- a/core/src/main/java/dev/hardwood/internal/reader/NestedLevelComputer.java
+++ b/core/src/main/java/dev/hardwood/internal/reader/NestedLevelComputer.java
@@ -131,37 +131,64 @@ public final class NestedLevelComputer {
         };
     }
 
-    /// Compute per-level null bitmaps from definition and repetition levels.
+    /// Computed per-level null and empty-list bitmaps, returned by [#computeLevelIndex].
+    ///
+    /// `levelNulls[k]` flags items at level k whose enclosing container is null;
+    /// `emptyListMarkers[k]` flags items whose container is present-but-empty
+    /// (the def level reached the parent of the repeated group but not the
+    /// repeated group itself). Both arrays are positionally aligned with the
+    /// items at level k. A `null` entry at any index means "no bits set" at
+    /// that level.
+    public record LevelIndex(BitSet[] levelNulls, BitSet[] emptyListMarkers) {}
+
+    /// Compute per-level null and empty-list bitmaps from definition and
+    /// repetition levels in a single pass.
+    ///
+    /// At each repeated level k with threshold `t = levelNullThresholds[k]`:
+    /// - `def < t` ⇒ the container is null (an ancestor is missing).
+    /// - `def == t` ⇒ the container exists but has no entries (empty list).
+    /// - `def > t` ⇒ the container has at least one entry (possibly null at
+    ///               the leaf, which is captured separately by the element-null
+    ///               bitmap from [#computeElementNulls]).
     ///
     /// @param levelNullThresholds per-level definition level thresholds from
     ///                            [#computeLevelNullThresholds]
-    /// @return array of BitSets, one per nesting level; null entries mean all-non-null at that level
-    public static BitSet[] computeLevelNulls(int[] defLevels, int[] repLevels,
-                                             int valueCount, int maxRepLevel,
-                                             int[] levelNullThresholds) {
+    public static LevelIndex computeLevelIndex(int[] defLevels, int[] repLevels,
+                                               int valueCount, int maxRepLevel,
+                                               int[] levelNullThresholds) {
         BitSet[] levelNulls = new BitSet[maxRepLevel];
+        BitSet[] emptyListMarkers = new BitSet[maxRepLevel];
 
         for (int k = 0; k < maxRepLevel; k++) {
             int defThreshold = levelNullThresholds[k];
             BitSet nullBits = null;
+            BitSet emptyBits = null;
 
             int itemIdx = 0;
             for (int i = 0; i < valueCount; i++) {
                 if (repLevels[i] <= k) {
-                    if (defLevels[i] < defThreshold) {
+                    int def = defLevels[i];
+                    if (def < defThreshold) {
                         if (nullBits == null) {
                             nullBits = new BitSet();
                         }
                         nullBits.set(itemIdx);
+                    }
+                    else if (def == defThreshold) {
+                        if (emptyBits == null) {
+                            emptyBits = new BitSet();
+                        }
+                        emptyBits.set(itemIdx);
                     }
                     itemIdx++;
                 }
             }
 
             levelNulls[k] = nullBits;
+            emptyListMarkers[k] = emptyBits;
         }
 
-        return levelNulls;
+        return new LevelIndex(levelNulls, emptyListMarkers);
     }
 
     /// Compute leaf-level null bitmap.

--- a/core/src/main/java/dev/hardwood/reader/ColumnReader.java
+++ b/core/src/main/java/dev/hardwood/reader/ColumnReader.java
@@ -324,9 +324,10 @@ public class ColumnReader implements AutoCloseable {
     ///
     /// Together with [#getLevelNulls(int)] this disambiguates the four
     /// container states a list/map can be in: null, empty, non-empty with null
-    /// element(s), and non-empty with value(s). Without this bitmap, an empty
-    /// list is indistinguishable from a list containing a single null element
-    /// because both encode as one phantom entry with [#getElementNulls()] set.
+    /// element(s), and non-empty with value(s). Specifically, this bitmap is
+    /// what lets a caller tell an empty list apart from a list containing a
+    /// single null element — in the underlying encoding both produce one
+    /// phantom entry that [#getElementNulls()] flags as null.
     ///
     /// @param level the nesting level (0 = outermost group)
     /// @return BitSet where set bits indicate empty containers, or null if no empties at that level

--- a/core/src/main/java/dev/hardwood/reader/ColumnReader.java
+++ b/core/src/main/java/dev/hardwood/reader/ColumnReader.java
@@ -329,6 +329,10 @@ public class ColumnReader implements AutoCloseable {
     /// single null element — in the underlying encoding both produce one
     /// phantom entry that [#getElementNulls()] flags as null.
     ///
+    /// A `null` return is the sparse representation of an all-zero bitmap
+    /// (no empty containers at this level in the current batch); callers
+    /// should treat it the same as an unset bit at every index.
+    ///
     /// @param level the nesting level (0 = outermost group)
     /// @return BitSet where set bits indicate empty containers, or null if no empties at that level
     public BitSet getEmptyListMarkers(int level) {

--- a/core/src/main/java/dev/hardwood/reader/ColumnReader.java
+++ b/core/src/main/java/dev/hardwood/reader/ColumnReader.java
@@ -47,7 +47,11 @@ import dev.hardwood.schema.ProjectedSchema;
 /// }
 /// ```
 ///
-/// **Simple list usage (nestingDepth=1):**
+/// **Simple list usage (nestingDepth=1):** a list/repeated container has four
+/// states (null, empty, list-with-null-element(s), list-with-value(s));
+/// `getLevelNulls` and `getEmptyListMarkers` together disambiguate the first
+/// two from the rest, and `getElementNulls` distinguishes null elements from
+/// real values inside a non-empty list.
 /// ```java
 /// try (ColumnReader reader = fileReader.columnReader("fare_components")) {
 ///     while (reader.nextBatch()) {
@@ -56,9 +60,11 @@ import dev.hardwood.schema.ProjectedSchema;
 ///         double[] values = reader.getDoubles();
 ///         int[] offsets = reader.getOffsets(0);
 ///         BitSet recordNulls = reader.getLevelNulls(0);
+///         BitSet emptyMarkers = reader.getEmptyListMarkers(0);
 ///         BitSet elementNulls = reader.getElementNulls();
 ///         for (int r = 0; r < recordCount; r++) {
-///             if (recordNulls != null && recordNulls.get(r)) continue;
+///             if (recordNulls != null && recordNulls.get(r)) continue;       // null list
+///             if (emptyMarkers != null && emptyMarkers.get(r)) continue;     // empty list
 ///             int start = offsets[r];
 ///             int end = (r + 1 < recordCount) ? offsets[r + 1] : valueCount;
 ///             for (int i = start; i < end; i++) {
@@ -92,6 +98,7 @@ public class ColumnReader implements AutoCloseable {
     // Computed nested data (lazily populated per batch)
     private int[][] multiLevelOffsets;
     private BitSet[] levelNulls;
+    private BitSet[] emptyListMarkers;
     private BitSet elementNulls;
     private boolean nestedDataComputed;
 
@@ -169,6 +176,7 @@ public class ColumnReader implements AutoCloseable {
         nestedDataComputed = false;
         multiLevelOffsets = null;
         levelNulls = null;
+        emptyListMarkers = null;
         elementNulls = null;
 
         return true;
@@ -311,6 +319,24 @@ public class ColumnReader implements AutoCloseable {
         return levelNulls[level];
     }
 
+    /// Empty-list bitmap at a given nesting level. A set bit means the
+    /// container at that level is non-null but contains zero entries.
+    ///
+    /// Together with [#getLevelNulls(int)] this disambiguates the four
+    /// container states a list/map can be in: null, empty, non-empty with null
+    /// element(s), and non-empty with value(s). Without this bitmap, an empty
+    /// list is indistinguishable from a list containing a single null element
+    /// because both encode as one phantom entry with [#getElementNulls()] set.
+    ///
+    /// @param level the nesting level (0 = outermost group)
+    /// @return BitSet where set bits indicate empty containers, or null if no empties at that level
+    public BitSet getEmptyListMarkers(int level) {
+        checkBatchAvailable();
+        checkNestedLevel(level);
+        ensureNestedDataComputed();
+        return emptyListMarkers[level];
+    }
+
     // ==================== Offsets for Repeated Columns ====================
 
     /// Nesting depth: 0 for flat, maxRepetitionLevel for nested.
@@ -397,6 +423,7 @@ public class ColumnReader implements AutoCloseable {
         elementNulls = currentNestedBatch.elementNulls;
         multiLevelOffsets = currentNestedBatch.multiLevelOffsets;
         levelNulls = currentNestedBatch.levelNulls;
+        emptyListMarkers = currentNestedBatch.emptyListMarkers;
 
         // Provide empty arrays when fields are null (non-repeated columns)
         if (multiLevelOffsets == null) {
@@ -404,6 +431,9 @@ public class ColumnReader implements AutoCloseable {
         }
         if (levelNulls == null) {
             levelNulls = new BitSet[maxRepetitionLevel];
+        }
+        if (emptyListMarkers == null) {
+            emptyListMarkers = new BitSet[maxRepetitionLevel];
         }
     }
 

--- a/core/src/test/java/dev/hardwood/ColumnReadersTest.java
+++ b/core/src/test/java/dev/hardwood/ColumnReadersTest.java
@@ -352,4 +352,82 @@ class ColumnReadersTest {
             assertThat(reader.getNestingDepth()).isEqualTo(0);
         }
     }
+
+    /// `primitive_lists_test.parquet` row 2 has `int_list = []` (empty) and
+    /// row 3 has `int_list = null`. This pins the public-API contract that
+    /// `getEmptyListMarkers` and `getLevelNulls` together separate the two
+    /// states — the underlying computer is covered by `NestedLevelComputerTest`,
+    /// here we only check that the bitmaps reach a caller through `ColumnReader`.
+    @Test
+    void testGetEmptyListMarkersDistinguishesEmptyFromNull() throws Exception {
+        Path filePath = Paths.get("src/test/resources/primitive_lists_test.parquet");
+
+        try (Hardwood hardwood = Hardwood.create();
+             ParquetFileReader parquet = hardwood.openAll(InputFile.ofPaths(List.of(filePath)));
+             ColumnReaders columns = parquet.columnReaders(ColumnProjection.columns("int_list.list.element"))) {
+
+            ColumnReader reader = columns.getColumnReader("int_list.list.element");
+            assertThat(reader.nextBatch()).isTrue();
+            assertThat(reader.getRecordCount()).isEqualTo(4);
+
+            BitSet levelNulls = reader.getLevelNulls(0);
+            BitSet emptyMarkers = reader.getEmptyListMarkers(0);
+
+            assertThat(levelNulls).isNotNull();
+            assertThat(levelNulls.get(3)).as("row 3 is null").isTrue();
+            assertThat(levelNulls.get(2)).as("row 2 is empty, not null").isFalse();
+
+            assertThat(emptyMarkers).isNotNull();
+            assertThat(emptyMarkers.get(2)).as("row 2 is empty").isTrue();
+            assertThat(emptyMarkers.get(3)).as("row 3 is null, not empty").isFalse();
+            assertThat(emptyMarkers.get(0)).as("row 0 has values").isFalse();
+            assertThat(emptyMarkers.get(1)).as("row 1 has values").isFalse();
+        }
+    }
+
+    @Test
+    void testGetEmptyListMarkersThrowsBeforeNextBatch() throws Exception {
+        Path filePath = Paths.get("src/test/resources/primitive_lists_test.parquet");
+
+        try (Hardwood hardwood = Hardwood.create();
+             ParquetFileReader parquet = hardwood.openAll(InputFile.ofPaths(List.of(filePath)));
+             ColumnReaders columns = parquet.columnReaders(ColumnProjection.columns("int_list.list.element"))) {
+
+            ColumnReader reader = columns.getColumnReader("int_list.list.element");
+            assertThatThrownBy(() -> reader.getEmptyListMarkers(0))
+                    .isInstanceOf(IllegalStateException.class)
+                    .hasMessageContaining("No batch available");
+        }
+    }
+
+    @Test
+    void testGetEmptyListMarkersThrowsForFlatColumn() throws Exception {
+        Path filePath = Paths.get("src/test/resources/plain_uncompressed.parquet");
+
+        try (Hardwood hardwood = Hardwood.create();
+             ParquetFileReader parquet = hardwood.openAll(InputFile.ofPaths(List.of(filePath)));
+             ColumnReaders columns = parquet.columnReaders(ColumnProjection.columns("id"))) {
+
+            ColumnReader reader = columns.getColumnReader("id");
+            assertThat(reader.nextBatch()).isTrue();
+            assertThatThrownBy(() -> reader.getEmptyListMarkers(0))
+                    .isInstanceOf(IllegalStateException.class)
+                    .hasMessageContaining("flat columns");
+        }
+    }
+
+    @Test
+    void testGetEmptyListMarkersThrowsForLevelOutOfRange() throws Exception {
+        Path filePath = Paths.get("src/test/resources/primitive_lists_test.parquet");
+
+        try (Hardwood hardwood = Hardwood.create();
+             ParquetFileReader parquet = hardwood.openAll(InputFile.ofPaths(List.of(filePath)));
+             ColumnReaders columns = parquet.columnReaders(ColumnProjection.columns("int_list.list.element"))) {
+
+            ColumnReader reader = columns.getColumnReader("int_list.list.element");
+            assertThat(reader.nextBatch()).isTrue();
+            assertThatThrownBy(() -> reader.getEmptyListMarkers(5))
+                    .isInstanceOf(IndexOutOfBoundsException.class);
+        }
+    }
 }

--- a/core/src/test/java/dev/hardwood/internal/reader/NestedLevelComputerTest.java
+++ b/core/src/test/java/dev/hardwood/internal/reader/NestedLevelComputerTest.java
@@ -1,0 +1,127 @@
+/*
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Copyright The original authors
+ *
+ *  Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package dev.hardwood.internal.reader;
+
+import java.util.BitSet;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/// Tests for [NestedLevelComputer].
+///
+/// The empty-list disambiguator added in #422 requires a single-pass
+/// computation that separates four container states from one another using
+/// just definition / repetition levels: null, empty, non-empty with null
+/// element(s), and non-empty with value(s). These tests pin the encoding
+/// boundaries so future refactors don't silently collapse them again.
+class NestedLevelComputerTest {
+
+    /// For schema `optional group my_list (LIST) { repeated group list { optional int32 element; } }`:
+    /// - my_list.maxDef = 1 (optional)
+    /// - list.maxDef = 2 (repeated counts as +1)
+    /// - element.maxDef = 3 (optional leaf)
+    /// - threshold[0] = list.maxDef - 1 = 1
+    ///
+    /// Four rows, one per container state:
+    /// - row 0: my_list = null         (def=0)
+    /// - row 1: my_list = []           (def=1, empty)
+    /// - row 2: my_list = [null]       (def=2)
+    /// - row 3: my_list = [42]         (def=3)
+    @Test
+    void distinguishesAllFourContainerStates() {
+        int[] defLevels = { 0, 1, 2, 3 };
+        int[] repLevels = { 0, 0, 0, 0 };
+        int valueCount = 4;
+        int maxRepLevel = 1;
+        int[] thresholds = { 1 };
+
+        NestedLevelComputer.LevelIndex index = NestedLevelComputer.computeLevelIndex(
+                defLevels, repLevels, valueCount, maxRepLevel, thresholds);
+
+        BitSet levelNulls = index.levelNulls()[0];
+        BitSet emptyMarkers = index.emptyListMarkers()[0];
+
+        // Only row 0 is null at the list level.
+        assertThat(levelNulls).isNotNull();
+        assertThat(levelNulls.get(0)).isTrue();
+        assertThat(levelNulls.get(1)).isFalse();
+        assertThat(levelNulls.get(2)).isFalse();
+        assertThat(levelNulls.get(3)).isFalse();
+
+        // Only row 1 is empty.
+        assertThat(emptyMarkers).isNotNull();
+        assertThat(emptyMarkers.get(0)).isFalse();
+        assertThat(emptyMarkers.get(1)).isTrue();
+        assertThat(emptyMarkers.get(2)).isFalse();
+        assertThat(emptyMarkers.get(3)).isFalse();
+
+        // Element-null bitmap must keep rows 2 (null element) and 1 / 0 (phantom)
+        // separate from row 3 (real value); the disambiguation between rows 1
+        // and 2 lives entirely in `emptyMarkers`.
+        BitSet elementNulls = NestedLevelComputer.computeElementNulls(defLevels, valueCount, 3);
+        assertThat(elementNulls).isNotNull();
+        assertThat(elementNulls.get(0)).isTrue();
+        assertThat(elementNulls.get(1)).isTrue();
+        assertThat(elementNulls.get(2)).isTrue();
+        assertThat(elementNulls.get(3)).isFalse();
+    }
+
+    /// When all containers are non-null and non-empty, both bitmaps stay null
+    /// (sparse representation — no allocation when nothing is set).
+    @Test
+    void leavesBitmapsNullWhenNoSpecialStates() {
+        int[] defLevels = { 3, 3, 3 };
+        int[] repLevels = { 0, 0, 0 };
+        int[] thresholds = { 1 };
+
+        NestedLevelComputer.LevelIndex index = NestedLevelComputer.computeLevelIndex(
+                defLevels, repLevels, 3, 1, thresholds);
+
+        assertThat(index.levelNulls()[0]).isNull();
+        assertThat(index.emptyListMarkers()[0]).isNull();
+    }
+
+    /// Nested-list case (maxRepLevel=2): the inner-list empty state is
+    /// captured at level 1, independently of the outer-list state at level 0.
+    /// Schema: `optional group outer (LIST) { repeated group list { optional group inner (LIST)
+    /// { repeated group list { optional int32 element; } } } }`
+    /// Thresholds: [1, 3] (outer-list at def 1, inner-list at def 3).
+    @Test
+    void emptyMarkersAreScopedPerLevel() {
+        // Three rows:
+        //   row 0: outer = []                           (def=1)
+        //   row 1: outer = [ null ]                     (def=2; inner null)
+        //   row 2: outer = [ [] ]                       (def=3; inner empty)
+        int[] defLevels = { 1, 2, 3 };
+        int[] repLevels = { 0, 0, 0 };
+        int[] thresholds = { 1, 3 };
+
+        NestedLevelComputer.LevelIndex index = NestedLevelComputer.computeLevelIndex(
+                defLevels, repLevels, 3, 2, thresholds);
+
+        // Level 0 (outer list)
+        assertThat(index.levelNulls()[0]).isNull();        // none of the outer lists are null
+        BitSet outerEmpty = index.emptyListMarkers()[0];
+        assertThat(outerEmpty.get(0)).isTrue();             // row 0 outer is empty
+        assertThat(outerEmpty.get(1)).isFalse();
+        assertThat(outerEmpty.get(2)).isFalse();
+
+        // Level 1 (inner list) — itemIdx counts every rep<=1 boundary, which
+        // here is every value (3 items).
+        BitSet innerNulls = index.levelNulls()[1];
+        assertThat(innerNulls.get(0)).isTrue();             // row 0: outer empty, inner shadowed as null
+        assertThat(innerNulls.get(1)).isTrue();             // row 1: inner explicitly null
+        assertThat(innerNulls.get(2)).isFalse();            // row 2: inner is empty, not null
+
+        BitSet innerEmpty = index.emptyListMarkers()[1];
+        assertThat(innerEmpty.get(0)).isFalse();
+        assertThat(innerEmpty.get(1)).isFalse();
+        assertThat(innerEmpty.get(2)).isTrue();             // row 2 inner is empty
+    }
+}

--- a/core/src/test/java/dev/hardwood/internal/reader/NestedLevelComputerTest.java
+++ b/core/src/test/java/dev/hardwood/internal/reader/NestedLevelComputerTest.java
@@ -40,12 +40,13 @@ class NestedLevelComputerTest {
         int valueCount = 4;
         int maxRepLevel = 1;
         int[] thresholds = { 1 };
+        int leafMaxDef = 3;
 
-        NestedLevelComputer.LevelIndex index = NestedLevelComputer.computeLevelIndex(
+        NestedLevelComputer.LevelBitmaps bitmaps = NestedLevelComputer.computeLevelBitmaps(
                 defLevels, repLevels, valueCount, maxRepLevel, thresholds);
 
-        BitSet levelNulls = index.levelNulls()[0];
-        BitSet emptyMarkers = index.emptyListMarkers()[0];
+        BitSet levelNulls = bitmaps.levelNulls()[0];
+        BitSet emptyMarkers = bitmaps.emptyListMarkers()[0];
 
         // Only row 0 is null at the list level.
         assertThat(levelNulls).isNotNull();
@@ -64,7 +65,7 @@ class NestedLevelComputerTest {
         // Element-null bitmap must keep rows 2 (null element) and 1 / 0 (phantom)
         // separate from row 3 (real value); the disambiguation between rows 1
         // and 2 lives entirely in `emptyMarkers`.
-        BitSet elementNulls = NestedLevelComputer.computeElementNulls(defLevels, valueCount, 3);
+        BitSet elementNulls = NestedLevelComputer.computeElementNulls(defLevels, valueCount, leafMaxDef);
         assertThat(elementNulls).isNotNull();
         assertThat(elementNulls.get(0)).isTrue();
         assertThat(elementNulls.get(1)).isTrue();
@@ -80,11 +81,11 @@ class NestedLevelComputerTest {
         int[] repLevels = { 0, 0, 0 };
         int[] thresholds = { 1 };
 
-        NestedLevelComputer.LevelIndex index = NestedLevelComputer.computeLevelIndex(
+        NestedLevelComputer.LevelBitmaps bitmaps = NestedLevelComputer.computeLevelBitmaps(
                 defLevels, repLevels, 3, 1, thresholds);
 
-        assertThat(index.levelNulls()[0]).isNull();
-        assertThat(index.emptyListMarkers()[0]).isNull();
+        assertThat(bitmaps.levelNulls()[0]).isNull();
+        assertThat(bitmaps.emptyListMarkers()[0]).isNull();
     }
 
     /// Nested-list case (maxRepLevel=2): the inner-list empty state is
@@ -102,26 +103,81 @@ class NestedLevelComputerTest {
         int[] repLevels = { 0, 0, 0 };
         int[] thresholds = { 1, 3 };
 
-        NestedLevelComputer.LevelIndex index = NestedLevelComputer.computeLevelIndex(
+        NestedLevelComputer.LevelBitmaps bitmaps = NestedLevelComputer.computeLevelBitmaps(
                 defLevels, repLevels, 3, 2, thresholds);
 
         // Level 0 (outer list)
-        assertThat(index.levelNulls()[0]).isNull();        // none of the outer lists are null
-        BitSet outerEmpty = index.emptyListMarkers()[0];
+        assertThat(bitmaps.levelNulls()[0]).isNull();      // none of the outer lists are null
+        BitSet outerEmpty = bitmaps.emptyListMarkers()[0];
         assertThat(outerEmpty.get(0)).isTrue();             // row 0 outer is empty
         assertThat(outerEmpty.get(1)).isFalse();
         assertThat(outerEmpty.get(2)).isFalse();
 
         // Level 1 (inner list) — itemIdx counts every rep<=1 boundary, which
         // here is every value (3 items).
-        BitSet innerNulls = index.levelNulls()[1];
+        BitSet innerNulls = bitmaps.levelNulls()[1];
         assertThat(innerNulls.get(0)).isTrue();             // row 0: outer empty, inner shadowed as null
         assertThat(innerNulls.get(1)).isTrue();             // row 1: inner explicitly null
         assertThat(innerNulls.get(2)).isFalse();            // row 2: inner is empty, not null
 
-        BitSet innerEmpty = index.emptyListMarkers()[1];
+        BitSet innerEmpty = bitmaps.emptyListMarkers()[1];
         assertThat(innerEmpty.get(0)).isFalse();
         assertThat(innerEmpty.get(1)).isFalse();
         assertThat(innerEmpty.get(2)).isTrue();             // row 2 inner is empty
+    }
+
+    /// Pins the `list<list<int>>` example shown in `docs/content/usage.md`
+    /// (the multi-level nesting subsection). The three records `[[1, 2], [3]]`,
+    /// `[]`, `[[], [4]]` produce the def/rep streams below; if the offsets
+    /// or per-level bitmaps drift, the docs table needs updating too.
+    @Test
+    void pinsMultiLevelDocsExample() {
+        // Schema: `optional matrix (LIST) { repeated list { optional element (LIST)
+        // { repeated list { optional int32 element; } } } }`
+        //   matrix.list.maxDef = 2 → threshold[0] = 1
+        //   matrix.list.element.list.maxDef = 4 → threshold[1] = 3
+        // Records:
+        //   rec 0 [[1,2],[3]]: (def=5, rep=0), (def=5, rep=2), (def=5, rep=1)
+        //   rec 1 []:          (def=1, rep=0)
+        //   rec 2 [[], [4]]:   (def=3, rep=0), (def=5, rep=1)
+        int[] defLevels = { 5, 5, 5, 1, 3, 5 };
+        int[] repLevels = { 0, 2, 1, 0, 0, 1 };
+        int valueCount = 6;
+        int recordCount = 3;
+        int maxRepLevel = 2;
+        int[] thresholds = { 1, 3 };
+        int leafMaxDef = 5;
+
+        int[][] offsets = NestedLevelComputer.computeMultiLevelOffsets(
+                repLevels, valueCount, recordCount, maxRepLevel);
+        NestedLevelComputer.LevelBitmaps bitmaps = NestedLevelComputer.computeLevelBitmaps(
+                defLevels, repLevels, valueCount, maxRepLevel, thresholds);
+        BitSet elementNulls = NestedLevelComputer.computeElementNulls(defLevels, valueCount, leafMaxDef);
+
+        // Outer offsets: record r → starting index in offsets[1].
+        assertThat(offsets[0]).containsExactly(0, 2, 3);
+        // Inner offsets: inner-list j → starting index in `values`.
+        assertThat(offsets[1]).containsExactly(0, 2, 3, 4, 5);
+
+        // Outer level: only record 1 (`[]`) is empty; none are null.
+        assertThat(bitmaps.levelNulls()[0]).isNull();
+        BitSet outerEmpty = bitmaps.emptyListMarkers()[0];
+        assertThat(outerEmpty.get(1)).isTrue();
+        assertThat(outerEmpty.cardinality()).isEqualTo(1);
+
+        // Inner level: index 2 is the phantom for record 1's empty outer
+        // (shadowed as null at level 1); index 3 is the empty `[]` inner of
+        // record 2.
+        BitSet innerNulls = bitmaps.levelNulls()[1];
+        assertThat(innerNulls.get(2)).isTrue();
+        assertThat(innerNulls.cardinality()).isEqualTo(1);
+        BitSet innerEmpty = bitmaps.emptyListMarkers()[1];
+        assertThat(innerEmpty.get(3)).isTrue();
+        assertThat(innerEmpty.cardinality()).isEqualTo(1);
+
+        // Phantom slots in the leaf array (`values[3]` and `values[4]`).
+        assertThat(elementNulls.get(3)).isTrue();
+        assertThat(elementNulls.get(4)).isTrue();
+        assertThat(elementNulls.cardinality()).isEqualTo(2);
     }
 }

--- a/docs/content/usage.md
+++ b/docs/content/usage.md
@@ -617,7 +617,14 @@ try (Hardwood hardwood = Hardwood.create();
 
 ### Nested and Repeated Columns
 
-For nested columns (lists, maps), `ColumnReader` provides multi-level offsets and per-level null bitmaps:
+For nested columns (lists, maps), `ColumnReader` provides multi-level offsets and per-level null bitmaps. A list/map container has four states the reader exposes separately:
+
+- **Null** — `getLevelNulls(level)` set at the container's index.
+- **Empty** — `getEmptyListMarkers(level)` set; the container exists but has no entries.
+- **Non-empty with null element(s)** — neither `getLevelNulls` nor `getEmptyListMarkers` set; `getElementNulls()` flags the null leaves inside the range.
+- **Non-empty with values** — only `getElementNulls()` indicates per-leaf nullability (or is `null` if all leaves are required).
+
+Without `getEmptyListMarkers`, an empty list is indistinguishable from a list containing a single null element — both encode as a single phantom entry with `getElementNulls()` set.
 
 ```java
 try (ColumnReader reader = fileReader.columnReader("tags")) {
@@ -625,12 +632,14 @@ try (ColumnReader reader = fileReader.columnReader("tags")) {
         int recordCount = reader.getRecordCount();
         int valueCount = reader.getValueCount();
         byte[][] values = reader.getBinaries();
-        int[] offsets = reader.getOffsets(0);            // record -> value position
-        BitSet recordNulls = reader.getLevelNulls(0);    // null list records
-        BitSet elementNulls = reader.getElementNulls();  // null elements within lists
+        int[] offsets = reader.getOffsets(0);                 // record -> value position
+        BitSet recordNulls = reader.getLevelNulls(0);         // null list records
+        BitSet emptyMarkers = reader.getEmptyListMarkers(0);  // empty (size 0) lists
+        BitSet elementNulls = reader.getElementNulls();       // null elements within lists
 
         for (int r = 0; r < recordCount; r++) {
-            if (recordNulls != null && recordNulls.get(r)) continue;
+            if (recordNulls != null && recordNulls.get(r)) continue;     // null list
+            if (emptyMarkers != null && emptyMarkers.get(r)) continue;   // empty list
             int start = offsets[r];
             int end = (r + 1 < recordCount) ? offsets[r + 1] : valueCount;
             for (int i = start; i < end; i++) {

--- a/docs/content/usage.md
+++ b/docs/content/usage.md
@@ -626,16 +626,24 @@ For nested columns (lists, maps), `ColumnReader` provides multi-level offsets an
 
 `getEmptyListMarkers()` is what lets you tell an empty list apart from a list containing a single null element: in the underlying encoding, both produce a single phantom entry that `getElementNulls()` flags as null, so without this bitmap they'd be indistinguishable.
 
-For a column `optional group tags (LIST) { repeated group list { optional binary element (STRING); } }` holding these four records:
+For a column `optional group tags (LIST) { repeated group list { optional binary element (STRING); } }`, the four container states look like this:
 
 | Record index | Logical value | `getLevelNulls(0)` | `getEmptyListMarkers(0)` | `offsets[0]` | `getElementNulls()` at value index |
 |---|---|---|---|---|---|
-| 0 | `null`        | `1` | `0` | `0` | `1` (phantom) |
-| 1 | `[]`          | `0` | `1` | `1` | `1` (phantom) |
-| 2 | `[null]`      | `0` | `0` | `2` | `1` (real null element) |
-| 3 | `["x"]`       | `0` | `0` | `3` | `0` (`values[3] = "x"`) |
+| 0 | `null`     | `1` | `0` | `0` | `1` (phantom) |
+| 1 | `[]`       | `0` | `1` | `1` | `1` (phantom) |
+| 2 | `[null]`   | `0` | `0` | `2` | `1` (real null element) |
+| 3 | `["x"]`    | `0` | `0` | `3` | `0` (`values[3] = "x"`) |
 
-The `values` array has length 4 (one entry per record); the entries at indices 0 and 1 are phantoms whose contents are unspecified — `getLevelNulls(0)` and `getEmptyListMarkers(0)` are what tell the reader to skip them rather than dereference them.
+`getLevelNulls(0)` and `getEmptyListMarkers(0)` are what tell the reader to skip the two phantom entries (rows 0 and 1) rather than dereference them.
+
+Multi-element lists stretch the `values` array beyond `recordCount`. For a single record holding `["a", null, "b"]`:
+
+| Record index | Logical value | `getLevelNulls(0)` | `getEmptyListMarkers(0)` | `offsets[0]` | `getElementNulls()` |
+|---|---|---|---|---|---|
+| 0 | `["a", null, "b"]` | `0` | `0` | `0` | bit 0 = `0`, bit 1 = `1`, bit 2 = `0` |
+
+`recordCount = 1` but `valueCount = 3`; the record's range runs from `offsets[0] = 0` to `valueCount = 3`, with `values[0] = "a"`, `values[1]` skipped (flagged in `getElementNulls()`), and `values[2] = "b"`.
 
 ```java
 try (ColumnReader reader = fileReader.columnReader("tags")) {
@@ -664,6 +672,67 @@ try (ColumnReader reader = fileReader.columnReader("tags")) {
 ```
 
 `getNestingDepth()` returns 0 for flat columns, or the number of offset levels for nested columns.
+
+#### Multi-level nesting
+
+For columns with `getNestingDepth() > 1` (e.g. `list<list<int>>`), every offset/bitmap method takes a `level` argument and you walk through the levels in turn. `getOffsets(k)` maps an item at level k to its starting index in level k+1, and the innermost level's offsets point into the leaf `values` array. `getLevelNulls(k)` and `getEmptyListMarkers(k)` describe the four container states at that level — same semantics as in the single-level case, just per nesting depth.
+
+For a column `optional group matrix (LIST) { repeated group list { optional group element (LIST) { repeated group list { optional int32 element; } } } }` (i.e. `list<list<int>>` with `getNestingDepth() == 2`) holding three records — `[[1, 2], [3]]`, `[]`, `[[], [4]]` — the outer level has one entry per record:
+
+| Record | Logical value     | `getLevelNulls(0)` | `getEmptyListMarkers(0)` | `getOffsets(0)` |
+|---|---|---|---|---|
+| 0 | `[[1, 2], [3]]`   | `0` | `0` | `0` |
+| 1 | `[]`              | `0` | `1` | `2` |
+| 2 | `[[], [4]]`       | `0` | `0` | `3` |
+
+The inner level enumerates every inner list (or phantom) across all records — each entry in `getOffsets(0)` indexes into this table, whose length is `getOffsets(1).length`:
+
+| Inner index | From   | Logical value                | `getLevelNulls(1)` | `getEmptyListMarkers(1)` | `getOffsets(1)` |
+|---|---|---|---|---|---|
+| 0 | record 0 | `[1, 2]`                   | `0` | `0` | `0` |
+| 1 | record 0 | `[3]`                      | `0` | `0` | `2` |
+| 2 | record 1 | (phantom — outer list `[]`) | `1` | `0` | `3` |
+| 3 | record 2 | `[]`                       | `0` | `1` | `4` |
+| 4 | record 2 | `[4]`                      | `0` | `0` | `5` |
+
+`values` has length 6: `[1, 2, 3, ?, ?, 4]`. Indexes 3 and 4 are phantoms (the outer `[]` of record 1 and the inner `[]` of record 2 respectively); `getElementNulls()` flags both.
+
+```java
+try (ColumnReader reader = fileReader.columnReader("matrix")) {
+    while (reader.nextBatch()) {
+        int recordCount = reader.getRecordCount();
+        int valueCount = reader.getValueCount();
+        int[] values = reader.getInts();
+        int[] outerOffsets = reader.getOffsets(0);
+        int[] innerOffsets = reader.getOffsets(1);
+        BitSet outerNulls = reader.getLevelNulls(0);
+        BitSet outerEmpty = reader.getEmptyListMarkers(0);
+        BitSet innerNulls = reader.getLevelNulls(1);
+        BitSet innerEmpty = reader.getEmptyListMarkers(1);
+        BitSet elementNulls = reader.getElementNulls();
+
+        for (int r = 0; r < recordCount; r++) {
+            if (outerNulls != null && outerNulls.get(r)) continue;     // outer null
+            if (outerEmpty != null && outerEmpty.get(r)) continue;     // outer empty
+            int innerStart = outerOffsets[r];
+            int innerEnd = (r + 1 < recordCount) ? outerOffsets[r + 1] : innerOffsets.length;
+            for (int j = innerStart; j < innerEnd; j++) {
+                if (innerNulls != null && innerNulls.get(j)) continue;
+                if (innerEmpty != null && innerEmpty.get(j)) continue;
+                int leafStart = innerOffsets[j];
+                int leafEnd = (j + 1 < innerOffsets.length) ? innerOffsets[j + 1] : valueCount;
+                for (int i = leafStart; i < leafEnd; i++) {
+                    if (elementNulls == null || !elementNulls.get(i)) {
+                        // process values[i]
+                    }
+                }
+            }
+        }
+    }
+}
+```
+
+Deeper nestings extend the same chain: at depth N you walk `getOffsets(0)` through `getOffsets(N - 1)`, checking the corresponding `getLevelNulls(k)` and `getEmptyListMarkers(k)` at each step before descending.
 
 ## Accessing File Metadata
 

--- a/docs/content/usage.md
+++ b/docs/content/usage.md
@@ -617,14 +617,25 @@ try (Hardwood hardwood = Hardwood.create();
 
 ### Nested and Repeated Columns
 
-For nested columns (lists, maps), `ColumnReader` provides multi-level offsets and per-level null bitmaps. A list/map container has four states the reader exposes separately:
+For nested columns (lists, maps), `ColumnReader` provides multi-level offsets and per-level null bitmaps. A list/map container has four states, and three bitmaps together identify which one each record is in:
 
 - **Null** — `getLevelNulls(level)` set at the container's index.
 - **Empty** — `getEmptyListMarkers(level)` set; the container exists but has no entries.
 - **Non-empty with null element(s)** — neither `getLevelNulls` nor `getEmptyListMarkers` set; `getElementNulls()` flags the null leaves inside the range.
 - **Non-empty with values** — only `getElementNulls()` indicates per-leaf nullability (or is `null` if all leaves are required).
 
-Without `getEmptyListMarkers`, an empty list is indistinguishable from a list containing a single null element — both encode as a single phantom entry with `getElementNulls()` set.
+`getEmptyListMarkers()` is what lets you tell an empty list apart from a list containing a single null element: in the underlying encoding, both produce a single phantom entry that `getElementNulls()` flags as null, so without this bitmap they'd be indistinguishable.
+
+For a column `optional group tags (LIST) { repeated group list { optional binary element (STRING); } }` holding these four records:
+
+| Record index | Logical value | `getLevelNulls(0)` | `getEmptyListMarkers(0)` | `offsets[0]` | `getElementNulls()` at value index |
+|---|---|---|---|---|---|
+| 0 | `null`        | `1` | `0` | `0` | `1` (phantom) |
+| 1 | `[]`          | `0` | `1` | `1` | `1` (phantom) |
+| 2 | `[null]`      | `0` | `0` | `2` | `1` (real null element) |
+| 3 | `["x"]`       | `0` | `0` | `3` | `0` (`values[3] = "x"`) |
+
+The `values` array has length 4 (one entry per record); the entries at indices 0 and 1 are phantoms whose contents are unspecified — `getLevelNulls(0)` and `getEmptyListMarkers(0)` are what tell the reader to skip them rather than dereference them.
 
 ```java
 try (ColumnReader reader = fileReader.columnReader("tags")) {

--- a/parquet-testing-runner/src/test/java/dev/hardwood/testing/ParquetComparisonTest.java
+++ b/parquet-testing-runner/src/test/java/dev/hardwood/testing/ParquetComparisonTest.java
@@ -63,11 +63,8 @@ class ParquetComparisonTest {
     void compareColumnsWithReference(Path testFile) throws Exception {
         String fileName = testFile.getFileName().toString();
 
-        // Skip files that are in either skip list
         assumeFalse(Utils.SKIPPED_FILES.contains(fileName),
                 "Skipping " + fileName + " (in skip list)");
-        assumeFalse(Utils.COLUMN_SKIPPED_FILES.contains(fileName),
-                "Skipping " + fileName + " (in column skip list)");
 
         runWithThreadDumpOnTimeout(() -> compareColumnsParquetFile(testFile), 120, fileName);
     }

--- a/parquet-testing-runner/src/test/java/dev/hardwood/testing/Utils.java
+++ b/parquet-testing-runner/src/test/java/dev/hardwood/testing/Utils.java
@@ -558,12 +558,9 @@ public class Utils {
     // ==================== Column-Level Comparison ====================
 
     /// Additional files to skip in column-level comparison tests beyond [#SKIPPED_FILES].
-    /// The remaining entry exercises Avro HashMap-backed map iteration order
-    /// against Hardwood's column-stream order, which the column-level
-    /// comparator can't yet canonicalize.
-    static final Set<String> COLUMN_SKIPPED_FILES = Set.of(
-            "nullable.impala.parquet"
-    );
+    /// Empty by default — every file the row-level comparison runs on is also
+    /// validated column-by-column.
+    static final Set<String> COLUMN_SKIPPED_FILES = Set.of();
 
     /// Compare a Parquet file column-by-column using [ColumnReader]s against parquet-java reference data.
     static void compareColumns(ParquetFileReader fileReader, List<GenericRecord> referenceRows)
@@ -666,6 +663,13 @@ public class Utils {
                                           List<GenericRecord> referenceRows) {
         int maxRep = colSchema.maxRepetitionLevel();
         List<String> path = colSchema.fieldPath().elements();
+        // parquet-java's AvroParquetReader exposes Parquet maps via HashMap-backed
+        // GenericData.Map, whose iteration order is non-deterministic. For
+        // map-key/map-value columns, that means the per-row key (or value) list
+        // may be in a different order than the Hardwood column-stream order.
+        // The row-level test sidesteps this with key-based lookup; here we
+        // canonicalize both sides by sorting innermost lists before comparing.
+        boolean isMapProjection = path.contains("key_value") || path.contains("map");
         int rowIdx = 0;
         while (reader.nextBatch()) {
             int recordCount = reader.getRecordCount();
@@ -675,6 +679,10 @@ public class Utils {
                         .isLessThan(referenceRows.size());
                 Object reconstructed = reconstructNested(reader, 0, r, maxRep);
                 Object expected = extractAvroAlongPath(referenceRows.get(rowIdx), path, 0);
+                if (isMapProjection) {
+                    sortInnermostLists(reconstructed);
+                    sortInnermostLists(expected);
+                }
                 String ctx = String.format("Row %d, column '%s'", rowIdx, colSchema.name());
                 deepCompareNested(ctx, expected, reconstructed);
                 rowIdx++;
@@ -683,6 +691,41 @@ public class Utils {
         assertThat(rowIdx)
                 .as("Column '%s' row count", colSchema.name())
                 .isEqualTo(referenceRows.size());
+    }
+
+    /// Recursively sort the deepest (leaf-bearing) lists in the reconstructed
+    /// shape so that order-dependent comparisons between Hardwood and Avro work
+    /// for map projections. Non-list values pass through unchanged.
+    @SuppressWarnings({"unchecked", "rawtypes"})
+    private static void sortInnermostLists(Object value) {
+        if (!(value instanceof List<?> list) || list.isEmpty()) {
+            return;
+        }
+        Object firstNonNull = null;
+        for (Object e : list) {
+            if (e != null) {
+                firstNonNull = e;
+                break;
+            }
+        }
+        if (firstNonNull instanceof List<?>) {
+            for (Object item : list) {
+                sortInnermostLists(item);
+            }
+            return;
+        }
+        ((List) list).sort((a, b) -> {
+            if (a == null && b == null) return 0;
+            if (a == null) return -1;
+            if (b == null) return 1;
+            if (a instanceof byte[] aBytes && b instanceof byte[] bBytes) {
+                return java.util.Arrays.compare(aBytes, bBytes);
+            }
+            if (a instanceof Comparable<?> && a.getClass() == b.getClass()) {
+                return ((Comparable<Object>) a).compareTo(b);
+            }
+            return 0;
+        });
     }
 
     /// Reconstruct one container's value from a nested [ColumnReader]'s

--- a/parquet-testing-runner/src/test/java/dev/hardwood/testing/Utils.java
+++ b/parquet-testing-runner/src/test/java/dev/hardwood/testing/Utils.java
@@ -558,11 +558,6 @@ public class Utils {
 
     // ==================== Column-Level Comparison ====================
 
-    /// Additional files to skip in column-level comparison tests beyond [#SKIPPED_FILES].
-    /// Empty by default — every file the row-level comparison runs on is also
-    /// validated column-by-column.
-    static final Set<String> COLUMN_SKIPPED_FILES = Set.of();
-
     /// Compare a Parquet file column-by-column using [ColumnReader]s against parquet-java reference data.
     static void compareColumns(ParquetFileReader fileReader, List<GenericRecord> referenceRows)
             throws IOException {

--- a/parquet-testing-runner/src/test/java/dev/hardwood/testing/Utils.java
+++ b/parquet-testing-runner/src/test/java/dev/hardwood/testing/Utils.java
@@ -575,10 +575,39 @@ public class Utils {
                     compareColumnReader(colSchema.name(), columnReader, referenceRows);
                 }
                 else {
-                    compareNestedColumnReader(colSchema, columnReader, referenceRows);
+                    compareNestedColumnReader(schema, colSchema, columnReader, referenceRows);
                 }
             }
         }
+    }
+
+    /// Returns true when the column has a MAP-annotated ancestor in the schema.
+    /// Walks the schema along the column's [dev.hardwood.metadata.FieldPath]
+    /// rather than relying on path-component name matching, since structural
+    /// names like `map` and `key_value` could legally be user-defined field
+    /// names elsewhere in the tree.
+    private static boolean isUnderMap(FileSchema schema, ColumnSchema colSchema) {
+        SchemaNode current = schema.getRootNode();
+        for (String name : colSchema.fieldPath().elements()) {
+            if (!(current instanceof SchemaNode.GroupNode group)) {
+                return false;
+            }
+            if (group.isMap()) {
+                return true;
+            }
+            SchemaNode next = null;
+            for (SchemaNode child : group.children()) {
+                if (child.name().equals(name)) {
+                    next = child;
+                    break;
+                }
+            }
+            if (next == null) {
+                return false;
+            }
+            current = next;
+        }
+        return false;
     }
 
     /// Returns true when the column lives inside a Variant group's `typed_value`
@@ -655,8 +684,8 @@ public class Utils {
     /// reconstructing each top-level record's value from the [ColumnReader]'s
     /// offsets/level-null/element-null arrays and matching it to the same value
     /// extracted from the Avro [GenericRecord] along the column's [dev.hardwood.metadata.FieldPath].
-    static void compareNestedColumnReader(ColumnSchema colSchema, ColumnReader reader,
-                                          List<GenericRecord> referenceRows) {
+    static void compareNestedColumnReader(FileSchema schema, ColumnSchema colSchema,
+                                          ColumnReader reader, List<GenericRecord> referenceRows) {
         int maxRep = colSchema.maxRepetitionLevel();
         List<String> path = colSchema.fieldPath().elements();
         // parquet-java's AvroParquetReader exposes Parquet maps via HashMap-backed
@@ -665,7 +694,7 @@ public class Utils {
         // may be in a different order than the Hardwood column-stream order.
         // The row-level test sidesteps this with key-based lookup; here we
         // canonicalize both sides by sorting innermost lists before comparing.
-        boolean isMapProjection = path.contains("key_value") || path.contains("map");
+        boolean isMapProjection = isUnderMap(schema, colSchema);
         int rowIdx = 0;
         while (reader.nextBatch()) {
             int recordCount = reader.getRecordCount();
@@ -720,7 +749,12 @@ public class Utils {
             if (a instanceof Comparable<?> && a.getClass() == b.getClass()) {
                 return ((Comparable<Object>) a).compareTo(b);
             }
-            return 0;
+            // Map projections at the column level only ever bottom out in
+            // primitive leaves. If something else shows up the comparator
+            // would silently no-op, which would mask a real ordering bug.
+            throw new IllegalStateException(
+                    "Unsupported leaf type for innermost-list sort: "
+                            + a.getClass().getName() + " vs " + b.getClass().getName());
         });
     }
 

--- a/parquet-testing-runner/src/test/java/dev/hardwood/testing/Utils.java
+++ b/parquet-testing-runner/src/test/java/dev/hardwood/testing/Utils.java
@@ -558,12 +558,11 @@ public class Utils {
     // ==================== Column-Level Comparison ====================
 
     /// Additional files to skip in column-level comparison tests beyond [#SKIPPED_FILES].
-    /// The remaining entries here exercise legacy MAP encodings and Avro
-    /// HashMap-backed iteration order; they're separate concerns from the
-    /// empty-list disambiguator and tracked separately.
+    /// The remaining entry exercises Avro HashMap-backed map iteration order
+    /// against Hardwood's column-stream order, which the column-level
+    /// comparator can't yet canonicalize.
     static final Set<String> COLUMN_SKIPPED_FILES = Set.of(
-            "nullable.impala.parquet",
-            "nonnullable.impala.parquet"
+            "nullable.impala.parquet"
     );
 
     /// Compare a Parquet file column-by-column using [ColumnReader]s against parquet-java reference data.
@@ -769,13 +768,23 @@ public class Utils {
                     }
                     return values;
                 }
-                if ("key_value".equals(name)) {
+                // `key_value` is the standard structural group name for MAPs;
+                // `map` is the legacy alias used by older writers (e.g. Hive,
+                // Impala). Both elide on the Avro side.
+                if ("key_value".equals(name) || "map".equals(name)) {
+                    pathIdx++;
+                    continue;
+                }
+                // A map can sit inside a LIST element (e.g. `arr.list.element.map.key_value...`).
+                // After the outer list distributes, the recursive walk arrives
+                // here with the list's structural names still ahead; elide them.
+                if (isStructuralListGroup(name)) {
                     pathIdx++;
                     continue;
                 }
                 throw new IllegalStateException(
                         "Path component '" + name + "' is not a valid map projection (expected"
-                                + " 'key', 'value', or 'key_value'); full path: " + path);
+                                + " 'key', 'value', 'key_value', or 'map'); full path: " + path);
             }
             if (current instanceof List<?> list) {
                 List<Object> mapped = new ArrayList<>(list.size());

--- a/parquet-testing-runner/src/test/java/dev/hardwood/testing/Utils.java
+++ b/parquet-testing-runner/src/test/java/dev/hardwood/testing/Utils.java
@@ -558,15 +558,10 @@ public class Utils {
     // ==================== Column-Level Comparison ====================
 
     /// Additional files to skip in column-level comparison tests beyond [#SKIPPED_FILES].
-    /// All listed files contain empty repeated groups: the public [ColumnReader] API
-    /// exposes per-record offsets, level-null bitmaps, and element-null bitmaps but
-    /// not definition levels, which are needed to distinguish an empty list (size 0,
-    /// no elements) from a list containing a single null element (size 1). Both
-    /// produce the same offset/null shape, so reconstruction can't tell them apart.
-    /// Tracked by #422 — once the public API exposes the missing signal, these
-    /// files can be removed from this set.
+    /// The remaining entries here exercise legacy MAP encodings and Avro
+    /// HashMap-backed iteration order; they're separate concerns from the
+    /// empty-list disambiguator and tracked separately.
     static final Set<String> COLUMN_SKIPPED_FILES = Set.of(
-            "null_list.parquet",
             "nullable.impala.parquet",
             "nonnullable.impala.parquet"
     );
@@ -692,13 +687,17 @@ public class Utils {
     }
 
     /// Reconstruct one container's value from a nested [ColumnReader]'s
-    /// offsets/level-nulls/element-nulls. Returns `null` when the container at
-    /// `level` is null, a `List` for outer levels, or a `List` of leaf values at
-    /// the innermost level.
+    /// offsets / level-nulls / empty-list markers / element-nulls. Returns
+    /// `null` when the container at `level` is null, an empty `List` when the
+    /// container is present-but-empty, or a populated `List` otherwise.
     private static Object reconstructNested(ColumnReader reader, int level, int idx, int maxRep) {
         BitSet levelNulls = reader.getLevelNulls(level);
         if (levelNulls != null && levelNulls.get(idx)) {
             return null;
+        }
+        BitSet emptyMarkers = reader.getEmptyListMarkers(level);
+        if (emptyMarkers != null && emptyMarkers.get(idx)) {
+            return List.of();
         }
         int[] offsets = reader.getOffsets(level);
         int start = offsets[idx];

--- a/parquet-testing-runner/src/test/java/dev/hardwood/testing/Utils.java
+++ b/parquet-testing-runner/src/test/java/dev/hardwood/testing/Utils.java
@@ -13,6 +13,7 @@ import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.BitSet;
 import java.util.Collection;
 import java.util.Iterator;
@@ -719,7 +720,7 @@ public class Utils {
             if (a == null) return -1;
             if (b == null) return 1;
             if (a instanceof byte[] aBytes && b instanceof byte[] bBytes) {
-                return java.util.Arrays.compare(aBytes, bBytes);
+                return Arrays.compare(aBytes, bBytes);
             }
             if (a instanceof Comparable<?> && a.getClass() == b.getClass()) {
                 return ((Comparable<Object>) a).compareTo(b);
@@ -763,21 +764,22 @@ public class Utils {
 
     /// Path components that name Parquet structural groups Avro elides when it
     /// lifts a LIST/MAP into native `array[]` / `map[]`. Includes the standard
-    /// 3-level encoding (`list`, `element`, `key_value`) and the legacy
-    /// 2-level LIST encoding rule 3a (`array`); rule 3b's `<list-name>_tuple` is
+    /// 3-level encoding (`list`, `element`, `key_value`), the legacy 2-level
+    /// LIST encoding rule 3a (`array`), and the legacy MAP alias `map` used by
+    /// older writers (e.g. Hive, Impala); rule 3b's `<list-name>_tuple` is
     /// matched by suffix, see [#isStructuralListGroup].
     /// Any other unknown name is treated as a real bug, not silently elided.
     private static final Set<String> STRUCTURAL_GROUP_NAMES = Set.of(
-            "list", "element", "key_value", "array");
+            "list", "element", "key_value", "array", "map");
 
     /// Walk a parquet-java [GenericRecord] along a leaf column's
     /// [dev.hardwood.metadata.FieldPath]. Avro elides Parquet's structural
-    /// group names (`list`, `element`, `key_value`, `array`, `<name>_tuple`)
-    /// when it lifts them into `array[]` / `map[]`; those components are
-    /// skipped during the walk. Any other path component that doesn't match
-    /// a field on the current record is a bug — fail loudly rather than
-    /// silently no-op. List elements receive the rest of the path applied
-    /// per-element; map keys/values are projected by name.
+    /// group names (`list`, `element`, `key_value`, `array`, `map`,
+    /// `<name>_tuple`) when it lifts them into `array[]` / `map[]`; those
+    /// components are skipped during the walk. Any other path component that
+    /// doesn't match a field on the current record is a bug — fail loudly
+    /// rather than silently no-op. List elements receive the rest of the path
+    /// applied per-element; map keys/values are projected by name.
     private static Object extractAvroAlongPath(Object current, List<String> path, int pathIdx) {
         while (pathIdx < path.size() && current != null) {
             String name = path.get(pathIdx);
@@ -811,16 +813,12 @@ public class Utils {
                     }
                     return values;
                 }
-                // `key_value` is the standard structural group name for MAPs;
-                // `map` is the legacy alias used by older writers (e.g. Hive,
-                // Impala). Both elide on the Avro side.
-                if ("key_value".equals(name) || "map".equals(name)) {
-                    pathIdx++;
-                    continue;
-                }
-                // A map can sit inside a LIST element (e.g. `arr.list.element.map.key_value...`).
-                // After the outer list distributes, the recursive walk arrives
-                // here with the list's structural names still ahead; elide them.
+                // Map structural names (`key_value`, legacy `map`) elide
+                // directly. List structural names (`list`, `element`, `array`,
+                // `<name>_tuple`) appear here when a map sits inside a LIST
+                // element (e.g. `arr.list.element.map.key_value...`) — after
+                // the outer list distributes, the recursive walk arrives here
+                // with the list's structural names still ahead.
                 if (isStructuralListGroup(name)) {
                     pathIdx++;
                     continue;


### PR DESCRIPTION
## Description
This pull request closes #422, which observed that the public `ColumnReader` API couldn't distinguish an empty list from a list containing one null element — both encoded identically in `offsets` / `levelNulls` / `elementNulls`. A nested container has four meaningful states (null, empty, non-empty with null element(s), non-empty with value(s)), but the public API only distinguished three; the underlying definition level was the disambiguator, computed internally and used by `NestedBatchIndex` / `PqListImpl.computeRange`, but never surfaced.

## Key Changes
- **Expose empty-list disambiguation on `ColumnReader`** via a new public `BitSet getEmptyListMarkers(int level)` parallel to `getLevelNulls`, computed in the same drain-thread pass. Documented in `usage.md` and pinned by
  `NestedLevelComputerTest`.
- **Adopt the disambiguator in column-level `ParquetComparisonTest`** by having `reconstructNested` short-circuit on the new bitmap, dropping `null_list.parquet` from `COLUMN_SKIPPED_FILES`.
- **Handle legacy MAP encoding and list-of-map paths in the test walker** by accepting `map` as a structural alias for `key_value` and eliding list-structural names inside Map projections, dropping `nonnullable.impala.parquet`.
- **Canonicalize map iteration order in the column-level comparator** by sorting innermost lists for map-projection columns since `AvroParquetReader` returns `HashMap`-backed maps, dropping `nullable.impala.parquet` and emptying `COLUMN_SKIPPED_FILES`.
  - Removed entire `COLUMN_SKIPPED_FILES` as it is now empty after these changes.

## Verification and Testing
The primary verification and major change associated with this effort centers around the introduction of a new `NestedLevelComputerTest` class explicitly designed to verify the successful disambiguation between the various list types that are supported. In addition to this, the expected suite of tests all pass end-to-end:
```
[INFO] core .................................. Tests run: 893, Failures: 0, Errors: 0, Skipped: 0
[INFO] parquet-testing-runner ................. Tests run: 564, Failures: 0, Errors: 0, Skipped: 61
[INFO] BUILD SUCCESS
```

## Checklist

- [x] Build via `./mvnw clean verify` passes
- [x] The commit message is prefixed with the issue key
- [x] Code changes are covered by tests
- [x] If this PR adds or changes user-facing behavior, `docs/` has been updated
