### PR TITLE
#470 Drop redundant intLists/longLists/doubleLists accessors

### DIFF
--- a/core/src/main/java/dev/hardwood/internal/reader/PqListImpl.java
+++ b/core/src/main/java/dev/hardwood/internal/reader/PqListImpl.java
@@ -288,21 +288,6 @@ final class PqListImpl implements PqList {
     }
 
     @Override
-    public List<PqIntList> intLists() {
-        return new NestedList<>(this::createInnerIntList);
-    }
-
-    @Override
-    public List<PqLongList> longLists() {
-        return new NestedList<>(this::createInnerLongList);
-    }
-
-    @Override
-    public List<PqDoubleList> doubleLists() {
-        return new NestedList<>(this::createInnerDoubleList);
-    }
-
-    @Override
     public List<PqMap> maps() {
         return new NestedList<>(this::createInnerMap);
     }
@@ -469,33 +454,6 @@ final class PqListImpl implements PqList {
         }
         return new PqListImpl(batch, innerListDesc, innerElement,
                 innerStart, innerEnd, innerSubLevel);
-    }
-
-    private PqIntList createInnerIntList(int index) {
-        PqList inner = createInnerGenericList(index);
-        if (inner == null) {
-            return null;
-        }
-        PqListImpl innerList = (PqListImpl) inner;
-        return new PqIntListImpl(batch, listDesc.firstLeafProjCol(), innerList.start, innerList.end);
-    }
-
-    private PqLongList createInnerLongList(int index) {
-        PqList inner = createInnerGenericList(index);
-        if (inner == null) {
-            return null;
-        }
-        PqListImpl innerList = (PqListImpl) inner;
-        return new PqLongListImpl(batch, listDesc.firstLeafProjCol(), innerList.start, innerList.end);
-    }
-
-    private PqDoubleList createInnerDoubleList(int index) {
-        PqList inner = createInnerGenericList(index);
-        if (inner == null) {
-            return null;
-        }
-        PqListImpl innerList = (PqListImpl) inner;
-        return new PqDoubleListImpl(batch, listDesc.firstLeafProjCol(), innerList.start, innerList.end);
     }
 
     private PqMap createInnerMap(int index) {

--- a/core/src/main/java/dev/hardwood/row/PqList.java
+++ b/core/src/main/java/dev/hardwood/row/PqList.java
@@ -48,8 +48,9 @@ import java.util.UUID;
 ///
 /// // Nested list (2D matrix)
 /// PqList matrix = rowReader.getList("matrix");
-/// for (PqIntList innerList : matrix.intLists()) {
-///     for (var it = innerList.iterator(); it.hasNext(); ) {
+/// for (PqList row : matrix.lists()) {
+///     PqIntList ints = row.ints();
+///     for (var it = ints.iterator(); it.hasNext(); ) {
 ///         int value = it.nextInt();
 ///     }
 /// }
@@ -57,7 +58,8 @@ import java.util.UUID;
 /// // Triple nested list (3D cube)
 /// PqList cube = rowReader.getList("cube");
 /// for (PqList plane : cube.lists()) {
-///     for (PqIntList innerList : plane.intLists()) {
+///     for (PqList row : plane.lists()) {
+///         PqIntList ints = row.ints();
 ///         // ...
 ///     }
 /// }
@@ -171,20 +173,9 @@ public interface PqList {
     List<PqStruct> structs();
 
     /// View the elements as a [List] of nested lists.
-    /// Use this for list-of-list structures.
+    /// Use this for list-of-list structures; call [#ints] / [#longs] / [#doubles]
+    /// on the inner [PqList] for primitive-typed inner lists.
     List<PqList> lists();
-
-    /// View the elements as a [List] of nested int lists.
-    /// Use this for list-of-int-list structures (e.g., 2D int matrix).
-    List<PqIntList> intLists();
-
-    /// View the elements as a [List] of nested long lists.
-    /// Use this for list-of-long-list structures.
-    List<PqLongList> longLists();
-
-    /// View the elements as a [List] of nested double lists.
-    /// Use this for list-of-double-list structures.
-    List<PqDoubleList> doubleLists();
 
     /// View the elements as a [List] of nested maps.
     List<PqMap> maps();

--- a/core/src/test/java/dev/hardwood/PqRowApiTest.java
+++ b/core/src/test/java/dev/hardwood/PqRowApiTest.java
@@ -277,7 +277,8 @@ public class PqRowApiTest {
             assertThat(matrix0.size()).isEqualTo(3);
 
             List<List<Integer>> matrixValues0 = new ArrayList<>();
-            for (PqIntList innerList : matrix0.intLists()) {
+            for (PqList row : matrix0.lists()) {
+                PqIntList innerList = row.ints();
                 List<Integer> innerValues = new ArrayList<>();
                 for (int i = 0; i < innerList.size(); i++) {
                     innerValues.add(innerList.get(i));
@@ -298,7 +299,8 @@ public class PqRowApiTest {
             assertThat(matrix1.size()).isEqualTo(1);
 
             List<List<Integer>> matrixValues1 = new ArrayList<>();
-            for (PqIntList innerList : matrix1.intLists()) {
+            for (PqList row : matrix1.lists()) {
+                PqIntList innerList = row.ints();
                 List<Integer> innerValues = new ArrayList<>();
                 for (int i = 0; i < innerList.size(); i++) {
                     innerValues.add(innerList.get(i));
@@ -315,7 +317,8 @@ public class PqRowApiTest {
             assertThat(matrix2.size()).isEqualTo(3);
 
             List<List<Integer>> matrixValues2 = new ArrayList<>();
-            for (PqIntList innerList : matrix2.intLists()) {
+            for (PqList row : matrix2.lists()) {
+                PqIntList innerList = row.ints();
                 List<Integer> innerValues = new ArrayList<>();
                 for (int i = 0; i < innerList.size(); i++) {
                     innerValues.add(innerList.get(i));
@@ -734,7 +737,8 @@ public class PqRowApiTest {
             List<List<List<Integer>>> cubeValues0 = new ArrayList<>();
             for (PqList plane : cube0.lists()) {
                 List<List<Integer>> middleValues = new ArrayList<>();
-                for (PqIntList intRow : plane.intLists()) {
+                for (PqList rowList : plane.lists()) {
+                    PqIntList intRow = rowList.ints();
                     List<Integer> innerValues = new ArrayList<>();
                     for (int i = 0; i < intRow.size(); i++) {
                         innerValues.add(intRow.get(i));
@@ -760,7 +764,8 @@ public class PqRowApiTest {
             List<List<List<Integer>>> cubeValues1 = new ArrayList<>();
             for (PqList plane : cube1.lists()) {
                 List<List<Integer>> middleValues = new ArrayList<>();
-                for (PqIntList intRow : plane.intLists()) {
+                for (PqList rowList : plane.lists()) {
+                    PqIntList intRow = rowList.ints();
                     List<Integer> innerValues = new ArrayList<>();
                     for (int i = 0; i < intRow.size(); i++) {
                         innerValues.add(intRow.get(i));
@@ -785,7 +790,8 @@ public class PqRowApiTest {
             List<List<List<Integer>>> cubeValues2 = new ArrayList<>();
             for (PqList plane : cube2.lists()) {
                 List<List<Integer>> middleValues = new ArrayList<>();
-                for (PqIntList intRow : plane.intLists()) {
+                for (PqList rowList : plane.lists()) {
+                    PqIntList intRow = rowList.ints();
                     List<Integer> innerValues = new ArrayList<>();
                     for (int i = 0; i < intRow.size(); i++) {
                         innerValues.add(intRow.get(i));

--- a/docs/content/usage/row-reader.md
+++ b/docs/content/usage/row-reader.md
@@ -83,7 +83,8 @@ try (ParquetFileReader fileReader = ParquetFileReader.open(InputFile.of(path));
             // Access nested lists (list<list<int>>) using primitive int lists
             PqList matrix = rowReader.getList("matrix");
             if (matrix != null) {
-                for (PqIntList innerList : matrix.intLists()) {
+                for (PqList row : matrix.lists()) {
+                    PqIntList innerList = row.ints();
                     for (var it = innerList.iterator(); it.hasNext(); ) {
                         int val = it.nextInt();
                         System.out.println("Value: " + val);
@@ -204,7 +205,7 @@ Both interfaces mirror the RowReader's typed accessor surface — `strings()` / 
 
 `PqMap.Entry`'s typed *key* accessor surface is intentionally narrower: `getStringKey()` / `getIntKey()` / `getLongKey()` / `getBinaryKey()` cover the four high-frequency map key types. Long-tail key types (DATE / TIME / TIMESTAMP / DECIMAL / UUID) fall through to `getKey()` (decoded) and `getRawKey()` (raw).
 
-`PqList.ints()` / `longs()` / `doubles()` return the specialized `PqIntList` / `PqLongList` / `PqDoubleList` types instead — these expose `PrimitiveIterator.OfInt` / `OfLong` / `OfDouble`, `int get(int)`, and `int[] toArray()` so primitive list iteration allocates no boxed wrappers. For nested `list<list<int>>` (or `<long>` / `<double>`), use `intLists()` / `longLists()` / `doubleLists()` to surface the inner lists as `PqIntList` / `PqLongList` / `PqDoubleList`.
+`PqList.ints()` / `longs()` / `doubles()` return the specialized `PqIntList` / `PqLongList` / `PqDoubleList` types instead — these expose `PrimitiveIterator.OfInt` / `OfLong` / `OfDouble`, `int get(int)`, and `int[] toArray()` so primitive list iteration allocates no boxed wrappers. For nested `list<list<int>>` (or `<long>` / `<double>`), iterate the outer list via `lists()` and call `ints()` / `longs()` / `doubles()` on each inner `PqList`; primitive element access stays unboxed at any nesting depth.
 
 #### Reading the physical value
 

--- a/performance-testing/micro-benchmarks/src/main/java/dev/hardwood/benchmarks/RecordFilterMicroBenchmark.java
+++ b/performance-testing/micro-benchmarks/src/main/java/dev/hardwood/benchmarks/RecordFilterMicroBenchmark.java
@@ -246,7 +246,9 @@ public class RecordFilterMicroBenchmark {
     private static BatchExchange.Batch batch(Object values, int recordCount) {
         BatchExchange.Batch b = new BatchExchange.Batch();
         b.values = values;
-        b.nulls = null; // schema is REQUIRED across all columns — no nulls.
+        // Schema is REQUIRED across all columns; `validity = null` is the
+        // sparse representation of "every leaf in this batch is present."
+        b.validity = null;
         b.recordCount = recordCount;
         return b;
     }


### PR DESCRIPTION
Follow-up to the previous #470 clean-up.