### PR TITLE
#318 Fixing missing accessors in tests stub

### DIFF
--- a/performance-testing/micro-benchmarks/src/main/java/dev/hardwood/benchmarks/RecordFilterMicroBenchmark.java
+++ b/performance-testing/micro-benchmarks/src/main/java/dev/hardwood/benchmarks/RecordFilterMicroBenchmark.java
@@ -194,6 +194,7 @@ public class RecordFilterMicroBenchmark {
         @Override public boolean getBoolean(String name) { return flagVal; }
 
         @Override public float getFloat(String name) { throw new UnsupportedOperationException(); }
+        @Override public Float getFloat16(String name) { throw new UnsupportedOperationException(); }
         @Override public String getString(String name) { throw new UnsupportedOperationException(); }
         @Override public byte[] getBinary(String name) { throw new UnsupportedOperationException(); }
         @Override public LocalDate getDate(String name) { throw new UnsupportedOperationException(); }


### PR DESCRIPTION
Fixing the missing methods of float16 accessor introduced in #439

## Checklist

- [x] Build via `./mvnw clean verify` passes
- [x] The commit message is prefixed with the issue key ("#123 Adding support for...")
- [x] Code changes are covered by tests
- [x] If this PR adds or changes user-facing behaviour, `docs/` has been updated
