### PR TITLE
#431 Add RowGroupPredicate for split-aware row group selection

### DIFF
--- a/core/src/main/java/dev/hardwood/reader/ParquetFileReader.java
+++ b/core/src/main/java/dev/hardwood/reader/ParquetFileReader.java
@@ -231,29 +231,30 @@ public class ParquetFileReader implements AutoCloseable {
     // ============================================================
 
     RowReader buildRowReader(ColumnProjection projection, FilterPredicate filter, long maxRows) {
-        return buildRowReader(projection, filter, maxRows, 0L);
+        return buildRowReader(projection, filter, null, maxRows, 0L);
     }
 
-    RowReader buildRowReader(ColumnProjection projection, FilterPredicate filter, long maxRows,
-                             long firstRow) {
+    RowReader buildRowReader(ColumnProjection projection, FilterPredicate filter,
+                             RowGroupPredicate rowGroupFilter, long maxRows, long firstRow) {
+        // Apply the row-group predicate (e.g. byte-range) up front so `firstRow` indexes
+        // into the kept sequence — a caller doing split-aware reading can seek inside *its*
+        // split. Stats-based row-group dropping (via FilterPredicate) stays inside the
+        // RowGroupIterator, so its semantics under `firstRow` are unchanged from before.
+        List<RowGroup> filteredRowGroups = rowGroupFilter == null
+                ? firstFileMetaData.rowGroups()
+                : filterRowGroups(null, rowGroupFilter);
+
         if (firstRow == 0L) {
-            return buildRowReader(projection, filter, maxRows, firstFileMetaData.rowGroups());
+            return buildRowReader(projection, filter, maxRows, filteredRowGroups);
         }
         // Locate the row group containing `firstRow` by walking cumulative
-        // RowGroup.numRows(). For multi-file readers this indexes into the
-        // first file only — cross-file firstRow is out of scope.
-        List<RowGroup> all = firstFileMetaData.rowGroups();
-        long totalRows = firstFileMetaData.numRows();
-        if (firstRow > totalRows) {
-            throw new IllegalArgumentException(
-                    "firstRow " + firstRow + " exceeds the file's total row count "
-                    + totalRows);
-        }
+        // RowGroup.numRows() over the filtered list. After the loop, `cumulative`
+        // equals the total row count of `filteredRowGroups` if no target was found.
         long cumulative = 0L;
-        int targetRg = all.size(); // sentinel: at-the-end yields empty reader
+        int targetRg = -1;
         long withinRg = 0L;
-        for (int i = 0; i < all.size(); i++) {
-            long rgRows = all.get(i).numRows();
+        for (int i = 0; i < filteredRowGroups.size(); i++) {
+            long rgRows = filteredRowGroups.get(i).numRows();
             if (firstRow < cumulative + rgRows) {
                 targetRg = i;
                 withinRg = firstRow - cumulative;
@@ -261,13 +262,18 @@ public class ParquetFileReader implements AutoCloseable {
             }
             cumulative += rgRows;
         }
-        if (targetRg >= all.size()) {
-            // firstRow == totalRows — empty reader.
+        if (targetRg < 0) {
+            if (firstRow > cumulative) {
+                throw new IllegalArgumentException(
+                        "firstRow " + firstRow
+                        + " exceeds the (row-group-filtered) total row count " + cumulative);
+            }
+            // firstRow == cumulative — empty reader.
             return buildRowReader(projection, filter, maxRows, List.<RowGroup>of());
         }
         List<RowGroup> rowGroups = targetRg == 0
-                ? all
-                : all.subList(targetRg, all.size());
+                ? filteredRowGroups
+                : filteredRowGroups.subList(targetRg, filteredRowGroups.size());
         // The reader yields from the start of `targetRg`. We bump maxRows
         // by the within-RG skip distance because head(N) bounds *yielded*
         // rows; the residue rows we discard via next() count too.
@@ -352,31 +358,47 @@ public class ParquetFileReader implements AutoCloseable {
     }
 
     ColumnReader buildColumnReader(String columnName, FilterPredicate filter) {
+        return buildColumnReader(columnName, filter, null);
+    }
+
+    ColumnReader buildColumnReader(
+            String columnName, FilterPredicate filter, RowGroupPredicate rowGroupFilter) {
         ensureSingleFile("columnReader(String)");
         InputFile inputFile = inputFiles.get(0);
-        if (filter == null) {
-            return ColumnReader.create(columnName, schema, inputFile, firstFileMetaData.rowGroups(), context);
-        }
-        ResolvedPredicate resolved = FilterPredicateResolver.resolve(filter, schema);
-        return ColumnReader.create(columnName, schema, inputFile, filterRowGroups(resolved), context, resolved);
+        ResolvedPredicate resolved = filter != null
+                ? FilterPredicateResolver.resolve(filter, schema) : null;
+        List<RowGroup> rowGroups = filterRowGroups(resolved, rowGroupFilter);
+        return ColumnReader.create(columnName, schema, inputFile, rowGroups, context, resolved);
     }
 
     ColumnReader buildColumnReader(int columnIndex, FilterPredicate filter) {
+        return buildColumnReader(columnIndex, filter, null);
+    }
+
+    ColumnReader buildColumnReader(
+            int columnIndex, FilterPredicate filter, RowGroupPredicate rowGroupFilter) {
         ensureSingleFile("columnReader(int)");
         InputFile inputFile = inputFiles.get(0);
-        if (filter == null) {
-            return ColumnReader.create(columnIndex, schema, inputFile, firstFileMetaData.rowGroups(), context);
-        }
-        ResolvedPredicate resolved = FilterPredicateResolver.resolve(filter, schema);
-        return ColumnReader.create(columnIndex, schema, inputFile, filterRowGroups(resolved), context, resolved);
+        ResolvedPredicate resolved = filter != null
+                ? FilterPredicateResolver.resolve(filter, schema) : null;
+        List<RowGroup> rowGroups = filterRowGroups(resolved, rowGroupFilter);
+        return ColumnReader.create(columnIndex, schema, inputFile, rowGroups, context, resolved);
     }
 
     ColumnReaders buildColumnReaders(ColumnProjection projection, FilterPredicate filter) {
+        return buildColumnReaders(projection, filter, null);
+    }
+
+    ColumnReaders buildColumnReaders(
+            ColumnProjection projection,
+            FilterPredicate filter,
+            RowGroupPredicate rowGroupFilter) {
         ResolvedPredicate resolved = filter != null
                 ? FilterPredicateResolver.resolve(filter, schema) : null;
+        List<RowGroup> rowGroups = filterRowGroups(resolved, rowGroupFilter);
 
         RowGroupIterator iterator = new RowGroupIterator(inputFiles, context, 0);
-        iterator.setFirstFile(schema, firstFileMetaData.rowGroups());
+        iterator.setFirstFile(schema, rowGroups);
         ProjectedSchema projected = iterator.initialize(projection, resolved);
         rowGroupIterators.add(iterator);
         return new ColumnReaders(context, iterator, schema, projected);
@@ -403,9 +425,22 @@ public class ParquetFileReader implements AutoCloseable {
     }
 
     private List<RowGroup> filterRowGroups(ResolvedPredicate filter) {
+        return filterRowGroups(filter, null);
+    }
+
+    /// Filter row groups by an optional column-statistics predicate and an optional
+    /// [RowGroupPredicate]. A row group is kept if and only if it passes both.
+    private List<RowGroup> filterRowGroups(
+            ResolvedPredicate filter, RowGroupPredicate rowGroupFilter) {
         List<RowGroup> all = firstFileMetaData.rowGroups();
+        // Evaluate the RowGroupPredicate first: in split-aware reads it is both
+        // cheaper (a midpoint compare for ByteRange) and more selective (one shard
+        // out of N), short-circuiting the column-statistics check on the rejected
+        // majority.
         List<RowGroup> kept = all.stream()
-                .filter(rg -> !RowGroupFilterEvaluator.canDropRowGroup(filter, rg))
+                .filter(rg -> rowGroupFilter == null || matches(rg, rowGroupFilter))
+                .filter(rg -> filter == null
+                        || !RowGroupFilterEvaluator.canDropRowGroup(filter, rg))
                 .toList();
 
         RowGroupFilterEvent event = new RowGroupFilterEvent();
@@ -416,6 +451,34 @@ public class ParquetFileReader implements AutoCloseable {
         event.commit();
 
         return kept;
+    }
+
+    /// Evaluate a [RowGroupPredicate] against one row group.
+    private static boolean matches(RowGroup rg, RowGroupPredicate p) {
+        return switch (p) {
+            case RowGroupPredicate.ByteRange b -> {
+                long mid = rowGroupMidpoint(rg);
+                yield mid >= b.startInclusive() && mid < b.endExclusive();
+            }
+            case RowGroupPredicate.And a -> {
+                for (RowGroupPredicate child : a.children()) {
+                    if (!matches(rg, child)) {
+                        yield false;
+                    }
+                }
+                yield true;
+            }
+        };
+    }
+
+    private static long rowGroupMidpoint(RowGroup rg) {
+        List<dev.hardwood.metadata.ColumnChunk> columns = rg.columns();
+        long start = columns.get(0).chunkStartOffset();
+        long compressed = 0;
+        for (dev.hardwood.metadata.ColumnChunk chunk : columns) {
+            compressed += chunk.metaData().totalCompressedSize();
+        }
+        return start + compressed / 2;
     }
 
     // ============================================================
@@ -441,6 +504,7 @@ public class ParquetFileReader implements AutoCloseable {
         private final ParquetFileReader fileReader;
         private ColumnProjection projection = ColumnProjection.all();
         private FilterPredicate filter;
+        private RowGroupPredicate rowGroupFilter;
         /// Positive: return at most `headRows` rows from the start.
         /// Zero (default): no limit.
         private long headRows;
@@ -465,9 +529,22 @@ public class ParquetFileReader implements AutoCloseable {
             return this;
         }
 
-        /// Apply a row-group / record-level filter predicate. Default: no filter.
+        /// Apply a column-statistics / record-level filter predicate. Default: no filter.
         public RowReaderBuilder filter(FilterPredicate filter) {
             this.filter = filter;
+            return this;
+        }
+
+        /// Apply a row-group selection predicate (e.g. byte-range, for split-aware reading).
+        /// Default: read every row group. Combines with [#filter(FilterPredicate)] via
+        /// intersection: a row group is read if and only if it passes both.
+        ///
+        /// Composes with [#head(long)] and [#firstRow(long)] over the *filtered* row-group
+        /// sequence — `firstRow(N)` skips `N` rows of the kept set, `head(N)` caps at `N`
+        /// rows of the kept set. Mutually exclusive with [#tail(long)] (tail mode requires
+        /// a known total row count, which row-group filtering invalidates).
+        public RowReaderBuilder filter(RowGroupPredicate rowGroupFilter) {
+            this.rowGroupFilter = rowGroupFilter;
             return this;
         }
 
@@ -527,13 +604,20 @@ public class ParquetFileReader implements AutoCloseable {
                 throw new IllegalArgumentException("tail cannot be combined with a filter: "
                         + "the set of matching rows is not known from row-group statistics alone");
             }
+            if (tailRows > 0 && rowGroupFilter != null) {
+                throw new IllegalArgumentException(
+                        "tail cannot be combined with a row-group filter: "
+                                + "tail mode requires a known total row count, which row-group "
+                                + "filtering invalidates");
+            }
             if (tailRows > 0 && firstRow > 0) {
                 throw new IllegalArgumentException("tail and firstRow are mutually exclusive");
             }
             if (tailRows > 0) {
                 return fileReader.buildTailRowReader(projection, tailRows);
             }
-            return fileReader.buildRowReader(projection, filter, headRows, firstRow);
+            return fileReader.buildRowReader(
+                    projection, filter, rowGroupFilter, headRows, firstRow);
         }
     }
 
@@ -556,6 +640,7 @@ public class ParquetFileReader implements AutoCloseable {
         private final int columnIndex;
         private final boolean byName;
         private FilterPredicate filter;
+        private RowGroupPredicate rowGroupFilter;
 
         private ColumnReaderBuilder(ParquetFileReader fileReader, String columnName) {
             this.fileReader = fileReader;
@@ -571,17 +656,26 @@ public class ParquetFileReader implements AutoCloseable {
             this.byName = false;
         }
 
-        /// Apply a row-group / page-level filter predicate. Default: no filter.
+        /// Apply a column-statistics filter — row groups whose statistics prove no row
+        /// matches are skipped. Default: no filter.
         public ColumnReaderBuilder filter(FilterPredicate filter) {
             this.filter = filter;
             return this;
         }
 
+        /// Apply a row-group selection predicate (e.g. byte-range, for split-aware reading).
+        /// Default: read every row group. Combines with [#filter(FilterPredicate)] via
+        /// intersection: a row group is read if and only if it passes both.
+        public ColumnReaderBuilder filter(RowGroupPredicate rowGroupFilter) {
+            this.rowGroupFilter = rowGroupFilter;
+            return this;
+        }
+
         public ColumnReader build() {
             if (byName) {
-                return fileReader.buildColumnReader(columnName, filter);
+                return fileReader.buildColumnReader(columnName, filter, rowGroupFilter);
             }
-            return fileReader.buildColumnReader(columnIndex, filter);
+            return fileReader.buildColumnReader(columnIndex, filter, rowGroupFilter);
         }
     }
 
@@ -605,6 +699,7 @@ public class ParquetFileReader implements AutoCloseable {
         private final ParquetFileReader fileReader;
         private final ColumnProjection projection;
         private FilterPredicate filter;
+        private RowGroupPredicate rowGroupFilter;
 
         private ColumnReadersBuilder(ParquetFileReader fileReader, ColumnProjection projection) {
             if (projection == null) {
@@ -614,14 +709,23 @@ public class ParquetFileReader implements AutoCloseable {
             this.projection = projection;
         }
 
-        /// Apply a row-group statistics filter. Default: no filter.
+        /// Apply a column-statistics filter — row groups whose statistics prove no row
+        /// matches are skipped. Default: no filter.
         public ColumnReadersBuilder filter(FilterPredicate filter) {
             this.filter = filter;
             return this;
         }
 
+        /// Apply a row-group selection predicate (e.g. byte-range, for split-aware reading).
+        /// Default: read every row group. Combines with [#filter(FilterPredicate)] via
+        /// intersection: a row group is read if and only if it passes both.
+        public ColumnReadersBuilder filter(RowGroupPredicate rowGroupFilter) {
+            this.rowGroupFilter = rowGroupFilter;
+            return this;
+        }
+
         public ColumnReaders build() {
-            return fileReader.buildColumnReaders(projection, filter);
+            return fileReader.buildColumnReaders(projection, filter, rowGroupFilter);
         }
     }
 

--- a/core/src/main/java/dev/hardwood/reader/RowGroupPredicate.java
+++ b/core/src/main/java/dev/hardwood/reader/RowGroupPredicate.java
@@ -1,0 +1,72 @@
+/*
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Copyright The original authors
+ *
+ *  Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package dev.hardwood.reader;
+
+import java.util.List;
+
+/// A predicate over row groups, used to select which row groups a reader scans.
+///
+/// Distinct from [FilterPredicate], which expresses constraints on **column values** and is
+/// checked against per-column statistics. A `RowGroupPredicate` expresses constraints on the
+/// **row group itself** (its byte position in the file, its ordinal index, the row range it
+/// spans). The two are sibling, AND-combined inputs to a reader: a row group is read if and only if it
+/// passes both.
+///
+/// Granularity: filtering happens at row-group resolution, not row resolution. A row group
+/// passes [#byteRange(long, long)] when its midpoint falls in the given byte range — every
+/// row in that row group is then read, even rows whose data extends outside the range. This
+/// is the standard Hadoop-input-format split convention.
+///
+/// Usage:
+/// ```java
+/// // Single split: read row groups whose midpoint is in [start, end).
+/// ColumnReader r = file.buildColumnReader("price")
+///         .filter(RowGroupPredicate.byteRange(splitStart, splitEnd))
+///         .build();
+///
+/// // Stacks with column-stats predicates — both apply, AND-combined.
+/// ColumnReader r = file.buildColumnReader("price")
+///         .filter(FilterPredicate.gt("price", 100))
+///         .filter(RowGroupPredicate.byteRange(splitStart, splitEnd))
+///         .build();
+/// ```
+public sealed interface RowGroupPredicate
+        permits RowGroupPredicate.ByteRange,
+                RowGroupPredicate.And {
+
+    /// Keep row groups whose data midpoint — start of the first column chunk plus half of
+    /// the on-disk compressed size — falls in `[startInclusive, endExclusive)`.
+    ///
+    /// This is the standard split convention: every row group lands in exactly one byte
+    /// range across a partitioning of the file, regardless of where the boundary falls
+    /// inside it.
+    ///
+    /// `endExclusive < startInclusive` is treated as an empty range. This matches callers
+    /// that pass `splitStart + splitLength` and tolerate long overflow on tail splits.
+    static RowGroupPredicate byteRange(long startInclusive, long endExclusive) {
+        return new ByteRange(startInclusive, endExclusive);
+    }
+
+    /// Keep row groups that match every child predicate (intersection).
+    static RowGroupPredicate and(RowGroupPredicate... children) {
+        if (children == null || children.length == 0) {
+            throw new IllegalArgumentException("AND predicate requires at least one child");
+        }
+        return new And(List.of(children));
+    }
+
+    /// Keep row groups whose midpoint falls in `[startInclusive, endExclusive)`.
+    /// Constructed via [#byteRange(long, long)].
+    record ByteRange(long startInclusive, long endExclusive) implements RowGroupPredicate {
+    }
+
+    /// Conjunction of row-group predicates — a row group passes if and only if every child passes.
+    /// Constructed via [#and(RowGroupPredicate...)].
+    record And(List<RowGroupPredicate> children) implements RowGroupPredicate {
+    }
+}

--- a/core/src/test/java/dev/hardwood/RowGroupFilterTest.java
+++ b/core/src/test/java/dev/hardwood/RowGroupFilterTest.java
@@ -1,0 +1,275 @@
+/*
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Copyright The original authors
+ *
+ *  Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package dev.hardwood;
+
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.List;
+
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import dev.hardwood.metadata.RowGroup;
+import dev.hardwood.reader.ColumnReader;
+import dev.hardwood.reader.ColumnReaders;
+import dev.hardwood.reader.FilterPredicate;
+import dev.hardwood.reader.ParquetFileReader;
+import dev.hardwood.reader.RowGroupPredicate;
+import dev.hardwood.reader.RowReader;
+import dev.hardwood.schema.ColumnProjection;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/// Integration tests for [RowGroupPredicate] across all reader builders.
+///
+/// Exercises `filter_pushdown_int.parquet` — a 3-row-group file with `id` 1-100, 101-200,
+/// 201-300 — and verifies that byte-range filtering yields the expected row-group subsets
+/// for [ParquetFileReader#buildColumnReader], [ParquetFileReader#buildColumnReaders], and
+/// [ParquetFileReader#buildRowReader].
+class RowGroupFilterTest {
+
+    private static final Path FIXTURE = Paths.get("src/test/resources/filter_pushdown_int.parquet");
+
+    private static long rg0Mid;
+    private static long rg1Mid;
+    private static long rg2Mid;
+    private static long fileLen;
+
+    @BeforeAll
+    static void readMidpoints() throws Exception {
+        try (ParquetFileReader reader = ParquetFileReader.open(InputFile.of(FIXTURE))) {
+            List<RowGroup> rgs = reader.getFileMetaData().rowGroups();
+            assertThat(rgs).hasSize(3);
+            rg0Mid = midpoint(rgs.get(0));
+            rg1Mid = midpoint(rgs.get(1));
+            rg2Mid = midpoint(rgs.get(2));
+            fileLen = FIXTURE.toFile().length();
+        }
+        assertThat(rg0Mid).isLessThan(rg1Mid);
+        assertThat(rg1Mid).isLessThan(rg2Mid);
+    }
+
+    private static long midpoint(RowGroup rg) {
+        long start = rg.columns().get(0).chunkStartOffset();
+        long compressed = 0;
+        for (var c : rg.columns()) {
+            compressed += c.metaData().totalCompressedSize();
+        }
+        return start + compressed / 2;
+    }
+
+    // ==================== ColumnReader path ====================
+
+    @Test
+    void columnReaderByteRangeCoveringEverythingReadsAllRows() throws Exception {
+        try (ParquetFileReader reader = ParquetFileReader.open(InputFile.of(FIXTURE));
+             ColumnReader col = reader.buildColumnReader("id")
+                     .filter(RowGroupPredicate.byteRange(0, fileLen))
+                     .build()) {
+            assertThat(countRows(col)).isEqualTo(300);
+        }
+    }
+
+    @Test
+    void columnReaderByteRangeCoveringNothingReadsZeroRows() throws Exception {
+        try (ParquetFileReader reader = ParquetFileReader.open(InputFile.of(FIXTURE));
+             ColumnReader col = reader.buildColumnReader("id")
+                     .filter(RowGroupPredicate.byteRange(fileLen + 1, fileLen + 100))
+                     .build()) {
+            assertThat(countRows(col)).isZero();
+        }
+    }
+
+    @Test
+    void columnReaderEmptyByteRangeReadsZeroRows() throws Exception {
+        // endExclusive < startInclusive → empty range. Used by callers that pass
+        // splitStart + splitLength and tolerate long overflow on tail splits.
+        try (ParquetFileReader reader = ParquetFileReader.open(InputFile.of(FIXTURE));
+             ColumnReader col = reader.buildColumnReader("id")
+                     .filter(RowGroupPredicate.byteRange(100, 50))
+                     .build()) {
+            assertThat(countRows(col)).isZero();
+        }
+    }
+
+    @Test
+    void columnReaderByteRangeKeepsOnlyRowGroupsByMidpointRule() throws Exception {
+        // Range covering only rg0 (up to but not including rg1's midpoint).
+        try (ParquetFileReader reader = ParquetFileReader.open(InputFile.of(FIXTURE));
+             ColumnReader col = reader.buildColumnReader("id")
+                     .filter(RowGroupPredicate.byteRange(0, rg1Mid))
+                     .build()) {
+            assertThat(firstAndLastIds(col)).containsExactly(1L, 100L);
+        }
+    }
+
+    @Test
+    void columnReaderByteRangeKeepsTwoComplementaryHalvesExactly() throws Exception {
+        // Two disjoint ranges should partition the file exactly: every row group lands in
+        // exactly one of them.
+        long boundary = rg1Mid; // midpoints: rg0 < rg1 < rg2; boundary at rg1's midpoint
+        long firstHalfRows = countWithRange(0, boundary);
+        long secondHalfRows = countWithRange(boundary, Long.MAX_VALUE);
+        assertThat(firstHalfRows + secondHalfRows).isEqualTo(300L);
+
+        // Sanity: the boundary cuts between rg0 and rg1, so first half = rg0 only.
+        assertThat(firstHalfRows).isEqualTo(100L);
+        assertThat(secondHalfRows).isEqualTo(200L);
+    }
+
+    @Test
+    void columnReaderAndCombinatorIntersectsRanges() throws Exception {
+        // Range A covers rg0+rg1; range B covers rg1+rg2; intersection is rg1.
+        try (ParquetFileReader reader = ParquetFileReader.open(InputFile.of(FIXTURE));
+             ColumnReader col = reader.buildColumnReader("id")
+                     .filter(RowGroupPredicate.and(
+                             RowGroupPredicate.byteRange(0, rg2Mid),
+                             RowGroupPredicate.byteRange(rg1Mid, fileLen)))
+                     .build()) {
+            assertThat(firstAndLastIds(col)).containsExactly(101L, 200L);
+        }
+    }
+
+    @Test
+    void columnReaderRowGroupFilterComposesWithFilterPredicate() throws Exception {
+        // Byte range keeps rg0+rg1 (id 1-200). FilterPredicate gt(id, 150) drops rg0
+        // (max=100) and keeps rg1 (max=200). Intersection: rg1 only.
+        try (ParquetFileReader reader = ParquetFileReader.open(InputFile.of(FIXTURE));
+             ColumnReader col = reader.buildColumnReader("id")
+                     .filter(FilterPredicate.gt("id", 150L))
+                     .filter(RowGroupPredicate.byteRange(0, rg2Mid))
+                     .build()) {
+            assertThat(firstAndLastIds(col)).containsExactly(101L, 200L);
+        }
+    }
+
+    // ==================== ColumnReaders path ====================
+
+    @Test
+    void columnReadersByteRangeKeepsOnlyExpectedRowGroups() throws Exception {
+        try (ParquetFileReader reader = ParquetFileReader.open(InputFile.of(FIXTURE));
+             ColumnReaders cols = reader.buildColumnReaders(ColumnProjection.columns("id"))
+                     .filter(RowGroupPredicate.byteRange(0, rg1Mid))
+                     .build()) {
+            ColumnReader col = cols.getColumnReader("id");
+            assertThat(firstAndLastIds(col)).containsExactly(1L, 100L);
+        }
+    }
+
+    // ==================== RowReader path ====================
+
+    @Test
+    void rowReaderByteRangeKeepsOnlyExpectedRowGroups() throws Exception {
+        try (ParquetFileReader reader = ParquetFileReader.open(InputFile.of(FIXTURE));
+             RowReader rows = reader.buildRowReader()
+                     .projection(ColumnProjection.columns("id"))
+                     .filter(RowGroupPredicate.byteRange(0, rg1Mid))
+                     .build()) {
+            int n = 0;
+            long firstId = -1;
+            long lastId = -1;
+            while (rows.hasNext()) {
+                rows.next();
+                long id = rows.getLong("id");
+                if (firstId < 0) firstId = id;
+                lastId = id;
+                n++;
+            }
+            assertThat(n).isEqualTo(100);
+            assertThat(firstId).isEqualTo(1L);
+            assertThat(lastId).isEqualTo(100L);
+        }
+    }
+
+    @Test
+    void rowReaderHeadComposesOverFilteredRowGroups() throws Exception {
+        // RowGroupPredicate keeps rg1+rg2 (rows 101..300); head(50) caps at first 50 of those.
+        try (ParquetFileReader reader = ParquetFileReader.open(InputFile.of(FIXTURE));
+             RowReader rows = reader.buildRowReader()
+                     .projection(ColumnProjection.columns("id"))
+                     .filter(RowGroupPredicate.byteRange(rg1Mid, fileLen))
+                     .head(50)
+                     .build()) {
+            long firstId = -1;
+            long lastId = -1;
+            int n = 0;
+            while (rows.hasNext()) {
+                rows.next();
+                long id = rows.getLong("id");
+                if (firstId < 0) firstId = id;
+                lastId = id;
+                n++;
+            }
+            assertThat(n).isEqualTo(50);
+            assertThat(firstId).isEqualTo(101L);
+            assertThat(lastId).isEqualTo(150L);
+        }
+    }
+
+    @Test
+    void rowReaderFirstRowIndexesIntoFilteredSequence() throws Exception {
+        // RowGroupPredicate keeps rg1+rg2 (rows 101..300 in id order). firstRow(10) skips
+        // 10 rows of the kept set, so we resume at id 111.
+        try (ParquetFileReader reader = ParquetFileReader.open(InputFile.of(FIXTURE));
+             RowReader rows = reader.buildRowReader()
+                     .projection(ColumnProjection.columns("id"))
+                     .filter(RowGroupPredicate.byteRange(rg1Mid, fileLen))
+                     .firstRow(10)
+                     .build()) {
+            assertThat(rows.hasNext()).isTrue();
+            rows.next();
+            assertThat(rows.getLong("id")).isEqualTo(111L);
+        }
+    }
+
+    @Test
+    void rowReaderTailRejectsRowGroupPredicate() throws Exception {
+        try (ParquetFileReader reader = ParquetFileReader.open(InputFile.of(FIXTURE))) {
+            assertThatThrownBy(() -> reader.buildRowReader()
+                    .projection(ColumnProjection.columns("id"))
+                    .filter(RowGroupPredicate.byteRange(0, fileLen))
+                    .tail(50)
+                    .build())
+                    .isInstanceOf(IllegalArgumentException.class)
+                    .hasMessageContaining("tail")
+                    .hasMessageContaining("row-group filter");
+        }
+    }
+
+    // ==================== Helpers ====================
+
+    private static long countRows(ColumnReader col) {
+        long n = 0;
+        while (col.nextBatch()) {
+            n += col.getRecordCount();
+        }
+        return n;
+    }
+
+    private static long countWithRange(long start, long end) throws Exception {
+        try (ParquetFileReader reader = ParquetFileReader.open(InputFile.of(FIXTURE));
+             ColumnReader col = reader.buildColumnReader("id")
+                     .filter(RowGroupPredicate.byteRange(start, end))
+                     .build()) {
+            return countRows(col);
+        }
+    }
+
+    private static long[] firstAndLastIds(ColumnReader col) {
+        long first = -1;
+        long last = -1;
+        while (col.nextBatch()) {
+            int n = col.getRecordCount();
+            long[] ids = col.getLongs();
+            if (first < 0 && n > 0) first = ids[0];
+            if (n > 0) last = ids[n - 1];
+        }
+        return new long[] {first, last};
+    }
+}

--- a/core/src/test/java/dev/hardwood/RowGroupPredicateTest.java
+++ b/core/src/test/java/dev/hardwood/RowGroupPredicateTest.java
@@ -1,0 +1,59 @@
+/*
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Copyright The original authors
+ *
+ *  Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package dev.hardwood;
+
+import org.junit.jupiter.api.Test;
+
+import dev.hardwood.reader.RowGroupPredicate;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class RowGroupPredicateTest {
+
+    @Test
+    void byteRangeFactoryProducesByteRangeRecord() {
+        RowGroupPredicate p = RowGroupPredicate.byteRange(10L, 100L);
+        assertThat(p).isInstanceOf(RowGroupPredicate.ByteRange.class);
+        RowGroupPredicate.ByteRange b = (RowGroupPredicate.ByteRange) p;
+        assertThat(b.startInclusive()).isEqualTo(10L);
+        assertThat(b.endExclusive()).isEqualTo(100L);
+    }
+
+    @Test
+    void byteRangeAcceptsEmptyRange() {
+        // endExclusive < startInclusive is documented as an empty range — used by callers
+        // that pass splitStart + splitLength and tolerate long overflow.
+        RowGroupPredicate p = RowGroupPredicate.byteRange(100L, 50L);
+        assertThat(p).isInstanceOf(RowGroupPredicate.ByteRange.class);
+    }
+
+    @Test
+    void andFactoryProducesAndRecord() {
+        RowGroupPredicate b1 = RowGroupPredicate.byteRange(0, 100);
+        RowGroupPredicate b2 = RowGroupPredicate.byteRange(50, 150);
+        RowGroupPredicate p = RowGroupPredicate.and(b1, b2);
+        assertThat(p).isInstanceOf(RowGroupPredicate.And.class);
+        RowGroupPredicate.And and = (RowGroupPredicate.And) p;
+        assertThat(and.children()).containsExactly(b1, b2);
+    }
+
+    @Test
+    void andRejectsEmptyChildren() {
+        assertThatThrownBy(RowGroupPredicate::and)
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("at least one child");
+    }
+
+    @Test
+    void andRejectsNullChildren() {
+        assertThatThrownBy(() -> RowGroupPredicate.and((RowGroupPredicate[]) null))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("at least one child");
+    }
+}

--- a/docs/content/release-notes.md
+++ b/docs/content/release-notes.md
@@ -13,6 +13,10 @@
 
 See [GitHub Releases](https://github.com/hardwood-hq/hardwood/releases) for downloads and more information.
 
+## Unreleased
+
+- `RowGroupPredicate` for split-aware row group selection. Pass `RowGroupPredicate.byteRange(start, end)` to any reader builder's `filter(...)` to restrict reading to the row groups whose midpoint falls in the given file byte range — the standard split convention used by Hadoop-style integrations (Flink `BulkFormat`, Spark file source, …). Combines with `FilterPredicate` via intersection. See [Split-Aware Reading](usage.md#split-aware-reading) and [#431](https://github.com/hardwood-hq/hardwood/issues/431).
+
 ## 1.0.0.Beta2 (2026-04-29)
 
 [Announcement blog post](https://www.morling.dev/blog/variant-support-interactive-parquet-file-tui-hardwood-1.0.0.beta2-is-out/)

--- a/docs/content/usage.md
+++ b/docs/content/usage.md
@@ -398,6 +398,51 @@ try (ParquetFileReader fileReader = ParquetFileReader.open(InputFile.of(path));
 
 When combined with a filter, the limit applies to the number of **matching** rows, not the total number of scanned rows.
 
+## Split-Aware Reading
+
+When you partition a file across parallel readers — Flink `BulkFormat`, Spark file source, MapReduce-style splits — each reader is assigned a byte range and is responsible for only the row groups owned by it. Express this with `RowGroupPredicate.byteRange(start, end)`, passed to any builder's `filter(...)`:
+
+```java
+import dev.hardwood.reader.RowGroupPredicate;
+
+// One reader subtask, owning the file's first quarter.
+try (ParquetFileReader fileReader = ParquetFileReader.open(InputFile.of(path));
+     ColumnReader col = fileReader.buildColumnReader("price")
+             .filter(RowGroupPredicate.byteRange(splitStart, splitEnd))
+             .build()) {
+    while (col.nextBatch()) {
+        // Only batches from row groups owned by this split.
+    }
+}
+```
+
+A row group is included if and only if its **midpoint** — the start of its first column chunk plus half of its on-disk compressed size — falls in `[start, end)`. This is the standard Hadoop-input-format split convention: across a partitioning of the file into disjoint byte ranges, every row group lands in exactly one range, regardless of where the split boundary falls inside the row group itself.
+
+**Granularity is row-group, not row.** A row group whose midpoint is in `[0, 1000)` is read in full, including any rows whose data extends beyond byte 1000. If you need true row-level windowing, combine `RowGroupPredicate` with [`RowReaderBuilder.firstRow(...)`](#seeking-to-an-absolute-row) and [`head(...)`](#row-limit).
+
+`RowGroupPredicate` composes with [`FilterPredicate`](#predicate-pushdown-filter) via intersection — both apply, and a row group is read if and only if it passes both:
+
+```java
+ColumnReader col = fileReader.buildColumnReader("price")
+        .filter(FilterPredicate.gt("price", 100))                  // column-stats
+        .filter(RowGroupPredicate.byteRange(splitStart, splitEnd)) // layout
+        .build();
+```
+
+`RowGroupPredicate.and(...)` lets you intersect multiple row-group conditions:
+
+```java
+.filter(RowGroupPredicate.and(
+        RowGroupPredicate.byteRange(splitStart, splitEnd),
+        RowGroupPredicate.byteRange(otherStart, otherEnd)))
+```
+
+The same `filter(RowGroupPredicate)` overload is available on `RowReaderBuilder` and `ColumnReadersBuilder`. On `RowReaderBuilder`, `firstRow(N)` and `head(N)` index over the *row-group-filtered* sequence — `firstRow(N)` skips `N` rows of the kept set, `head(N)` caps reading at `N` rows of the kept set. Combining `RowGroupPredicate` with `tail(N)` is rejected: tail mode requires a known total row count, which row-group filtering invalidates.
+
+### Empty ranges
+
+`byteRange(start, end)` where `end < start` is a documented empty range — the reader yields zero rows. This matches callers that pass `splitStart + splitLength` and tolerate long overflow on tail splits (a tail split with `length = Long.MAX_VALUE` overflows to a negative end, which your reader will then treat as empty if no preceding split has already covered the rest of the file).
+
 ### Reading the Tail of a File
 
 The `tail(N)` builder method reads the trailing rows of the file instead of the leading ones. Row groups that do not overlap the tail are skipped entirely, so pages for earlier row groups are never fetched or decoded — especially useful on remote backends like S3, where unneeded row groups avoid HTTP range requests altogether.


### PR DESCRIPTION
Hadoop-style integrations (Flink BulkFormat, Spark file source, …) need to assign each parallel reader a byte range and read only the row groups owned by it. Previously ParquetFileReader.open(InputFile) always read every row group, so such integrations had to forfeit file-level parallelism. Introduce RowGroupPredicate.byteRange(start, end) that selects row groups by midpoint and a filter(RowGroupPredicate) overload on every reader builder, composing with FilterPredicate via intersection.