### PR TITLE
#386 Fix help text cutoff in dive by implementing word wrapping

### DIFF
--- a/cli/src/main/java/dev/hardwood/cli/dive/internal/DataPreviewScreen.java
+++ b/cli/src/main/java/dev/hardwood/cli/dive/internal/DataPreviewScreen.java
@@ -277,7 +277,7 @@ public final class DataPreviewScreen {
             ownership[i] = all.size();
             if (isExpanded) {
                 String fullValue = i < expanded.size() ? expanded.get(i) : value;
-                List<String> wrapped = wrapValue(fullValue, valueBudget);
+                List<String> wrapped = Strings.hardWrap(fullValue, valueBudget);
                 if (wrapped.isEmpty()) {
                     wrapped.add("");
                 }
@@ -322,7 +322,7 @@ public final class DataPreviewScreen {
                 String shown;
                 if (isExpanded) {
                     String fullValue = fieldIdx < expanded.size() ? expanded.get(fieldIdx) : value;
-                    List<String> wrapped = wrapValue(fullValue, valueBudget);
+                    List<String> wrapped = Strings.hardWrap(fullValue, valueBudget);
                     shown = wrapped.isEmpty() ? "" : wrapped.get(0);
                 }
                 else {
@@ -334,7 +334,7 @@ public final class DataPreviewScreen {
             }
             else if (isExpanded) {
                 String fullValue = fieldIdx < expanded.size() ? expanded.get(fieldIdx) : value;
-                List<String> wrapped = wrapValue(fullValue, valueBudget);
+                List<String> wrapped = Strings.hardWrap(fullValue, valueBudget);
                 int contIdx = cursorLine - fieldFirstLine;
                 String text = contIdx < wrapped.size() ? wrapped.get(contIdx) : "";
                 all.set(cursorLine, Line.from(new Span(continuationIndent + text, selectionStyle)));
@@ -399,30 +399,6 @@ public final class DataPreviewScreen {
                 .left()
                 .build()
                 .render(area, buffer);
-    }
-
-    /// Splits a possibly multi-line value into display lines that each fit
-    /// within `width` cells. Hard line breaks in the source are preserved;
-    /// each segment is then chunked at `width` if it's longer.
-    private static List<String> wrapValue(String value, int width) {
-        List<String> out = new ArrayList<>();
-        if (width <= 0) {
-            out.add(value);
-            return out;
-        }
-        for (String line : value.split("\n", -1)) {
-            if (line.isEmpty()) {
-                out.add("");
-                continue;
-            }
-            int i = 0;
-            while (i < line.length()) {
-                int end = Math.min(line.length(), i + width);
-                out.add(line.substring(i, end));
-                i = end;
-            }
-        }
-        return out;
     }
 
     public static String keybarKeys(ScreenState.DataPreview state, ParquetModel model) {

--- a/cli/src/main/java/dev/hardwood/cli/dive/internal/HelpOverlay.java
+++ b/cli/src/main/java/dev/hardwood/cli/dive/internal/HelpOverlay.java
@@ -38,36 +38,40 @@ public final class HelpOverlay {
         // that the Paragraph doesn't paint.
         dev.tamboui.widgets.Clear.INSTANCE.render(area, buffer);
 
-        List<Line> lines = List.of(
-                Line.from(new Span("Navigation", Theme.accent().bold())),
-                kv("↑ / ↓", "move selection"),
-                kv("g / G", "jump to first / last row"),
-                kv("Enter", "drill into selected item"),
-                kv("Esc / Backspace", "go back one level"),
-                kv("Tab / Shift-Tab", "switch focused pane"),
-                kv("o", "return to Overview"),
-                Line.empty(),
-                Line.from(new Span("Schema tree", Theme.accent().bold())),
-                kv("→ / Enter", "expand group · drill leaf"),
-                kv("←", "collapse group"),
-                kv("e / c", "expand / collapse all groups"),
-                Line.empty(),
-                Line.from(new Span("Inline search", Theme.accent().bold())),
-                kv("/", "enter filter mode (Schema, Column index, Dictionary)"),
-                kv("Enter", "commit filter"),
-                kv("Esc", "clear filter"),
-                Line.empty(),
-                Line.from(new Span("Global", Theme.accent().bold())),
-                kv("?", "toggle this help"),
-                kv("q / Ctrl-C", "quit"),
-                Line.empty(),
-                Line.from(new Span("Data preview", Theme.accent().bold())),
-                kv("PgDn / PgUp", "page forward / back (Shift+↓/↑ on macOS)"),
-                kv("← / →", "scroll visible columns"),
-                kv("g / G", "jump to first / last row of file"),
-                Line.empty(),
-                Line.from(new Span("Version: " + Version.getVersion(), Theme.dim())),
-                Line.from(new Span("Press ? or Esc to close", Theme.dim())));
+        int descBudget = Math.max(1, (width - 2) - 20);
+
+        List<Line> lines = new java.util.ArrayList<>();
+
+                lines.add(Line.from(new Span("Navigation", Theme.accent().bold())));
+                lines.addAll(kv("↑ / ↓", "move selection", descBudget));
+                lines.addAll(kv("g / G", "jump to first / last row", descBudget));
+                lines.addAll(kv("Enter", "drill into selected item", descBudget));
+                lines.addAll(kv("Esc / Backspace", "go back one level", descBudget));
+                lines.addAll(kv("Tab / Shift-Tab", "switch focused pane", descBudget));
+                lines.addAll(kv("o", "return to Overview", descBudget));
+                lines.add(Line.empty());
+                lines.add(Line.from(new Span("Schema tree", Theme.accent().bold())));
+                lines.addAll(kv("→ / Enter", "expand group · drill leaf", descBudget));
+                lines.addAll(kv("←", "collapse group", descBudget));
+                lines.addAll(kv("e / c", "expand / collapse all groups", descBudget));
+                lines.add(Line.empty());
+                lines.add(Line.from(new Span("Inline search", Theme.accent().bold())));
+                lines.addAll(kv("/", "enter filter mode (Schema, Column index, Dictionary)", descBudget));
+                lines.addAll(kv("Enter", "commit filter", descBudget));
+                lines.addAll(kv("Esc", "clear filter", descBudget));
+                lines.add(Line.empty());
+                lines.add(Line.from(new Span("Global", Theme.accent().bold())));
+                lines.addAll(kv("?", "toggle this help", descBudget));
+                lines.addAll(kv("q / Ctrl-C", "quit", descBudget));
+                lines.add(Line.empty());
+                lines.add(Line.from(new Span("Data preview", Theme.accent().bold())));
+                lines.addAll(kv("PgDn / PgUp", "page forward / back (Shift+↓/↑ on macOS)", descBudget));
+                lines.addAll(kv("← / →", "scroll visible columns", descBudget));
+                lines.addAll(kv("g / G", "jump to first / last row of file", descBudget));
+                lines.add(Line.empty());
+                lines.add(Line.from(new Span("Version: " + Version.getVersion(), Theme.dim())));
+                lines.add(Line.from(new Span("Press ? or Esc to close", Theme.dim())));
+
 
         Block block = Block.builder()
                 .title(" hardwood dive — help ")
@@ -77,14 +81,48 @@ public final class HelpOverlay {
         Paragraph.builder().block(block).text(Text.from(lines)).left().build().render(area, buffer);
     }
 
-    private static Line kv(String key, String description) {
-        return Line.from(
+    private static List<Line> kv(String key, String description, int descBudget) {
+        List<Line> result = new java.util.ArrayList<>();
+        List<String> wrappedDescription = wrapValue(description, descBudget);
+
+        result.add(Line.from(
                 Span.raw("  "),
                 new Span(padRight(key, 18), Theme.primary()),
-                new Span(description, Style.EMPTY));
+                new Span(wrappedDescription.isEmpty() ? "" : wrappedDescription.get(0), Style.EMPTY)
+        ));
+
+        for (int i = 1; i < wrappedDescription.size(); i++){
+            result.add(Line.from(
+                    Span.raw(" ".repeat(20)),
+                    new Span(wrappedDescription.get(i), Style.EMPTY)
+            ));
+        }
+
+        return result;
     }
 
     private static String padRight(String s, int width) {
         return Strings.padRight(s, width);
+    }
+
+    private static List<String> wrapValue(String value, int width) {
+        List<String> out = new java.util.ArrayList<>();
+        if (width <= 0) {
+            out.add(value);
+            return out;
+        }
+        for (String line : value.split("\n", -1)) {
+            if (line.isEmpty()) {
+                out.add("");
+                continue;
+            }
+            int i = 0;
+            while (i < line.length()) {
+                int end = Math.min(line.length(), i + width);
+                out.add(line.substring(i, end));
+                i = end;
+            }
+        }
+        return out;
     }
 }

--- a/cli/src/main/java/dev/hardwood/cli/dive/internal/HelpOverlay.java
+++ b/cli/src/main/java/dev/hardwood/cli/dive/internal/HelpOverlay.java
@@ -31,48 +31,49 @@ public final class HelpOverlay {
 
     public static void render(Buffer buffer, Rect screenArea) {
         int width = Math.min(60, screenArea.width() - 4);
-        int height = Math.min(33, screenArea.height() - 2);
+        int descBudget = Math.max(1, (width - 2) - 20);
+
+        List<Line> lines = new ArrayList<>();
+        lines.add(Line.from(new Span("Navigation", Theme.accent().bold())));
+        lines.addAll(kv("↑ / ↓", "move selection", descBudget));
+        lines.addAll(kv("g / G", "jump to first / last row", descBudget));
+        lines.addAll(kv("Enter", "drill into selected item", descBudget));
+        lines.addAll(kv("Esc / Backspace", "go back one level", descBudget));
+        lines.addAll(kv("Tab / Shift-Tab", "switch focused pane", descBudget));
+        lines.addAll(kv("o", "return to Overview", descBudget));
+        lines.add(Line.empty());
+        lines.add(Line.from(new Span("Schema tree", Theme.accent().bold())));
+        lines.addAll(kv("→ / Enter", "expand group · drill leaf", descBudget));
+        lines.addAll(kv("←", "collapse group", descBudget));
+        lines.addAll(kv("e / c", "expand / collapse all groups", descBudget));
+        lines.add(Line.empty());
+        lines.add(Line.from(new Span("Inline search", Theme.accent().bold())));
+        lines.addAll(kv("/", "enter filter mode (Schema, Column index, Dictionary)", descBudget));
+        lines.addAll(kv("Enter", "commit filter", descBudget));
+        lines.addAll(kv("Esc", "clear filter", descBudget));
+        lines.add(Line.empty());
+        lines.add(Line.from(new Span("Global", Theme.accent().bold())));
+        lines.addAll(kv("?", "toggle this help", descBudget));
+        lines.addAll(kv("q / Ctrl-C", "quit", descBudget));
+        lines.add(Line.empty());
+        lines.add(Line.from(new Span("Data preview", Theme.accent().bold())));
+        lines.addAll(kv("PgDn / PgUp", "page forward / back (Shift+↓/↑ on macOS)", descBudget));
+        lines.addAll(kv("← / →", "scroll visible columns", descBudget));
+        lines.addAll(kv("g / G", "jump to first / last row of file", descBudget));
+        lines.add(Line.empty());
+        lines.add(Line.from(new Span("Version: " + Version.getVersion(), Theme.dim())));
+        lines.add(Line.from(new Span("Press ? or Esc to close", Theme.dim())));
+
+        // Height is derived from the produced line count (plus 2 for the borders)
+        // so the overlay grows with the wrapped content. Capped to the screen so
+        // we don't draw outside the buffer.
+        int height = Math.min(lines.size() + 2, screenArea.height() - 2);
         int x = screenArea.left() + (screenArea.width() - width) / 2;
         int y = screenArea.top() + (screenArea.height() - height) / 2;
         Rect area = new Rect(x, y, width, height);
         // Wipe the area so the underlying screen doesn't bleed through cells
         // that the Paragraph doesn't paint.
         dev.tamboui.widgets.Clear.INSTANCE.render(area, buffer);
-
-        int descBudget = Math.max(1, (width - 2) - 20);
-
-        List<Line> lines = new ArrayList<>();
-
-                lines.add(Line.from(new Span("Navigation", Theme.accent().bold())));
-                lines.addAll(kv("↑ / ↓", "move selection", descBudget));
-                lines.addAll(kv("g / G", "jump to first / last row", descBudget));
-                lines.addAll(kv("Enter", "drill into selected item", descBudget));
-                lines.addAll(kv("Esc / Backspace", "go back one level", descBudget));
-                lines.addAll(kv("Tab / Shift-Tab", "switch focused pane", descBudget));
-                lines.addAll(kv("o", "return to Overview", descBudget));
-                lines.add(Line.empty());
-                lines.add(Line.from(new Span("Schema tree", Theme.accent().bold())));
-                lines.addAll(kv("→ / Enter", "expand group · drill leaf", descBudget));
-                lines.addAll(kv("←", "collapse group", descBudget));
-                lines.addAll(kv("e / c", "expand / collapse all groups", descBudget));
-                lines.add(Line.empty());
-                lines.add(Line.from(new Span("Inline search", Theme.accent().bold())));
-                lines.addAll(kv("/", "enter filter mode (Schema, Column index, Dictionary)", descBudget));
-                lines.addAll(kv("Enter", "commit filter", descBudget));
-                lines.addAll(kv("Esc", "clear filter", descBudget));
-                lines.add(Line.empty());
-                lines.add(Line.from(new Span("Global", Theme.accent().bold())));
-                lines.addAll(kv("?", "toggle this help", descBudget));
-                lines.addAll(kv("q / Ctrl-C", "quit", descBudget));
-                lines.add(Line.empty());
-                lines.add(Line.from(new Span("Data preview", Theme.accent().bold())));
-                lines.addAll(kv("PgDn / PgUp", "page forward / back (Shift+↓/↑ on macOS)", descBudget));
-                lines.addAll(kv("← / →", "scroll visible columns", descBudget));
-                lines.addAll(kv("g / G", "jump to first / last row of file", descBudget));
-                lines.add(Line.empty());
-                lines.add(Line.from(new Span("Version: " + Version.getVersion(), Theme.dim())));
-                lines.add(Line.from(new Span("Press ? or Esc to close", Theme.dim())));
-
 
         Block block = Block.builder()
                 .title(" hardwood dive — help ")
@@ -84,15 +85,15 @@ public final class HelpOverlay {
 
     private static List<Line> kv(String key, String description, int descBudget) {
         List<Line> result = new ArrayList<>();
-        List<String> wrappedDescription = wrapValue(description, Math.max(1, descBudget - 1));
+        List<String> wrappedDescription = Strings.wordWrap(description, descBudget);
 
         result.add(Line.from(
                 Span.raw("  "),
-                new Span(padRight(key, 18), Theme.primary()),
+                new Span(Strings.padRight(key, 18), Theme.primary()),
                 new Span(wrappedDescription.isEmpty() ? "" : wrappedDescription.get(0), Style.EMPTY)
         ));
 
-        for (int i = 1; i < wrappedDescription.size(); i++){
+        for (int i = 1; i < wrappedDescription.size(); i++) {
             result.add(Line.from(
                     Span.raw(" ".repeat(20)),
                     new Span(wrappedDescription.get(i), Style.EMPTY)
@@ -100,56 +101,5 @@ public final class HelpOverlay {
         }
 
         return result;
-    }
-
-    private static String padRight(String s, int width) {
-        return Strings.padRight(s, width);
-    }
-
-    private static List<String> wrapValue(String value, int width) {
-        List<String> out = new ArrayList<>();
-        if (width <= 0) {
-            out.add(value);
-            return out;
-        }
-        for (String line : value.split("\n", -1)) {
-            if (line.isEmpty()) {
-                out.add("");
-                continue;
-            }
-
-            String[] words = line.split(" ", -1);
-            StringBuilder currentLine = new StringBuilder();
-
-            for (String word : words) {
-                // If a single word is strictly longer than the whole width,
-                // we are forced to character-wrap it so it doesn't break the UI boundary.
-                while (word.length() > width) {
-                    if (!currentLine.isEmpty()) {
-                        out.add(currentLine.toString());
-                        currentLine.setLength(0);
-                    }
-                    out.add(word.substring(0, width));
-                    word = word.substring(width);
-                }
-
-                if (currentLine.isEmpty()) {
-                    currentLine.append(word);
-                } else if (currentLine.length() + 1 + word.length() <= width) {
-                    currentLine.append(" ").append(word);
-                } else {
-                    out.add(currentLine.toString());
-                    currentLine.setLength(0);
-                    currentLine.append(word);
-                }
-
-            }
-
-            if (!currentLine.isEmpty()) {
-                out.add(currentLine.toString());
-            }
-
-        }
-        return out;
     }
 }

--- a/cli/src/main/java/dev/hardwood/cli/dive/internal/HelpOverlay.java
+++ b/cli/src/main/java/dev/hardwood/cli/dive/internal/HelpOverlay.java
@@ -7,6 +7,7 @@
  */
 package dev.hardwood.cli.dive.internal;
 
+import java.util.ArrayList;
 import java.util.List;
 
 import dev.hardwood.cli.internal.Version;
@@ -30,7 +31,7 @@ public final class HelpOverlay {
 
     public static void render(Buffer buffer, Rect screenArea) {
         int width = Math.min(60, screenArea.width() - 4);
-        int height = Math.min(31, screenArea.height() - 2);
+        int height = Math.min(33, screenArea.height() - 2);
         int x = screenArea.left() + (screenArea.width() - width) / 2;
         int y = screenArea.top() + (screenArea.height() - height) / 2;
         Rect area = new Rect(x, y, width, height);
@@ -40,7 +41,7 @@ public final class HelpOverlay {
 
         int descBudget = Math.max(1, (width - 2) - 20);
 
-        List<Line> lines = new java.util.ArrayList<>();
+        List<Line> lines = new ArrayList<>();
 
                 lines.add(Line.from(new Span("Navigation", Theme.accent().bold())));
                 lines.addAll(kv("↑ / ↓", "move selection", descBudget));
@@ -82,8 +83,8 @@ public final class HelpOverlay {
     }
 
     private static List<Line> kv(String key, String description, int descBudget) {
-        List<Line> result = new java.util.ArrayList<>();
-        List<String> wrappedDescription = wrapValue(description, descBudget);
+        List<Line> result = new ArrayList<>();
+        List<String> wrappedDescription = wrapValue(description, Math.max(1, descBudget - 1));
 
         result.add(Line.from(
                 Span.raw("  "),
@@ -106,7 +107,7 @@ public final class HelpOverlay {
     }
 
     private static List<String> wrapValue(String value, int width) {
-        List<String> out = new java.util.ArrayList<>();
+        List<String> out = new ArrayList<>();
         if (width <= 0) {
             out.add(value);
             return out;
@@ -116,12 +117,38 @@ public final class HelpOverlay {
                 out.add("");
                 continue;
             }
-            int i = 0;
-            while (i < line.length()) {
-                int end = Math.min(line.length(), i + width);
-                out.add(line.substring(i, end));
-                i = end;
+
+            String[] words = line.split(" ", -1);
+            StringBuilder currentLine = new StringBuilder();
+
+            for (String word : words) {
+                // If a single word is strictly longer than the whole width,
+                // we are forced to character-wrap it so it doesn't break the UI boundary.
+                while (word.length() > width) {
+                    if (!currentLine.isEmpty()) {
+                        out.add(currentLine.toString());
+                        currentLine.setLength(0);
+                    }
+                    out.add(word.substring(0, width));
+                    word = word.substring(width);
+                }
+
+                if (currentLine.isEmpty()) {
+                    currentLine.append(word);
+                } else if (currentLine.length() + 1 + word.length() <= width) {
+                    currentLine.append(" ").append(word);
+                } else {
+                    out.add(currentLine.toString());
+                    currentLine.setLength(0);
+                    currentLine.append(word);
+                }
+
             }
+
+            if (!currentLine.isEmpty()) {
+                out.add(currentLine.toString());
+            }
+
         }
         return out;
     }

--- a/cli/src/main/java/dev/hardwood/cli/dive/internal/Strings.java
+++ b/cli/src/main/java/dev/hardwood/cli/dive/internal/Strings.java
@@ -7,6 +7,9 @@
  */
 package dev.hardwood.cli.dive.internal;
 
+import java.util.ArrayList;
+import java.util.List;
+
 /// Small string helpers shared by `dive` screens. Kept here so the
 /// truncation/padding behavior — including the ellipsis character — stays
 /// consistent across every screen that draws columnar content.
@@ -36,5 +39,71 @@ public final class Strings {
             return s;
         }
         return ELLIPSIS + s.substring(s.length() - maxWidth + 1);
+    }
+
+    /// Word-wraps `value` so each returned line fits within `width` cells.
+    /// Hard line breaks in the source are preserved. Words longer than `width`
+    /// are character-chunked so they don't overflow the boundary.
+    public static List<String> wordWrap(String value, int width) {
+        List<String> out = new ArrayList<>();
+        if (width <= 0) {
+            out.add(value);
+            return out;
+        }
+        for (String line : value.split("\n", -1)) {
+            if (line.isEmpty()) {
+                out.add("");
+                continue;
+            }
+            String[] words = line.split(" ", -1);
+            StringBuilder currentLine = new StringBuilder();
+            for (String word : words) {
+                while (word.length() > width) {
+                    if (!currentLine.isEmpty()) {
+                        out.add(currentLine.toString());
+                        currentLine.setLength(0);
+                    }
+                    out.add(word.substring(0, width));
+                    word = word.substring(width);
+                }
+                if (currentLine.isEmpty()) {
+                    currentLine.append(word);
+                } else if (currentLine.length() + 1 + word.length() <= width) {
+                    currentLine.append(" ").append(word);
+                } else {
+                    out.add(currentLine.toString());
+                    currentLine.setLength(0);
+                    currentLine.append(word);
+                }
+            }
+            if (!currentLine.isEmpty()) {
+                out.add(currentLine.toString());
+            }
+        }
+        return out;
+    }
+
+    /// Splits `value` into display lines of at most `width` cells without
+    /// respecting word boundaries. Hard line breaks in the source are
+    /// preserved; each segment is then chunked at `width` if it's longer.
+    public static List<String> hardWrap(String value, int width) {
+        List<String> out = new ArrayList<>();
+        if (width <= 0) {
+            out.add(value);
+            return out;
+        }
+        for (String line : value.split("\n", -1)) {
+            if (line.isEmpty()) {
+                out.add("");
+                continue;
+            }
+            int i = 0;
+            while (i < line.length()) {
+                int end = Math.min(line.length(), i + width);
+                out.add(line.substring(i, end));
+                i = end;
+            }
+        }
+        return out;
     }
 }

--- a/cli/src/test/java/dev/hardwood/cli/dive/DiveRenderTest.java
+++ b/cli/src/test/java/dev/hardwood/cli/dive/DiveRenderTest.java
@@ -19,7 +19,9 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
 
 import dev.hardwood.InputFile;
+import dev.hardwood.cli.dive.internal.HelpOverlay;
 import dev.hardwood.cli.dive.internal.Keys;
+import dev.tamboui.buffer.Buffer;
 import dev.tamboui.layout.Rect;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -214,9 +216,9 @@ class DiveRenderTest {
         // At 80 width, the description budget is 38 chars.
         // The longest description is 52 chars, so it should be forced to wrap.
         Rect screenArea = new Rect(0, 0, 80, 40);
-        dev.tamboui.buffer.Buffer buffer = dev.tamboui.buffer.Buffer.empty(screenArea);
+        Buffer buffer = Buffer.empty(screenArea);
 
-        dev.hardwood.cli.dive.internal.HelpOverlay.render(buffer, screenArea);
+        HelpOverlay.render(buffer, screenArea);
 
         StringBuilder sb = new StringBuilder();
         for (int y = 0; y < screenArea.height(); y++) {
@@ -228,8 +230,8 @@ class DiveRenderTest {
         }
         String screenText = sb.toString();
 
-        assertThat(screenText).contains("enter filter mode (Schema, Column inde");
-        assertThat(screenText).contains("                    x, Dictionary)");
+        assertThat(screenText).contains("enter filter mode (Schema, Column ");
+        assertThat(screenText).contains("               index, Dictionary) ");
     }
 
     static Stream<org.junit.jupiter.params.provider.Arguments> smokeMatrix() {

--- a/cli/src/test/java/dev/hardwood/cli/dive/DiveRenderTest.java
+++ b/cli/src/test/java/dev/hardwood/cli/dive/DiveRenderTest.java
@@ -220,6 +220,28 @@ class DiveRenderTest {
 
         HelpOverlay.render(buffer, screenArea);
 
+        assertThat(renderToString(buffer, screenArea))
+                .contains("enter filter mode (Schema, Column ")
+                .contains("               index, Dictionary) ");
+    }
+
+    @Test
+    void helpOverlayFitsAllKeybindingsAtNarrowWidth() {
+        // At 50×40 the overlay width drops to 46 (descBudget 24), so many more
+        // descriptions wrap onto a second line. The overlay's height must grow
+        // with the content; otherwise the bottom keybindings get clipped — the
+        // same failure mode that motivated #386, just at a different breakpoint.
+        Rect screenArea = new Rect(0, 0, 50, 40);
+        Buffer buffer = Buffer.empty(screenArea);
+
+        HelpOverlay.render(buffer, screenArea);
+
+        // The "Press ? or Esc to close" sentinel is the very last line of the
+        // overlay; if it renders, no content above it can have been clipped.
+        assertThat(renderToString(buffer, screenArea)).contains("Press ? or Esc to close");
+    }
+
+    private static String renderToString(Buffer buffer, Rect screenArea) {
         StringBuilder sb = new StringBuilder();
         for (int y = 0; y < screenArea.height(); y++) {
             for (int x = 0; x < screenArea.width(); x++) {
@@ -228,10 +250,7 @@ class DiveRenderTest {
             }
             sb.append("\n");
         }
-        String screenText = sb.toString();
-
-        assertThat(screenText).contains("enter filter mode (Schema, Column ");
-        assertThat(screenText).contains("               index, Dictionary) ");
+        return sb.toString();
     }
 
     static Stream<org.junit.jupiter.params.provider.Arguments> smokeMatrix() {

--- a/cli/src/test/java/dev/hardwood/cli/dive/DiveRenderTest.java
+++ b/cli/src/test/java/dev/hardwood/cli/dive/DiveRenderTest.java
@@ -209,6 +209,29 @@ class DiveRenderTest {
         }
     }
 
+    @Test
+    void helpOverlayWrapsLongDescriptions() {
+        // At 80 width, the description budget is 38 chars.
+        // The longest description is 52 chars, so it should be forced to wrap.
+        Rect screenArea = new Rect(0, 0, 80, 40);
+        dev.tamboui.buffer.Buffer buffer = dev.tamboui.buffer.Buffer.empty(screenArea);
+
+        dev.hardwood.cli.dive.internal.HelpOverlay.render(buffer, screenArea);
+
+        StringBuilder sb = new StringBuilder();
+        for (int y = 0; y < screenArea.height(); y++) {
+            for (int x = 0; x < screenArea.width(); x++) {
+                String sym = buffer.get(x, y).symbol();
+                sb.append(sym == null || sym.isEmpty() ? ' ' : sym);
+            }
+            sb.append("\n");
+        }
+        String screenText = sb.toString();
+
+        assertThat(screenText).contains("enter filter mode (Schema, Column inde");
+        assertThat(screenText).contains("                    x, Dictionary)");
+    }
+
     static Stream<org.junit.jupiter.params.provider.Arguments> smokeMatrix() {
         // Pick a handful of fixtures that span the file-shape space:
         // CI present / absent, dict present / absent, nested, variant.


### PR DESCRIPTION
#386 Fix help text cutoff in dive by implementing word wrapping

<img width="734" height="637" alt="image" src="https://github.com/user-attachments/assets/13535aa5-046e-43e6-ad75-6f3bbd95f7ee" />

<img width="624" height="684" alt="image" src="https://github.com/user-attachments/assets/2beffaad-12b4-4f47-9a59-b81330d9edf7" />

---
## Checklist

- [x] Build via `./mvnw clean verify` passes
- [x] The commit message is prefixed with the issue key ("#123 Adding support for...")
- [x] Code changes are covered by tests
- [ ] If this PR adds or changes user-facing behaviour, `docs/` has been updated
