### PR TITLE
#460 Drop field-named type validation on flat and nested accessors

### DIFF
--- a/core/src/main/java/dev/hardwood/internal/reader/FlatRowReader.java
+++ b/core/src/main/java/dev/hardwood/internal/reader/FlatRowReader.java
@@ -429,12 +429,12 @@ public final class FlatRowReader implements RowReader {
 
     @Override
     public int getInt(String name) {
-        return getInt(resolveAndValidate(name, PhysicalType.INT32));
+        return getInt(resolveIndex(name));
     }
 
     @Override
     public long getLong(String name) {
-        return getLong(resolveAndValidate(name, PhysicalType.INT64));
+        return getLong(resolveIndex(name));
     }
 
     @Override
@@ -444,12 +444,12 @@ public final class FlatRowReader implements RowReader {
 
     @Override
     public double getDouble(String name) {
-        return getDouble(resolveAndValidate(name, PhysicalType.DOUBLE));
+        return getDouble(resolveIndex(name));
     }
 
     @Override
     public boolean getBoolean(String name) {
-        return getBoolean(resolveAndValidate(name, PhysicalType.BOOLEAN));
+        return getBoolean(resolveIndex(name));
     }
 
     // ==================== String / Binary ====================
@@ -824,16 +824,6 @@ public final class FlatRowReader implements RowReader {
         int index = nameToIndex.get(name);
         if (index < 0) {
             throw new IllegalArgumentException(prefix() + "Column not in projection: " + name);
-        }
-        return index;
-    }
-
-    private int resolveAndValidate(String name, PhysicalType expectedType) {
-        int index = resolveIndex(name);
-        if (physicalTypes[index] != expectedType) {
-            throw new IllegalArgumentException(prefix()
-                    + "Field '" + name + "' has physical type " + physicalTypes[index]
-                    + ", expected " + expectedType);
         }
         return index;
     }

--- a/core/src/main/java/dev/hardwood/internal/reader/NestedBatchDataView.java
+++ b/core/src/main/java/dev/hardwood/internal/reader/NestedBatchDataView.java
@@ -113,18 +113,11 @@ public final class NestedBatchDataView {
     }
 
     private TopLevelFieldMap.FieldDesc.Primitive lookupPrimitive(String name) {
-        TopLevelFieldMap.FieldDesc desc = lookupField(name);
-        if (!(desc instanceof TopLevelFieldMap.FieldDesc.Primitive prim)) {
-            throw new IllegalArgumentException(prefix() + "Field '" + name + "' is not a primitive type");
-        }
-        return prim;
+        return (TopLevelFieldMap.FieldDesc.Primitive) lookupField(name);
     }
 
     private TopLevelFieldMap.FieldDesc.Primitive lookupPrimitiveByIndex(int projectedIndex) {
-        if (!(fieldDescs[projectedIndex] instanceof TopLevelFieldMap.FieldDesc.Primitive prim)) {
-            throw new IllegalArgumentException(prefix() + "Field at index " + projectedIndex + " is not a primitive type");
-        }
-        return prim;
+        return (TopLevelFieldMap.FieldDesc.Primitive) fieldDescs[projectedIndex];
     }
 
     public boolean isNull(String name) {
@@ -393,10 +386,7 @@ public final class NestedBatchDataView {
     // ==================== Nested Type Accessors (by name) ====================
 
     public PqStruct getStruct(String name) {
-        TopLevelFieldMap.FieldDesc desc = lookupField(name);
-        if (!(desc instanceof TopLevelFieldMap.FieldDesc.Struct structDesc)) {
-            throw new IllegalArgumentException(prefix() + "Field '" + name + "' is not a struct");
-        }
+        TopLevelFieldMap.FieldDesc.Struct structDesc = (TopLevelFieldMap.FieldDesc.Struct) lookupField(name);
         if (isStructNull(structDesc)) {
             return null;
         }
@@ -404,24 +394,17 @@ public final class NestedBatchDataView {
     }
 
     public PqList getList(String name) {
-        TopLevelFieldMap.FieldDesc.ListOf listDesc = lookupList(name);
-        return createList(listDesc);
+        return createList((TopLevelFieldMap.FieldDesc.ListOf) lookupField(name));
     }
 
     public PqMap getMap(String name) {
-        TopLevelFieldMap.FieldDesc desc = lookupField(name);
-        if (!(desc instanceof TopLevelFieldMap.FieldDesc.MapOf mapDesc)) {
-            throw new IllegalArgumentException(prefix() + "Field '" + name + "' is not a map");
-        }
-        return createMap(mapDesc);
+        return createMap((TopLevelFieldMap.FieldDesc.MapOf) lookupField(name));
     }
 
     // ==================== Nested Type Accessors (by index) ====================
 
     public PqStruct getStruct(int projectedIndex) {
-        if (!(fieldDescs[projectedIndex] instanceof TopLevelFieldMap.FieldDesc.Struct structDesc)) {
-            throw new IllegalArgumentException(prefix() + "Field at index " + projectedIndex + " is not a struct");
-        }
+        TopLevelFieldMap.FieldDesc.Struct structDesc = (TopLevelFieldMap.FieldDesc.Struct) fieldDescs[projectedIndex];
         if (isStructNull(structDesc)) {
             return null;
         }
@@ -433,10 +416,7 @@ public final class NestedBatchDataView {
     }
 
     public PqMap getMap(int projectedIndex) {
-        if (!(fieldDescs[projectedIndex] instanceof TopLevelFieldMap.FieldDesc.MapOf mapDesc)) {
-            throw new IllegalArgumentException(prefix() + "Field at index " + projectedIndex + " is not a map");
-        }
-        return createMap(mapDesc);
+        return createMap((TopLevelFieldMap.FieldDesc.MapOf) fieldDescs[projectedIndex]);
     }
 
     // ==================== Generic Value Access ====================
@@ -528,14 +508,6 @@ public final class NestedBatchDataView {
         }
     }
 
-    private TopLevelFieldMap.FieldDesc.ListOf lookupList(String name) {
-        TopLevelFieldMap.FieldDesc desc = lookupField(name);
-        if (!(desc instanceof TopLevelFieldMap.FieldDesc.ListOf listDesc)) {
-            throw new IllegalArgumentException(prefix() + "Field '" + name + "' is not a list");
-        }
-        return listDesc;
-    }
-
     private PqList createList(TopLevelFieldMap.FieldDesc.ListOf listDesc) {
         return PqListImpl.createGenericList(batchIndex, listDesc, rowIndex, -1);
     }
@@ -569,18 +541,11 @@ public final class NestedBatchDataView {
     // ==================== Variant accessor ====================
 
     public PqVariant getVariant(String name) {
-        TopLevelFieldMap.FieldDesc desc = lookupField(name);
-        if (!(desc instanceof TopLevelFieldMap.FieldDesc.Variant variantDesc)) {
-            throw new IllegalArgumentException(prefix() + "Field '" + name + "' is not annotated as VARIANT");
-        }
-        return createVariant(variantDesc);
+        return createVariant((TopLevelFieldMap.FieldDesc.Variant) lookupField(name));
     }
 
     public PqVariant getVariant(int projectedIndex) {
-        if (!(fieldDescs[projectedIndex] instanceof TopLevelFieldMap.FieldDesc.Variant variantDesc)) {
-            throw new IllegalArgumentException(prefix() + "Field at index " + projectedIndex + " is not annotated as VARIANT");
-        }
-        return createVariant(variantDesc);
+        return createVariant((TopLevelFieldMap.FieldDesc.Variant) fieldDescs[projectedIndex]);
     }
 
     private final VariantShredReassembler variantReassembler = new VariantShredReassembler();

--- a/core/src/main/java/dev/hardwood/internal/reader/PqListImpl.java
+++ b/core/src/main/java/dev/hardwood/internal/reader/PqListImpl.java
@@ -176,24 +176,14 @@ final class PqListImpl implements PqList {
     }
 
     // ==================== Primitive Type Accessors ====================
-    //
-    // Each accessor validates `elementSchema` once at construction so the
-    // per-element decode reduces to a cast (primitives) or a delegate to
-    // `convertLogicalType` (logical-typed objects). Wrong-type access
-    // throws field-named `IllegalArgumentException` from the accessor
-    // call rather than from the first element decode, so
-    // `pqList.dates()` on a STRING list fails fast even when the list
-    // happens to be empty.
 
     @Override
     public PqIntList ints() {
-        ValueConverter.validatePhysicalType(elementSchema, PhysicalType.INT32);
         return new PqIntListImpl(batch, listDesc.firstLeafProjCol(), start, end);
     }
 
     @Override
     public PqLongList longs() {
-        ValueConverter.validatePhysicalType(elementSchema, PhysicalType.INT64);
         return new PqLongListImpl(batch, listDesc.firstLeafProjCol(), start, end);
     }
 
@@ -206,19 +196,16 @@ final class PqListImpl implements PqList {
                 && prim.logicalType() instanceof LogicalType.Float16Type) {
             return new LeafList<>(raw -> ValueConverter.convertLogicalType(raw, elementSchema, Float.class));
         }
-        ValueConverter.validatePhysicalType(elementSchema, PhysicalType.FLOAT);
         return new LeafList<>(raw -> (Float) raw);
     }
 
     @Override
     public PqDoubleList doubles() {
-        ValueConverter.validatePhysicalType(elementSchema, PhysicalType.DOUBLE);
         return new PqDoubleListImpl(batch, listDesc.firstLeafProjCol(), start, end);
     }
 
     @Override
     public List<Boolean> booleans() {
-        ValueConverter.validatePhysicalType(elementSchema, PhysicalType.BOOLEAN);
         return new LeafList<>(raw -> (Boolean) raw);
     }
 
@@ -226,7 +213,6 @@ final class PqListImpl implements PqList {
 
     @Override
     public List<String> strings() {
-        ValueConverter.validatePhysicalType(elementSchema, PhysicalType.BYTE_ARRAY);
         return new LeafList<>(raw -> {
             if (raw instanceof String s) return s;
             return new String((byte[]) raw, StandardCharsets.UTF_8);
@@ -235,43 +221,36 @@ final class PqListImpl implements PqList {
 
     @Override
     public List<byte[]> binaries() {
-        ValueConverter.validatePhysicalType(elementSchema, PhysicalType.BYTE_ARRAY, PhysicalType.FIXED_LEN_BYTE_ARRAY);
         return new LeafList<>(raw -> (byte[]) raw);
     }
 
     @Override
     public List<LocalDate> dates() {
-        ValueConverter.validateLogicalType(elementSchema, LogicalType.DateType.class);
         return new LeafList<>(raw -> ValueConverter.convertLogicalType(raw, elementSchema, LocalDate.class));
     }
 
     @Override
     public List<LocalTime> times() {
-        ValueConverter.validateLogicalType(elementSchema, LogicalType.TimeType.class);
         return new LeafList<>(raw -> ValueConverter.convertLogicalType(raw, elementSchema, LocalTime.class));
     }
 
     @Override
     public List<Instant> timestamps() {
-        ValueConverter.validateLogicalType(elementSchema, LogicalType.TimestampType.class);
         return new LeafList<>(raw -> ValueConverter.convertLogicalType(raw, elementSchema, Instant.class));
     }
 
     @Override
     public List<BigDecimal> decimals() {
-        ValueConverter.validateLogicalType(elementSchema, LogicalType.DecimalType.class);
         return new LeafList<>(raw -> ValueConverter.convertLogicalType(raw, elementSchema, BigDecimal.class));
     }
 
     @Override
     public List<UUID> uuids() {
-        ValueConverter.validateLogicalType(elementSchema, LogicalType.UuidType.class);
         return new LeafList<>(raw -> ValueConverter.convertLogicalType(raw, elementSchema, UUID.class));
     }
 
     @Override
     public List<PqInterval> intervals() {
-        ValueConverter.validateLogicalType(elementSchema, LogicalType.IntervalType.class);
         return new LeafList<>(raw -> ValueConverter.convertLogicalType(raw, elementSchema, PqInterval.class));
     }
 

--- a/core/src/main/java/dev/hardwood/internal/reader/ValueConverter.java
+++ b/core/src/main/java/dev/hardwood/internal/reader/ValueConverter.java
@@ -20,7 +20,7 @@ import dev.hardwood.metadata.PhysicalType;
 import dev.hardwood.row.PqInterval;
 import dev.hardwood.schema.SchemaNode;
 
-/// Shared validation and conversion logic for PqStruct, PqList, and PqMap implementations.
+/// Shared decode helpers used by `PqStruct`, `PqList`, and `PqMap` flyweights.
 public final class ValueConverter {
 
     private ValueConverter() {
@@ -32,7 +32,6 @@ public final class ValueConverter {
         if (rawValue == null) {
             return null;
         }
-        validatePhysicalType(schema, PhysicalType.INT32);
         return (Integer) rawValue;
     }
 
@@ -40,7 +39,6 @@ public final class ValueConverter {
         if (rawValue == null) {
             return null;
         }
-        validatePhysicalType(schema, PhysicalType.INT64);
         return (Long) rawValue;
     }
 
@@ -48,15 +46,13 @@ public final class ValueConverter {
         if (rawValue == null) {
             return null;
         }
-        // Accept either physical FLOAT or FLBA(2) annotated FLOAT16; the latter
-        // decodes the half-precision payload to a single-precision Float so
-        // callers don't need to know the on-disk encoding.
+        // FLBA(2) annotated FLOAT16 decodes the half-precision payload to a
+        // single-precision Float so callers don't need to know the on-disk encoding.
         if (schema instanceof SchemaNode.PrimitiveNode primitive
                 && primitive.type() == PhysicalType.FIXED_LEN_BYTE_ARRAY
                 && primitive.logicalType() instanceof LogicalType.Float16Type) {
             return convertLogicalType(rawValue, schema, Float.class);
         }
-        validatePhysicalType(schema, PhysicalType.FLOAT);
         return (Float) rawValue;
     }
 
@@ -64,7 +60,6 @@ public final class ValueConverter {
         if (rawValue == null) {
             return null;
         }
-        validatePhysicalType(schema, PhysicalType.DOUBLE);
         return (Double) rawValue;
     }
 
@@ -72,7 +67,6 @@ public final class ValueConverter {
         if (rawValue == null) {
             return null;
         }
-        validatePhysicalType(schema, PhysicalType.BOOLEAN);
         return (Boolean) rawValue;
     }
 
@@ -82,7 +76,6 @@ public final class ValueConverter {
         if (rawValue == null) {
             return null;
         }
-        validateStringType(schema);
         if (rawValue instanceof String) {
             return (String) rawValue;
         }
@@ -93,7 +86,6 @@ public final class ValueConverter {
         if (rawValue == null) {
             return null;
         }
-        validatePhysicalType(schema, PhysicalType.BYTE_ARRAY, PhysicalType.FIXED_LEN_BYTE_ARRAY);
         return (byte[]) rawValue;
     }
 
@@ -101,7 +93,6 @@ public final class ValueConverter {
         if (rawValue == null) {
             return null;
         }
-        validateLogicalType(schema, LogicalType.DateType.class);
         return convertLogicalType(rawValue, schema, LocalDate.class);
     }
 
@@ -109,7 +100,6 @@ public final class ValueConverter {
         if (rawValue == null) {
             return null;
         }
-        validateLogicalType(schema, LogicalType.TimeType.class);
         return convertLogicalType(rawValue, schema, LocalTime.class);
     }
 
@@ -120,7 +110,6 @@ public final class ValueConverter {
         if (schema instanceof SchemaNode.PrimitiveNode primitive && primitive.type() == PhysicalType.INT96) {
             return LogicalTypeConverter.int96ToInstant((byte[]) rawValue);
         }
-        validateLogicalType(schema, LogicalType.TimestampType.class);
         return convertLogicalType(rawValue, schema, Instant.class);
     }
 
@@ -128,7 +117,6 @@ public final class ValueConverter {
         if (rawValue == null) {
             return null;
         }
-        validateLogicalType(schema, LogicalType.DecimalType.class);
         return convertLogicalType(rawValue, schema, BigDecimal.class);
     }
 
@@ -136,7 +124,6 @@ public final class ValueConverter {
         if (rawValue == null) {
             return null;
         }
-        validateLogicalType(schema, LogicalType.UuidType.class);
         return convertLogicalType(rawValue, schema, UUID.class);
     }
 
@@ -144,7 +131,6 @@ public final class ValueConverter {
         if (rawValue == null) {
             return null;
         }
-        validateLogicalType(schema, LogicalType.IntervalType.class);
         return convertLogicalType(rawValue, schema, PqInterval.class);
     }
 
@@ -180,74 +166,6 @@ public final class ValueConverter {
         return LogicalTypeConverter.convert(rawValue, primitive.type(), logicalType);
     }
 
-    // ==================== Validation Helpers ====================
-
-    static void validatePhysicalType(SchemaNode schema, PhysicalType... expectedTypes) {
-        if (!(schema instanceof SchemaNode.PrimitiveNode primitive)) {
-            throw new IllegalArgumentException(
-                    "Field '" + schema.name() + "' is not a primitive type");
-        }
-        for (PhysicalType expected : expectedTypes) {
-            if (primitive.type() == expected) {
-                return;
-            }
-        }
-        throw new IllegalArgumentException(
-                "Field '" + schema.name() + "' has physical type " + primitive.type()
-                        + ", expected " + (expectedTypes.length == 1 ? expectedTypes[0] : java.util.Arrays.toString(expectedTypes)));
-    }
-
-    private static void validateStringType(SchemaNode schema) {
-        if (!(schema instanceof SchemaNode.PrimitiveNode primitive)) {
-            throw new IllegalArgumentException(
-                    "Field '" + schema.name() + "' is not a primitive type");
-        }
-        // STRING can be BYTE_ARRAY with or without STRING logical type annotation
-        if (primitive.type() != PhysicalType.BYTE_ARRAY) {
-            throw new IllegalArgumentException(
-                    "Field '" + schema.name() + "' has physical type " + primitive.type()
-                            + ", expected BYTE_ARRAY for STRING");
-        }
-    }
-
-    static void validateLogicalType(SchemaNode schema, Class<? extends LogicalType> expectedType) {
-        if (!(schema instanceof SchemaNode.PrimitiveNode primitive)) {
-            throw new IllegalArgumentException(
-                    "Field '" + schema.name() + "' is not a primitive type");
-        }
-        LogicalType logicalType = primitive.logicalType();
-        if (logicalType == null || !expectedType.isInstance(logicalType)) {
-            throw new IllegalArgumentException(
-                    "Field '" + schema.name() + "' has logical type "
-                            + (logicalType == null ? "none" : logicalType.getClass().getSimpleName())
-                            + ", expected " + expectedType.getSimpleName());
-        }
-    }
-
-    static void validateGroupType(SchemaNode schema, boolean expectList, boolean expectMap) {
-        if (!(schema instanceof SchemaNode.GroupNode group)) {
-            throw new IllegalArgumentException(
-                    "Field '" + schema.name() + "' is not a group type");
-        }
-        if (expectList && !group.isList()) {
-            throw new IllegalArgumentException(
-                    "Field '" + schema.name() + "' is not a list");
-        }
-        if (expectMap && !group.isMap()) {
-            throw new IllegalArgumentException(
-                    "Field '" + schema.name() + "' is not a map");
-        }
-        if (!expectList && !expectMap && (group.isList() || group.isMap())) {
-            throw new IllegalArgumentException(
-                    "Field '" + schema.name() + "' is a list or map, not a struct");
-        }
-    }
-
-    /// Package-private decode helper that skips schema validation. Intended for
-    /// hot-path call sites (typed [dev.hardwood.row.PqList] iterators) that
-    /// have already validated `schema` against the expected logical type — pre-flight
-    /// validation hoists out of the per-element lambda, leaving each lambda call
-    /// at one `instanceof` short-circuit plus a delegate to [LogicalTypeConverter].
     static <T> T convertLogicalType(Object rawValue, SchemaNode schema, Class<T> expectedClass) {
         // If already converted (e.g., by RecordAssembler for nested structures), return as-is
         if (expectedClass.isInstance(rawValue)) {

--- a/core/src/main/java/dev/hardwood/row/FieldAccessor.java
+++ b/core/src/main/java/dev/hardwood/row/FieldAccessor.java
@@ -30,7 +30,6 @@ public interface FieldAccessor {
     /// @param name the field name
     /// @return the int value
     /// @throws NullPointerException if the field is null
-    /// @throws IllegalArgumentException if the field type is not INT32
     int getInt(String name);
 
     /// Get an INT64 field value by name.
@@ -38,7 +37,6 @@ public interface FieldAccessor {
     /// @param name the field name
     /// @return the long value
     /// @throws NullPointerException if the field is null
-    /// @throws IllegalArgumentException if the field type is not INT64
     long getLong(String name);
 
     /// Get a FLOAT field value by name. Also accepts FLOAT16 columns
@@ -48,7 +46,6 @@ public interface FieldAccessor {
     /// @param name the field name
     /// @return the float value
     /// @throws NullPointerException if the field is null
-    /// @throws IllegalArgumentException if the field type is neither FLOAT nor FLOAT16
     float getFloat(String name);
 
     /// Get a DOUBLE field value by name.
@@ -56,7 +53,6 @@ public interface FieldAccessor {
     /// @param name the field name
     /// @return the double value
     /// @throws NullPointerException if the field is null
-    /// @throws IllegalArgumentException if the field type is not DOUBLE
     double getDouble(String name);
 
     /// Get a BOOLEAN field value by name.
@@ -64,7 +60,6 @@ public interface FieldAccessor {
     /// @param name the field name
     /// @return the boolean value
     /// @throws NullPointerException if the field is null
-    /// @throws IllegalArgumentException if the field type is not BOOLEAN
     boolean getBoolean(String name);
 
     // ==================== Object Types ====================
@@ -73,49 +68,42 @@ public interface FieldAccessor {
     ///
     /// @param name the field name
     /// @return the string value, or null if the field is null
-    /// @throws IllegalArgumentException if the field type is not STRING
     String getString(String name);
 
     /// Get a BINARY field value by name.
     ///
     /// @param name the field name
     /// @return the byte array, or null if the field is null
-    /// @throws IllegalArgumentException if the field type is not BINARY
     byte[] getBinary(String name);
 
     /// Get a DATE field value by name.
     ///
     /// @param name the field name
     /// @return the date value, or null if the field is null
-    /// @throws IllegalArgumentException if the field type is not DATE
     LocalDate getDate(String name);
 
     /// Get a TIME field value by name.
     ///
     /// @param name the field name
     /// @return the time value, or null if the field is null
-    /// @throws IllegalArgumentException if the field type is not TIME
     LocalTime getTime(String name);
 
     /// Get a TIMESTAMP field value by name.
     ///
     /// @param name the field name
     /// @return the instant value, or null if the field is null
-    /// @throws IllegalArgumentException if the field type is not TIMESTAMP
     Instant getTimestamp(String name);
 
     /// Get a DECIMAL field value by name.
     ///
     /// @param name the field name
     /// @return the decimal value, or null if the field is null
-    /// @throws IllegalArgumentException if the field type is not DECIMAL
     BigDecimal getDecimal(String name);
 
     /// Get a UUID field value by name.
     ///
     /// @param name the field name
     /// @return the UUID value, or null if the field is null
-    /// @throws IllegalArgumentException if the field type is not UUID
     UUID getUuid(String name);
 
     /// Get an INTERVAL field value by name.
@@ -127,7 +115,6 @@ public interface FieldAccessor {
     ///
     /// @param name the field name
     /// @return the interval value, or null if the field is null
-    /// @throws IllegalArgumentException if the field type is not INTERVAL
     PqInterval getInterval(String name);
 
     // ==================== Variant ====================
@@ -140,7 +127,6 @@ public interface FieldAccessor {
     ///
     /// @param name the field name
     /// @return the Variant accessor, or null if the field is null
-    /// @throws IllegalArgumentException if the field is not annotated as VARIANT
     PqVariant getVariant(String name);
 
     // ==================== Generic Fallback ====================

--- a/core/src/main/java/dev/hardwood/row/PqMap.java
+++ b/core/src/main/java/dev/hardwood/row/PqMap.java
@@ -61,24 +61,18 @@ public interface PqMap {
     /// True if this map contains an entry with the given STRING key.
     ///
     /// @throws NullPointerException if `key` is null
-    /// @throws ClassCastException if the map's key column is not STRING / BYTE_ARRAY
     boolean containsKey(String key);
 
     /// True if this map contains an entry with the given INT32 key.
-    ///
-    /// @throws ClassCastException if the map's key column is not INT32
     boolean containsKey(int key);
 
     /// True if this map contains an entry with the given INT64 key.
-    ///
-    /// @throws ClassCastException if the map's key column is not INT64
     boolean containsKey(long key);
 
     /// True if this map contains an entry with the given byte-array key.
     /// Byte equality follows [java.util.Arrays#equals(byte[], byte[])].
     ///
     /// @throws NullPointerException if `key` is null
-    /// @throws ClassCastException if the map's key column is not BYTE_ARRAY / FIXED_LEN_BYTE_ARRAY
     boolean containsKey(byte[] key);
 
     /// Look up the decoded value for a STRING key.
@@ -89,19 +83,16 @@ public interface PqMap {
     ///
     /// @return the decoded value, or `null` if the key is absent or its value is null
     /// @throws NullPointerException if `key` is null
-    /// @throws ClassCastException if the map's key column is not STRING / BYTE_ARRAY
     Object getValue(String key);
 
     /// Look up the decoded value for an INT32 key.
     ///
     /// @return the decoded value, or `null` if the key is absent or its value is null
-    /// @throws ClassCastException if the map's key column is not INT32
     Object getValue(int key);
 
     /// Look up the decoded value for an INT64 key.
     ///
     /// @return the decoded value, or `null` if the key is absent or its value is null
-    /// @throws ClassCastException if the map's key column is not INT64
     Object getValue(long key);
 
     /// Look up the decoded value for a byte-array key.
@@ -109,26 +100,22 @@ public interface PqMap {
     ///
     /// @return the decoded value, or `null` if the key is absent or its value is null
     /// @throws NullPointerException if `key` is null
-    /// @throws ClassCastException if the map's key column is not BYTE_ARRAY / FIXED_LEN_BYTE_ARRAY
     Object getValue(byte[] key);
 
     /// Look up the raw physical value for a STRING key — mirrors [Entry#getRawValue].
     ///
     /// @return the raw value, or `null` if the key is absent or its value is null
     /// @throws NullPointerException if `key` is null
-    /// @throws ClassCastException if the map's key column is not STRING / BYTE_ARRAY
     Object getRawValue(String key);
 
     /// Look up the raw physical value for an INT32 key — mirrors [Entry#getRawValue].
     ///
     /// @return the raw value, or `null` if the key is absent or its value is null
-    /// @throws ClassCastException if the map's key column is not INT32
     Object getRawValue(int key);
 
     /// Look up the raw physical value for an INT64 key — mirrors [Entry#getRawValue].
     ///
     /// @return the raw value, or `null` if the key is absent or its value is null
-    /// @throws ClassCastException if the map's key column is not INT64
     Object getRawValue(long key);
 
     /// Look up the raw physical value for a byte-array key — mirrors [Entry#getRawValue].
@@ -136,7 +123,6 @@ public interface PqMap {
     ///
     /// @return the raw value, or `null` if the key is absent or its value is null
     /// @throws NullPointerException if `key` is null
-    /// @throws ClassCastException if the map's key column is not BYTE_ARRAY / FIXED_LEN_BYTE_ARRAY
     Object getRawValue(byte[] key);
 
     /// A single key-value entry in a map.
@@ -155,13 +141,11 @@ public interface PqMap {
         /// Get the key as an INT32.
         ///
         /// @return the int key value
-        /// @throws IllegalArgumentException if the key type is not INT32
         int getIntKey();
 
         /// Get the key as an INT64.
         ///
         /// @return the long key value
-        /// @throws IllegalArgumentException if the key type is not INT64
         long getLongKey();
 
         // ==================== Key Accessors - Objects ====================
@@ -169,13 +153,11 @@ public interface PqMap {
         /// Get the key as a STRING.
         ///
         /// @return the string key value
-        /// @throws IllegalArgumentException if the key type is not STRING
         String getStringKey();
 
         /// Get the key as a BINARY.
         ///
         /// @return the byte array key value
-        /// @throws IllegalArgumentException if the key type is not BINARY
         byte[] getBinaryKey();
 
         /// Get the key, decoded to its logical-type representation.
@@ -205,35 +187,30 @@ public interface PqMap {
         ///
         /// @return the int value
         /// @throws NullPointerException if the value is null
-        /// @throws IllegalArgumentException if the value type is not INT32
         int getIntValue();
 
         /// Get the value as an INT64.
         ///
         /// @return the long value
         /// @throws NullPointerException if the value is null
-        /// @throws IllegalArgumentException if the value type is not INT64
         long getLongValue();
 
         /// Get the value as a FLOAT.
         ///
         /// @return the float value
         /// @throws NullPointerException if the value is null
-        /// @throws IllegalArgumentException if the value type is not FLOAT
         float getFloatValue();
 
         /// Get the value as a DOUBLE.
         ///
         /// @return the double value
         /// @throws NullPointerException if the value is null
-        /// @throws IllegalArgumentException if the value type is not DOUBLE
         double getDoubleValue();
 
         /// Get the value as a BOOLEAN.
         ///
         /// @return the boolean value
         /// @throws NullPointerException if the value is null
-        /// @throws IllegalArgumentException if the value type is not BOOLEAN
         boolean getBooleanValue();
 
         // ==================== Value Accessors - Objects ====================
@@ -241,49 +218,41 @@ public interface PqMap {
         /// Get the value as a STRING.
         ///
         /// @return the string value, or null if the value is null
-        /// @throws IllegalArgumentException if the value type is not STRING
         String getStringValue();
 
         /// Get the value as a BINARY.
         ///
         /// @return the byte array value, or null if the value is null
-        /// @throws IllegalArgumentException if the value type is not BINARY
         byte[] getBinaryValue();
 
         /// Get the value as a DATE.
         ///
         /// @return the date value, or null if the value is null
-        /// @throws IllegalArgumentException if the value type is not DATE
         LocalDate getDateValue();
 
         /// Get the value as a TIME.
         ///
         /// @return the time value, or null if the value is null
-        /// @throws IllegalArgumentException if the value type is not TIME
         LocalTime getTimeValue();
 
         /// Get the value as a TIMESTAMP.
         ///
         /// @return the instant value, or null if the value is null
-        /// @throws IllegalArgumentException if the value type is not TIMESTAMP
         Instant getTimestampValue();
 
         /// Get the value as a DECIMAL.
         ///
         /// @return the decimal value, or null if the value is null
-        /// @throws IllegalArgumentException if the value type is not DECIMAL
         BigDecimal getDecimalValue();
 
         /// Get the value as a UUID.
         ///
         /// @return the UUID value, or null if the value is null
-        /// @throws IllegalArgumentException if the value type is not UUID
         UUID getUuidValue();
 
         /// Get the value as an INTERVAL.
         ///
         /// @return the interval value, or null if the value is null
-        /// @throws IllegalArgumentException if the value type is not INTERVAL
         PqInterval getIntervalValue();
 
         // ==================== Value Accessors - Nested Types ====================
@@ -291,19 +260,16 @@ public interface PqMap {
         /// Get the value as a nested struct.
         ///
         /// @return the nested struct, or null if the value is null
-        /// @throws IllegalArgumentException if the value type is not a struct
         PqStruct getStructValue();
 
         /// Get the value as a LIST.
         ///
         /// @return the list value, or null if the value is null
-        /// @throws IllegalArgumentException if the value type is not a list
         PqList getListValue();
 
         /// Get the value as a MAP.
         ///
         /// @return the nested map, or null if the value is null
-        /// @throws IllegalArgumentException if the value type is not a map
         PqMap getMapValue();
 
         /// Get the value as a VARIANT.
@@ -312,7 +278,6 @@ public interface PqMap {
         /// shredded variant values throw [UnsupportedOperationException].
         ///
         /// @return the variant, or null if the value is null
-        /// @throws IllegalArgumentException if the value type is not a variant
         /// @throws UnsupportedOperationException if the variant is shredded
         PqVariant getVariantValue();
 

--- a/core/src/main/java/dev/hardwood/row/StructAccessor.java
+++ b/core/src/main/java/dev/hardwood/row/StructAccessor.java
@@ -39,7 +39,6 @@ public interface StructAccessor extends FieldAccessor {
     ///
     /// @param name the field name
     /// @return the nested struct, or null if the field is null
-    /// @throws IllegalArgumentException if the field type is not a struct
     PqStruct getStruct(String name);
 
     // ==================== Generic List ====================
@@ -48,14 +47,12 @@ public interface StructAccessor extends FieldAccessor {
     ///
     /// @param name the field name
     /// @return the list, or null if the field is null
-    /// @throws IllegalArgumentException if the field type is not a list
     PqList getList(String name);
 
     /// Get a MAP field value by name.
     ///
     /// @param name the field name
     /// @return the map, or null if the field is null
-    /// @throws IllegalArgumentException if the field type is not a map
     PqMap getMap(String name);
 
     // ==================== Accessors by Index ====================

--- a/core/src/test/java/dev/hardwood/FileNameInExceptionTest.java
+++ b/core/src/test/java/dev/hardwood/FileNameInExceptionTest.java
@@ -65,41 +65,28 @@ class FileNameInExceptionTest {
     // ==================== RowReader (multi-file) ====================
 
     @Test
-    void multiFileRowReaderAttributesNullErrorsToTheirOwnFileName(@TempDir Path tempDir) throws Exception {
-        // Copy the optional-column fixture under a second, distinct name so the
-        // file-boundary detection in ColumnWorker is actually exercised — not
-        // just the same name twice. Within each 100-row file, `optional_value`
-        // is null on every third row (0-indexed positions 2, 5, 8, …). Reading
-        // the same null offset from both files surfaces a file-prefixed NPE
-        // attributed to whichever file the current row came from.
-        Path firstFile = Paths.get("src/test/resources/delta_binary_packed_optional_test.parquet");
-        String firstFileName = "delta_binary_packed_optional_test.parquet";
+    void multiFileRowReaderTypeMismatchThrowsClassCastException(@TempDir Path tempDir) throws Exception {
+        // Copy the test file under a second name so the file-boundary detection in
+        // ColumnWorker is actually exercised. plain_uncompressed.parquet has 3 rows;
+        // the multi-file reader emits rows 0–2 from TEST_FILE then rows 3–5 from
+        // the copy. Every row must still surface a ClassCastException for a wrong-
+        // type access, regardless of which file the current row came from.
         Path secondFile = tempDir.resolve("second_file.parquet");
-        Files.copy(firstFile, secondFile);
+        Files.copy(TEST_FILE, secondFile);
 
         try (Hardwood hardwood = Hardwood.create();
              ParquetFileReader parquet = hardwood.openAll(
-                     InputFile.ofPaths(List.of(firstFile, secondFile)));
+                     InputFile.ofPaths(List.of(TEST_FILE, secondFile)));
              RowReader reader = parquet.rowReader()) {
 
-            // Advance to position 2 (first null row in the first file)
-            for (int i = 0; i < 3; i++) {
+            for (int i = 0; i < 6; i++) {
                 assertThat(reader.hasNext()).isTrue();
                 reader.next();
+                assertThatThrownBy(() -> reader.getInt("id"))
+                        .isInstanceOf(ClassCastException.class);
             }
-            assertThatThrownBy(() -> reader.getInt("optional_value"))
-                    .isInstanceOf(NullPointerException.class)
-                    .hasMessageContaining("[" + firstFileName + "]");
 
-            // Advance through the rest of file 1 and to position 102 (first
-            // null row of file 2)
-            for (int i = 3; i < 103; i++) {
-                assertThat(reader.hasNext()).isTrue();
-                reader.next();
-            }
-            assertThatThrownBy(() -> reader.getInt("optional_value"))
-                    .isInstanceOf(NullPointerException.class)
-                    .hasMessageContaining("[second_file.parquet]");
+            assertThat(reader.hasNext()).isFalse();
         }
     }
 

--- a/core/src/test/java/dev/hardwood/FileNameInExceptionTest.java
+++ b/core/src/test/java/dev/hardwood/FileNameInExceptionTest.java
@@ -65,28 +65,41 @@ class FileNameInExceptionTest {
     // ==================== RowReader (multi-file) ====================
 
     @Test
-    void multiFileRowReaderTypeMismatchThrowsClassCastException(@TempDir Path tempDir) throws Exception {
-        // Copy the test file under a second name so the file-boundary detection in
-        // ColumnWorker is actually exercised. plain_uncompressed.parquet has 3 rows;
-        // the multi-file reader emits rows 0–2 from TEST_FILE then rows 3–5 from
-        // the copy. Every row must still surface a ClassCastException for a wrong-
-        // type access, regardless of which file the current row came from.
+    void multiFileRowReaderAttributesNullErrorsToTheirOwnFileName(@TempDir Path tempDir) throws Exception {
+        // Copy the optional-column fixture under a second, distinct name so the
+        // file-boundary detection in ColumnWorker is actually exercised — not
+        // just the same name twice. Within each 100-row file, `optional_value`
+        // is null on every third row (0-indexed positions 2, 5, 8, …). Reading
+        // the same null offset from both files surfaces a file-prefixed NPE
+        // attributed to whichever file the current row came from.
+        Path firstFile = Paths.get("src/test/resources/delta_binary_packed_optional_test.parquet");
+        String firstFileName = "delta_binary_packed_optional_test.parquet";
         Path secondFile = tempDir.resolve("second_file.parquet");
-        Files.copy(TEST_FILE, secondFile);
+        Files.copy(firstFile, secondFile);
 
         try (Hardwood hardwood = Hardwood.create();
              ParquetFileReader parquet = hardwood.openAll(
-                     InputFile.ofPaths(List.of(TEST_FILE, secondFile)));
+                     InputFile.ofPaths(List.of(firstFile, secondFile)));
              RowReader reader = parquet.rowReader()) {
 
-            for (int i = 0; i < 6; i++) {
+            // Advance to position 2 (first null row in the first file)
+            for (int i = 0; i < 3; i++) {
                 assertThat(reader.hasNext()).isTrue();
                 reader.next();
-                assertThatThrownBy(() -> reader.getInt("id"))
-                        .isInstanceOf(ClassCastException.class);
             }
+            assertThatThrownBy(() -> reader.getInt("optional_value"))
+                    .isInstanceOf(NullPointerException.class)
+                    .hasMessageContaining("[" + firstFileName + "]");
 
-            assertThat(reader.hasNext()).isFalse();
+            // Advance through the rest of file 1 and to position 102 (first
+            // null row of file 2)
+            for (int i = 3; i < 103; i++) {
+                assertThat(reader.hasNext()).isTrue();
+                reader.next();
+            }
+            assertThatThrownBy(() -> reader.getInt("optional_value"))
+                    .isInstanceOf(NullPointerException.class)
+                    .hasMessageContaining("[second_file.parquet]");
         }
     }
 

--- a/core/src/test/java/dev/hardwood/FileNameInExceptionTest.java
+++ b/core/src/test/java/dev/hardwood/FileNameInExceptionTest.java
@@ -34,21 +34,6 @@ class FileNameInExceptionTest {
     // ==================== RowReader (single file) ====================
 
     @Test
-    void rowReaderTypeMismatchIncludesFileName() throws Exception {
-        try (ParquetFileReader fileReader = ParquetFileReader.open(InputFile.of(TEST_FILE));
-             RowReader reader = fileReader.rowReader()) {
-
-            assertThat(reader.hasNext()).isTrue();
-            reader.next();
-
-            // "id" column is LONG — requesting INT throws via resolveAndValidate
-            assertThatThrownBy(() -> reader.getInt("id"))
-                    .isInstanceOf(IllegalArgumentException.class)
-                    .hasMessage("[" + FILE_NAME + "] Field 'id' has physical type INT64, expected INT32");
-        }
-    }
-
-    @Test
     void rowReaderMissingColumnIncludesFileName() throws Exception {
         try (ParquetFileReader fileReader = ParquetFileReader.open(InputFile.of(TEST_FILE));
              RowReader reader = fileReader.rowReader()) {
@@ -60,47 +45,6 @@ class FileNameInExceptionTest {
             assertThatThrownBy(() -> reader.getLong("nonexistent"))
                     .isInstanceOf(IllegalArgumentException.class)
                     .hasMessage("[" + FILE_NAME + "] Column not in projection: nonexistent");
-        }
-    }
-
-    // ==================== RowReader (multi-file) ====================
-
-    @Test
-    void multiFileRowReaderAttributesEachFileToItsOwnName(@TempDir Path tempDir) throws Exception {
-        // Copy the test file under a second, distinct name so the file-boundary
-        // detection in ColumnWorker is actually exercised — not just the same name twice.
-        // plain_uncompressed.parquet has 3 rows; the multi-file reader should emit
-        // rows from TEST_FILE first (rows 0–2), then from second_file (rows 3–5).
-        Path secondFile = tempDir.resolve("second_file.parquet");
-        Files.copy(TEST_FILE, secondFile);
-
-        String firstFileError = "[" + FILE_NAME + "] Field 'id' has physical type INT64, expected INT32";
-        String secondFileError = "[second_file.parquet] Field 'id' has physical type INT64, expected INT32";
-
-        try (Hardwood hardwood = Hardwood.create();
-             ParquetFileReader parquet = hardwood.openAll(
-                     InputFile.ofPaths(List.of(TEST_FILE, secondFile)));
-             RowReader reader = parquet.rowReader()) {
-
-            // Rows 0–2 come from TEST_FILE
-            for (int i = 0; i < 3; i++) {
-                assertThat(reader.hasNext()).isTrue();
-                reader.next();
-                assertThatThrownBy(() -> reader.getInt("id"))
-                        .isInstanceOf(IllegalArgumentException.class)
-                        .hasMessage(firstFileError);
-            }
-
-            // Rows 3–5 come from secondFile
-            for (int i = 0; i < 3; i++) {
-                assertThat(reader.hasNext()).isTrue();
-                reader.next();
-                assertThatThrownBy(() -> reader.getInt("id"))
-                        .isInstanceOf(IllegalArgumentException.class)
-                        .hasMessage(secondFileError);
-            }
-
-            assertThat(reader.hasNext()).isFalse();
         }
     }
 

--- a/core/src/test/java/dev/hardwood/FileNameInExceptionTest.java
+++ b/core/src/test/java/dev/hardwood/FileNameInExceptionTest.java
@@ -34,6 +34,20 @@ class FileNameInExceptionTest {
     // ==================== RowReader (single file) ====================
 
     @Test
+    void rowReaderTypeMismatchThrowsClassCastException() throws Exception {
+        try (ParquetFileReader fileReader = ParquetFileReader.open(InputFile.of(TEST_FILE));
+             RowReader reader = fileReader.rowReader()) {
+
+            assertThat(reader.hasNext()).isTrue();
+            reader.next();
+
+            // "id" is LONG — requesting INT fails via the underlying long[]→int[] cast.
+            assertThatThrownBy(() -> reader.getInt("id"))
+                    .isInstanceOf(ClassCastException.class);
+        }
+    }
+
+    @Test
     void rowReaderMissingColumnIncludesFileName() throws Exception {
         try (ParquetFileReader fileReader = ParquetFileReader.open(InputFile.of(TEST_FILE));
              RowReader reader = fileReader.rowReader()) {
@@ -45,6 +59,34 @@ class FileNameInExceptionTest {
             assertThatThrownBy(() -> reader.getLong("nonexistent"))
                     .isInstanceOf(IllegalArgumentException.class)
                     .hasMessage("[" + FILE_NAME + "] Column not in projection: nonexistent");
+        }
+    }
+
+    // ==================== RowReader (multi-file) ====================
+
+    @Test
+    void multiFileRowReaderTypeMismatchThrowsClassCastException(@TempDir Path tempDir) throws Exception {
+        // Copy the test file under a second name so the file-boundary detection in
+        // ColumnWorker is actually exercised. plain_uncompressed.parquet has 3 rows;
+        // the multi-file reader emits rows 0–2 from TEST_FILE then rows 3–5 from
+        // the copy. Every row must still surface a ClassCastException for a wrong-
+        // type access, regardless of which file the current row came from.
+        Path secondFile = tempDir.resolve("second_file.parquet");
+        Files.copy(TEST_FILE, secondFile);
+
+        try (Hardwood hardwood = Hardwood.create();
+             ParquetFileReader parquet = hardwood.openAll(
+                     InputFile.ofPaths(List.of(TEST_FILE, secondFile)));
+             RowReader reader = parquet.rowReader()) {
+
+            for (int i = 0; i < 6; i++) {
+                assertThat(reader.hasNext()).isTrue();
+                reader.next();
+                assertThatThrownBy(() -> reader.getInt("id"))
+                        .isInstanceOf(ClassCastException.class);
+            }
+
+            assertThat(reader.hasNext()).isFalse();
         }
     }
 

--- a/core/src/test/java/dev/hardwood/FileNameInExceptionTest.java
+++ b/core/src/test/java/dev/hardwood/FileNameInExceptionTest.java
@@ -62,34 +62,6 @@ class FileNameInExceptionTest {
         }
     }
 
-    // ==================== RowReader (multi-file) ====================
-
-    @Test
-    void multiFileRowReaderTypeMismatchThrowsClassCastException(@TempDir Path tempDir) throws Exception {
-        // Copy the test file under a second name so the file-boundary detection in
-        // ColumnWorker is actually exercised. plain_uncompressed.parquet has 3 rows;
-        // the multi-file reader emits rows 0–2 from TEST_FILE then rows 3–5 from
-        // the copy. Every row must still surface a ClassCastException for a wrong-
-        // type access, regardless of which file the current row came from.
-        Path secondFile = tempDir.resolve("second_file.parquet");
-        Files.copy(TEST_FILE, secondFile);
-
-        try (Hardwood hardwood = Hardwood.create();
-             ParquetFileReader parquet = hardwood.openAll(
-                     InputFile.ofPaths(List.of(TEST_FILE, secondFile)));
-             RowReader reader = parquet.rowReader()) {
-
-            for (int i = 0; i < 6; i++) {
-                assertThat(reader.hasNext()).isTrue();
-                reader.next();
-                assertThatThrownBy(() -> reader.getInt("id"))
-                        .isInstanceOf(ClassCastException.class);
-            }
-
-            assertThat(reader.hasNext()).isFalse();
-        }
-    }
-
     // ==================== ColumnReader (single file) ====================
 
     @Test

--- a/core/src/test/java/dev/hardwood/PqRowApiTest.java
+++ b/core/src/test/java/dev/hardwood/PqRowApiTest.java
@@ -408,10 +408,10 @@ public class PqRowApiTest {
         try (ParquetFileReader fileReader = ParquetFileReader.open(InputFile.of(parquetFile));
              RowReader rowReader = fileReader.rowReader()) {
             rowReader.next();
-            // name is a STRING field, not INT32
+            // name is a STRING field, not INT32 — surfaces as a ClassCastException
+            // from the underlying value-array cast.
             assertThatThrownBy(() -> rowReader.getInt("name"))
-                    .isInstanceOf(IllegalArgumentException.class)
-                    .hasMessageContaining("name");
+                    .isInstanceOf(ClassCastException.class);
         }
     }
 

--- a/core/src/test/java/dev/hardwood/PqRowApiTest.java
+++ b/core/src/test/java/dev/hardwood/PqRowApiTest.java
@@ -422,10 +422,10 @@ public class PqRowApiTest {
         try (ParquetFileReader fileReader = ParquetFileReader.open(InputFile.of(parquetFile));
              RowReader rowReader = fileReader.rowReader()) {
             rowReader.next();
-            // address is a struct, not a list
+            // address is a struct, not a list — surfaces as a ClassCastException
+            // from the underlying FieldDesc cast.
             assertThatThrownBy(() -> rowReader.getList("address"))
-                    .isInstanceOf(IllegalArgumentException.class)
-                    .hasMessageContaining("not a list");
+                    .isInstanceOf(ClassCastException.class);
         }
     }
 

--- a/core/src/test/java/dev/hardwood/TypedAccessorErrorMessagesTest.java
+++ b/core/src/test/java/dev/hardwood/TypedAccessorErrorMessagesTest.java
@@ -19,26 +19,24 @@ import dev.hardwood.row.PqList;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
-/// Coverage for the `PqList` typed-iterator validation hoist
-/// (hardwood#469): wrong-type iteration must fail at iterator construction
-/// with a field-named error, not lazily on the first element decode.
+/// Coverage for `PqList` typed-iterator behavior on wrong element types
+/// (hardwood#460): wrong-type access surfaces as a [ClassCastException] from
+/// the element decode rather than a typed pre-flight validation.
 class TypedAccessorErrorMessagesTest {
 
     private static final Path FIXTURE =
             Paths.get("src/test/resources/typed_accessors_issue_445.parquet");
 
     @Test
-    void pqListTypedIteratorValidatesAtConstructionNotFirstElement() throws Exception {
+    void pqListWrongElementTypeFailsOnElementDecode() throws Exception {
         try (ParquetFileReader fileReader = ParquetFileReader.open(InputFile.of(FIXTURE));
              RowReader rowReader = fileReader.rowReader()) {
             rowReader.next();
-            // `intervals` is a List<INTERVAL>; calling .dates() on it must
-            // throw immediately at iterator construction with a field-named
-            // error, not later when the first element is decoded.
+            // `intervals` is a List<INTERVAL>; iterating it as dates fails on the
+            // first element decode rather than at iterator construction.
             PqList intervals = rowReader.getList("intervals");
-            assertThatThrownBy(intervals::dates)
-                    .isInstanceOf(IllegalArgumentException.class)
-                    .hasMessageContaining("DateType");
+            assertThatThrownBy(() -> intervals.dates().get(0))
+                    .isInstanceOf(ClassCastException.class);
         }
     }
 

--- a/docs/content/usage.md
+++ b/docs/content/usage.md
@@ -48,7 +48,7 @@ Hardwood throws specific exceptions for common error conditions:
 |-----------|------|
 | `IOException` | Any I/O error: invalid Parquet file (bad magic number, corrupt footer), local-disk read errors, S3 transport failures (after retry exhaustion — see [S3](s3.md)) |
 | `UnsupportedOperationException` | Compression codec library not on classpath — the message names the required dependency |
-| `IllegalArgumentException` | Accessing a column not in the projection, type mismatch on accessor, or invalid column name |
+| `IllegalArgumentException` | Accessing a column not in the projection, or invalid column name |
 | `NullPointerException` | Calling a primitive accessor (`getInt`, `getLong`, etc.) on a null field without checking `isNull()` first |
 | `NoSuchElementException` | Calling `next()` on a `RowReader` when `hasNext()` returns `false` |
 | `IllegalStateException` | Calling `ColumnReader` accessors before `nextBatch()`, or calling nested-column methods on a flat column |

--- a/docs/content/usage/row-reader.md
+++ b/docs/content/usage/row-reader.md
@@ -155,7 +155,7 @@ All accessor methods are available in two forms:
 | `getVariant` | BYTE_ARRAY pair | VARIANT | `PqVariant` |
 | `isNull` | Any | Any | `boolean` |
 
-All methods are available as both `method(name)` and `method(index)`, except `getStruct`, `getList`, `getMap`, and `getVariant` which are name-based only.
+All methods are available as both `method(name)` and `method(index)`.
 
 #### Null handling
 

--- a/docs/content/usage/row-reader.md
+++ b/docs/content/usage/row-reader.md
@@ -161,9 +161,9 @@ All methods are available as both `method(name)` and `method(index)`, except `ge
 
 Primitive accessors (`getInt`, `getLong`, `getFloat`, `getDouble`, `getBoolean`) throw `NullPointerException` if the field is null — always check with `isNull()` first. Object accessors (`getString`, `getDate`, `getTimestamp`, `getDecimal`, `getUuid`, `getInterval`, `getStruct`, `getList`, `getMap`) return `null` for null fields.
 
-#### Type validation
+#### Type mismatches
 
-The API validates at runtime that the requested type matches the schema. Mismatches throw `IllegalArgumentException` with a descriptive message.
+Requesting the wrong type for a column (e.g. `getInt` on a `LONG` column, `getDate` on a `STRING` column) is a programming error; the call fails at runtime with an unchecked exception. The specific exception type is unspecified and may change between releases — do not catch it as part of normal control flow. Check the schema up front if the column type isn't known statically.
 
 #### Index-based access
 


### PR DESCRIPTION
Hello, meanwhile discovering null improvement options, this PR applies what we were discussing on https://github.com/hardwood-hq/hardwood/issues/460 to delete the validations. It's showing almost 7~8% imrpovement e2e. 

# E2E Tests

## This branch: 

```
PERFORMANCE TEST RESULTS
Environment:
  CPU cores:       10
  Java version:    25.0.3
  OS:              Mac OS X aarch64
Data:
  Files processed: 117
  Total rows:      644,521,685
  Total size:      9,143.1 MB
  Runs per contender: 10
Performance (all runs):
  Contender                          Time (s)     Records/sec   Records/sec/core       MB/sec
  -----------------------------------------------------------------------------------------------
  Hardwood (row reader named) [1]        11.32      56,921,459          5,692,146        807.5
  Hardwood (row reader named) [2]        11.36      56,751,051          5,675,105        805.1
  Hardwood (row reader named) [3]        11.30      57,027,224          5,702,722        809.0
  Hardwood (row reader named) [4]        11.52      55,943,207          5,594,321        793.6
  Hardwood (row reader named) [5]        11.59      55,629,353          5,562,935        789.2
  Hardwood (row reader named) [6]        11.20      57,556,857          5,755,686        816.5
  Hardwood (row reader named) [7]        11.29      57,067,619          5,706,762        809.6
  Hardwood (row reader named) [8]        11.18      57,664,998          5,766,500        818.0
  Hardwood (row reader named) [9]        11.25      57,270,454          5,727,045        812.4
  Hardwood (row reader named) [10]        11.20      57,567,139          5,756,714        816.6
  Hardwood (row reader named) [AVG]        11.32      56,936,545          5,693,654        807.7
                                   min: 11.18s, max: 11.59s, spread: 0.41s
```

## Main branch: 

```
PERFORMANCE TEST RESULTS
Environment:
  CPU cores:       10
  Java version:    25.0.3
  OS:              Mac OS X aarch64
Data:
  Files processed: 117
  Total rows:      644,521,685
  Total size:      9,143.1 MB
  Runs per contender: 10
Performance (all runs):
  Contender                          Time (s)     Records/sec   Records/sec/core       MB/sec
  -----------------------------------------------------------------------------------------------
  Hardwood (row reader named) [1]        12.25      52,635,499          5,263,550        746.7
  Hardwood (row reader named) [2]        12.20      52,816,659          5,281,666        749.3
  Hardwood (row reader named) [3]        12.19      52,859,976          5,285,998        749.9
  Hardwood (row reader named) [4]        12.22      52,734,551          5,273,455        748.1
  Hardwood (row reader named) [5]        12.22      52,764,772          5,276,477        748.5
  Hardwood (row reader named) [6]        12.21      52,773,412          5,277,341        748.6
  Hardwood (row reader named) [7]        12.22      52,725,923          5,272,592        748.0
  Hardwood (row reader named) [8]        12.25      52,605,426          5,260,543        746.3
  Hardwood (row reader named) [9]        12.29      52,451,309          5,245,131        744.1
  Hardwood (row reader named) [10]        12.19      52,855,641          5,285,564        749.8
  Hardwood (row reader named) [AVG]        12.22      52,725,923          5,272,592        748.0
                                   min: 12.19s, max: 12.29s, spread: 0.10s
```

# Nested: 

## This branch: 

```
NESTED SCHEMA PERFORMANCE TEST RESULTS
====================================================================================================

Environment:
  CPU cores:       10
  Java version:    25.0.3
  OS:              Mac OS X aarch64

Data:
  Total rows:      4,671,392
  File size:       594.0 MB
  Runs per contender: 5

Performance (all runs):
  Contender                          Time (s)     Records/sec   Records/sec/core       MB/sec
  -----------------------------------------------------------------------------------------------
  Hardwood (named) [1]                   1.97       2,372,469            237,247        301.7
  Hardwood (named) [2]                   1.45       3,232,797            323,280        411.1
  Hardwood (named) [3]                   1.49       3,137,268            313,727        398.9
  Hardwood (named) [4]                   1.47       3,175,657            317,566        403.8
  Hardwood (named) [5]                   1.48       3,156,346            315,635        401.4
  Hardwood (named) [AVG]                 1.57       2,975,409            297,541        378.4
                                   min: 1.45s, max: 1.97s, spread: 0.52s
```

## Main branch: 


```
NESTED SCHEMA PERFORMANCE TEST RESULTS
====================================================================================================

Environment:
  CPU cores:       10
  Java version:    25.0.3
  OS:              Mac OS X aarch64

Data:
  Total rows:      4,671,392
  File size:       594.0 MB
  Runs per contender: 5

Performance (all runs):
  Contender                          Time (s)     Records/sec   Records/sec/core       MB/sec
  -----------------------------------------------------------------------------------------------
  Hardwood (named) [1]                   1.51       3,085,464            308,546        392.4
  Hardwood (named) [2]                   1.52       3,069,246            306,925        390.3
  Hardwood (named) [3]                   1.62       2,890,713            289,071        367.6
  Hardwood (named) [4]                   1.61       2,905,095            290,509        369.4
  Hardwood (named) [5]                   1.56       2,990,648            299,065        380.3
  Hardwood (named) [AVG]                 1.56       2,986,824            298,682        379.8
                                   min: 1.51s, max: 1.62s, spread: 0.10s
```


## Checklist

- [x] Build via `./mvnw clean verify` passes
- [x] The commit message is prefixed with the issue key ("#123 Adding support for...")
- [x] Code changes are covered by tests
- [ ] If this PR adds or changes user-facing behaviour, `docs/` has been updated
