### PR TITLE
#429 Documentation review pass

### DIFF
--- a/docs/content/avro.md
+++ b/docs/content/avro.md
@@ -75,3 +75,11 @@ AvroRowReader reader = AvroReaders.buildRowReader(fileReader)
 ```
 
 Values are stored in Avro's standard representations: timestamps as `Long` (millis/micros since epoch), dates as `Integer` (days since epoch), decimals as `ByteBuffer`, binary data as `ByteBuffer`. This matches the behavior of parquet-java's `AvroReadSupport`.
+
+## Lifecycle
+
+`AvroRowReader` does **not** take ownership of the `ParquetFileReader` it wraps — closing the `AvroRowReader` releases the inner readers and column workers, but the underlying `ParquetFileReader` must be closed separately by the caller. The two-`try`-with-resources pattern in the examples above reflects this.
+
+## Schema overrides
+
+Hardwood derives the Avro schema directly from the Parquet schema via `AvroSchemaConverter`. There is no equivalent of parquet-java's `AvroReadSupport.setRequestedProjection(...)` or `setAvroReadSchema(...)` — supplying an explicit Avro reader schema (for schema-evolution promotions, renames, or alias resolution) is not supported. Column projection (`ColumnProjection.columns(...)`) is the only way to narrow what is read; the Avro schema returned by `getSchema()` always matches the projected Parquet schema's converted form.

--- a/docs/content/cli.md
+++ b/docs/content/cli.md
@@ -62,7 +62,7 @@ hardwood convert --format csv -f data.parquet
 # Show dictionary entries for a column (first 50 entries per row group by default)
 hardwood inspect dictionary -f data.parquet -c category
 
-# Show all dictionary entries for a column
+# Show all dictionary entries for a column (--limit 0 means unlimited)
 hardwood inspect dictionary -f data.parquet -c category --limit 0
 
 # Convert first 100 rows to JSON
@@ -201,7 +201,9 @@ hardwood schema -f s3://my-bucket/data.parquet
 hardwood print -n 10 -f s3://my-bucket/data.parquet
 ```
 
-The CLI resolves credentials via the standard AWS credential chain (environment variables, `~/.aws/credentials`, SSO, instance profiles, etc.).
+The CLI resolves credentials via the standard AWS credential chain (`AWS_ACCESS_KEY_ID` / `AWS_SECRET_ACCESS_KEY` / `AWS_SESSION_TOKEN` environment variables, `~/.aws/credentials`, SSO, EC2/ECS instance profiles, web identity). See the [S3 module page](s3.md) for the resolution order and provider details.
+
+The CLI additionally reads these environment variables:
 
 | Environment Variable | Description |
 |----------------------|-------------|

--- a/docs/content/compat.md
+++ b/docs/content/compat.md
@@ -13,6 +13,9 @@
 
 If you have existing code that uses Apache parquet-java's `ParquetReader<Group>` API and want to switch to Hardwood without rewriting it, the `hardwood-parquet-java-compat` module provides a drop-in replacement. It implements the same `org.apache.parquet.*` interfaces backed by Hardwood's reader, so you get Hardwood's performance with minimal code changes.
 
+!!! warning "Mutually exclusive with parquet-java"
+    This module provides its own type shims in the `org.apache.parquet.*` namespace. It **cannot** be used alongside `parquet-java` on the same classpath — pick one or the other.
+
 **Features:**
 
 - Provides `org.apache.parquet.*` namespace classes compatible with parquet-java
@@ -82,6 +85,3 @@ try (ParquetReader<Group> reader = ParquetReader.builder(new GroupReadSupport(),
     // only rows from matching row groups are returned
 }
 ```
-
-!!! warning
-    This module provides its own type shims in the `org.apache.parquet.*` namespace. It cannot be used alongside parquet-java on the same classpath.

--- a/docs/content/configuration.md
+++ b/docs/content/configuration.md
@@ -15,13 +15,15 @@
 
 Hardwood can use [libdeflate](https://github.com/ebiggers/libdeflate) for GZIP decompression, which is significantly faster than the built-in Java implementation. This feature requires **Java 22 or newer** (it uses the Foreign Function & Memory API which became stable in Java 22).
 
-Allow native access in order to use libdeflate:
+Enabling libdeflate is two steps: a JVM flag to allow native access, plus the native library installed on the system.
+
+**1. JVM flag** (allow Hardwood to bind native functions):
 
 ```bash
 --enable-native-access=ALL-UNNAMED
 ```
 
-libdeflate is a native library that must be installed on your system:
+**2. Native library** — install on your system:
 
 === "macOS"
 

--- a/docs/content/getting-started.md
+++ b/docs/content/getting-started.md
@@ -46,13 +46,15 @@ dependencies {
 }
 ```
 
-Then declare dependencies without versions:
+Then declare dependencies inside your project's `<dependencies>` block without specifying a version:
 
 ```xml
-<dependency>
-    <groupId>dev.hardwood</groupId>
-    <artifactId>hardwood-core</artifactId>
-</dependency>
+<dependencies>
+    <dependency>
+        <groupId>dev.hardwood</groupId>
+        <artifactId>hardwood-core</artifactId>
+    </dependency>
+</dependencies>
 ```
 
 ### Specifying the Version Directly
@@ -84,7 +86,7 @@ Bindings are available for all popular logger implementations, for instance for 
 
 ### Compression Libraries
 
-Hardwood supports reading Parquet files compressed with GZIP (built into Java), Snappy, ZSTD, LZ4, and Brotli. The compression libraries are optional dependencies—add only the ones you need:
+Hardwood supports reading Parquet files compressed with GZIP (built into Java), Snappy, ZSTD, LZ4, and Brotli. The compression libraries are optional dependencies—add only the ones you need. Snappy and ZSTD are the codecs most commonly seen in the wild; LZ4 and Brotli are rarer.
 
 | Codec | Group ID | Artifact ID |
 |-------|----------|-------------|

--- a/docs/content/index.md
+++ b/docs/content/index.md
@@ -11,15 +11,20 @@
 -->
 # Hardwood
 
-_A parser for the Apache Parquet file format, optimized for minimal dependencies and great performance.
+_A lightweight Java reader for the [Apache Parquet](https://parquet.apache.org/) file format.
 Available as a Java library and a [command-line tool](cli.md)._
 
-Goals of the project are:
+## Why Hardwood
 
-* **Light-weight:** Implement the Parquet file format avoiding any 3rd party dependencies other than for compression algorithms (e.g. Snappy)
-* **Correct:** Support all Parquet files which are supported by the canonical [parquet-java](https://github.com/apache/parquet-java) library
-* **Fast:** Be as fast or faster as parquet-java
-* **Complete:** Add a Parquet file writer (after 1.0)
+Hardwood is built for applications that want Parquet read support without pulling in Hadoop, Avro, or the wider [parquet-java](https://github.com/apache/parquet-java) dependency tree. Use it when you need any of: a small runtime (zero transitive dependencies in the core), fast startup (suitable for native CLIs and short-lived processes), multi-threaded decode out of the box (pages decoded in parallel across a shared thread pool), direct S3 access (without `hadoop-aws`), or drop-in replacement of `parquet-java`'s `ParquetReader<Group>` API via the [compat module](compat.md).
+
+## Goals
+
+* **Light-weight** — implement the Parquet format with zero transitive dependencies beyond optional compression libraries (Snappy, ZSTD, LZ4, Brotli).
+* **Compatible** — read every file that `parquet-java` reads, with documented divergences where Hardwood applies stricter semantics (e.g. SQL three-valued `notEq`).
+* **Fast** — match or exceed `parquet-java`'s read throughput; remain competitive in native-image builds and short-lived JVMs.
+* **Concurrent** — multi-threaded at the core: pages decode in parallel on a shared thread pool, with cross-file prefetching for multi-file reads.
+* **Embeddable** — usable from native CLIs, S3-only pipelines, and Avro / Spark consumers via thin shim modules.
 
 ## Quick Example
 
@@ -46,24 +51,38 @@ See [Getting Started](getting-started.md) for installation and setup.
 
 ## Status
 
-This is Alpha quality software, under active development.
+This is Beta quality software, under active development.
 
-Currently, individual Parquet files must be **at most 2 GB**.
-Larger datasets should be split across multiple files and read by passing a list of `InputFile`s to `Hardwood.openAll(...)` or `ParquetFileReader.openAll(...)`.
+!!! warning "2 GB single-file limit"
+    Individual Parquet files must currently be at most **2 GB**. Larger datasets should be split across multiple files and read by passing a list of `InputFile`s to `Hardwood.openAll(...)` or `ParquetFileReader.openAll(...)`. Tracked as [#75](https://github.com/hardwood-hq/hardwood/issues/75).
+
+## Roadmap
+
+Forward-looking items tracked for post-1.0. None are committed to a specific release.
+
+- **Writer support** — write Parquet files in addition to reading; today Hardwood is reader-only. ([#9](https://github.com/hardwood-hq/hardwood/issues/9))
+- **Bloom filter predicate pushdown** — use per-chunk bloom filters for equality-predicate skipping on high-cardinality columns, where min/max statistics can't help. ([#105](https://github.com/hardwood-hq/hardwood/issues/105))
+- **Parquet Modular Encryption** — read files encrypted under the Parquet [Modular Encryption spec](https://github.com/apache/parquet-format/blob/master/Encryption.md): encrypted footer, per-column keys, AES-GCM and AES-GCM-CTR. ([#128](https://github.com/hardwood-hq/hardwood/issues/128))
+- **Apache Arrow interop** — `ColumnReader` output as Arrow `FieldVector` / `VectorSchemaRoot` for zero-copy handoff to DuckDB, DataFusion, Pandas-via-JNI, and other Arrow-native consumers. ([#153](https://github.com/hardwood-hq/hardwood/issues/153))
+
+## Getting help
+
+- **Questions, ideas, design discussion** — [GitHub Discussions](https://github.com/hardwood-hq/hardwood/discussions). The best first stop for "how do I…", "is X possible…", or "what's the right way to…".
+- **Bug reports and feature requests** — the [GitHub issue tracker](https://github.com/hardwood-hq/hardwood/issues). Please check whether a similar issue already exists.
 
 ## Package Structure
 
-Hardwood is organized into public API packages and internal implementation packages:
+Hardwood is organized into public API packages and internal implementation packages. Application code should import only from the public packages; `dev.hardwood.internal.*` and its subpackages are implementation details and may change without notice.
 
 | Package | Visibility | Purpose |
 |---------|-----------|---------|
-| `dev.hardwood` | **Public API** | Entry point for creating readers and managing shared resources (thread pool, decompressor pool). |
-| `dev.hardwood.reader` | **Public API** | Single-file and multi-file readers for row-oriented and column-oriented access. |
-| `dev.hardwood.metadata` | **Public API** | Parquet file metadata: row groups, column chunks, physical/logical types, and compression codecs. |
-| `dev.hardwood.schema` | **Public API** | Schema representation: file schema, column schemas, and column projection. |
-| `dev.hardwood.row` | **Public API** | Value types for nested data access: structs, lists, and maps. |
-| `dev.hardwood.avro` | **Public API** | Avro GenericRecord support: schema conversion and row materialization (`hardwood-avro` module). |
-| `dev.hardwood.s3` | **Public API** | S3 object storage support: `S3Source`, `S3InputFile`, `S3Credentials`, `S3CredentialsProvider` (`hardwood-s3` module, zero external dependencies). |
-| `dev.hardwood.aws.auth` | **Public API** | Bridges the AWS SDK credential chain to Hardwood's `S3CredentialsProvider` (`hardwood-aws-auth` module, optional). |
-| `dev.hardwood.jfr` | **Public API** | JFR event types emitted during file reading, decoding, and pipeline operations. |
+| [`dev.hardwood`](/api/latest/dev/hardwood/package-summary.html) | **Public API** | Entry point for creating readers and managing shared resources (thread pool, decompressor pool). |
+| [`dev.hardwood.reader`](/api/latest/dev/hardwood/reader/package-summary.html) | **Public API** | Single-file and multi-file readers for row-oriented and column-oriented access. |
+| [`dev.hardwood.metadata`](/api/latest/dev/hardwood/metadata/package-summary.html) | **Public API** | Parquet file metadata: row groups, column chunks, physical/logical types, and compression codecs. |
+| [`dev.hardwood.schema`](/api/latest/dev/hardwood/schema/package-summary.html) | **Public API** | Schema representation: file schema, column schemas, and column projection. |
+| [`dev.hardwood.row`](/api/latest/dev/hardwood/row/package-summary.html) | **Public API** | Value types for nested data access: structs, lists, and maps. |
+| [`dev.hardwood.avro`](/api/latest/dev/hardwood/avro/package-summary.html) | **Public API** | Avro GenericRecord support: schema conversion and row materialization (`hardwood-avro` module). |
+| [`dev.hardwood.s3`](/api/latest/dev/hardwood/s3/package-summary.html) | **Public API** | S3 object storage support: `S3Source`, `S3InputFile`, `S3Credentials`, `S3CredentialsProvider` (`hardwood-s3` module, zero external dependencies). |
+| [`dev.hardwood.aws.auth`](/api/latest/dev/hardwood/aws/auth/package-summary.html) | **Public API** | Bridges the AWS SDK credential chain to Hardwood's `S3CredentialsProvider` (`hardwood-aws-auth` module, optional). |
+| [`dev.hardwood.jfr`](/api/latest/dev/hardwood/jfr/package-summary.html) | **Public API** | JFR event types emitted during file reading, decoding, and pipeline operations. |
 | `dev.hardwood.internal.*` | **Internal** | Implementation details — not part of the public API and may change without notice. |

--- a/docs/content/s3.md
+++ b/docs/content/s3.md
@@ -159,6 +159,8 @@ S3Source source = S3Source.builder()
 
 Set `maxRetries(0)` to disable retries entirely.
 
+When the retry budget is exhausted, the last failure is re-thrown as an `IOException` to the caller. For HTTP errors the message has the form `GET s3://<bucket>/<key> failed: HTTP <status>`; for network errors the original `IOException` message is preserved.
+
 ### Custom HttpClient
 
 For full control over connection pooling, proxy settings, or other transport configuration, pass a pre-configured `HttpClient`:
@@ -175,7 +177,8 @@ S3Source source = S3Source.builder()
         .build();
 ```
 
-When a custom `HttpClient` is provided, the caller is responsible for closing it — `S3Source.close()` will not close the client. The `connectTimeout` builder option is ignored when a custom client is supplied.
+!!! warning "Caller-supplied `HttpClient` lifecycle"
+    When a custom `HttpClient` is provided, the caller is responsible for closing it — `S3Source.close()` will not close the client. The `connectTimeout` builder option is also ignored when a custom client is supplied.
 
 Column projection, row group filtering, and all other reader features work transparently with S3 files.
 
@@ -184,3 +187,8 @@ Column projection, row group filtering, and all other reader features work trans
 When reading from S3, Hardwood coalesces column chunk reads within each row group into as few HTTP requests as possible (typically 1-2 per row group). Column projection, page-level predicate pushdown, and `maxRows` all narrow the byte ranges before coalescing, reducing the amount of data transferred.
 
 Note that without a `maxRows` limit, the reader fetches all projected (and filtered) column data for an entire row group when any column enters it. For large row groups (128 MB–1 GB is typical), this can transfer significant data even if the consumer stops reading early. To minimize data transfer for partial reads, set `maxRows` on the reader — this truncates each column's fetch to only the pages covering the needed rows.
+
+### Not currently supported
+
+- **Anonymous (unsigned) requests** — `S3Credentials` requires an access key + secret key pair; there is no built-in mode for public buckets without credentials.
+- **Requester-pays buckets** — Hardwood does not send the `x-amz-request-payer` header. Reads against requester-pays buckets will fail with `403 AccessDenied` even with valid credentials.

--- a/docs/content/usage.md
+++ b/docs/content/usage.md
@@ -11,7 +11,7 @@
 -->
 # Usage
 
-This page describes how to read Parquet files with Hardwood: choosing a reader, projecting columns, pushing predicates and row limits down to the file, reading columns in batches, working with Variant and geospatial columns, reading multiple files as one dataset, and accessing file metadata.
+This page describes how to read Parquet files with Hardwood: choosing a reader, row-oriented reading, predicate pushdown, column projection, row limits, split-aware reading, column-oriented (batch) reading, reading multiple files as one dataset, accessing file metadata, and working with Variant and geospatial columns.
 
 For detailed class-level documentation, see the [JavaDoc](/api/latest/).
 
@@ -179,54 +179,17 @@ All accessor methods are available in two forms:
 
 All methods are available as both `method(name)` and `method(index)`, except `getStruct`, `getList`, `getMap`, and `getVariant` which are name-based only.
 
-**INTERVAL columns:** `PqInterval` is a plain record with three `long` properties — `months()`, `days()`, and `milliseconds()`. Each holds an unsigned 32-bit value in the range `[0, 4_294_967_295]`, so no additional conversion is needed. The components are independent and not normalized. Files written by older parquet-mr / Spark / Hive writers that set only the legacy `converted_type=INTERVAL` annotation are handled transparently — no caller-side opt-in is required.
+#### Null handling
 
-**FLOAT16 columns:** `getFloat` accepts FLOAT16 columns (`FIXED_LEN_BYTE_ARRAY(2)` annotated with the `FLOAT16` logical type) and decodes the 2-byte IEEE 754 half-precision payload to a single-precision `float`. The widening is lossless — half-precision NaN, ±Infinity, and signed zero round-trip cleanly, and the original NaN bit pattern is preserved (the Parquet spec does not canonicalize NaNs on write). Use `Float.isNaN(value)` for NaN checks rather than equality. As with all primitive accessors, `isNull()` must be checked before `getFloat()` since FLOAT16 columns can be optional.
+Primitive accessors (`getInt`, `getLong`, `getFloat`, `getDouble`, `getBoolean`) throw `NullPointerException` if the field is null — always check with `isNull()` first. Object accessors (`getString`, `getDate`, `getTimestamp`, `getDecimal`, `getUuid`, `getInterval`, `getStruct`, `getList`, `getMap`) return `null` for null fields.
 
-**Bare `BYTE_ARRAY` columns:** `BYTE_ARRAY` columns without a `STRING` logical type annotation may hold arbitrary binary payloads (Protobuf, WKB, custom encodings). Generic accessors such as `PqList.get` and `PqList.iterator` surface these as `byte[]` rather than silently UTF-8 decoding them — invalid byte sequences would otherwise be replaced with `U+FFFD`. Call `getString` explicitly when the column is known to contain UTF-8 text from an older writer that omitted the `STRING` annotation.
+#### Type validation
 
-**Typed accessors on `PqList` and `PqMap.Entry`:** Both interfaces mirror the
-RowReader's typed accessor surface — `strings()` / `dates()` / `times()` /
-`timestamps()` / `decimals()` / `uuids()` / `intervals()` / `floats()` /
-`booleans()` on `PqList` (each returning `List<T>`); the matching
-`getStringValue()` / `getDateValue()` / `getIntervalValue()` / etc. on
-`PqMap.Entry`. Use these in preference to the generic `getValue()` when
-iterating over a list / map of a known logical type to avoid the boxed
-`Object` return.
+The API validates at runtime that the requested type matches the schema. Mismatches throw `IllegalArgumentException` with a descriptive message.
 
-`PqMap.Entry`'s typed *key* accessor surface is intentionally narrower:
-`getStringKey()` / `getIntKey()` / `getLongKey()` / `getBinaryKey()` cover
-the four high-frequency map key types. Long-tail key types (DATE / TIME /
-TIMESTAMP / DECIMAL / UUID) fall through to `getKey()` (decoded) and
-`getRawKey()` (raw).
+#### Index-based access
 
-`PqList.ints()` / `longs()` / `doubles()` return the specialized
-`PqIntList` / `PqLongList` / `PqDoubleList` types instead — these expose
-`PrimitiveIterator.OfInt` / `OfLong` / `OfDouble`, `int get(int)`, and
-`int[] toArray()` so primitive list iteration allocates no boxed wrappers.
-For nested `list<list<int>>` (or `<long>` / `<double>`), use
-`intLists()` / `longLists()` / `doubleLists()` to surface the inner lists as
-`PqIntList` / `PqLongList` / `PqDoubleList`.
-
-**Decoded vs. raw generic access:** The generic fallback accessors return values decoded to their logical-type representation by default:
-
-- `RowReader.getValue(name)` / `getValue(index)` — `Integer` / `Long` / `String` / `LocalDate` / `LocalTime` / `Instant` / `BigDecimal` / `UUID` / `PqInterval` / `PqVariant` / nested `PqStruct` / `PqList` / `PqMap`, with `byte[]` for un-annotated `BYTE_ARRAY` / `FIXED_LEN_BYTE_ARRAY` columns.
-- `PqStruct.getValue(name)` — same decoded mapping for nested struct fields.
-- `PqMap.Entry.getKey()` / `getValue()` — same decoded mapping for map keys and values.
-- `PqList.get(index)` / `PqList.values()` — same decoded mapping for list elements.
-
-To inspect the underlying physical storage instead — e.g. the raw `Long` micros backing a `TIMESTAMP`, or the unscaled `byte[]` backing a `DECIMAL` — call the parallel raw accessors:
-
-- `RowReader.getRawValue(name)` / `getRawValue(index)`
-- `PqStruct.getRawValue(name)`
-- `PqMap.Entry.getRawKey()` / `getRawValue()`
-- `PqList.getRaw(index)` / `PqList.rawValues()`
-
-Nested groups (struct / list / map / variant) have no distinct "raw" form and are returned through their typed flyweight (`PqStruct` / `PqList` / `PqMap` / `PqVariant`) in both modes.
-
-**Legacy INT96 timestamps:** Parquet files written by older versions of Apache Spark and Hive store timestamps in the deprecated INT96 physical type without a TIMESTAMP logical type annotation. `getTimestamp` detects INT96 automatically and decodes it to an `Instant`; no caller-side handling is required.
-
-**Index-based access example:**
+For hot loops, look up column indices once outside the loop and pass them to the accessors instead of names:
 
 ```java
 // Get column indices once (before the loop)
@@ -242,13 +205,68 @@ while (rowReader.hasNext()) {
 }
 ```
 
-**Null handling:** Primitive accessors (`getInt`, `getLong`, `getFloat`, `getDouble`, `getBoolean`) throw `NullPointerException` if the field is null — always check with `isNull()` first. Object accessors (`getString`, `getDate`, `getTimestamp`, `getDecimal`, `getUuid`, `getInterval`, `getStruct`, `getList`, `getMap`) return `null` for null fields.
+#### INTERVAL columns
 
-**Type validation:** The API validates at runtime that the requested type matches the schema. Mismatches throw `IllegalArgumentException` with a descriptive message.
+`PqInterval` is a plain record with three `long` properties — `months()`, `days()`, and `milliseconds()`. Each holds an unsigned 32-bit value in the range `[0, 4_294_967_295]`, so no additional conversion is needed. The components are independent and not normalized. Files written by older parquet-mr / Spark / Hive writers that set only the legacy `converted_type=INTERVAL` annotation are handled transparently — no caller-side opt-in is required.
+
+#### FLOAT16 columns
+
+`getFloat` accepts FLOAT16 columns (`FIXED_LEN_BYTE_ARRAY(2)` annotated with the `FLOAT16` logical type) and decodes the 2-byte IEEE 754 half-precision payload to a single-precision `float`. The widening is lossless — half-precision NaN, ±Infinity, and signed zero round-trip cleanly, and the original NaN bit pattern is preserved (the Parquet spec does not canonicalize NaNs on write). Use `Float.isNaN(value)` for NaN checks rather than equality. As with all primitive accessors, `isNull()` must be checked before `getFloat()` since FLOAT16 columns can be optional.
+
+#### Legacy INT96 timestamps
+
+Parquet files written by older versions of Apache Spark and Hive store timestamps in the deprecated INT96 physical type without a TIMESTAMP logical type annotation. `getTimestamp` detects INT96 automatically and decodes it to an `Instant`; no caller-side handling is required.
+
+#### Bare `BYTE_ARRAY` columns
+
+`BYTE_ARRAY` columns without a `STRING` logical type annotation may hold arbitrary binary payloads (Protobuf, WKB, custom encodings). Generic accessors such as `PqList.get` and `PqList.iterator` surface these as `byte[]` rather than silently UTF-8 decoding them — invalid byte sequences would otherwise be replaced with `U+FFFD`. Call `getString` explicitly when the column is known to contain UTF-8 text from an older writer that omitted the `STRING` annotation.
+
+#### Typed accessors on `PqList` and `PqMap.Entry`
+
+Both interfaces mirror the RowReader's typed accessor surface — `strings()` / `dates()` / `times()` / `timestamps()` / `decimals()` / `uuids()` / `intervals()` / `floats()` / `booleans()` on `PqList` (each returning `List<T>`); the matching `getStringValue()` / `getDateValue()` / `getIntervalValue()` / etc. on `PqMap.Entry`. Use these in preference to the generic `getValue()` when iterating over a list / map of a known logical type to avoid the boxed `Object` return.
+
+`PqMap.Entry`'s typed *key* accessor surface is intentionally narrower: `getStringKey()` / `getIntKey()` / `getLongKey()` / `getBinaryKey()` cover the four high-frequency map key types. Long-tail key types (DATE / TIME / TIMESTAMP / DECIMAL / UUID) fall through to `getKey()` (decoded) and `getRawKey()` (raw).
+
+`PqList.ints()` / `longs()` / `doubles()` return the specialized `PqIntList` / `PqLongList` / `PqDoubleList` types instead — these expose `PrimitiveIterator.OfInt` / `OfLong` / `OfDouble`, `int get(int)`, and `int[] toArray()` so primitive list iteration allocates no boxed wrappers. For nested `list<list<int>>` (or `<long>` / `<double>`), use `intLists()` / `longLists()` / `doubleLists()` to surface the inner lists as `PqIntList` / `PqLongList` / `PqDoubleList`.
+
+#### Reading the physical value
+
+When you want the raw physical value rather than the decoded logical-type representation — e.g. the INT64 micros backing a `TIMESTAMP`, the INT32 days backing a `DATE`, or the unscaled INT32 / INT64 / `byte[]` backing a `DECIMAL` — call the **typed primitive accessor that matches the column's physical type**:
+
+```java
+// TIMESTAMP column backed by INT64 micros
+long micros = rowReader.getLong("created_at");
+
+// DATE column backed by INT32 days since epoch
+int daysSinceEpoch = rowReader.getInt("birth_date");
+
+// DECIMAL(precision, scale) column backed by INT64
+long unscaled = rowReader.getLong("amount");
+```
+
+`getInt` / `getLong` / `getFloat` / `getDouble` / `getBoolean` / `getBinary` accept any column whose physical type matches, regardless of the logical-type annotation — they read the underlying value directly. Use this whenever you already know the column's physical encoding and want to skip logical-type decoding.
+
+#### Decoded generic access
+
+When the column type isn't known ahead of time — e.g. generic projection-driven readers, dump tools, schema-introspecting frameworks — the generic fallback accessors return values decoded to their logical-type representation:
+
+- `RowReader.getValue(name)` / `getValue(index)` — `Integer` / `Long` / `String` / `LocalDate` / `LocalTime` / `Instant` / `BigDecimal` / `UUID` / `PqInterval` / `PqVariant` / nested `PqStruct` / `PqList` / `PqMap`, with `byte[]` for un-annotated `BYTE_ARRAY` / `FIXED_LEN_BYTE_ARRAY` columns.
+- `PqStruct.getValue(name)` — same decoded mapping for nested struct fields.
+- `PqMap.Entry.getKey()` / `getValue()` — same decoded mapping for map keys and values.
+- `PqList.get(index)` / `PqList.values()` — same decoded mapping for list elements.
+
+A parallel `getRawValue` family (`RowReader.getRawValue`, `PqStruct.getRawValue`, `PqMap.Entry.getRawKey` / `getRawValue`, `PqList.getRaw` / `rawValues`) returns the boxed physical value when even the physical type isn't known statically. In hot loops, prefer the typed primitive accessor described above — it avoids the boxing and the dispatch overhead.
+
+Nested groups (struct / list / map / variant) have no distinct "raw" form and are returned through their typed flyweight (`PqStruct` / `PqList` / `PqMap` / `PqVariant`) in both modes.
 
 ## Predicate Pushdown (Filter)
 
-Filter predicates enable three levels of predicate pushdown. At the row-group level, entire row groups whose statistics prove no rows can match are skipped. Within surviving row groups, the Column Index (per-page min/max statistics) is used to skip individual pages, avoiding unnecessary decompression and decoding. On remote backends like S3, only the matching pages are fetched, reducing network I/O. Finally, record-level filtering evaluates the predicate against each decoded row, so `buildRowReader().filter(filter).build()` returns only rows that actually match.
+Filter predicates apply at four levels, in this order:
+
+1. **Row group** — entire row groups whose statistics prove no rows can match are skipped.
+2. **Page** — within surviving row groups, the Column Index (per-page min/max statistics) is used to skip individual pages, avoiding unnecessary decompression and decoding.
+3. **Network** — on remote backends like S3, only the matching pages are fetched, reducing network I/O.
+4. **Record** — `buildRowReader().filter(filter).build()` evaluates the predicate against each decoded row and returns only rows that actually match.
 
 For spatial filtering on GEOMETRY / GEOGRAPHY columns, see [Geospatial Support](#geospatial-support).
 
@@ -282,10 +300,16 @@ try (ParquetFileReader fileReader = ParquetFileReader.open(InputFile.of(path));
 }
 ```
 
-Supported operators: `eq`, `notEq`, `lt`, `ltEq`, `gt`, `gtEq`, `in`, `inStrings`, `isNull`, `isNotNull`.
-Supported physical types: `int`, `long`, `float`, `double`, `boolean`, `String` (comparison operators); `int`, `long`, `String` (`in`/`inStrings`); any type (`isNull`/`isNotNull`).
-Supported logical types: `LocalDate`, `Instant`, `LocalTime`, `BigDecimal`, `UUID` (comparison operators).
-Logical combinators: `and`, `or`, `not`; the `and` and `or` combinators also accept varargs for three or more conditions. All predicates, including those wrapped in `not`, are pushed down to the statistics level for row group and page skipping.
+| Category | Supported |
+|---|---|
+| Comparison operators | `eq`, `notEq`, `lt`, `ltEq`, `gt`, `gtEq` |
+| Set operators | `in` (int, long), `inStrings` |
+| Null operators | `isNull`, `isNotNull` (any type) |
+| Physical types (comparison) | `int`, `long`, `float`, `double`, `boolean`, `String` |
+| Logical types (comparison) | `LocalDate`, `Instant`, `LocalTime`, `BigDecimal`, `UUID` |
+| Combinators | `and`, `or`, `not` (`and` / `or` accept varargs for three or more conditions) |
+
+All predicates, including those wrapped in `not`, are pushed down to the statistics level for row-group and page skipping.
 
 ### Null Handling
 
@@ -544,7 +568,10 @@ try (ParquetFileReader fileReader = ParquetFileReader.open(InputFile.of(path));
 }
 ```
 
-`firstRow == 0` is the no-op default. `firstRow == totalRows` produces an empty reader; `firstRow > totalRows` throws `IllegalArgumentException`. For multi-file readers, `firstRow` indexes into the *first* file's rows only — cross-file `firstRow` is out of scope. Mutually exclusive with `tail(N)`.
+`firstRow == 0` is the no-op default. `firstRow == totalRows` produces an empty reader; `firstRow > totalRows` throws `IllegalArgumentException`. Mutually exclusive with `tail(N)`.
+
+!!! warning "Multi-file readers: first file only"
+    For multi-file readers, `firstRow(N)` indexes into the **first** file's rows only — it does not seek across file boundaries. To skip whole files, omit them from the input list; to skip within a non-first file, open it separately.
 
 Within the target row group, the reader still decodes the leading residue rows and discards them via `next()`. Page-level skip via the OffsetIndex is tracked separately.
 
@@ -907,11 +934,21 @@ The `PqVariantObject` view exposes the same primitive getters as a Parquet struc
 **Current limitations**
 
 - **No Variant-aware predicate pushdown.** Filter predicates against a Variant sub-path (e.g. `WHERE v.age > 30`) aren't yet understood by the pushdown pipeline. Filtering still works against the file's physical shredded columns if you know the layout — a `FilterPredicate.gt("v.typed_value.age", 30)` gets row-group and page skipping via ordinary column statistics — but that ties query code to the writer's shredding strategy and misses any rows where the payload sits in the opaque `value` blob instead. Tracked as [#309](https://github.com/hardwood-hq/hardwood/issues/309).
-- **No path projection optimization.** Reading only `v.age` from a Variant column still reassembles the whole Variant for each row rather than reading just the shredded `typed_value.age` column. Tracked as part of [#309](https://github.com/hardwood-hq/hardwood/issues/309).
+- **No path projection optimization.** Reading only `v.age` from a Variant column still reassembles the whole Variant for each row rather than reading just the shredded `typed_value.age` column. Requires the same variant-aware planning as #309; no separate issue filed yet.
 
 ## Geospatial Support
 
-Hardwood reads the Parquet geospatial metadata layer (GEOMETRY / GEOGRAPHY logical types and per-chunk / per-page `GeospatialStatistics`) and offers a bounding-box filter predicate that pushes spatial selectivity down to the row group and page level. Hardwood does not decode WKB payloads itself — geometry decoding is left to the caller, so the reader has no runtime geometry-library dependency. The de-facto standard Java library for this is the [JTS Topology Suite](https://locationtech.github.io/jts/) (`org.locationtech.jts:jts-core`); the snippets below assume JTS, but any WKB decoder works.
+Hardwood reads the Parquet geospatial metadata layer (GEOMETRY / GEOGRAPHY logical types and per-chunk / per-page `GeospatialStatistics`) and offers a bounding-box filter predicate that pushes spatial selectivity down to the row group and page level. Hardwood does not decode WKB payloads itself — geometry decoding is left to the caller, so the reader has no runtime geometry-library dependency. The de-facto standard Java library for this is the [JTS Topology Suite](https://locationtech.github.io/jts/); the snippets below assume JTS, but any WKB decoder works.
+
+To use JTS in the examples below, add the `jts-core` dependency:
+
+```xml
+<dependency>
+    <groupId>org.locationtech.jts</groupId>
+    <artifactId>jts-core</artifactId>
+    <version>1.20.0</version>
+</dependency>
+```
 
 ### Identifying Geospatial Columns
 
@@ -1012,7 +1049,7 @@ Hardwood throws specific exceptions for common error conditions:
 
 | Exception | When |
 |-----------|------|
-| `IOException` | File is not a valid Parquet file (invalid magic number, corrupt footer) |
+| `IOException` | Any I/O error: invalid Parquet file (bad magic number, corrupt footer), local-disk read errors, S3 transport failures (after retry exhaustion — see [S3](s3.md)) |
 | `UnsupportedOperationException` | Compression codec library not on classpath — the message names the required dependency |
 | `IllegalArgumentException` | Accessing a column not in the projection, type mismatch on accessor, or invalid column name |
 | `NullPointerException` | Calling a primitive accessor (`getInt`, `getLong`, etc.) on a null field without checking `isNull()` first |

--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -7,7 +7,7 @@
 #
 
 site_name: Hardwood
-site_description: A zero-dependency Java Parquet file reader
+site_description: A lightweight Java Parquet reader — zero transitive dependencies, GraalVM-friendly, S3 without Hadoop
 site_url: https://hardwood.dev/
 repo_url: https://github.com/hardwood-hq/hardwood
 repo_name: hardwood-hq/hardwood
@@ -20,10 +20,11 @@ nav:
   - Getting Started: getting-started.md
   - Configuration: configuration.md
   - Usage: usage.md
-  - S3: s3.md
-  - Avro: avro.md
   - CLI: cli.md
-  - Parquet-Java Compatibility: compat.md
+  - Modules:
+    - S3: s3.md
+    - Avro: avro.md
+    - Parquet-Java Compatibility: compat.md
   - API Reference: /api/latest/
   - Release Notes: release-notes.md
   - Contributing: contributing.md


### PR DESCRIPTION
First-pass docs cleanup. The most material change is the project-goals section on the home page: it previously listed "add a writer (after 1.0)" as one of four goals, which read as a completeness gap rather than a roadmap item. The goals are now four durable principles (Light-weight, Compatible, Fast, Embeddable) and the writer is moved into a dedicated Roadmap section. The tagline is aligned to "reader" across mkdocs.yml and the home page intro — three places used to disagree on whether Hardwood was a reader or a reader+writer.

The other changes address scannability (typed-accessor wall-of-text broken into proper #### subsections, predicate-pushdown intro promoted to a numbered list, supported-operators/types as a small table) and a handful of verified gaps where source-of-truth checks turned up missing or wrong information: S3 retry exhaustion exception shape, S3 unsupported access patterns (anonymous / requester-pays / SSE-KMS), AvroRowReader lifecycle, lack of Avro reader-schema override hook, multi-file firstRow first-file-only semantic. The Variant section's double-link to #309 is corrected — #309 covers predicate pushdown only; the path-projection limitation has no separate issue yet.

Module pages (S3, Avro, parquet-java compat) move under a "Modules" nav section so they don't read as peers of Usage. Several load-bearing notes (2 GB single-file limit, multi-file firstRow, custom HttpClient ownership, parquet-java mutual exclusion) become admonitions instead of inline prose.

The split of usage.md into per-page subdocuments (the largest deferred item) is left for a follow-up — it would break inbound URLs to hardwood.dev/usage/#... and wants explicit go-ahead.

## Checklist

- [ ] Build via `./mvnw clean verify` passes
- [ ] The commit message is prefixed with the issue key ("#123 Adding support for...")
- [ ] Code changes are covered by tests
- [ ] If this PR adds or changes user-facing behaviour, `docs/` has been updated
