### PR TITLE
#438 To enforce some rules from CLAUDE.md

### DIFF
--- a/.github/workflows/cli-early-access.yml
+++ b/.github/workflows/cli-early-access.yml
@@ -70,7 +70,7 @@ jobs:
           path: ~/.m2/repository/dev/hardwood/
 
       - name: 'Build Native Image'
-        run: ./mvnw -ntp -B -Dnative package -pl cli -DskipTests
+        run: ./mvnw -ntp -B -Dnative package -pl :hardwood-error-prone-checks,:hardwood-cli -DskipTests
 
       - name: 'Upload build artifact (tar.gz)'
         if: ${{ runner.os != 'Windows' }}

--- a/.github/workflows/main-build.yml
+++ b/.github/workflows/main-build.yml
@@ -51,7 +51,7 @@ jobs:
           fi
 
       - name: 'Build and install BOMs, test-support, core and avro'
-        run: ./mvnw -B clean install -pl :hardwood-bom,:hardwood-test-bom,:hardwood-test-support,:hardwood-core,:hardwood-avro
+        run: ./mvnw -B clean install -pl :hardwood-error-prone-checks,:hardwood-bom,:hardwood-test-bom,:hardwood-test-support,:hardwood-core,:hardwood-avro
 
       - name: 'Upload built artifacts'
         uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f  # v7 — https://github.com/actions/upload-artifact/releases/tag/v7
@@ -108,7 +108,7 @@ jobs:
           path: ~/.m2/repository/dev/hardwood/
 
       - name: 'Build and install s3 and aws-auth'
-        run: ./mvnw -B clean install -pl :hardwood-s3,:hardwood-aws-auth
+        run: ./mvnw -B clean install -pl :hardwood-error-prone-checks,:hardwood-s3,:hardwood-aws-auth
 
       - name: 'Upload built artifacts'
         uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f  # v7 — https://github.com/actions/upload-artifact/releases/tag/v7
@@ -161,7 +161,7 @@ jobs:
           merge-multiple: true
 
       - name: 'Build and install cli'
-        run: ./mvnw -B clean install -pl :hardwood-cli
+        run: ./mvnw -B clean install -pl :hardwood-error-prone-checks,:hardwood-cli
 
       - name: 'Upload built artifacts'
         uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f  # v7 — https://github.com/actions/upload-artifact/releases/tag/v7
@@ -212,7 +212,7 @@ jobs:
           merge-multiple: true
 
       - name: 'Build and install parquet-java-compat'
-        run: ./mvnw -B clean install -pl :hardwood-parquet-java-compat
+        run: ./mvnw -B clean install -pl :hardwood-error-prone-checks,:hardwood-parquet-java-compat
 
       - name: 'Upload built artifacts'
         uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f  # v7 — https://github.com/actions/upload-artifact/releases/tag/v7
@@ -255,7 +255,7 @@ jobs:
           path: ~/.m2/repository/dev/hardwood/
 
       - name: 'Build and install parquet-testing-runner'
-        run: ./mvnw -B clean install -pl :hardwood-parquet-testing-runner
+        run: ./mvnw -B clean install -pl :hardwood-error-prone-checks,:hardwood-parquet-testing-runner
 
       - name: 'Upload built artifacts'
         uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f  # v7 — https://github.com/actions/upload-artifact/releases/tag/v7
@@ -336,7 +336,7 @@ jobs:
           path: ~/.m2/repository/dev/hardwood/
 
       - name: 'Run integration tests'
-        run: ./mvnw -B verify -pl :hardwood-integration-test
+        run: ./mvnw -B verify -pl :hardwood-error-prone-checks,:hardwood-integration-test
 
   api-change-report:
     needs: build-core
@@ -374,7 +374,7 @@ jobs:
         run: |
           JAPICMP_OLD_VERSION="$(sed -n 's/^Latest version: \([^,]*\),.*/\1/p' README.md)"
           echo "Comparing against ${JAPICMP_OLD_VERSION}"
-          ./mvnw -ntp -B package japicmp:cmp -pl :hardwood-core -DskipTests -Djapicmp.oldVersion="${JAPICMP_OLD_VERSION}"
+          ./mvnw -ntp -B package japicmp:cmp -pl :hardwood-error-prone-checks,:hardwood-core -DskipTests -Djapicmp.oldVersion="${JAPICMP_OLD_VERSION}"
 
       - name: 'Upload API change report'
         uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f  # v7 — https://github.com/actions/upload-artifact/releases/tag/v7

--- a/.github/workflows/main-build.yml
+++ b/.github/workflows/main-build.yml
@@ -58,6 +58,7 @@ jobs:
         with:
           name: maven-repo-core
           path: |
+            ~/.m2/repository/dev/hardwood/hardwood-error-prone-checks/
             ~/.m2/repository/dev/hardwood/hardwood-bom/
             ~/.m2/repository/dev/hardwood/hardwood-test-bom/
             ~/.m2/repository/dev/hardwood/hardwood-test-support/
@@ -108,7 +109,7 @@ jobs:
           path: ~/.m2/repository/dev/hardwood/
 
       - name: 'Build and install s3 and aws-auth'
-        run: ./mvnw -B clean install -pl :hardwood-error-prone-checks,:hardwood-s3,:hardwood-aws-auth
+        run: ./mvnw -B clean install -pl :hardwood-s3,:hardwood-aws-auth
 
       - name: 'Upload built artifacts'
         uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f  # v7 — https://github.com/actions/upload-artifact/releases/tag/v7
@@ -161,7 +162,7 @@ jobs:
           merge-multiple: true
 
       - name: 'Build and install cli'
-        run: ./mvnw -B clean install -pl :hardwood-error-prone-checks,:hardwood-cli
+        run: ./mvnw -B clean install -pl :hardwood-cli
 
       - name: 'Upload built artifacts'
         uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f  # v7 — https://github.com/actions/upload-artifact/releases/tag/v7
@@ -212,7 +213,7 @@ jobs:
           merge-multiple: true
 
       - name: 'Build and install parquet-java-compat'
-        run: ./mvnw -B clean install -pl :hardwood-error-prone-checks,:hardwood-parquet-java-compat
+        run: ./mvnw -B clean install -pl :hardwood-parquet-java-compat
 
       - name: 'Upload built artifacts'
         uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f  # v7 — https://github.com/actions/upload-artifact/releases/tag/v7
@@ -255,7 +256,7 @@ jobs:
           path: ~/.m2/repository/dev/hardwood/
 
       - name: 'Build and install parquet-testing-runner'
-        run: ./mvnw -B clean install -pl :hardwood-error-prone-checks,:hardwood-parquet-testing-runner
+        run: ./mvnw -B clean install -pl :hardwood-parquet-testing-runner
 
       - name: 'Upload built artifacts'
         uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f  # v7 — https://github.com/actions/upload-artifact/releases/tag/v7
@@ -336,7 +337,7 @@ jobs:
           path: ~/.m2/repository/dev/hardwood/
 
       - name: 'Run integration tests'
-        run: ./mvnw -B verify -pl :hardwood-error-prone-checks,:hardwood-integration-test
+        run: ./mvnw -B verify -pl :hardwood-integration-test
 
   api-change-report:
     needs: build-core
@@ -374,7 +375,7 @@ jobs:
         run: |
           JAPICMP_OLD_VERSION="$(sed -n 's/^Latest version: \([^,]*\),.*/\1/p' README.md)"
           echo "Comparing against ${JAPICMP_OLD_VERSION}"
-          ./mvnw -ntp -B package japicmp:cmp -pl :hardwood-error-prone-checks,:hardwood-core -DskipTests -Djapicmp.oldVersion="${JAPICMP_OLD_VERSION}"
+          ./mvnw -ntp -B package japicmp:cmp -pl :hardwood-core -DskipTests -Djapicmp.oldVersion="${JAPICMP_OLD_VERSION}"
 
       - name: 'Upload API change report'
         uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f  # v7 — https://github.com/actions/upload-artifact/releases/tag/v7

--- a/.github/workflows/performance.yml
+++ b/.github/workflows/performance.yml
@@ -78,7 +78,7 @@ jobs:
             overture-maps-places-
 
       - name: 'Install core, s3 and aws-auth into local repo'
-        run: ./mvnw -B -DskipTests install -pl :hardwood-core,:hardwood-avro,:hardwood-s3,:hardwood-aws-auth -am
+        run: ./mvnw -B -DskipTests install -pl :hardwood-error-prone-checks,:hardwood-core,:hardwood-avro,:hardwood-s3,:hardwood-aws-auth -am
 
       - name: 'Run performance tests (with SIMD)'
         # Defaults match push-to-main: Flat + Nested over the full cached
@@ -88,4 +88,4 @@ jobs:
           MAVEN_OPTS: '--add-modules jdk.incubator.vector'
           PERF_RUNS: ${{ inputs.perf_runs || '5' }}
           TESTS: ${{ inputs.tests || 'FlatPerformanceTest,NestedPerformanceTest' }}
-        run: ./mvnw -B verify -Pperformance-test -pl :hardwood-performance-testing -amd -Dperf.start="$PERF_START" -Dperf.end="$PERF_END" -Dperf.runs="$PERF_RUNS" -Dtest="$TESTS" -Dsurefire.failIfNoSpecifiedTests=false
+        run: ./mvnw -B verify -Pperformance-test -pl :hardwood-error-prone-checks,:hardwood-performance-testing -amd -Dperf.start="$PERF_START" -Dperf.end="$PERF_END" -Dperf.runs="$PERF_RUNS" -Dtest="$TESTS" -Dsurefire.failIfNoSpecifiedTests=false

--- a/.github/workflows/performance.yml
+++ b/.github/workflows/performance.yml
@@ -88,4 +88,4 @@ jobs:
           MAVEN_OPTS: '--add-modules jdk.incubator.vector'
           PERF_RUNS: ${{ inputs.perf_runs || '5' }}
           TESTS: ${{ inputs.tests || 'FlatPerformanceTest,NestedPerformanceTest' }}
-        run: ./mvnw -B verify -Pperformance-test -pl :hardwood-error-prone-checks,:hardwood-performance-testing -amd -Dperf.start="$PERF_START" -Dperf.end="$PERF_END" -Dperf.runs="$PERF_RUNS" -Dtest="$TESTS" -Dsurefire.failIfNoSpecifiedTests=false
+        run: ./mvnw -B verify -Pperformance-test -pl :hardwood-performance-testing -amd -Dperf.start="$PERF_START" -Dperf.end="$PERF_END" -Dperf.runs="$PERF_RUNS" -Dtest="$TESTS" -Dsurefire.failIfNoSpecifiedTests=false

--- a/.github/workflows/pr-build.yml
+++ b/.github/workflows/pr-build.yml
@@ -51,7 +51,7 @@ jobs:
           fi
 
       - name: 'Build and install BOMs, test-support, core and avro'
-        run: ./mvnw -B clean install -pl :hardwood-bom,:hardwood-test-bom,:hardwood-test-support,:hardwood-core,:hardwood-avro
+        run: ./mvnw -B clean install -pl :hardwood-error-prone-checks,:hardwood-bom,:hardwood-test-bom,:hardwood-test-support,:hardwood-core,:hardwood-avro
 
       - name: 'Upload built artifacts'
         uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f  # v7 — https://github.com/actions/upload-artifact/releases/tag/v7
@@ -108,7 +108,7 @@ jobs:
           path: ~/.m2/repository/dev/hardwood/
 
       - name: 'Build and install s3 and aws-auth'
-        run: ./mvnw -B clean install -pl :hardwood-s3,:hardwood-aws-auth
+        run: ./mvnw -B clean install -pl :hardwood-error-prone-checks,:hardwood-s3,:hardwood-aws-auth
 
       - name: 'Upload built artifacts'
         uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f  # v7 — https://github.com/actions/upload-artifact/releases/tag/v7
@@ -161,7 +161,7 @@ jobs:
           merge-multiple: true
 
       - name: 'Build and install cli'
-        run: ./mvnw -B clean install -pl :hardwood-cli
+        run: ./mvnw -B clean install -pl :hardwood-error-prone-checks,:hardwood-cli
 
       - name: 'Upload built artifacts'
         uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f  # v7 — https://github.com/actions/upload-artifact/releases/tag/v7
@@ -212,7 +212,7 @@ jobs:
           merge-multiple: true
 
       - name: 'Build and install parquet-java-compat'
-        run: ./mvnw -B clean install -pl :hardwood-parquet-java-compat
+        run: ./mvnw -B clean install -pl :hardwood-error-prone-checks,:hardwood-parquet-java-compat
 
       - name: 'Upload built artifacts'
         uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f  # v7 — https://github.com/actions/upload-artifact/releases/tag/v7
@@ -255,7 +255,7 @@ jobs:
           path: ~/.m2/repository/dev/hardwood/
 
       - name: 'Build and install parquet-testing-runner'
-        run: ./mvnw -B clean install -pl :hardwood-parquet-testing-runner
+        run: ./mvnw -B clean install -pl :hardwood-error-prone-checks,:hardwood-parquet-testing-runner
 
       - name: 'Upload built artifacts'
         uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f  # v7 — https://github.com/actions/upload-artifact/releases/tag/v7
@@ -372,15 +372,15 @@ jobs:
 
       - name: 'Run integration tests (Java 21)'
         if: ${{ !matrix.install_libdeflate && !matrix.enable_incubating }}
-        run: ./mvnw -B verify -pl :hardwood-integration-test
+        run: ./mvnw -B verify -pl :hardwood-error-prone-checks,:hardwood-integration-test
 
       - name: 'Run integration tests (with libdeflate)'
         if: ${{ matrix.install_libdeflate && !matrix.enable_incubating }}
-        run: ./mvnw -B verify -pl :hardwood-integration-test -Dlibdeflate.required=true -DargLine="--enable-native-access=ALL-UNNAMED"
+        run: ./mvnw -B verify -pl :hardwood-error-prone-checks,:hardwood-integration-test -Dlibdeflate.required=true -DargLine="--enable-native-access=ALL-UNNAMED"
 
       - name: 'Run integration tests (with incubating APIs)'
         if: ${{ matrix.install_libdeflate && matrix.enable_incubating }}
-        run: ./mvnw -B verify -pl :hardwood-integration-test -Dlibdeflate.required=true -DargLine="--enable-native-access=ALL-UNNAMED --add-modules jdk.incubator.vector"
+        run: ./mvnw -B verify -pl :hardwood-error-prone-checks,:hardwood-integration-test -Dlibdeflate.required=true -DargLine="--enable-native-access=ALL-UNNAMED --add-modules jdk.incubator.vector"
 
   # Verify the native CLI build on PRs
   native-build-check:
@@ -429,4 +429,4 @@ jobs:
         # -DskipSurefire=true skips the JVM @QuarkusMainTest suite (already run
         # in the `build-cli` job); Failsafe still runs the native smoke ITs during
         # integration-test.
-        run: ./mvnw -ntp -B -Dnative verify -pl cli -DskipSurefire=true
+        run: ./mvnw -ntp -B -Dnative verify -pl :hardwood-error-prone-checks,:hardwood-cli -DskipSurefire=true

--- a/.github/workflows/pr-build.yml
+++ b/.github/workflows/pr-build.yml
@@ -58,6 +58,7 @@ jobs:
         with:
           name: maven-repo-core
           path: |
+            ~/.m2/repository/dev/hardwood/hardwood-error-prone-checks/
             ~/.m2/repository/dev/hardwood/hardwood-bom/
             ~/.m2/repository/dev/hardwood/hardwood-test-bom/
             ~/.m2/repository/dev/hardwood/hardwood-test-support/
@@ -108,7 +109,7 @@ jobs:
           path: ~/.m2/repository/dev/hardwood/
 
       - name: 'Build and install s3 and aws-auth'
-        run: ./mvnw -B clean install -pl :hardwood-error-prone-checks,:hardwood-s3,:hardwood-aws-auth
+        run: ./mvnw -B clean install -pl :hardwood-s3,:hardwood-aws-auth
 
       - name: 'Upload built artifacts'
         uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f  # v7 — https://github.com/actions/upload-artifact/releases/tag/v7
@@ -161,7 +162,7 @@ jobs:
           merge-multiple: true
 
       - name: 'Build and install cli'
-        run: ./mvnw -B clean install -pl :hardwood-error-prone-checks,:hardwood-cli
+        run: ./mvnw -B clean install -pl :hardwood-cli
 
       - name: 'Upload built artifacts'
         uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f  # v7 — https://github.com/actions/upload-artifact/releases/tag/v7
@@ -212,7 +213,7 @@ jobs:
           merge-multiple: true
 
       - name: 'Build and install parquet-java-compat'
-        run: ./mvnw -B clean install -pl :hardwood-error-prone-checks,:hardwood-parquet-java-compat
+        run: ./mvnw -B clean install -pl :hardwood-parquet-java-compat
 
       - name: 'Upload built artifacts'
         uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f  # v7 — https://github.com/actions/upload-artifact/releases/tag/v7
@@ -255,7 +256,7 @@ jobs:
           path: ~/.m2/repository/dev/hardwood/
 
       - name: 'Build and install parquet-testing-runner'
-        run: ./mvnw -B clean install -pl :hardwood-error-prone-checks,:hardwood-parquet-testing-runner
+        run: ./mvnw -B clean install -pl :hardwood-parquet-testing-runner
 
       - name: 'Upload built artifacts'
         uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f  # v7 — https://github.com/actions/upload-artifact/releases/tag/v7
@@ -372,15 +373,15 @@ jobs:
 
       - name: 'Run integration tests (Java 21)'
         if: ${{ !matrix.install_libdeflate && !matrix.enable_incubating }}
-        run: ./mvnw -B verify -pl :hardwood-error-prone-checks,:hardwood-integration-test
+        run: ./mvnw -B verify -pl :hardwood-integration-test
 
       - name: 'Run integration tests (with libdeflate)'
         if: ${{ matrix.install_libdeflate && !matrix.enable_incubating }}
-        run: ./mvnw -B verify -pl :hardwood-error-prone-checks,:hardwood-integration-test -Dlibdeflate.required=true -DargLine="--enable-native-access=ALL-UNNAMED"
+        run: ./mvnw -B verify -pl :hardwood-integration-test -Dlibdeflate.required=true -DargLine="--enable-native-access=ALL-UNNAMED"
 
       - name: 'Run integration tests (with incubating APIs)'
         if: ${{ matrix.install_libdeflate && matrix.enable_incubating }}
-        run: ./mvnw -B verify -pl :hardwood-error-prone-checks,:hardwood-integration-test -Dlibdeflate.required=true -DargLine="--enable-native-access=ALL-UNNAMED --add-modules jdk.incubator.vector"
+        run: ./mvnw -B verify -pl :hardwood-integration-test -Dlibdeflate.required=true -DargLine="--enable-native-access=ALL-UNNAMED --add-modules jdk.incubator.vector"
 
   # Verify the native CLI build on PRs
   native-build-check:
@@ -429,4 +430,4 @@ jobs:
         # -DskipSurefire=true skips the JVM @QuarkusMainTest suite (already run
         # in the `build-cli` job); Failsafe still runs the native smoke ITs during
         # integration-test.
-        run: ./mvnw -ntp -B -Dnative verify -pl :hardwood-error-prone-checks,:hardwood-cli -DskipSurefire=true
+        run: ./mvnw -ntp -B -Dnative verify -pl :hardwood-cli -DskipSurefire=true

--- a/.github/workflows/release-cli.yml
+++ b/.github/workflows/release-cli.yml
@@ -63,7 +63,7 @@ jobs:
           cache: maven
 
       - name: 'Build Native Image'
-        run: ./mvnw -ntp -B -Dnative package -pl cli -am -DskipTests "-Ddist.qualifier=${{ inputs.release-version }}"
+        run: ./mvnw -ntp -B -Dnative package -pl :hardwood-error-prone-checks,:hardwood-cli -am -DskipTests "-Ddist.qualifier=${{ inputs.release-version }}"
 
       - name: 'Upload build artifact (tar.gz)'
         if: ${{ runner.os != 'Windows' }}

--- a/.mvn/jvm.config
+++ b/.mvn/jvm.config
@@ -1,0 +1,10 @@
+--add-exports jdk.compiler/com.sun.tools.javac.api=ALL-UNNAMED
+--add-exports jdk.compiler/com.sun.tools.javac.file=ALL-UNNAMED
+--add-exports jdk.compiler/com.sun.tools.javac.main=ALL-UNNAMED
+--add-exports jdk.compiler/com.sun.tools.javac.model=ALL-UNNAMED
+--add-exports jdk.compiler/com.sun.tools.javac.parser=ALL-UNNAMED
+--add-exports jdk.compiler/com.sun.tools.javac.processing=ALL-UNNAMED
+--add-exports jdk.compiler/com.sun.tools.javac.tree=ALL-UNNAMED
+--add-exports jdk.compiler/com.sun.tools.javac.util=ALL-UNNAMED
+--add-opens jdk.compiler/com.sun.tools.javac.code=ALL-UNNAMED
+--add-opens jdk.compiler/com.sun.tools.javac.comp=ALL-UNNAMED

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -37,14 +37,14 @@ Avoid fully-qualified class names within the code, always add imports.
 Avoid object access and boxing as much as possible. Always prefer primitive access also if it means several similar methods.
 Before writing new code, search for existing patterns in the same class/package that accomplish the same thing (e.g., the DRY principle). Extract repeated logic into helper methods within the same class rather than duplicating it. When a pattern appears multiple times, consider consolidating it into a single well-named method with overloads if needed.
 Be conservative with base class refactoring. Do not pull implementation details up into abstract base classes unless the logic is truly identical across all subclasses with no foreseeable divergence. Shared helpers are better than shared template methods when subclasses may need different control flow.
-Never use `var` syntax.
+Never use `var` syntax. Enforced by the `NoVar` Error Prone check in `error-prone-checks/`.
 GitHub Actions should always referenced by SHA.
 
 # Documentation
 
 User-facing docs (`docs/content/*.md` and public-API JavaDoc) describe **what the API does and how to use it**. Do not include rationale for design decisions, comparisons to other internal APIs, or "we chose X to match Y" justifications — users don't need to know why two parts of the project share a convention, only that they do. Design rationale belongs in `_designs/*.md` (audience: maintainers and reviewers); user docs describe the end state directly.
 
-All JavaDoc comments must use Markdown `///` syntax (JEP 467), not the legacy `/** */` block comment style.
+All JavaDoc comments must use Markdown `///` syntax (JEP 467), not the legacy `/** */` block comment style. Enforced by the `NoLegacyJavadoc` Error Prone check in `error-prone-checks/`.
 Key rules for `///` Markdown JavaDoc:
 - Use backtick-fenced code blocks (e.g. ` ```java `) instead of `<pre>{@code ...}</pre>`.
 - Use `[ClassName]` reference links instead of `{@link ClassName}`.

--- a/_designs/ERROR_PRONE_RULE_ENFORCEMENT.md
+++ b/_designs/ERROR_PRONE_RULE_ENFORCEMENT.md
@@ -1,0 +1,101 @@
+# Error Prone Rule Enforcement
+
+**Status: Implemented**
+
+## Overview
+
+A subset of the coding rules in [CLAUDE.md](../CLAUDE.md) are enforced mechanically
+at compile time using [Error Prone](https://errorprone.info/) with project-local
+checks. The checks live in a dedicated `hardwood-error-prone-checks` Maven module and
+are wired into every other module's `javac` invocation as an annotation processor.
+
+Two rules are enforced today:
+
+- `NoVar` — flags any use of Java `var` (local variable type inference).
+- `NoLegacyJavadoc` — flags any `/** */` JavaDoc block; only `///` Markdown JavaDoc
+  (JEP 467) is allowed.
+
+Both produce a compile error pointing at the offending file and line; the rule name
+and a one-line reason appear in the diagnostic.
+
+## Module layout
+
+```
+error-prone-checks/
+├── pom.xml
+└── src/
+    ├── main/java/dev/hardwood/build/errorprone/
+    │   ├── JavaSourceFiles.java       # shared helper: is this file under src/(main|test)/java*/?
+    │   ├── NoVar.java
+    │   └── NoLegacyJavadoc.java
+    └── test/java/dev/hardwood/build/errorprone/
+        ├── NoVarTest.java
+        └── NoLegacyJavadocTest.java
+```
+
+`JavaSourceFiles.isConventionalJavaSource(...)` accepts any source root matching
+`/src/(main|test)/java\d*/`, so multi-release source roots like `core/src/main/java22/`
+are checked alongside the standard `src/main/java/` root. Sources outside any
+conventional Java root (e.g. `target/generated-sources/...`) are skipped — generated
+code and third-party stubs must not fail the build.
+
+## Build wiring
+
+The Error Prone plugin and the `hardwood-error-prone-checks` annotation-processor
+path live in the parent pom's `qa` profile (alongside the license check, formatter,
+import sort, and plugin-version enforcer). The `qa` profile activates by default via
+`!quick`, so:
+
+- `./mvnw verify` — runs Error Prone (matches CI behaviour).
+- `./mvnw -Dquick verify` — skips Error Prone for fast inner-loop builds.
+
+The `error-prone-checks` module itself opts out of inheriting Error Prone (via
+`combine.self="override"` on `compilerArgs` and `annotationProcessorPaths`) to avoid
+a circular dependency. The `performance-testing/micro-benchmarks` module uses
+`combine.children="append"` so its own compiler args (JMH annotation processor,
+`--add-modules jdk.incubator.vector`) compose with the qa profile's Error Prone
+args. The `core` module's `compile-java22` execution uses `combine.children="append"`
+on its compiler args for the same reason.
+
+## Reactor install
+
+Annotation-processor paths are resolved from the local Maven repository, not from
+the in-flight reactor. To make `hardwood-error-prone-checks` available to later
+modules during a single `./mvnw install` run, the module installs itself at the
+`package` phase (not the default `install` phase) via an explicit
+`install-for-reactor-compiler-plugin-resolution` execution.
+
+## CI propagation
+
+GitHub Actions workflows that run `./mvnw … -pl <module-list>` need
+`hardwood-error-prone-checks` to be either built in the same reactor or already
+present in the local Maven repository. Two strategies are used:
+
+- **Multi-job workflows** (`main-build.yml`, `pr-build.yml`): the first install
+  job (`build-core`) includes `:hardwood-error-prone-checks` in its `-pl` list and
+  uploads the resulting JAR as part of the `maven-repo-core` artifact. Downstream
+  jobs download the artifact into `~/.m2/repository/dev/hardwood/` and can omit the
+  module from their own `-pl` lists.
+- **Single-job workflows** (`performance.yml`, `cli-early-access.yml`,
+  `release-cli.yml`): the install step lists `:hardwood-error-prone-checks`
+  explicitly, since there is no upstream job to seed the local Maven repository.
+
+## JDK module exports
+
+Error Prone needs access to internal `jdk.compiler` packages to inspect the javac
+AST. The required `--add-exports` / `--add-opens` flags are declared in:
+
+- `.mvn/jvm.config` — applies to the Maven invocation itself (the compiler plugin
+  runs in-process with Maven).
+- `error-prone-checks/pom.xml` `<compilerArgs>` — applies when compiling the
+  checks against the Error Prone API.
+- `error-prone-checks/pom.xml` `<surefire><argLine>` — applies when running the
+  check unit tests, which use `CompilationTestHelper` to invoke javac in-process.
+
+## Rules not yet enforced
+
+CLAUDE.md lists several other mechanically-checkable rules (no fully-qualified class
+names, GitHub Actions referenced by SHA, etc.). Those are out of scope for the
+initial enforcement module; the framework is set up so additional checks can be
+added incrementally as new files under
+`error-prone-checks/src/main/java/dev/hardwood/build/errorprone/`.

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -121,7 +121,7 @@
                 <compileSourceRoot>${project.basedir}/src/main/java22</compileSourceRoot>
               </compileSourceRoots>
               <multiReleaseOutput>true</multiReleaseOutput>
-              <compilerArgs>
+              <compilerArgs combine.children="append">
                 <arg>--add-modules</arg>
                 <arg>jdk.incubator.vector</arg>
               </compilerArgs>

--- a/core/src/main/java/dev/hardwood/internal/encoding/PlainDecoder.java
+++ b/core/src/main/java/dev/hardwood/internal/encoding/PlainDecoder.java
@@ -10,6 +10,10 @@ package dev.hardwood.internal.encoding;
 import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
+import java.nio.DoubleBuffer;
+import java.nio.FloatBuffer;
+import java.nio.IntBuffer;
+import java.nio.LongBuffer;
 import java.util.Arrays;
 
 import dev.hardwood.metadata.PhysicalType;
@@ -66,7 +70,7 @@ public class PlainDecoder implements ValueDecoder {
             if (pos + numBytes > data.length) {
                 throw new IOException("Unexpected EOF while reading INT64 values");
             }
-            var longBuffer = ByteBuffer.wrap(data, pos, numBytes).order(ByteOrder.LITTLE_ENDIAN).asLongBuffer();
+            LongBuffer longBuffer = ByteBuffer.wrap(data, pos, numBytes).order(ByteOrder.LITTLE_ENDIAN).asLongBuffer();
             pos += numBytes;
             for (int i = 0; i < output.length; i++) {
                 if (definitionLevels[i] == maxDefLevel) {
@@ -98,7 +102,7 @@ public class PlainDecoder implements ValueDecoder {
             if (pos + numBytes > data.length) {
                 throw new IOException("Unexpected EOF while reading DOUBLE values");
             }
-            var doubleBuffer = ByteBuffer.wrap(data, pos, numBytes).order(ByteOrder.LITTLE_ENDIAN).asDoubleBuffer();
+            DoubleBuffer doubleBuffer = ByteBuffer.wrap(data, pos, numBytes).order(ByteOrder.LITTLE_ENDIAN).asDoubleBuffer();
             pos += numBytes;
             for (int i = 0; i < output.length; i++) {
                 if (definitionLevels[i] == maxDefLevel) {
@@ -130,7 +134,7 @@ public class PlainDecoder implements ValueDecoder {
             if (pos + numBytes > data.length) {
                 throw new IOException("Unexpected EOF while reading INT32 values");
             }
-            var intBuffer = ByteBuffer.wrap(data, pos, numBytes).order(ByteOrder.LITTLE_ENDIAN).asIntBuffer();
+            IntBuffer intBuffer = ByteBuffer.wrap(data, pos, numBytes).order(ByteOrder.LITTLE_ENDIAN).asIntBuffer();
             pos += numBytes;
             for (int i = 0; i < output.length; i++) {
                 if (definitionLevels[i] == maxDefLevel) {
@@ -162,7 +166,7 @@ public class PlainDecoder implements ValueDecoder {
             if (pos + numBytes > data.length) {
                 throw new IOException("Unexpected EOF while reading FLOAT values");
             }
-            var floatBuffer = ByteBuffer.wrap(data, pos, numBytes).order(ByteOrder.LITTLE_ENDIAN).asFloatBuffer();
+            FloatBuffer floatBuffer = ByteBuffer.wrap(data, pos, numBytes).order(ByteOrder.LITTLE_ENDIAN).asFloatBuffer();
             pos += numBytes;
             for (int i = 0; i < output.length; i++) {
                 if (definitionLevels[i] == maxDefLevel) {

--- a/core/src/test/java/dev/hardwood/DeltaBinaryPackedTest.java
+++ b/core/src/test/java/dev/hardwood/DeltaBinaryPackedTest.java
@@ -12,6 +12,7 @@ import java.nio.file.Paths;
 
 import org.junit.jupiter.api.Test;
 
+import dev.hardwood.metadata.ColumnChunk;
 import dev.hardwood.metadata.Encoding;
 import dev.hardwood.metadata.RowGroup;
 import dev.hardwood.reader.ParquetFileReader;
@@ -32,8 +33,8 @@ class DeltaBinaryPackedTest {
             // Verify all columns use DELTA_BINARY_PACKED encoding
             RowGroup rowGroup = reader.getFileMetaData().rowGroups().get(0);
             for (int i = 0; i < reader.getFileSchema().getColumnCount(); i++) {
-                var columnChunk = rowGroup.columns().get(i);
-                var columnName = reader.getFileSchema().getColumn(i).name();
+                ColumnChunk columnChunk = rowGroup.columns().get(i);
+                String columnName = reader.getFileSchema().getColumn(i).name();
                 assertThat(columnChunk.metaData().encodings())
                         .as("Column '%s' should use DELTA_BINARY_PACKED encoding", columnName)
                         .contains(Encoding.DELTA_BINARY_PACKED);
@@ -72,8 +73,8 @@ class DeltaBinaryPackedTest {
             // Verify all columns use DELTA_BINARY_PACKED encoding
             RowGroup rowGroup = reader.getFileMetaData().rowGroups().get(0);
             for (int i = 0; i < reader.getFileSchema().getColumnCount(); i++) {
-                var columnChunk = rowGroup.columns().get(i);
-                var columnName = reader.getFileSchema().getColumn(i).name();
+                ColumnChunk columnChunk = rowGroup.columns().get(i);
+                String columnName = reader.getFileSchema().getColumn(i).name();
                 assertThat(columnChunk.metaData().encodings())
                         .as("Column '%s' should use DELTA_BINARY_PACKED encoding", columnName)
                         .contains(Encoding.DELTA_BINARY_PACKED);
@@ -114,8 +115,8 @@ class DeltaBinaryPackedTest {
 
             // Verify string columns use DELTA_LENGTH_BYTE_ARRAY encoding
             RowGroup rowGroup = reader.getFileMetaData().rowGroups().get(0);
-            var nameColumn = rowGroup.columns().get(1); // name is column 1
-            var descColumn = rowGroup.columns().get(2); // description is column 2
+            ColumnChunk nameColumn = rowGroup.columns().get(1); // name is column 1
+            ColumnChunk descColumn = rowGroup.columns().get(2); // description is column 2
             assertThat(nameColumn.metaData().encodings())
                     .as("Column 'name' should use DELTA_LENGTH_BYTE_ARRAY encoding")
                     .contains(Encoding.DELTA_LENGTH_BYTE_ARRAY);

--- a/core/src/test/java/dev/hardwood/DeltaByteArrayTest.java
+++ b/core/src/test/java/dev/hardwood/DeltaByteArrayTest.java
@@ -12,6 +12,7 @@ import java.nio.file.Paths;
 
 import org.junit.jupiter.api.Test;
 
+import dev.hardwood.metadata.ColumnChunk;
 import dev.hardwood.metadata.Encoding;
 import dev.hardwood.metadata.RowGroup;
 import dev.hardwood.reader.ParquetFileReader;
@@ -31,8 +32,8 @@ class DeltaByteArrayTest {
 
             // Verify string columns use DELTA_BYTE_ARRAY encoding
             RowGroup rowGroup = reader.getFileMetaData().rowGroups().get(0);
-            var prefixColumn = rowGroup.columns().get(1); // prefix_strings is column 1
-            var varyingColumn = rowGroup.columns().get(2); // varying_strings is column 2
+            ColumnChunk prefixColumn = rowGroup.columns().get(1); // prefix_strings is column 1
+            ColumnChunk varyingColumn = rowGroup.columns().get(2); // varying_strings is column 2
             assertThat(prefixColumn.metaData().encodings())
                     .as("Column 'prefix_strings' should use DELTA_BYTE_ARRAY encoding")
                     .contains(Encoding.DELTA_BYTE_ARRAY);

--- a/core/src/test/java/dev/hardwood/KeyValueMetadataTest.java
+++ b/core/src/test/java/dev/hardwood/KeyValueMetadataTest.java
@@ -13,6 +13,7 @@ import java.util.Map;
 
 import org.junit.jupiter.api.Test;
 
+import dev.hardwood.metadata.ColumnChunk;
 import dev.hardwood.metadata.ColumnMetaData;
 import dev.hardwood.metadata.FileMetaData;
 import dev.hardwood.metadata.RowGroup;
@@ -98,7 +99,7 @@ class KeyValueMetadataTest {
 
         try (ParquetFileReader reader = ParquetFileReader.open(InputFile.of(parquetFile))) {
             RowGroup rowGroup = reader.getFileMetaData().rowGroups().get(0);
-            for (var chunk : rowGroup.columns()) {
+            for (ColumnChunk chunk : rowGroup.columns()) {
                 assertThat(chunk.metaData().keyValueMetadata()).isEmpty();
             }
         }

--- a/core/src/test/java/dev/hardwood/LogicalTypesMetadataTest.java
+++ b/core/src/test/java/dev/hardwood/LogicalTypesMetadataTest.java
@@ -14,6 +14,7 @@ import org.junit.jupiter.api.Test;
 
 import dev.hardwood.metadata.LogicalType;
 import dev.hardwood.reader.ParquetFileReader;
+import dev.hardwood.schema.FileSchema;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -25,7 +26,7 @@ public class LogicalTypesMetadataTest {
         Path parquetFile = Paths.get("src/test/resources/logical_types_test.parquet");
 
         try (ParquetFileReader fileReader = ParquetFileReader.open(InputFile.of(parquetFile))) {
-            var schema = fileReader.getFileSchema();
+            FileSchema schema = fileReader.getFileSchema();
 
             // Verify logical types are parsed correctly
             assertThat(schema.getColumn("name").logicalType()).isInstanceOf(
@@ -74,66 +75,66 @@ public class LogicalTypesMetadataTest {
                     LogicalType.BsonType.class);
 
             // Verify TIMESTAMP units are correctly parsed
-            var timestampMillis = (LogicalType.TimestampType) schema
+            LogicalType.TimestampType timestampMillis = (LogicalType.TimestampType) schema
                     .getColumn("created_at_millis").logicalType();
             assertThat(timestampMillis.unit()).isEqualTo(
                     LogicalType.TimestampType.TimeUnit.MILLIS);
             assertThat(timestampMillis.isAdjustedToUTC()).isTrue();
 
-            var timestampMicros = (LogicalType.TimestampType) schema
+            LogicalType.TimestampType timestampMicros = (LogicalType.TimestampType) schema
                     .getColumn("created_at_micros").logicalType();
             assertThat(timestampMicros.unit()).isEqualTo(
                     LogicalType.TimestampType.TimeUnit.MICROS);
             assertThat(timestampMicros.isAdjustedToUTC()).isTrue();
 
-            var timestampNanos = (LogicalType.TimestampType) schema
+            LogicalType.TimestampType timestampNanos = (LogicalType.TimestampType) schema
                     .getColumn("created_at_nanos").logicalType();
             assertThat(timestampNanos.unit()).isEqualTo(
                     LogicalType.TimestampType.TimeUnit.NANOS);
             assertThat(timestampNanos.isAdjustedToUTC()).isTrue();
 
             // Verify TIME units are correctly parsed
-            var timeMillis = (LogicalType.TimeType) schema
+            LogicalType.TimeType timeMillis = (LogicalType.TimeType) schema
                     .getColumn("wake_time_millis").logicalType();
             assertThat(timeMillis.unit()).isEqualTo(
                     LogicalType.TimeType.TimeUnit.MILLIS);
 
-            var timeMicros = (LogicalType.TimeType) schema
+            LogicalType.TimeType timeMicros = (LogicalType.TimeType) schema
                     .getColumn("wake_time_micros").logicalType();
             assertThat(timeMicros.unit()).isEqualTo(
                     LogicalType.TimeType.TimeUnit.MICROS);
 
-            var timeNanos = (LogicalType.TimeType) schema
+            LogicalType.TimeType timeNanos = (LogicalType.TimeType) schema
                     .getColumn("wake_time_nanos").logicalType();
             assertThat(timeNanos.unit()).isEqualTo(
                     LogicalType.TimeType.TimeUnit.NANOS);
 
-            var decimalType = (LogicalType.DecimalType) schema.getColumn("balance")
+            LogicalType.DecimalType decimalType = (LogicalType.DecimalType) schema.getColumn("balance")
                     .logicalType();
             assertThat(decimalType.scale()).isEqualTo(2);
             assertThat(decimalType.precision()).isEqualTo(10);
 
-            var intType = (LogicalType.IntType) schema.getColumn("tiny_int").logicalType();
+            LogicalType.IntType intType = (LogicalType.IntType) schema.getColumn("tiny_int").logicalType();
             assertThat(intType.bitWidth()).isEqualTo(8);
             assertThat(intType.isSigned()).isTrue();
 
             // Verify unsigned integer types
-            var tinyUintType = (LogicalType.IntType) schema.getColumn("tiny_uint")
+            LogicalType.IntType tinyUintType = (LogicalType.IntType) schema.getColumn("tiny_uint")
                     .logicalType();
             assertThat(tinyUintType.bitWidth()).isEqualTo(8);
             assertThat(tinyUintType.isSigned()).isFalse();
 
-            var smallUintType = (LogicalType.IntType) schema.getColumn("small_uint")
+            LogicalType.IntType smallUintType = (LogicalType.IntType) schema.getColumn("small_uint")
                     .logicalType();
             assertThat(smallUintType.bitWidth()).isEqualTo(16);
             assertThat(smallUintType.isSigned()).isFalse();
 
-            var mediumUintType = (LogicalType.IntType) schema.getColumn("medium_uint")
+            LogicalType.IntType mediumUintType = (LogicalType.IntType) schema.getColumn("medium_uint")
                     .logicalType();
             assertThat(mediumUintType.bitWidth()).isEqualTo(32);
             assertThat(mediumUintType.isSigned()).isFalse();
 
-            var bigUintType = (LogicalType.IntType) schema.getColumn("big_uint")
+            LogicalType.IntType bigUintType = (LogicalType.IntType) schema.getColumn("big_uint")
                     .logicalType();
             assertThat(bigUintType.bitWidth()).isEqualTo(64);
             assertThat(bigUintType.isSigned()).isFalse();
@@ -145,7 +146,7 @@ public class LogicalTypesMetadataTest {
         Path parquetFile = Paths.get("src/test/resources/interval_logical_type_test.parquet");
 
         try (ParquetFileReader fileReader = ParquetFileReader.open(InputFile.of(parquetFile))) {
-            var schema = fileReader.getFileSchema();
+            FileSchema schema = fileReader.getFileSchema();
             assertThat(schema.getColumn("duration").logicalType()).isInstanceOf(
                     LogicalType.IntervalType.class);
         }

--- a/core/src/test/java/dev/hardwood/MapSchemaTest.java
+++ b/core/src/test/java/dev/hardwood/MapSchemaTest.java
@@ -20,6 +20,7 @@ import dev.hardwood.reader.RowReader;
 import dev.hardwood.row.PqList;
 import dev.hardwood.row.PqMap;
 import dev.hardwood.row.PqStruct;
+import dev.hardwood.schema.FileSchema;
 import dev.hardwood.schema.SchemaNode;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -32,29 +33,29 @@ public class MapSchemaTest {
         Path parquetFile = Paths.get("src/test/resources/simple_map_test.parquet");
 
         try (ParquetFileReader fileReader = ParquetFileReader.open(InputFile.of(parquetFile))) {
-            var schema = fileReader.getFileSchema();
-            var root = schema.getRootNode();
+            FileSchema schema = fileReader.getFileSchema();
+            SchemaNode.GroupNode root = schema.getRootNode();
 
             // Root should have 3 children: id, name, attributes
             assertThat(root.children()).hasSize(3);
 
             // Check attributes MAP
-            var attributesNode = root.children().get(2);
+            SchemaNode attributesNode = root.children().get(2);
             assertThat(attributesNode).isInstanceOf(SchemaNode.GroupNode.class);
-            var attributesGroup = (SchemaNode.GroupNode) attributesNode;
+            SchemaNode.GroupNode attributesGroup = (SchemaNode.GroupNode) attributesNode;
             assertThat(attributesGroup.name()).isEqualTo("attributes");
             assertThat(attributesGroup.isMap()).isTrue();
             assertThat(attributesGroup.convertedType()).isEqualTo(ConvertedType.MAP);
 
             // MAP has structure: attributes (MAP) -> key_value (REPEATED) -> key, value
             assertThat(attributesGroup.children()).hasSize(1);
-            var keyValueGroup = (SchemaNode.GroupNode) attributesGroup.children().get(0);
+            SchemaNode.GroupNode keyValueGroup = (SchemaNode.GroupNode) attributesGroup.children().get(0);
             assertThat(keyValueGroup.children()).hasSize(2); // key and value
 
-            var keyNode = (SchemaNode.PrimitiveNode) keyValueGroup.children().get(0);
+            SchemaNode.PrimitiveNode keyNode = (SchemaNode.PrimitiveNode) keyValueGroup.children().get(0);
             assertThat(keyNode.name()).isEqualTo("key");
 
-            var valueNode = (SchemaNode.PrimitiveNode) keyValueGroup.children().get(1);
+            SchemaNode.PrimitiveNode valueNode = (SchemaNode.PrimitiveNode) keyValueGroup.children().get(1);
             assertThat(valueNode.name()).isEqualTo("value");
         }
     }
@@ -122,24 +123,24 @@ public class MapSchemaTest {
         Path parquetFile = Paths.get("src/test/resources/map_of_maps_test.parquet");
 
         try (ParquetFileReader fileReader = ParquetFileReader.open(InputFile.of(parquetFile))) {
-            var schema = fileReader.getFileSchema();
-            var root = schema.getRootNode();
+            FileSchema schema = fileReader.getFileSchema();
+            SchemaNode.GroupNode root = schema.getRootNode();
 
             // Root should have 3 children: id, name, nested_map
             assertThat(root.children()).hasSize(3);
 
             // Check nested_map MAP<string, MAP<string, int32>>
-            var nestedMapNode = (SchemaNode.GroupNode) root.children().get(2);
+            SchemaNode.GroupNode nestedMapNode = (SchemaNode.GroupNode) root.children().get(2);
             assertThat(nestedMapNode.name()).isEqualTo("nested_map");
             assertThat(nestedMapNode.isMap()).isTrue();
 
             // Navigate to inner map
-            var outerKeyValue = (SchemaNode.GroupNode) nestedMapNode.children().get(0);
+            SchemaNode.GroupNode outerKeyValue = (SchemaNode.GroupNode) nestedMapNode.children().get(0);
             assertThat(outerKeyValue.children()).hasSize(2); // key and value
 
-            var valueNode = outerKeyValue.children().get(1);
+            SchemaNode valueNode = outerKeyValue.children().get(1);
             assertThat(valueNode).isInstanceOf(SchemaNode.GroupNode.class);
-            var innerMapGroup = (SchemaNode.GroupNode) valueNode;
+            SchemaNode.GroupNode innerMapGroup = (SchemaNode.GroupNode) valueNode;
             assertThat(innerMapGroup.isMap()).isTrue();
         }
     }

--- a/core/src/test/java/dev/hardwood/NestedSchemaTest.java
+++ b/core/src/test/java/dev/hardwood/NestedSchemaTest.java
@@ -15,6 +15,7 @@ import org.junit.jupiter.api.Test;
 import dev.hardwood.metadata.ConvertedType;
 import dev.hardwood.metadata.RepetitionType;
 import dev.hardwood.reader.ParquetFileReader;
+import dev.hardwood.schema.FileSchema;
 import dev.hardwood.schema.SchemaNode;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -27,32 +28,32 @@ public class NestedSchemaTest {
         Path parquetFile = Paths.get("src/test/resources/nested_struct_test.parquet");
 
         try (ParquetFileReader fileReader = ParquetFileReader.open(InputFile.of(parquetFile))) {
-            var schema = fileReader.getFileSchema();
-            var root = schema.getRootNode();
+            FileSchema schema = fileReader.getFileSchema();
+            SchemaNode.GroupNode root = schema.getRootNode();
 
             // Root should have 2 children: id and address
             assertThat(root.children()).hasSize(2);
 
             // Check id column
-            var idNode = root.children().get(0);
+            SchemaNode idNode = root.children().get(0);
             assertThat(idNode).isInstanceOf(SchemaNode.PrimitiveNode.class);
             assertThat(idNode.name()).isEqualTo("id");
             assertThat(idNode.maxDefinitionLevel()).isEqualTo(0); // REQUIRED
             assertThat(idNode.maxRepetitionLevel()).isEqualTo(0);
 
             // Check address struct
-            var addressNode = root.children().get(1);
+            SchemaNode addressNode = root.children().get(1);
             assertThat(addressNode).isInstanceOf(SchemaNode.GroupNode.class);
             assertThat(addressNode.name()).isEqualTo("address");
             assertThat(addressNode.maxDefinitionLevel()).isEqualTo(1); // OPTIONAL
             assertThat(addressNode.maxRepetitionLevel()).isEqualTo(0);
 
-            var addressGroup = (SchemaNode.GroupNode) addressNode;
+            SchemaNode.GroupNode addressGroup = (SchemaNode.GroupNode) addressNode;
             assertThat(addressGroup.isStruct()).isTrue();
             assertThat(addressGroup.children()).hasSize(3); // street, city, zip
 
             // Check nested fields have correct levels
-            var streetNode = (SchemaNode.PrimitiveNode) addressGroup.children().get(0);
+            SchemaNode.PrimitiveNode streetNode = (SchemaNode.PrimitiveNode) addressGroup.children().get(0);
             assertThat(streetNode.name()).isEqualTo("street");
             assertThat(streetNode.maxDefinitionLevel()).isEqualTo(2); // parent(1) + optional(1)
             assertThat(streetNode.maxRepetitionLevel()).isEqualTo(0);
@@ -71,16 +72,16 @@ public class NestedSchemaTest {
         Path parquetFile = Paths.get("src/test/resources/list_basic_test.parquet");
 
         try (ParquetFileReader fileReader = ParquetFileReader.open(InputFile.of(parquetFile))) {
-            var schema = fileReader.getFileSchema();
-            var root = schema.getRootNode();
+            FileSchema schema = fileReader.getFileSchema();
+            SchemaNode.GroupNode root = schema.getRootNode();
 
             // Root should have 3 children: id, tags, scores
             assertThat(root.children()).hasSize(3);
 
             // Check tags LIST
-            var tagsNode = root.children().get(1);
+            SchemaNode tagsNode = root.children().get(1);
             assertThat(tagsNode).isInstanceOf(SchemaNode.GroupNode.class);
-            var tagsGroup = (SchemaNode.GroupNode) tagsNode;
+            SchemaNode.GroupNode tagsGroup = (SchemaNode.GroupNode) tagsNode;
             assertThat(tagsGroup.name()).isEqualTo("tags");
             assertThat(tagsGroup.isList()).isTrue();
             assertThat(tagsGroup.convertedType()).isEqualTo(ConvertedType.LIST);
@@ -88,20 +89,20 @@ public class NestedSchemaTest {
 
             // List has 3-level encoding: tags (LIST) -> list (REPEATED) -> element
             assertThat(tagsGroup.children()).hasSize(1);
-            var innerGroup = (SchemaNode.GroupNode) tagsGroup.children().get(0);
+            SchemaNode.GroupNode innerGroup = (SchemaNode.GroupNode) tagsGroup.children().get(0);
             assertThat(innerGroup.name()).isEqualTo("list");
             assertThat(innerGroup.repetitionType()).isEqualTo(RepetitionType.REPEATED);
             assertThat(innerGroup.maxDefinitionLevel()).isEqualTo(2); // parent(1) + repeated counts as optional(1)
             assertThat(innerGroup.maxRepetitionLevel()).isEqualTo(1);
 
             // Element is the actual string column
-            var elementNode = (SchemaNode.PrimitiveNode) innerGroup.children().get(0);
+            SchemaNode.PrimitiveNode elementNode = (SchemaNode.PrimitiveNode) innerGroup.children().get(0);
             assertThat(elementNode.name()).isEqualTo("element");
             assertThat(elementNode.maxDefinitionLevel()).isEqualTo(3); // list(2) + optional(1)
             assertThat(elementNode.maxRepetitionLevel()).isEqualTo(1);
 
             // getListElement() helper should work
-            var listElement = tagsGroup.getListElement();
+            SchemaNode listElement = tagsGroup.getListElement();
             assertThat(listElement).isNotNull();
             assertThat(listElement.name()).isEqualTo("element");
         }
@@ -112,21 +113,21 @@ public class NestedSchemaTest {
         Path parquetFile = Paths.get("src/test/resources/list_struct_test.parquet");
 
         try (ParquetFileReader fileReader = ParquetFileReader.open(InputFile.of(parquetFile))) {
-            var schema = fileReader.getFileSchema();
-            var root = schema.getRootNode();
+            FileSchema schema = fileReader.getFileSchema();
+            SchemaNode.GroupNode root = schema.getRootNode();
 
             // Root should have 2 children: id, items
             assertThat(root.children()).hasSize(2);
 
             // Check items LIST
-            var itemsNode = (SchemaNode.GroupNode) root.children().get(1);
+            SchemaNode.GroupNode itemsNode = (SchemaNode.GroupNode) root.children().get(1);
             assertThat(itemsNode.name()).isEqualTo("items");
             assertThat(itemsNode.isList()).isTrue();
 
             // The list element should be a struct
-            var listElement = itemsNode.getListElement();
+            SchemaNode listElement = itemsNode.getListElement();
             assertThat(listElement).isInstanceOf(SchemaNode.GroupNode.class);
-            var elementGroup = (SchemaNode.GroupNode) listElement;
+            SchemaNode.GroupNode elementGroup = (SchemaNode.GroupNode) listElement;
             assertThat(elementGroup.name()).isEqualTo("element");
             assertThat(elementGroup.isStruct()).isTrue();
             assertThat(elementGroup.children()).hasSize(2); // name, quantity

--- a/core/src/test/java/dev/hardwood/internal/compression/libdeflate/LibdeflateDecompressorIT.java
+++ b/core/src/test/java/dev/hardwood/internal/compression/libdeflate/LibdeflateDecompressorIT.java
@@ -16,6 +16,7 @@ import org.junit.jupiter.api.Assumptions;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
+import dev.hardwood.internal.compression.Decompressor;
 import dev.hardwood.internal.compression.DecompressorFactory;
 import dev.hardwood.internal.compression.GzipDecompressor;
 import dev.hardwood.metadata.CompressionCodec;
@@ -111,7 +112,7 @@ class LibdeflateDecompressorIT {
     @Test
     void factorySelectsLibdeflateWhenAvailable() {
         DecompressorFactory factory = new DecompressorFactory(pool);
-        var decompressor = factory.getDecompressor(CompressionCodec.GZIP);
+        Decompressor decompressor = factory.getDecompressor(CompressionCodec.GZIP);
 
         assertThat(decompressor).isInstanceOf(LibdeflateDecompressor.class);
     }

--- a/core/src/test/java/dev/hardwood/internal/reader/RangeBackedInputFileTest.java
+++ b/core/src/test/java/dev/hardwood/internal/reader/RangeBackedInputFileTest.java
@@ -12,6 +12,7 @@ import java.nio.ByteBuffer;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.stream.Stream;
 
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
@@ -165,7 +166,7 @@ class RangeBackedInputFileTest {
     }
 
     private static long countCacheFiles(Path dir) throws IOException {
-        try (var stream = Files.list(dir)) {
+        try (Stream<Path> stream = Files.list(dir)) {
             return stream.filter(p -> p.getFileName().toString().startsWith("hardwood-range-")).count();
         }
     }

--- a/error-prone-checks/pom.xml
+++ b/error-prone-checks/pom.xml
@@ -103,6 +103,19 @@
           </argLine>
         </configuration>
       </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-install-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>install-for-reactor-compiler-plugin-resolution</id>
+            <phase>package</phase>
+            <goals>
+              <goal>install</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
     </plugins>
   </build>
 </project>

--- a/error-prone-checks/pom.xml
+++ b/error-prone-checks/pom.xml
@@ -118,4 +118,17 @@
       </plugin>
     </plugins>
   </build>
+
+  <profiles>
+    <!-- Skip enforcer on Java 21 since this module only builds the Error Prone checks. -->
+    <profile>
+      <id>java21</id>
+      <activation>
+        <jdk>[21,25)</jdk>
+      </activation>
+      <properties>
+        <enforcer.skip>true</enforcer.skip>
+      </properties>
+    </profile>
+  </profiles>
 </project>

--- a/error-prone-checks/pom.xml
+++ b/error-prone-checks/pom.xml
@@ -1,0 +1,108 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+     SPDX-License-Identifier: Apache-2.0
+
+     Copyright The original authors
+
+     Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>dev.hardwood</groupId>
+    <artifactId>hardwood-parent</artifactId>
+    <version>1.0.0-SNAPSHOT</version>
+  </parent>
+
+  <artifactId>hardwood-error-prone-checks</artifactId>
+  <name>Hardwood Error Prone Checks</name>
+
+  <properties>
+    <maven.compiler.release/>
+    <maven.compiler.source>${java.version}</maven.compiler.source>
+    <maven.compiler.target>${java.version}</maven.compiler.target>
+  </properties>
+
+  <dependencies>
+    <dependency>
+      <groupId>com.google.auto.service</groupId>
+      <artifactId>auto-service-annotations</artifactId>
+      <version>${auto-service.version}</version>
+      <optional>true</optional>
+    </dependency>
+    <dependency>
+      <groupId>com.google.errorprone</groupId>
+      <artifactId>error_prone_check_api</artifactId>
+      <version>${error-prone.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>com.google.errorprone</groupId>
+      <artifactId>error_prone_test_helpers</artifactId>
+      <version>${error-prone.version}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-api</artifactId>
+      <version>5.14.1</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-engine</artifactId>
+      <version>5.14.1</version>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <configuration>
+          <compilerArgs combine.self="override">
+            <arg>--add-exports=jdk.compiler/com.sun.tools.javac.api=ALL-UNNAMED</arg>
+            <arg>--add-exports=jdk.compiler/com.sun.tools.javac.code=ALL-UNNAMED</arg>
+            <arg>--add-exports=jdk.compiler/com.sun.tools.javac.comp=ALL-UNNAMED</arg>
+            <arg>--add-exports=jdk.compiler/com.sun.tools.javac.file=ALL-UNNAMED</arg>
+            <arg>--add-exports=jdk.compiler/com.sun.tools.javac.main=ALL-UNNAMED</arg>
+            <arg>--add-exports=jdk.compiler/com.sun.tools.javac.model=ALL-UNNAMED</arg>
+            <arg>--add-exports=jdk.compiler/com.sun.tools.javac.parser=ALL-UNNAMED</arg>
+            <arg>--add-exports=jdk.compiler/com.sun.tools.javac.processing=ALL-UNNAMED</arg>
+            <arg>--add-exports=jdk.compiler/com.sun.tools.javac.tree=ALL-UNNAMED</arg>
+            <arg>--add-exports=jdk.compiler/com.sun.tools.javac.util=ALL-UNNAMED</arg>
+          </compilerArgs>
+          <annotationProcessorPaths combine.self="override">
+            <path>
+              <groupId>com.google.auto.service</groupId>
+              <artifactId>auto-service</artifactId>
+              <version>${auto-service.version}</version>
+            </path>
+          </annotationProcessorPaths>
+        </configuration>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-surefire-plugin</artifactId>
+        <configuration>
+          <argLine>
+            --add-exports=jdk.compiler/com.sun.tools.javac.api=ALL-UNNAMED
+            --add-exports=jdk.compiler/com.sun.tools.javac.file=ALL-UNNAMED
+            --add-exports=jdk.compiler/com.sun.tools.javac.main=ALL-UNNAMED
+            --add-exports=jdk.compiler/com.sun.tools.javac.model=ALL-UNNAMED
+            --add-exports=jdk.compiler/com.sun.tools.javac.parser=ALL-UNNAMED
+            --add-exports=jdk.compiler/com.sun.tools.javac.processing=ALL-UNNAMED
+            --add-exports=jdk.compiler/com.sun.tools.javac.tree=ALL-UNNAMED
+            --add-exports=jdk.compiler/com.sun.tools.javac.util=ALL-UNNAMED
+            --add-opens=jdk.compiler/com.sun.tools.javac.code=ALL-UNNAMED
+            --add-opens=jdk.compiler/com.sun.tools.javac.comp=ALL-UNNAMED
+          </argLine>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/error-prone-checks/pom.xml
+++ b/error-prone-checks/pom.xml
@@ -116,6 +116,13 @@
           </execution>
         </executions>
       </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-javadoc-plugin</artifactId>
+        <configuration>
+          <skip>true</skip>
+        </configuration>
+      </plugin>
     </plugins>
   </build>
 

--- a/error-prone-checks/pom.xml
+++ b/error-prone-checks/pom.xml
@@ -89,20 +89,16 @@
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-surefire-plugin</artifactId>
         <configuration>
-          <argLine>
-            --add-exports=jdk.compiler/com.sun.tools.javac.api=ALL-UNNAMED
-            --add-exports=jdk.compiler/com.sun.tools.javac.file=ALL-UNNAMED
-            --add-exports=jdk.compiler/com.sun.tools.javac.main=ALL-UNNAMED
-            --add-exports=jdk.compiler/com.sun.tools.javac.model=ALL-UNNAMED
-            --add-exports=jdk.compiler/com.sun.tools.javac.parser=ALL-UNNAMED
-            --add-exports=jdk.compiler/com.sun.tools.javac.processing=ALL-UNNAMED
-            --add-exports=jdk.compiler/com.sun.tools.javac.tree=ALL-UNNAMED
-            --add-exports=jdk.compiler/com.sun.tools.javac.util=ALL-UNNAMED
-            --add-opens=jdk.compiler/com.sun.tools.javac.code=ALL-UNNAMED
-            --add-opens=jdk.compiler/com.sun.tools.javac.comp=ALL-UNNAMED
-          </argLine>
+          <!-- Reuse the Maven JVM's jdk.compiler exports/opens; CompilationTestHelper invokes javac in-process. -->
+          <argLine>@${maven.multiModuleProjectDirectory}/.mvn/jvm.config</argLine>
         </configuration>
       </plugin>
+      <!--
+        Install this artifact at the `package` phase (not the default `install` phase) so
+        that later modules in the same reactor can resolve it as an annotation processor
+        via maven-compiler-plugin's `<annotationProcessorPaths>`. Annotation processor
+        paths are looked up from the local Maven repository, not from the in-flight reactor.
+      -->
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-install-plugin</artifactId>

--- a/error-prone-checks/src/main/java/dev/hardwood/build/errorprone/JavaSourceFiles.java
+++ b/error-prone-checks/src/main/java/dev/hardwood/build/errorprone/JavaSourceFiles.java
@@ -1,0 +1,23 @@
+/*
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Copyright The original authors
+ *
+ *  Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package dev.hardwood.build.errorprone;
+
+import com.google.errorprone.VisitorState;
+
+final class JavaSourceFiles {
+
+    private static final String MAIN_JAVA = "/src/main/java/";
+    private static final String TEST_JAVA = "/src/test/java/";
+
+    private JavaSourceFiles() {}
+
+    static boolean isConventionalJavaSource(VisitorState state) {
+        String path = state.getPath().getCompilationUnit().getSourceFile().toUri().getPath().replace('\\', '/');
+        return path.contains(MAIN_JAVA) || path.contains(TEST_JAVA);
+    }
+}

--- a/error-prone-checks/src/main/java/dev/hardwood/build/errorprone/JavaSourceFiles.java
+++ b/error-prone-checks/src/main/java/dev/hardwood/build/errorprone/JavaSourceFiles.java
@@ -7,17 +7,18 @@
  */
 package dev.hardwood.build.errorprone;
 
+import java.util.regex.Pattern;
+
 import com.google.errorprone.VisitorState;
 
 final class JavaSourceFiles {
 
-    private static final String MAIN_JAVA = "/src/main/java/";
-    private static final String TEST_JAVA = "/src/test/java/";
+    private static final Pattern CONVENTIONAL_SOURCE_ROOT = Pattern.compile("/src/(main|test)/java\\d*/");
 
     private JavaSourceFiles() {}
 
     static boolean isConventionalJavaSource(VisitorState state) {
         String path = state.getPath().getCompilationUnit().getSourceFile().toUri().getPath().replace('\\', '/');
-        return path.contains(MAIN_JAVA) || path.contains(TEST_JAVA);
+        return CONVENTIONAL_SOURCE_ROOT.matcher(path).find();
     }
 }

--- a/error-prone-checks/src/main/java/dev/hardwood/build/errorprone/NoLegacyJavadoc.java
+++ b/error-prone-checks/src/main/java/dev/hardwood/build/errorprone/NoLegacyJavadoc.java
@@ -1,0 +1,73 @@
+/*
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Copyright The original authors
+ *
+ *  Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package dev.hardwood.build.errorprone;
+
+import com.google.auto.service.AutoService;
+import com.google.errorprone.BugPattern;
+import com.google.errorprone.VisitorState;
+import com.google.errorprone.bugpatterns.BugChecker;
+import com.google.errorprone.fixes.ErrorProneEndPosTable;
+import com.google.errorprone.fixes.ErrorPronePosition;
+import com.google.errorprone.matchers.Description;
+import com.sun.source.tree.CompilationUnitTree;
+import com.sun.tools.javac.tree.JCTree;
+
+/// Enforces Hardwood's policy requiring Markdown JavaDoc comments.
+@AutoService(BugChecker.class)
+@BugPattern(
+        name = "NoLegacyJavadoc",
+        summary = "JavaDoc must use Markdown /// syntax, not /** */; see CLAUDE.md:47.",
+        severity = BugPattern.SeverityLevel.ERROR)
+public final class NoLegacyJavadoc extends BugChecker implements BugChecker.CompilationUnitTreeMatcher {
+
+    private static final String LEGACY_JAVADOC_START = "/**";
+
+    @Override
+    public Description matchCompilationUnit(CompilationUnitTree tree, VisitorState state) {
+        if (!JavaSourceFiles.isConventionalJavaSource(state)) {
+            return Description.NO_MATCH;
+        }
+
+        int start = state.getSourceCode().toString().indexOf(LEGACY_JAVADOC_START);
+        if (start < 0) {
+            return Description.NO_MATCH;
+        }
+        return describeMatch(new SourceOffsetPosition((JCTree) tree, start));
+    }
+
+    private static final class SourceOffsetPosition implements ErrorPronePosition {
+
+        private final JCTree tree;
+        private final int start;
+
+        private SourceOffsetPosition(JCTree tree, int start) {
+            this.tree = tree;
+            this.start = start;
+        }
+
+        @Override
+        public int getStartPosition() {
+            return start;
+        }
+
+        @Override
+        public int getPreferredPosition() {
+            return start;
+        }
+
+        @Override
+        public JCTree getTree() {
+            return tree;
+        }
+
+        @Override
+        public int getEndPosition(ErrorProneEndPosTable endPositions) {
+            return start + LEGACY_JAVADOC_START.length();
+        }
+    }
+}

--- a/error-prone-checks/src/main/java/dev/hardwood/build/errorprone/NoLegacyJavadoc.java
+++ b/error-prone-checks/src/main/java/dev/hardwood/build/errorprone/NoLegacyJavadoc.java
@@ -21,7 +21,7 @@ import com.sun.tools.javac.tree.JCTree;
 @AutoService(BugChecker.class)
 @BugPattern(
         name = "NoLegacyJavadoc",
-        summary = "JavaDoc must use Markdown /// syntax, not /** */; see CLAUDE.md:47.",
+        summary = "JavaDoc must use Markdown /// syntax, not /** */; see CLAUDE.md.",
         severity = BugPattern.SeverityLevel.ERROR)
 public final class NoLegacyJavadoc extends BugChecker implements BugChecker.CompilationUnitTreeMatcher {
 

--- a/error-prone-checks/src/main/java/dev/hardwood/build/errorprone/NoVar.java
+++ b/error-prone-checks/src/main/java/dev/hardwood/build/errorprone/NoVar.java
@@ -1,0 +1,37 @@
+/*
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Copyright The original authors
+ *
+ *  Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package dev.hardwood.build.errorprone;
+
+import com.google.auto.service.AutoService;
+import com.google.errorprone.BugPattern;
+import com.google.errorprone.VisitorState;
+import com.google.errorprone.bugpatterns.BugChecker;
+import com.google.errorprone.matchers.Description;
+import com.sun.source.tree.VariableTree;
+import com.sun.tools.javac.tree.JCTree.JCVariableDecl;
+
+/// Enforces Hardwood's policy against Java local-variable type inference.
+@AutoService(BugChecker.class)
+@BugPattern(
+        name = "NoVar",
+        summary = "Do not use var; see CLAUDE.md:40.",
+        severity = BugPattern.SeverityLevel.ERROR)
+public final class NoVar extends BugChecker implements BugChecker.VariableTreeMatcher {
+
+    @Override
+    public Description matchVariable(VariableTree tree, VisitorState state) {
+        if (!JavaSourceFiles.isConventionalJavaSource(state) || !usesVarType(tree)) {
+            return Description.NO_MATCH;
+        }
+        return describeMatch(tree);
+    }
+
+    private static boolean usesVarType(VariableTree tree) {
+        return tree instanceof JCVariableDecl && ((JCVariableDecl) tree).declaredUsingVar();
+    }
+}

--- a/error-prone-checks/src/main/java/dev/hardwood/build/errorprone/NoVar.java
+++ b/error-prone-checks/src/main/java/dev/hardwood/build/errorprone/NoVar.java
@@ -19,7 +19,7 @@ import com.sun.tools.javac.tree.JCTree.JCVariableDecl;
 @AutoService(BugChecker.class)
 @BugPattern(
         name = "NoVar",
-        summary = "Do not use var; see CLAUDE.md:40.",
+        summary = "Do not use var; CLAUDE.md requires explicit types.",
         severity = BugPattern.SeverityLevel.ERROR)
 public final class NoVar extends BugChecker implements BugChecker.VariableTreeMatcher {
 

--- a/error-prone-checks/src/test/java/dev/hardwood/build/errorprone/NoLegacyJavadocTest.java
+++ b/error-prone-checks/src/test/java/dev/hardwood/build/errorprone/NoLegacyJavadocTest.java
@@ -1,0 +1,58 @@
+/*
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Copyright The original authors
+ *
+ *  Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package dev.hardwood.build.errorprone;
+
+import org.junit.jupiter.api.Test;
+
+import com.google.errorprone.CompilationTestHelper;
+
+final class NoLegacyJavadocTest {
+
+    private final CompilationTestHelper compilationHelper =
+            CompilationTestHelper.newInstance(NoLegacyJavadoc.class, getClass());
+
+    @Test
+    void rejectsLegacyJavadocBlockComments() {
+        compilationHelper
+                .addSourceLines(
+                        "src/main/java/dev/hardwood/Test.java",
+                        "package dev.hardwood;",
+                        "// BUG: Diagnostic contains: CLAUDE.md:47.",
+                        "/**",
+                        " * Legacy JavaDoc.",
+                        " */",
+                        "final class Test {}")
+                .doTest();
+    }
+
+    @Test
+    void allowsMarkdownJavadocAndRegularBlockComments() {
+        compilationHelper
+                .addSourceLines(
+                        "src/test/java/dev/hardwood/Test.java",
+                        "package dev.hardwood;",
+                        "/// Markdown JavaDoc.",
+                        "final class Test {",
+                        "  /* Regular block comments are allowed. */",
+                        "}")
+                .doTest();
+    }
+
+    @Test
+    void ignoresSourcesOutsideConventionalJavaRoots() {
+        compilationHelper
+                .addSourceLines(
+                        "src/main/java22/dev/hardwood/Test.java",
+                        "package dev.hardwood;",
+                        "/**",
+                        " * Legacy JavaDoc.",
+                        " */",
+                        "final class Test {}")
+                .doTest();
+    }
+}

--- a/error-prone-checks/src/test/java/dev/hardwood/build/errorprone/NoLegacyJavadocTest.java
+++ b/error-prone-checks/src/test/java/dev/hardwood/build/errorprone/NoLegacyJavadocTest.java
@@ -22,7 +22,7 @@ final class NoLegacyJavadocTest {
                 .addSourceLines(
                         "src/main/java/dev/hardwood/Test.java",
                         "package dev.hardwood;",
-                        "// BUG: Diagnostic contains: CLAUDE.md:47.",
+                        "// BUG: Diagnostic contains: Markdown",
                         "/**",
                         " * Legacy JavaDoc.",
                         " */",
@@ -44,10 +44,24 @@ final class NoLegacyJavadocTest {
     }
 
     @Test
-    void ignoresSourcesOutsideConventionalJavaRoots() {
+    void rejectsLegacyJavadocInMultiReleaseSourceRoot() {
         compilationHelper
                 .addSourceLines(
                         "src/main/java22/dev/hardwood/Test.java",
+                        "package dev.hardwood;",
+                        "// BUG: Diagnostic contains: Markdown",
+                        "/**",
+                        " * Legacy JavaDoc.",
+                        " */",
+                        "final class Test {}")
+                .doTest();
+    }
+
+    @Test
+    void ignoresSourcesOutsideConventionalJavaRoots() {
+        compilationHelper
+                .addSourceLines(
+                        "target/generated-sources/annotations/dev/hardwood/Test.java",
                         "package dev.hardwood;",
                         "/**",
                         " * Legacy JavaDoc.",

--- a/error-prone-checks/src/test/java/dev/hardwood/build/errorprone/NoVarTest.java
+++ b/error-prone-checks/src/test/java/dev/hardwood/build/errorprone/NoVarTest.java
@@ -1,0 +1,99 @@
+/*
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Copyright The original authors
+ *
+ *  Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package dev.hardwood.build.errorprone;
+
+import org.junit.jupiter.api.Test;
+
+import com.google.errorprone.CompilationTestHelper;
+
+final class NoVarTest {
+
+    private final CompilationTestHelper compilationHelper = CompilationTestHelper.newInstance(NoVar.class, getClass());
+
+    @Test
+    void rejectsLocalVariableTypeInference() {
+        compilationHelper
+                .addSourceLines(
+                        "src/main/java/dev/hardwood/Test.java",
+                        "package dev.hardwood;",
+                        "final class Test {",
+                        "  void test() {",
+                        "    // BUG: Diagnostic contains: Do not use var; see CLAUDE.md:40.",
+                        "    var value = \"value\";",
+                        "  }",
+                        "}")
+                .doTest();
+    }
+
+    @Test
+    void rejectsEnhancedForVariableTypeInference() {
+        compilationHelper
+                .addSourceLines(
+                        "src/test/java/dev/hardwood/Test.java",
+                        "package dev.hardwood;",
+                        "import java.util.List;",
+                        "final class Test {",
+                        "  void test(List<String> values) {",
+                        "    // BUG: Diagnostic contains: Do not use var; see CLAUDE.md:40.",
+                        "    for (var value : values) {",
+                        "      value.length();",
+                        "    }",
+                        "  }",
+                        "}")
+                .doTest();
+    }
+
+    @Test
+    void rejectsTryWithResourcesVariableTypeInference() {
+        compilationHelper
+                .addSourceLines(
+                        "src/test/java/dev/hardwood/Test.java",
+                        "package dev.hardwood;",
+                        "import java.io.StringReader;",
+                        "final class Test {",
+                        "  void test() throws Exception {",
+                        "    // BUG: Diagnostic contains: Do not use var; see CLAUDE.md:40.",
+                        "    try (var reader = new StringReader(\"value\")) {",
+                        "      reader.read();",
+                        "    }",
+                        "  }",
+                        "}")
+                .doTest();
+    }
+
+    @Test
+    void allowsExplicitTypesAndNonCodeVarText() {
+        compilationHelper
+                .addSourceLines(
+                        "src/main/java/dev/hardwood/Test.java",
+                        "package dev.hardwood;",
+                        "final class Test {",
+                        "  void test() {",
+                        "    String value = \"var\";",
+                        "    // var is allowed in comments.",
+                        "    String var = value;",
+                        "    var.length();",
+                        "  }",
+                        "}")
+                .doTest();
+    }
+
+    @Test
+    void ignoresSourcesOutsideConventionalJavaRoots() {
+        compilationHelper
+                .addSourceLines(
+                        "src/main/java22/dev/hardwood/Test.java",
+                        "package dev.hardwood;",
+                        "final class Test {",
+                        "  void test() {",
+                        "    var value = \"value\";",
+                        "  }",
+                        "}")
+                .doTest();
+    }
+}

--- a/error-prone-checks/src/test/java/dev/hardwood/build/errorprone/NoVarTest.java
+++ b/error-prone-checks/src/test/java/dev/hardwood/build/errorprone/NoVarTest.java
@@ -23,7 +23,7 @@ final class NoVarTest {
                         "package dev.hardwood;",
                         "final class Test {",
                         "  void test() {",
-                        "    // BUG: Diagnostic contains: Do not use var; see CLAUDE.md:40.",
+                        "    // BUG: Diagnostic contains: Do not use var",
                         "    var value = \"value\";",
                         "  }",
                         "}")
@@ -39,7 +39,7 @@ final class NoVarTest {
                         "import java.util.List;",
                         "final class Test {",
                         "  void test(List<String> values) {",
-                        "    // BUG: Diagnostic contains: Do not use var; see CLAUDE.md:40.",
+                        "    // BUG: Diagnostic contains: Do not use var",
                         "    for (var value : values) {",
                         "      value.length();",
                         "    }",
@@ -57,7 +57,7 @@ final class NoVarTest {
                         "import java.io.StringReader;",
                         "final class Test {",
                         "  void test() throws Exception {",
-                        "    // BUG: Diagnostic contains: Do not use var; see CLAUDE.md:40.",
+                        "    // BUG: Diagnostic contains: Do not use var",
                         "    try (var reader = new StringReader(\"value\")) {",
                         "      reader.read();",
                         "    }",
@@ -84,10 +84,25 @@ final class NoVarTest {
     }
 
     @Test
-    void ignoresSourcesOutsideConventionalJavaRoots() {
+    void rejectsLocalVariableTypeInferenceInMultiReleaseSourceRoot() {
         compilationHelper
                 .addSourceLines(
                         "src/main/java22/dev/hardwood/Test.java",
+                        "package dev.hardwood;",
+                        "final class Test {",
+                        "  void test() {",
+                        "    // BUG: Diagnostic contains: Do not use var",
+                        "    var value = \"value\";",
+                        "  }",
+                        "}")
+                .doTest();
+    }
+
+    @Test
+    void ignoresSourcesOutsideConventionalJavaRoots() {
+        compilationHelper
+                .addSourceLines(
+                        "target/generated-sources/annotations/dev/hardwood/Test.java",
                         "package dev.hardwood;",
                         "final class Test {",
                         "  void test() {",

--- a/parquet-java-compat/src/main/java/org/apache/parquet/example/data/simple/SimpleGroup.java
+++ b/parquet-java-compat/src/main/java/org/apache/parquet/example/data/simple/SimpleGroup.java
@@ -114,12 +114,12 @@ public class SimpleGroup extends Group {
     }
 
     private boolean isListType(GroupType groupType) {
-        var originalType = groupType.getOriginalType();
+        org.apache.parquet.schema.OriginalType originalType = groupType.getOriginalType();
         return originalType == org.apache.parquet.schema.OriginalType.LIST;
     }
 
     private boolean isMapType(GroupType groupType) {
-        var originalType = groupType.getOriginalType();
+        org.apache.parquet.schema.OriginalType originalType = groupType.getOriginalType();
         return originalType == org.apache.parquet.schema.OriginalType.MAP
                 || originalType == org.apache.parquet.schema.OriginalType.MAP_KEY_VALUE;
     }

--- a/parquet-java-compat/src/main/java/org/apache/parquet/example/data/simple/SimpleGroup.java
+++ b/parquet-java-compat/src/main/java/org/apache/parquet/example/data/simple/SimpleGroup.java
@@ -13,6 +13,7 @@ import java.util.Map;
 import org.apache.parquet.example.data.Group;
 import org.apache.parquet.io.api.Binary;
 import org.apache.parquet.schema.GroupType;
+import org.apache.parquet.schema.OriginalType;
 import org.apache.parquet.schema.Type;
 
 import dev.hardwood.reader.RowReader;
@@ -114,14 +115,13 @@ public class SimpleGroup extends Group {
     }
 
     private boolean isListType(GroupType groupType) {
-        org.apache.parquet.schema.OriginalType originalType = groupType.getOriginalType();
-        return originalType == org.apache.parquet.schema.OriginalType.LIST;
+        OriginalType originalType = groupType.getOriginalType();
+        return originalType == OriginalType.LIST;
     }
 
     private boolean isMapType(GroupType groupType) {
-        org.apache.parquet.schema.OriginalType originalType = groupType.getOriginalType();
-        return originalType == org.apache.parquet.schema.OriginalType.MAP
-                || originalType == org.apache.parquet.schema.OriginalType.MAP_KEY_VALUE;
+        OriginalType originalType = groupType.getOriginalType();
+        return originalType == OriginalType.MAP || originalType == OriginalType.MAP_KEY_VALUE;
     }
 
     private Object capturePrimitiveFromRowReader(RowReader rowReader, String fieldName, Type fieldType) {

--- a/parquet-testing-runner/src/test/java/dev/hardwood/testing/ParquetTestingRepoTest.java
+++ b/parquet-testing-runner/src/test/java/dev/hardwood/testing/ParquetTestingRepoTest.java
@@ -24,6 +24,7 @@ import dev.hardwood.InputFile;
 import dev.hardwood.metadata.FileMetaData;
 import dev.hardwood.reader.ColumnReader;
 import dev.hardwood.reader.ParquetFileReader;
+import dev.hardwood.schema.ColumnSchema;
 
 /// Test reading files from the apache/parquet-testing repository.
 /// This test helps identify which files we can currently parse.
@@ -154,7 +155,7 @@ class ParquetTestingRepoTest {
             // Read ALL columns using batch API to verify we can parse everything
             int totalValuesRead = 0;
             for (int colIdx = 0; colIdx < reader.getFileSchema().getColumnCount(); colIdx++) {
-                var column = reader.getFileSchema().getColumn(colIdx);
+                ColumnSchema column = reader.getFileSchema().getColumn(colIdx);
 
                 if (colIdx == 0) {
                     System.out.println("Column " + colIdx + ": " + column.name() + " (" + column.type() + ")");

--- a/parquet-testing-runner/src/test/java/dev/hardwood/testing/Utils.java
+++ b/parquet-testing-runner/src/test/java/dev/hardwood/testing/Utils.java
@@ -21,6 +21,7 @@ import java.util.Map;
 import java.util.Set;
 import java.util.stream.Stream;
 
+import org.apache.avro.Schema;
 import org.apache.avro.generic.GenericData;
 import org.apache.avro.generic.GenericRecord;
 import org.apache.avro.util.Utf8;
@@ -913,7 +914,7 @@ public class Utils {
 
     /// Get reference value for a flat column from a GenericRecord.
     private static Object getRefColumnValue(GenericRecord record, String fieldName) {
-        var field = record.getSchema().getField(fieldName);
+        Schema.Field field = record.getSchema().getField(fieldName);
         if (field == null) {
             return SkipMarker.INSTANCE;
         }
@@ -921,9 +922,9 @@ public class Utils {
         if (value == null) {
             return null;
         }
-        var fieldSchema = field.schema();
+        Schema fieldSchema = field.schema();
         if (fieldSchema.getType() == org.apache.avro.Schema.Type.UNION) {
-            for (var subSchema : fieldSchema.getTypes()) {
+            for (Schema subSchema : fieldSchema.getTypes()) {
                 if (subSchema.getType() != org.apache.avro.Schema.Type.NULL) {
                     fieldSchema = subSchema;
                     break;
@@ -971,7 +972,7 @@ public class Utils {
 
     /// Get a value from the ColumnReader at a batch index, using the appropriate typed array.
     private static Object getColumnReaderValue(ColumnReader reader, int index) {
-        var colSchema = reader.getColumnSchema();
+        ColumnSchema colSchema = reader.getColumnSchema();
         return switch (colSchema.type()) {
             case INT32 -> reader.getInts()[index];
             case INT64 -> reader.getLongs()[index];

--- a/performance-testing/end-to-end/src/test/java/dev/hardwood/perf/NestedPerformanceTest.java
+++ b/performance-testing/end-to-end/src/test/java/dev/hardwood/perf/NestedPerformanceTest.java
@@ -14,6 +14,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.EnumSet;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
@@ -868,7 +869,7 @@ class NestedPerformanceTest {
             System.out.println("Correctness Verification:");
             System.out.println(String.format("  %-25s %10s %10s %10s %12s %12s %10s",
                     "", "min_ver", "max_ver", "rows", "websites", "sources", "addresses"));
-            for (var entry : results.entrySet()) {
+            for (Map.Entry<Contender, List<Result>> entry : results.entrySet()) {
                 Result r = entry.getValue().get(0);
                 System.out.println(String.format("  %-25s %,10d %,10d %,10d %,12d %,12d %,10d",
                         entry.getKey().displayName(),
@@ -884,7 +885,7 @@ class NestedPerformanceTest {
                 "Contender", "Time (s)", "Records/sec", "Records/sec/core", "MB/sec"));
         System.out.println("  " + "-".repeat(95));
 
-        for (var entry : results.entrySet()) {
+        for (Map.Entry<Contender, List<Result>> entry : results.entrySet()) {
             Contender c = entry.getKey();
             List<Result> contenderResults = entry.getValue();
             int cores = isHardwood(c) ? cpuCores : 1;
@@ -931,11 +932,11 @@ class NestedPerformanceTest {
             return;
         }
 
-        var first = results.entrySet().iterator().next();
+        Map.Entry<Contender, List<Result>> first = results.entrySet().iterator().next();
         Result reference = first.getValue().get(0);
         String referenceName = first.getKey().displayName();
 
-        for (var entry : results.entrySet()) {
+        for (Map.Entry<Contender, List<Result>> entry : results.entrySet()) {
             if (entry.getKey() == first.getKey()) continue;
             Result other = entry.getValue().get(0);
             String otherName = entry.getKey().displayName();

--- a/performance-testing/end-to-end/src/test/java/dev/hardwood/perf/PageDecodeAllocationProfileTest.java
+++ b/performance-testing/end-to-end/src/test/java/dev/hardwood/perf/PageDecodeAllocationProfileTest.java
@@ -84,7 +84,7 @@ public class PageDecodeAllocationProfileTest {
                 "File", "Pages", "Total Alloc", "Avg/Page", "Uncompressed");
         System.out.println("-".repeat(100));
 
-        for (var entry : allResults.entrySet()) {
+        for (Map.Entry<String, FileResult> entry : allResults.entrySet()) {
             FileResult r = entry.getValue();
             System.out.printf("%-45s %8d %11.1f KB %11.1f KB %11.1f KB%n",
                     entry.getKey(),
@@ -100,7 +100,7 @@ public class PageDecodeAllocationProfileTest {
         // Print allocation ratio (allocated / uncompressed data = overhead multiplier)
         System.out.printf("%-45s %8s %14s%n", "File", "Pages", "Alloc Ratio");
         System.out.println("-".repeat(70));
-        for (var entry : allResults.entrySet()) {
+        for (Map.Entry<String, FileResult> entry : allResults.entrySet()) {
             FileResult r = entry.getValue();
             double ratio = r.totalUncompressedBytes > 0
                     ? (double) r.totalAllocatedBytes / r.totalUncompressedBytes
@@ -215,7 +215,7 @@ public class PageDecodeAllocationProfileTest {
             totals[2]++;
         }
 
-        for (var entry : columnTotals.entrySet()) {
+        for (Map.Entry<String, long[]> entry : columnTotals.entrySet()) {
             long[] totals = entry.getValue();
             double ratio = totals[1] > 0 ? (double) totals[0] / totals[1] : 0;
             PageProfile sample = pageProfiles.stream()

--- a/performance-testing/micro-benchmarks/pom.xml
+++ b/performance-testing/micro-benchmarks/pom.xml
@@ -66,12 +66,26 @@
         <configuration>
           <annotationProcessorPaths>
             <path>
+              <groupId>com.google.errorprone</groupId>
+              <artifactId>error_prone_core</artifactId>
+              <version>${error-prone.version}</version>
+            </path>
+            <path>
+              <groupId>dev.hardwood</groupId>
+              <artifactId>hardwood-error-prone-checks</artifactId>
+              <version>${project.version}</version>
+            </path>
+            <path>
               <groupId>org.openjdk.jmh</groupId>
               <artifactId>jmh-generator-annprocess</artifactId>
               <version>${jmh.version}</version>
             </path>
           </annotationProcessorPaths>
           <compilerArgs>
+            <arg>-XDcompilePolicy=simple</arg>
+            <arg>--should-stop=ifError=FLOW</arg>
+            <arg>-Xplugin:ErrorProne -XepDisableAllChecks -Xep:NoVar:ERROR -Xep:NoLegacyJavadoc:ERROR</arg>
+            <arg>-XDaddTypeAnnotationsToSymbol=true</arg>
             <arg>--add-modules</arg>
             <arg>jdk.incubator.vector</arg>
           </compilerArgs>

--- a/performance-testing/micro-benchmarks/pom.xml
+++ b/performance-testing/micro-benchmarks/pom.xml
@@ -64,28 +64,14 @@
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-compiler-plugin</artifactId>
         <configuration>
-          <annotationProcessorPaths>
-            <path>
-              <groupId>com.google.errorprone</groupId>
-              <artifactId>error_prone_core</artifactId>
-              <version>${error-prone.version}</version>
-            </path>
-            <path>
-              <groupId>dev.hardwood</groupId>
-              <artifactId>hardwood-error-prone-checks</artifactId>
-              <version>${project.version}</version>
-            </path>
+          <annotationProcessorPaths combine.children="append">
             <path>
               <groupId>org.openjdk.jmh</groupId>
               <artifactId>jmh-generator-annprocess</artifactId>
               <version>${jmh.version}</version>
             </path>
           </annotationProcessorPaths>
-          <compilerArgs>
-            <arg>-XDcompilePolicy=simple</arg>
-            <arg>--should-stop=ifError=FLOW</arg>
-            <arg>-Xplugin:ErrorProne -XepDisableAllChecks -Xep:NoVar:ERROR -Xep:NoLegacyJavadoc:ERROR</arg>
-            <arg>-XDaddTypeAnnotationsToSymbol=true</arg>
+          <compilerArgs combine.children="append">
             <arg>--add-modules</arg>
             <arg>jdk.incubator.vector</arg>
           </compilerArgs>

--- a/pom.xml
+++ b/pom.xml
@@ -46,6 +46,7 @@
   </scm>
 
   <modules>
+    <module>error-prone-checks</module>
     <module>bom</module>
     <module>test-bom</module>
     <module>test-support</module>
@@ -60,6 +61,8 @@
   </modules>
 
   <properties>
+    <auto-service.version>1.1.1</auto-service.version>
+    <error-prone.version>2.49.0</error-prone.version>
     <hadoop.version>3.4.3</hadoop.version>
     <java.version>21</java.version>
     <java.version.build>25</java.version.build>
@@ -153,6 +156,24 @@
           <version>3.14.1</version>
           <configuration>
             <parameters>true</parameters>
+            <compilerArgs>
+              <arg>-XDcompilePolicy=simple</arg>
+              <arg>--should-stop=ifError=FLOW</arg>
+              <arg>-Xplugin:ErrorProne -XepDisableAllChecks -Xep:NoVar:ERROR -Xep:NoLegacyJavadoc:ERROR</arg>
+              <arg>-XDaddTypeAnnotationsToSymbol=true</arg>
+            </compilerArgs>
+            <annotationProcessorPaths>
+              <path>
+                <groupId>com.google.errorprone</groupId>
+                <artifactId>error_prone_core</artifactId>
+                <version>${error-prone.version}</version>
+              </path>
+              <path>
+                <groupId>dev.hardwood</groupId>
+                <artifactId>hardwood-error-prone-checks</artifactId>
+                <version>${project.version}</version>
+              </path>
+            </annotationProcessorPaths>
           </configuration>
         </plugin>
         <plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -156,24 +156,6 @@
           <version>3.14.1</version>
           <configuration>
             <parameters>true</parameters>
-            <compilerArgs>
-              <arg>-XDcompilePolicy=simple</arg>
-              <arg>--should-stop=ifError=FLOW</arg>
-              <arg>-Xplugin:ErrorProne -XepDisableAllChecks -Xep:NoVar:ERROR -Xep:NoLegacyJavadoc:ERROR</arg>
-              <arg>-XDaddTypeAnnotationsToSymbol=true</arg>
-            </compilerArgs>
-            <annotationProcessorPaths>
-              <path>
-                <groupId>com.google.errorprone</groupId>
-                <artifactId>error_prone_core</artifactId>
-                <version>${error-prone.version}</version>
-              </path>
-              <path>
-                <groupId>dev.hardwood</groupId>
-                <artifactId>hardwood-error-prone-checks</artifactId>
-                <version>${project.version}</version>
-              </path>
-            </annotationProcessorPaths>
           </configuration>
         </plugin>
         <plugin>
@@ -307,6 +289,30 @@
       </activation>
       <build>
         <plugins>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-compiler-plugin</artifactId>
+            <configuration>
+              <compilerArgs combine.children="append">
+                <arg>-XDcompilePolicy=simple</arg>
+                <arg>--should-stop=ifError=FLOW</arg>
+                <arg>-Xplugin:ErrorProne -XepDisableAllChecks -Xep:NoVar:ERROR -Xep:NoLegacyJavadoc:ERROR</arg>
+                <arg>-XDaddTypeAnnotationsToSymbol=true</arg>
+              </compilerArgs>
+              <annotationProcessorPaths combine.children="append">
+                <path>
+                  <groupId>com.google.errorprone</groupId>
+                  <artifactId>error_prone_core</artifactId>
+                  <version>${error-prone.version}</version>
+                </path>
+                <path>
+                  <groupId>dev.hardwood</groupId>
+                  <artifactId>hardwood-error-prone-checks</artifactId>
+                  <version>${project.version}</version>
+                </path>
+              </annotationProcessorPaths>
+            </configuration>
+          </plugin>
           <plugin>
             <groupId>com.mycila</groupId>
             <artifactId>license-maven-plugin</artifactId>


### PR DESCRIPTION
Closes #438 

## Checklist

- [x] Build via `./mvnw clean verify` passes
- [x] The commit message is prefixed with the issue key ("#438 To enforce some rules from CLAUDE.md")
- [x] Code changes are covered by tests
- [x] If this PR adds or changes user-facing behaviour, `docs/` has been updated

I implemented:
- enforcement through ErrorProne. "no-var" and "/// javadoc" checks are in place. 
- clean up of existing `var`

I didn't implement:
- "Avoid fully-qualified class names" because I have doubts since two similar classes are possible and one of them may use fully qualified name
- "GitHub Actions should always be referenced by SHA" because YML files are out of scope of ErrorProne (I don't have extensive experience with ErrorProne, correct me if I am wrong).