### PR TITLE
#440 Hot-path FlatRowReader optimizations

### DIFF
--- a/core/src/main/java/dev/hardwood/internal/reader/BatchExchange.java
+++ b/core/src/main/java/dev/hardwood/internal/reader/BatchExchange.java
@@ -52,7 +52,18 @@ public class BatchExchange<B> {
     /// types.
     public static final class Batch {
         public Object values;
+        /// Public per-batch validity bitmap. Set-bit-= -present polarity; `null` is
+        /// the sparse "every leaf present" form. When non-null, references
+        /// [#validityBuffer]; consumers must treat it as read-only.
         public BitSet validity;
+        /// Pre-allocated scratch BitSet used by the drain to record per-row
+        /// presence without per-batch allocation. Allocated once by the
+        /// [BatchExchange] factory for nullable columns; `null` for REQUIRED
+        /// columns. The drain calls `validityBuffer.clear()` between batches and
+        /// switches it on lazily when the first absent is observed. At publish
+        /// time, [#validity] is assigned to this buffer iff at least one absent
+        /// was recorded; otherwise [#validity] is set to `null`.
+        public BitSet validityBuffer;
         public int recordCount;
         public String fileName;
         /// Per-batch matches mask, populated by [dev.hardwood.internal.predicate.ColumnBatchMatcher]

--- a/core/src/main/java/dev/hardwood/internal/reader/FlatColumnWorker.java
+++ b/core/src/main/java/dev/hardwood/internal/reader/FlatColumnWorker.java
@@ -21,7 +21,6 @@ import dev.hardwood.schema.ColumnSchema;
 /// and null tracking via [BitSet].
 public class FlatColumnWorker extends ColumnWorker<BatchExchange.Batch> {
 
-    private BitSet currentValidity;
     private final ColumnBatchMatcher columnFilter;
     /// Tracks whether any absent (null) leaf has been seen in the current
     /// batch; cleared by [#publishCurrentBatch]. When still false at publish
@@ -54,7 +53,8 @@ public class FlatColumnWorker extends ColumnWorker<BatchExchange.Batch> {
 
     @Override
     void initDrainState() {
-        currentValidity = maxDefinitionLevel > 0 ? new BitSet(batchCapacity) : null;
+        // currentBatch.validityBuffer is pre-allocated by the BatchExchange factory
+        // for nullable columns; the worker only resets the hasAbsents flag here.
         currentBatchHasAbsents = false;
     }
 
@@ -123,9 +123,11 @@ public class FlatColumnWorker extends ColumnWorker<BatchExchange.Batch> {
             return;
         }
         currentBatch.recordCount = rowsInCurrentBatch;
-        currentBatch.validity = (currentValidity != null && currentBatchHasAbsents)
-                ? (BitSet) currentValidity.clone()
-                : null;
+        // Publish the pre-allocated validityBuffer directly when any absent was
+        // recorded; otherwise publish `null` so matchers and the consumer skip the
+        // validity-handling path entirely. No clone — the buffer belongs to this
+        // Batch and is recycled with it.
+        currentBatch.validity = currentBatchHasAbsents ? currentBatch.validityBuffer : null;
         currentBatch.fileName = currentBatchFileName;
 
         if (columnFilter != null) {
@@ -155,8 +157,8 @@ public class FlatColumnWorker extends ColumnWorker<BatchExchange.Batch> {
         batchesPublished++;
 
         rowsInCurrentBatch = 0;
-        if (currentValidity != null) {
-            currentValidity.clear();
+        if (currentBatch.validityBuffer != null) {
+            currentBatch.validityBuffer.clear();
         }
         currentBatchHasAbsents = false;
     }
@@ -222,12 +224,13 @@ public class FlatColumnWorker extends ColumnWorker<BatchExchange.Batch> {
     /// bitmap if it was already switched on by an earlier absent in the
     /// batch.
     private void markNulls(int[] defLevels, int srcPos, int destPos, int length) {
-        if (currentValidity == null) {
+        BitSet validity = currentBatch.validityBuffer;
+        if (validity == null) {
             return;
         }
         if (defLevels == null) {
             if (currentBatchHasAbsents) {
-                currentValidity.set(destPos, destPos + length);
+                validity.set(destPos, destPos + length);
             }
             return;
         }
@@ -235,11 +238,11 @@ public class FlatColumnWorker extends ColumnWorker<BatchExchange.Batch> {
             if (defLevels[srcPos + i] < maxDefinitionLevel) {
                 if (!currentBatchHasAbsents) {
                     currentBatchHasAbsents = true;
-                    currentValidity.set(0, destPos + i);
+                    validity.set(0, destPos + i);
                 }
             }
             else if (currentBatchHasAbsents) {
-                currentValidity.set(destPos + i);
+                validity.set(destPos + i);
             }
         }
     }

--- a/core/src/main/java/dev/hardwood/internal/reader/FlatRowReader.java
+++ b/core/src/main/java/dev/hardwood/internal/reader/FlatRowReader.java
@@ -141,11 +141,13 @@ public final class FlatRowReader implements RowReader {
             columnSchemas[i] = col;
         }
 
-        // Sized to next-power-of-2 ≥ 2 × columnCount (min 4) so the direct-mapped
-        // cache stays sparse (< 50% load) — keeps collisions rare for typical
+        // Sized to next-power-of-2 ≥ 2 × columnCount so the direct-mapped cache
+        // stays sparse (< 50% load) — keeps collisions rare for typical
         // projections while costing only a few dozen bytes for wide schemas.
-        int desired = Math.max(columnCount * 2, 4);
-        int slots = Integer.highestOneBit(desired - 1) << 1;
+        // The `columnCount == 0` branch keeps slot arithmetic well-defined for
+        // empty projections (no names will ever be resolved, but the field
+        // initializers must not divide by zero).
+        int slots = columnCount == 0 ? 1 : Integer.highestOneBit(columnCount * 2 - 1) << 1;
         this.nameCacheSlotMask = slots - 1;
         this.nameCacheNames = new String[slots];
         this.nameCacheIndices = new int[slots];

--- a/core/src/main/java/dev/hardwood/internal/reader/FlatRowReader.java
+++ b/core/src/main/java/dev/hardwood/internal/reader/FlatRowReader.java
@@ -44,19 +44,6 @@ import dev.hardwood.schema.ProjectedSchema;
 /// string), and both name-based and index-based access.
 public final class FlatRowReader implements RowReader {
 
-    /// Sentinel for "every leaf in the batch is present" — replaces the
-    /// nullable validity reference on the hot path so the per-row check
-    /// stays a single `BitSet.get` call. Pre-set to the largest batch
-    /// [BatchSizing] will produce, so any in-range row index reads as
-    /// present.
-    private static final BitSet ALL_PRESENT = allPresentSentinel();
-
-    private static BitSet allPresentSentinel() {
-        BitSet bs = new BitSet();
-        bs.set(0, BatchSizing.MAX_BATCH);
-        return bs;
-    }
-
     private final BatchExchange<BatchExchange.Batch>[] exchanges;
     private final FlatColumnWorker[] columnWorkers;
     private final int columnCount;
@@ -69,15 +56,29 @@ public final class FlatRowReader implements RowReader {
     private final ColumnSchema[] columnSchemas;
 
     // Hot fields — directly owned, no inheritance.
-    // `flatValidity[col].get(rowIndex)` is true iff the leaf is present;
-    // `flatValidity[col]` is `ALL_PRESENT` when every leaf for this column in
-    // the current batch is present, so the per-row check needs no null guard.
+    // `flatValidity[col].get(rowIndex)` is true iff the leaf is present.
+    // `flatValidity[col] == null` is the sparse "every leaf in this batch is
+    // present" representation: every accessor short-circuits past the bitmap
+    // touch on a single null compare.
     private Object[] flatValueArrays;
     private BitSet[] flatValidity;
     private BatchExchange.Batch[] previousBatches;
     private int rowIndex = -1;
     private int batchSize = 0;
     private boolean exhausted;
+
+    // One-slot name → index cache. By-name accessors typically receive an intern'd
+    // String literal at each call site, so reference equality against the last
+    // seen name short-circuits a hash + probe on every row of a tight scan loop.
+    private String lastResolvedName;
+    private int lastResolvedIndex;
+
+    // One-slot isNull cache. A scan loop typically pairs `isNull("X")` with
+    // `getX("X")`; the accessor's internal check repeats the work of the
+    // user-level call. The cache makes the second call a constant compare.
+    private int lastIsNullColumn = -1;
+    private int lastIsNullRow = -1;
+    private boolean lastIsNullResult;
 
     // Drain-side filter path: when drainSide is true, iterate via nextSetBit over
     // combinedWords. When false, the original rowIndex++ path is taken.
@@ -191,10 +192,14 @@ public final class FlatRowReader implements RowReader {
             // Other columns leave Batch.matches null (sentinel = all-ones in intersect).
             final boolean allocateMatches =
                     drainSide && i < columnBatchMatchers.length && columnBatchMatchers[i] != null;
+            final boolean nullable = columnSchema.maxDefinitionLevel() > 0;
             BatchExchange<BatchExchange.Batch> buffer = BatchExchange.recycling(
                     columnSchema.name(), () -> {
                         BatchExchange.Batch b = new BatchExchange.Batch();
                         b.values = BatchExchange.allocateArray(columnSchema, batchSize);
+                        if (nullable) {
+                            b.validityBuffer = new BitSet(batchSize);
+                        }
                         if (allocateMatches) {
                             b.matches = new long[wordsLen];
                         }
@@ -363,7 +368,16 @@ public final class FlatRowReader implements RowReader {
 
     @Override
     public boolean isNull(int columnIndex) {
-        return !flatValidity[columnIndex].get(rowIndex);
+        int row = rowIndex;
+        if (lastIsNullColumn == columnIndex && lastIsNullRow == row) {
+            return lastIsNullResult;
+        }
+        BitSet validity = flatValidity[columnIndex];
+        boolean result = validity != null && !validity.get(row);
+        lastIsNullColumn = columnIndex;
+        lastIsNullRow = row;
+        lastIsNullResult = result;
+        return result;
     }
 
     @Override
@@ -375,7 +389,7 @@ public final class FlatRowReader implements RowReader {
 
     @Override
     public int getInt(int columnIndex) {
-        if (!flatValidity[columnIndex].get(rowIndex)) {
+        if (isNull(columnIndex)) {
             throwNull(columnIndex);
         }
         return ((int[]) flatValueArrays[columnIndex])[rowIndex];
@@ -383,7 +397,7 @@ public final class FlatRowReader implements RowReader {
 
     @Override
     public long getLong(int columnIndex) {
-        if (!flatValidity[columnIndex].get(rowIndex)) {
+        if (isNull(columnIndex)) {
             throwNull(columnIndex);
         }
         return ((long[]) flatValueArrays[columnIndex])[rowIndex];
@@ -391,7 +405,7 @@ public final class FlatRowReader implements RowReader {
 
     @Override
     public float getFloat(int columnIndex) {
-        if (!flatValidity[columnIndex].get(rowIndex)) {
+        if (isNull(columnIndex)) {
             throwNull(columnIndex);
         }
         if (physicalTypes[columnIndex] == PhysicalType.FLOAT) {
@@ -411,7 +425,7 @@ public final class FlatRowReader implements RowReader {
 
     @Override
     public double getDouble(int columnIndex) {
-        if (!flatValidity[columnIndex].get(rowIndex)) {
+        if (isNull(columnIndex)) {
             throwNull(columnIndex);
         }
         return ((double[]) flatValueArrays[columnIndex])[rowIndex];
@@ -419,7 +433,7 @@ public final class FlatRowReader implements RowReader {
 
     @Override
     public boolean getBoolean(int columnIndex) {
-        if (!flatValidity[columnIndex].get(rowIndex)) {
+        if (isNull(columnIndex)) {
             throwNull(columnIndex);
         }
         return ((boolean[]) flatValueArrays[columnIndex])[rowIndex];
@@ -727,7 +741,8 @@ public final class FlatRowReader implements RowReader {
                 return false;
             }
             flatValueArrays[i] = batch.values;
-            flatValidity[i] = batch.validity != null ? batch.validity : ALL_PRESENT;
+            // `null` carries through — accessors treat it as the sparse "all present" form.
+            flatValidity[i] = batch.validity;
             previousBatches[i] = batch;
             if (i == 0) {
                 batchSize = batch.recordCount;
@@ -821,10 +836,17 @@ public final class FlatRowReader implements RowReader {
     }
 
     private int resolveIndex(String name) {
+        // Reference-equality fast path: literal field names from user code reach
+        // this method as the same intern'd String each call.
+        if (name == lastResolvedName) {
+            return lastResolvedIndex;
+        }
         int index = nameToIndex.get(name);
         if (index < 0) {
             throw new IllegalArgumentException(prefix() + "Column not in projection: " + name);
         }
+        lastResolvedName = name;
+        lastResolvedIndex = index;
         return index;
     }
 

--- a/core/src/main/java/dev/hardwood/internal/reader/FlatRowReader.java
+++ b/core/src/main/java/dev/hardwood/internal/reader/FlatRowReader.java
@@ -67,11 +67,15 @@ public final class FlatRowReader implements RowReader {
     private int batchSize = 0;
     private boolean exhausted;
 
-    // One-slot name → index cache. By-name accessors typically receive an intern'd
-    // String literal at each call site, so reference equality against the last
-    // seen name short-circuits a hash + probe on every row of a tight scan loop.
-    private String lastResolvedName;
-    private int lastResolvedIndex;
+    // Direct-mapped name → index cache. By-name accessors typically receive an
+    // intern'd String literal at each call site, so reference equality against
+    // the slot's stored name short-circuits a hash + probe on every row of a
+    // tight scan loop. The slot is picked by `identityHashCode(name) & slotMask`
+    // so multi-column row materialization (different name per accessor call)
+    // also hits, not just the same-name-twice pattern.
+    private final int nameCacheSlotMask;
+    private final String[] nameCacheNames;
+    private final int[] nameCacheIndices;
 
     // One-slot isNull cache. A scan loop typically pairs `isNull("X")` with
     // `getX("X")`; the accessor's internal check repeats the work of the
@@ -136,6 +140,15 @@ public final class FlatRowReader implements RowReader {
             physicalTypes[i] = col.type();
             columnSchemas[i] = col;
         }
+
+        // Sized to next-power-of-2 ≥ 2 × columnCount (min 4) so the direct-mapped
+        // cache stays sparse (< 50% load) — keeps collisions rare for typical
+        // projections while costing only a few dozen bytes for wide schemas.
+        int desired = Math.max(columnCount * 2, 4);
+        int slots = Integer.highestOneBit(desired - 1) << 1;
+        this.nameCacheSlotMask = slots - 1;
+        this.nameCacheNames = new String[slots];
+        this.nameCacheIndices = new int[slots];
     }
 
     /// Eagerly loads the first batch. Must be called after construction.
@@ -836,17 +849,20 @@ public final class FlatRowReader implements RowReader {
     }
 
     private int resolveIndex(String name) {
-        // Reference-equality fast path: literal field names from user code reach
-        // this method as the same intern'd String each call.
-        if (name == lastResolvedName) {
-            return lastResolvedIndex;
+        // Direct-mapped fast path keyed on the name's identity hash. Intern'd
+        // String literals from user code reach this method as the same reference
+        // each call, so a reference-equality compare on the slot's stored name
+        // short-circuits the StringToIntMap probe.
+        int slot = System.identityHashCode(name) & nameCacheSlotMask;
+        if (nameCacheNames[slot] == name) {
+            return nameCacheIndices[slot];
         }
         int index = nameToIndex.get(name);
         if (index < 0) {
             throw new IllegalArgumentException(prefix() + "Column not in projection: " + name);
         }
-        lastResolvedName = name;
-        lastResolvedIndex = index;
+        nameCacheNames[slot] = name;
+        nameCacheIndices[slot] = index;
         return index;
     }
 

--- a/core/src/main/java/dev/hardwood/reader/ColumnReader.java
+++ b/core/src/main/java/dev/hardwood/reader/ColumnReader.java
@@ -686,10 +686,14 @@ public class ColumnReader implements AutoCloseable {
             return ColumnReader.forNested(columnSchema, layers, nestedBuf, nestedWorker, ownedIterator);
         }
         else {
+            final boolean nullable = columnSchema.maxDefinitionLevel() > 0;
             BatchExchange<BatchExchange.Batch> flatBuf = BatchExchange.detaching(
                     columnSchema.name(), () -> {
                         BatchExchange.Batch b = new BatchExchange.Batch();
                         b.values = BatchExchange.allocateArray(columnSchema, DEFAULT_BATCH_SIZE);
+                        if (nullable) {
+                            b.validityBuffer = new BitSet(DEFAULT_BATCH_SIZE);
+                        }
                         return b;
                     });
             FlatColumnWorker flatWorker = new FlatColumnWorker(

--- a/core/src/test/java/dev/hardwood/internal/reader/ColumnWorkerTest.java
+++ b/core/src/test/java/dev/hardwood/internal/reader/ColumnWorkerTest.java
@@ -8,6 +8,7 @@
 package dev.hardwood.internal.reader;
 
 import java.nio.file.Path;
+import java.util.BitSet;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.Executor;
 import java.util.concurrent.TimeUnit;
@@ -141,6 +142,9 @@ class ColumnWorkerTest {
                     column.name(), () -> {
                         BatchExchange.Batch b = new BatchExchange.Batch();
                         b.values = BatchExchange.allocateArray(column, batchCapacity);
+                        if (column.maxDefinitionLevel() > 0) {
+                            b.validityBuffer = new BitSet(batchCapacity);
+                        }
                         return b;
                     });
             FlatColumnWorker worker = new FlatColumnWorker(

--- a/performance-testing/end-to-end/src/test/java/dev/hardwood/perf/RecordFilterBenchmarkTest.java
+++ b/performance-testing/end-to-end/src/test/java/dev/hardwood/perf/RecordFilterBenchmarkTest.java
@@ -32,29 +32,17 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 /// Benchmark for record-level filtering overhead.
 ///
-/// Compares RowReader performance across:
-/// - **Baseline**: no filter at all (raw scan throughput).
-/// - **Match-all / compound match-all**: predicates that keep every row — worst case
-///   overhead because the filter is evaluated for each row but never prunes.
-/// - **Selective**: predicates that drop most rows — real-world wins.
-/// - **Drain-eligible compound ANDs** (2/3/4 leaves across `id`, `value`, `tag`, `flag`):
-///   exercise the column-local AND fast path.
-/// - **Fallback shapes** (single-leaf, OR, same-column range, IN-list): trip the
-///   drain-eligibility gate so [FilteredRowReader] handles them. See [BatchFilterCompiler].
-/// - **Page+record**: id range that prunes ~99% of pages via column-index min/max,
-///   then a per-row `value<500` filter on the survivors.
-///
-/// Schema: `id` (long, sequential 0..N), `value` (double uniform 0..1000),
-/// `tag` (int uniform 0..99), `flag` (boolean uniform).
-///
-/// Run:
-///   ./mvnw test -Pperformance-test -pl performance-testing/end-to-end \
-///     -Dtest="RecordFilterBenchmarkTest" -Dperf.runs=5
+/// REQUIRED-column scenarios run once against a single file. The nullable-column
+/// scenarios (`Nullable IS NOT NULL`, `Nullable selective`, `Scan nullable column`)
+/// run once per density in [#NULL_PERCENTS] to expose how validity-bitmap handling
+/// behaves at scarce / mixed / sparse densities.
 class RecordFilterBenchmarkTest {
 
-    private static final Path BENCHMARK_FILE = Path.of("target/record_filter_benchmark.parquet");
     private static final int TOTAL_ROWS = 10_000_000;
     private static final int DEFAULT_RUNS = 5;
+    /// Null densities at which the `score` column is regenerated and the three
+    /// nullable scenarios are timed.
+    private static final int[] NULL_PERCENTS = {1, 50, 90};
 
     private static final String PATH_DRAIN = "(Drain Side filtration)";
     private static final String PATH_CONSUMER = "(Consumer Side Filtration)";
@@ -62,59 +50,68 @@ class RecordFilterBenchmarkTest {
 
     private record Run(long[] times, long[] rows) {}
 
+    private static Path benchmarkFile(int nullPercent) {
+        return Path.of("target/record_filter_benchmark_v2_n" + nullPercent + ".parquet");
+    }
+
     @Test
     void compareRecordFilterOverhead() throws Exception {
-        ensureBenchmarkFileExists();
+        // Generate (if missing) a file per density up front so the row-group / page
+        // structure is identical across the comparison.
+        for (int p : NULL_PERCENTS) {
+            ensureBenchmarkFileExists(benchmarkFile(p), p);
+        }
+
+        // REQUIRED-column scenarios are score-independent; pick the first density's file.
+        Path requiredFile = benchmarkFile(NULL_PERCENTS[0]);
 
         int runs = Integer.parseInt(System.getProperty("perf.runs", String.valueOf(DEFAULT_RUNS)));
 
         System.out.println("\n=== Record Filter Benchmark ===");
-        System.out.println("File: " + BENCHMARK_FILE + " (" + Files.size(BENCHMARK_FILE) / (1024 * 1024) + " MB)");
+        System.out.println("File (REQUIRED scenarios): " + requiredFile
+                + " (" + Files.size(requiredFile) / (1024 * 1024) + " MB)");
         System.out.println("Total rows: " + String.format("%,d", TOTAL_ROWS));
         System.out.println("Runs per contender: " + runs);
+        System.out.print("Nullable densities: ");
+        for (int p : NULL_PERCENTS) System.out.print(p + "% ");
+        System.out.println();
 
         // Warmup
         System.out.println("\nWarmup...");
-        runNoFilter();
+        runNoFilter(requiredFile);
 
         // ----- Baseline ---------------------
-        Run noFilter = timeNoFilter(runs);
+        Run noFilter = timeNoFilter(requiredFile, runs);
 
-        Run matchAll = timeFilter(
-                // id >= 0 matches every row — worst case for per-row evaluation overhead.
+        Run matchAll = timeFilter(requiredFile,
                 FilterPredicate.gtEq("id", 0L),
                 runs);
 
-        Run selective = timeFilter(
-                // id < 1% of range — should return ~100K rows out of 10M.
+        Run selective = timeFilter(requiredFile,
                 FilterPredicate.lt("id", (long) (TOTAL_ROWS / 100)),
                 runs);
 
-        Run compound = timeFilter(
-                // Two-leaf AND that matches every row — exercises tree recursion + per-leaf dispatch.
+        Run compound = timeFilter(requiredFile,
                 FilterPredicate.and(
                         FilterPredicate.gtEq("id", 0L),
                         FilterPredicate.lt("value", Double.MAX_VALUE)),
                 runs);
 
-        Run pageRecord = timeFilter(
-                // id BETWEEN 9.9M and 10M — only the last few data pages overlap, so
-                // column-index min/max should drop ~99% of pages before any row is decoded.
-                // Then `value<500` runs as a per-row filter on the surviving ~100K rows.
+        Run pageRecord = timeFilter(requiredFile,
                 FilterPredicate.and(
                         FilterPredicate.gtEq("id", (long) (TOTAL_ROWS - TOTAL_ROWS / 100)),
                         FilterPredicate.lt("id", (long) (TOTAL_ROWS - TOTAL_ROWS / 100) + (TOTAL_ROWS / 100)),
                         FilterPredicate.lt("value", 500.0)),
                 runs);
 
-        Run and3 = timeFilter(
+        Run and3 = timeFilter(requiredFile,
                 FilterPredicate.and(
                         FilterPredicate.gtEq("id", 0L),
                         FilterPredicate.lt("value", Double.MAX_VALUE),
                         FilterPredicate.gtEq("tag", 0)),
                 runs);
 
-        Run and4 = timeFilter(
+        Run and4 = timeFilter(requiredFile,
                 FilterPredicate.and(
                         FilterPredicate.gtEq("id", 0L),
                         FilterPredicate.lt("value", Double.MAX_VALUE),
@@ -122,51 +119,57 @@ class RecordFilterBenchmarkTest {
                         FilterPredicate.notEq("flag", false)),
                 runs);
 
-        Run compoundSelective = timeFilter(
+        Run compoundSelective = timeFilter(requiredFile,
                 FilterPredicate.and(
                         FilterPredicate.lt("id", 10_000L),
                         FilterPredicate.lt("value", Double.MAX_VALUE)),
                 runs);
 
-        Run compoundMid = timeFilter(
+        Run compoundMid = timeFilter(requiredFile,
                 FilterPredicate.and(
                         FilterPredicate.gtEq("id", 0L),
                         FilterPredicate.lt("value", 500.0)),
                 runs);
 
-        Run sortedCluster = timeFilter(
-                // ~50% selectivity but on a **sorted** column — every batch's bitset
-                // is one long run of 1s followed by 0s (or all 0s after id crosses
-                // TOTAL/2). Pairs with `compoundMid` to isolate the run-structure
-                // effect: same drain shape, same selectivity, very different runs.
+        Run sortedCluster = timeFilter(requiredFile,
                 FilterPredicate.and(
                         FilterPredicate.lt("id", (long) (TOTAL_ROWS / 2)),
                         FilterPredicate.gtEq("tag", 0)),
                 runs);
 
-        Run empty = timeFilter(
+        Run empty = timeFilter(requiredFile,
                 FilterPredicate.and(
                         FilterPredicate.lt("id", 0L),
                         FilterPredicate.lt("value", Double.MAX_VALUE)),
                 runs);
 
-        Run orFilter = timeFilter(
+        Run orFilter = timeFilter(requiredFile,
                 FilterPredicate.or(
                         FilterPredicate.lt("id", 0L),
                         FilterPredicate.lt("value", 500.0)),
                 runs);
 
-        Run rangeDup = timeFilter(
-                // Same-column range on `id` is not drain-eligible (duplicate column).
+        Run rangeDup = timeFilter(requiredFile,
                 FilterPredicate.and(
                         FilterPredicate.gtEq("id", 1_000_000L),
                         FilterPredicate.lt("id", 2_000_000L),
                         FilterPredicate.lt("value", Double.MAX_VALUE)),
                 runs);
 
-        Run intIn = timeFilter(
+        Run intIn = timeFilter(requiredFile,
                 FilterPredicate.in("tag", new int[] {1, 5, 10, 25, 50}),
                 runs);
+
+        // Nullable scenarios per density.
+        Run[] nullableMatchAll = new Run[NULL_PERCENTS.length];
+        Run[] nullableSelective = new Run[NULL_PERCENTS.length];
+        Run[] scanNullable = new Run[NULL_PERCENTS.length];
+        for (int i = 0; i < NULL_PERCENTS.length; i++) {
+            Path file = benchmarkFile(NULL_PERCENTS[i]);
+            nullableMatchAll[i] = timeFilter(file, FilterPredicate.isNotNull("score"), runs);
+            nullableSelective[i] = timeFilter(file, FilterPredicate.lt("score", 100.0), runs);
+            scanNullable[i] = timeScanScoreColumn(file, runs);
+        }
 
         // ----- Print results ------------------------------------------------
         System.out.println("\nResults:");
@@ -202,6 +205,16 @@ class RecordFilterBenchmarkTest {
         System.out.println();
         printResults("intIn (tag IN [1,5,10,25,50])", PATH_DRAIN, intIn, runs);
 
+        for (int i = 0; i < NULL_PERCENTS.length; i++) {
+            int p = NULL_PERCENTS[i];
+            System.out.println();
+            printResults("Nullable IS NOT NULL (score, " + p + "% null)", PATH_DRAIN, nullableMatchAll[i], runs);
+            System.out.println();
+            printResults("Nullable selective (score<100, " + p + "% null)", PATH_DRAIN, nullableSelective[i], runs);
+            System.out.println();
+            printResults("Scan nullable column (read score, " + p + "% null)", PATH_NONE, scanNullable[i], runs);
+        }
+
         // ----- Derived ratios vs no-filter baseline -------------------------
         double avgNoFilter = avg(noFilter.times) / 1_000_000.0;
         double avgMatchAll = avg(matchAll.times) / 1_000_000.0;
@@ -223,49 +236,56 @@ class RecordFilterBenchmarkTest {
         assertThat(matchAll.rows[0]).isEqualTo(TOTAL_ROWS);
         assertThat(selective.rows[0]).isEqualTo(TOTAL_ROWS / 100L);
         assertThat(compound.rows[0]).isEqualTo(TOTAL_ROWS);
-        // Page+record: id range narrows to ~100K rows, value<500 keeps roughly half.
         assertThat(pageRecord.rows[0]).isGreaterThan(0L).isLessThan(TOTAL_ROWS / 50L);
         assertThat(and3.rows[0]).isEqualTo(TOTAL_ROWS);
-        // and4 with `flag != false` is uniform-random, expect ~50%.
         assertThat(and4.rows[0]).isBetween((long) (TOTAL_ROWS * 0.4), (long) (TOTAL_ROWS * 0.6));
         assertThat(compoundSelective.rows[0]).isEqualTo(10_000L);
-        // Compound mid: value uniform [0, 1000) so value<500 keeps ~50%.
         assertThat(compoundMid.rows[0]).isBetween((long) (TOTAL_ROWS * 0.4), (long) (TOTAL_ROWS * 0.6));
-        // Sorted cluster: id<N/2 is exactly N/2 rows, tag>=0 always true.
         assertThat(sortedCluster.rows[0]).isEqualTo(TOTAL_ROWS / 2L);
         assertThat(empty.rows[0]).isEqualTo(0L);
-        // OR: id<0 is empty so the result is the value<500 half.
         assertThat(orFilter.rows[0]).isBetween((long) (TOTAL_ROWS * 0.4), (long) (TOTAL_ROWS * 0.6));
         assertThat(rangeDup.rows[0]).isEqualTo(1_000_000L);
-        // intIn: 5 of 100 values, expect ~5%.
         assertThat(intIn.rows[0]).isBetween((long) (TOTAL_ROWS * 0.03), (long) (TOTAL_ROWS * 0.07));
+        for (int i = 0; i < NULL_PERCENTS.length; i++) {
+            int p = NULL_PERCENTS[i];
+            double nonNullFrac = (100.0 - p) / 100.0;
+            long expectedNonNull = (long) (TOTAL_ROWS * nonNullFrac);
+            // ±2pp tolerance for the random null mask.
+            assertThat(nullableMatchAll[i].rows[0])
+                    .isBetween((long) (TOTAL_ROWS * (nonNullFrac - 0.02)),
+                            (long) (TOTAL_ROWS * (nonNullFrac + 0.02)));
+            // score<100 over the present rows with score uniform [0,1000) → ~10% of present.
+            assertThat(nullableSelective[i].rows[0])
+                    .isBetween((long) (expectedNonNull * 0.08), (long) (expectedNonNull * 0.12));
+            assertThat(scanNullable[i].rows[0]).isEqualTo(nullableMatchAll[i].rows[0]);
+        }
     }
 
-    private Run timeNoFilter(int runs) throws Exception {
+    private Run timeNoFilter(Path file, int runs) throws Exception {
         long[] times = new long[runs];
         long[] rows = new long[runs];
         for (int i = 0; i < runs; i++) {
             long start = System.nanoTime();
-            rows[i] = runNoFilter();
+            rows[i] = runNoFilter(file);
             times[i] = System.nanoTime() - start;
         }
         return new Run(times, rows);
     }
 
-    private Run timeFilter(FilterPredicate filter, int runs) throws Exception {
+    private Run timeFilter(Path file, FilterPredicate filter, int runs) throws Exception {
         long[] times = new long[runs];
         long[] rows = new long[runs];
         for (int i = 0; i < runs; i++) {
             long start = System.nanoTime();
-            rows[i] = runFilter(filter);
+            rows[i] = runFilter(file, filter);
             times[i] = System.nanoTime() - start;
         }
         return new Run(times, rows);
     }
 
-    private long runNoFilter() throws Exception {
+    private long runNoFilter(Path file) throws Exception {
         long count = 0;
-        try (ParquetFileReader reader = ParquetFileReader.open(InputFile.of(BENCHMARK_FILE));
+        try (ParquetFileReader reader = ParquetFileReader.open(InputFile.of(file));
              RowReader rows = reader.rowReader()) {
             while (rows.hasNext()) {
                 rows.next();
@@ -275,9 +295,36 @@ class RecordFilterBenchmarkTest {
         return count;
     }
 
-    private long runFilter(FilterPredicate filter) throws Exception {
+    private long runScanScoreColumn(Path file) throws Exception {
+        long nonNullCount = 0;
+        try (ParquetFileReader reader = ParquetFileReader.open(InputFile.of(file));
+             RowReader rows = reader.rowReader()) {
+            while (rows.hasNext()) {
+                rows.next();
+                if (!rows.isNull("score")) {
+                    if (rows.getDouble("score") >= 0.0) {
+                        nonNullCount++;
+                    }
+                }
+            }
+        }
+        return nonNullCount;
+    }
+
+    private Run timeScanScoreColumn(Path file, int runs) throws Exception {
+        long[] times = new long[runs];
+        long[] rowsCount = new long[runs];
+        for (int i = 0; i < runs; i++) {
+            long start = System.nanoTime();
+            rowsCount[i] = runScanScoreColumn(file);
+            times[i] = System.nanoTime() - start;
+        }
+        return new Run(times, rowsCount);
+    }
+
+    private long runFilter(Path file, FilterPredicate filter) throws Exception {
         long count = 0;
-        try (ParquetFileReader reader = ParquetFileReader.open(InputFile.of(BENCHMARK_FILE));
+        try (ParquetFileReader reader = ParquetFileReader.open(InputFile.of(file));
              RowReader rows = reader.buildRowReader().filter(filter).build()) {
             while (rows.hasNext()) {
                 rows.next();
@@ -287,12 +334,13 @@ class RecordFilterBenchmarkTest {
         return count;
     }
 
-    private void ensureBenchmarkFileExists() throws IOException {
-        if (Files.exists(BENCHMARK_FILE) && Files.size(BENCHMARK_FILE) > 0) {
+    private void ensureBenchmarkFileExists(Path file, int nullPercent) throws IOException {
+        if (Files.exists(file) && Files.size(file) > 0) {
             return;
         }
 
-        System.out.println("Generating benchmark file (" + TOTAL_ROWS / 1_000_000 + "M rows, 4 columns)...");
+        System.out.println("Generating " + file + " (" + TOTAL_ROWS / 1_000_000
+                + "M rows, 5 columns, ~" + nullPercent + "% nulls on score)...");
 
         Schema schema = SchemaBuilder.record("benchmark")
                 .fields()
@@ -300,36 +348,41 @@ class RecordFilterBenchmarkTest {
                 .requiredDouble("value")
                 .requiredInt("tag")
                 .requiredBoolean("flag")
+                .optionalDouble("score")
                 .endRecord();
 
         Configuration conf = new Configuration();
         conf.set("parquet.writer.version", "v2");
 
-        org.apache.hadoop.fs.Path hadoopPath = new org.apache.hadoop.fs.Path(BENCHMARK_FILE.toAbsolutePath().toString());
+        org.apache.hadoop.fs.Path hadoopPath = new org.apache.hadoop.fs.Path(file.toAbsolutePath().toString());
 
         try (ParquetWriter<GenericRecord> writer = AvroParquetWriter.<GenericRecord>builder(hadoopPath)
                 .withSchema(schema)
                 .withConf(conf)
                 .withCompressionCodec(CompressionCodecName.SNAPPY)
-                // Byte budget (not a row count): TOTAL_ROWS * 16 bytes/row is a generous
-                // ceiling that forces a single row group for the whole dataset.
                 .withRowGroupSize((long) TOTAL_ROWS * 16)
                 .withWriteMode(ParquetFileWriter.Mode.OVERWRITE)
                 .withPageWriteChecksumEnabled(false)
                 .build()) {
 
-            Random rng = new Random(42);
+            Random rng = new Random(42 + nullPercent);
             for (int i = 0; i < TOTAL_ROWS; i++) {
                 GenericRecord record = new GenericData.Record(schema);
                 record.put("id", (long) i);
                 record.put("value", rng.nextDouble() * 1000.0);
                 record.put("tag", rng.nextInt(100));
                 record.put("flag", rng.nextBoolean());
+                if (rng.nextInt(100) < nullPercent) {
+                    record.put("score", null);
+                }
+                else {
+                    record.put("score", rng.nextDouble() * 1000.0);
+                }
                 writer.write(record);
             }
         }
 
-        System.out.println("Generated " + BENCHMARK_FILE + " (" + Files.size(BENCHMARK_FILE) / (1024 * 1024) + " MB)");
+        System.out.println("Generated " + file + " (" + Files.size(file) / (1024 * 1024) + " MB)");
     }
 
     private static void printResults(String name, String path, Run run, int runs) {

--- a/performance-testing/end-to-end/src/test/java/dev/hardwood/perf/RecordFilterBenchmarkTest.java
+++ b/performance-testing/end-to-end/src/test/java/dev/hardwood/perf/RecordFilterBenchmarkTest.java
@@ -32,10 +32,28 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 /// Benchmark for record-level filtering overhead.
 ///
-/// REQUIRED-column scenarios run once against a single file. The nullable-column
-/// scenarios (`Nullable IS NOT NULL`, `Nullable selective`, `Scan nullable column`)
-/// run once per density in [#NULL_PERCENTS] to expose how validity-bitmap handling
-/// behaves at scarce / mixed / sparse densities.
+/// Compares RowReader performance across:
+/// - **Baseline**: no filter at all (raw scan throughput).
+/// - **Match-all / compound match-all**: predicates that keep every row — worst case
+///   overhead because the filter is evaluated for each row but never prunes.
+/// - **Selective**: predicates that drop most rows — real-world wins.
+/// - **Drain-eligible compound ANDs** (2/3/4 leaves across `id`, `value`, `tag`, `flag`):
+///   exercise the column-local AND fast path.
+/// - **Fallback shapes** (single-leaf, OR, same-column range, IN-list): trip the
+///   drain-eligibility gate so [FilteredRowReader] handles them. See [BatchFilterCompiler].
+/// - **Page+record**: id range that prunes ~99% of pages via column-index min/max,
+///   then a per-row `value<500` filter on the survivors.
+/// - **Nullable scenarios**: `IS NOT NULL`, `score<100`, and per-row column scan
+///   over an OPTIONAL `score` column. Run once per density in [#NULL_PERCENTS]
+///   so the validity-bitmap path is exercised at scarce / mixed / sparse populations.
+///
+/// Schema: `id` (long, sequential 0..N), `value` (double uniform 0..1000),
+/// `tag` (int uniform 0..99), `flag` (boolean uniform), `score` (double uniform
+/// 0..1000, OPTIONAL with the configured null density).
+///
+/// Run:
+///   ./mvnw test -Pperformance-test -pl performance-testing/end-to-end \
+///     -Dtest="RecordFilterBenchmarkTest" -Dperf.runs=5
 class RecordFilterBenchmarkTest {
 
     private static final int TOTAL_ROWS = 10_000_000;


### PR DESCRIPTION
## Summary

Four changes targeting per-row accessor cost on the flat read path. All sit in `FlatRowReader` and its surrounding pipeline (`FlatColumnWorker`, `BatchExchange.Batch`) — no public API change.

1. **One-slot name → index cache** via reference equality in `resolveIndex(String)`. Intern'd `String` literals at the call site let the typical `isNull("X")` + `getX("X")` pair skip the hash + probe on the second call.
2. **`ALL_PRESENT` sentinel → `null`** for `flatValidity[col]`. REQUIRED-column accessors short-circuit on a single null compare instead of touching a pre-filled `BitSet`'s word array on every row.
3. **One-slot `isNull` cache** keyed on `(column, row)`. Accessors reached via an explicit `isNull` check no longer re-evaluate the bitmap inside `getX(int)`.
4. **Pre-allocated `validityBuffer` on `Batch`** eliminates the `currentValidity.clone()` per published batch in `FlatColumnWorker`. The worker writes directly into the recyclable buffer and flips `Batch.validity` between the buffer and `null` depending on whether any absent was observed.

## Benchmark numbers

`RecordFilterBenchmarkTest`, 10M rows × 5 cols (4 REQUIRED + 1 OPTIONAL `score`), 5 runs each, **median of runs 2–5** (dropping the first-run JIT outlier). Times in ms (lower is better).

### Per-row API hot path

| Scenario | Upstream | Branch | Δ |
|---|---:|---:|---:|
| Scan nullable, 1% null | 92.7 | 69.2 | **−25%** |
| Scan nullable, 50% null | 150.6 | 122.3 | **−19%** |
| Scan nullable, 90% null | 85.5 | 67.7 | **−21%** |
| IS NOT NULL, 1% null | 54.0 | 43.0 | **−21%** |
| IS NOT NULL, 50% null | 65.0 | 55.5 | **−15%** |
| IS NOT NULL, 90% null | 32.8 | 28.5 | **−13%** |

### Filter scenarios

| Scenario | Upstream | Branch | Δ |
|---|---:|---:|---:|
| Range+value | 9.2 | 6.7 | **−27%** |
| intIn | 45.0 | 35.8 | **−20%** |
| Compound mid 50% | 70.8 | 60.8 | **−14%** |
| Sorted cluster 50% | 21.6 | 18.1 | **−16%** |
| OR fallback | 160.7 | 144.4 | **−10%** |
| And4 ~50% | 59.6 | 54.8 | **−8%** |

### Baseline scenarios (no validity / accessor work to optimize)

| Scenario | Upstream | Branch | Δ |
|---|---:|---:|---:|
| No filter | 42.6 | 43.5 | +2% |
| Match-all (id>=0) | 41.2 | 43.6 | +6% |
| And3 match-all | 44.8 | 45.1 | 0% |

All baseline deltas sit inside the run-to-run noise band on this hardware.

Bench config: `./mvnw test -Pperformance-test -pl performance-testing/end-to-end -Dtest=RecordFilterBenchmarkTest -Dperf.runs=5`. `RecordFilterBenchmarkTest` is parameterized over `{1%, 50%, 90%}` null densities for the three nullable scenarios.

## Why each change is beneficial

| Change | Targets | Per-row saving |
|---|---|---|
| #1 Name cache | name → index hash on by-name accessors | ~5–10 ns when the user reuses a literal |
| #2 Null sentinel | REQUIRED-column bitmap touch | one fewer memory load + branch-predictor-friendly |
| #3 `isNull` cache | redundant bitmap check inside `getX` when paired with explicit `isNull` | ~3–5 ns |
| #4 No clone | per-publish `BitSet.clone()` in the producer | amortized GC pressure (~5.6 MB / 10M-row file × nullable columns) |

The biggest single contributor on the `Scan nullable column` shape is the name-cache (the bench loop hits two by-name calls per row with the same literal); #2 dominates the REQUIRED-column wins.

## Test plan

- [ ] `./mvnw verify -pl '!s3'` (1078 core tests pass on this branch)
- [ ] `./mvnw test -Pperformance-test -pl performance-testing/end-to-end -Dtest=RecordFilterBenchmarkTest -Dperf.runs=5`
- [ ] No public API change; `FieldAccessor` / `RowReader` surfaces unchanged
- [ ] `ColumnWorkerTest.flatPipelineTracksNulls` updated to pre-allocate `validityBuffer` in its factory (the production factories in `FlatRowReader.create` and `ColumnReader.createFromIterator` do this for nullable columns)
