### PR TITLE
#453 Fix flaky S3 byte-comparison test

### DIFF
--- a/s3/src/test/java/dev/hardwood/s3/S3SelectiveReadJfrTest.java
+++ b/s3/src/test/java/dev/hardwood/s3/S3SelectiveReadJfrTest.java
@@ -215,18 +215,24 @@ public class S3SelectiveReadJfrTest extends AbstractJfrRecorderTest {
 
     @Test
     void projectionTransfersFewerBytes() throws Exception {
-        // page_index_test.parquet is 170 KB (> 64 KB tail cache), so column chunk
-        // reads go to the network and are observable via jdk.SocketRead. Use
-        // the file size as the full-read baseline — a full read can't transfer
-        // more than the file itself.
-        long oneColumnBytes = readAndMeasureSocketBytes(PAGE_INDEX_FILE,
-                ColumnProjection.columns("id"), null);
+        // page_index_test.parquet is 170 KB (> 64 KB tail cache), so column chunks
+        // reads go to the network.
+        S3InputFile s3File = (S3InputFile) source.inputFile("test-bucket", PAGE_INDEX_FILE);
+        try (ParquetFileReader reader = ParquetFileReader.open(s3File);
+             RowReader rows = reader.buildRowReader().projection(ColumnProjection.columns("id")).build()) {
+            while (rows.hasNext()) {
+                rows.next();
+            }
+        }
+        long oneColumnBytes = s3File.networkBytesFetched();
 
         assertThat(oneColumnBytes)
                 .as("Reading 1 of 3 columns should still transfer some bytes (file > tail cache)")
                 .isGreaterThan(0);
         assertThat(oneColumnBytes)
-                .as("Reading 1 of 3 columns should transfer fewer bytes than the file size")
+                .as("Reading 1 of 3 columns should transfer fewer bytes than the file size; "
+                        + "oneColumn=%,d bytes, fileSize=%,d bytes"
+                                .formatted(oneColumnBytes, pageIndexFileSize))
                 .isLessThan(pageIndexFileSize);
     }
 
@@ -547,29 +553,4 @@ public class S3SelectiveReadJfrTest extends AbstractJfrRecorderTest {
                 .isLessThan(10);
     }
 
-    // ==================== Helpers ====================
-
-    /// Reads `file` with the given projection/filter and returns the total
-    /// `jdk.SocketRead.bytesRead` captured during the read. Starts the test
-    /// recording itself, so the caller must not have called `enable(...)`.
-    private long readAndMeasureSocketBytes(String file, ColumnProjection projection,
-            FilterPredicate filter) throws Exception {
-        enable("jdk.SocketRead");
-        try (ParquetFileReader reader = ParquetFileReader.open(
-                source.inputFile("test-bucket", file))) {
-            try (RowReader rows = filter != null
-                    ? reader.buildRowReader().projection(projection).filter(filter).build()
-                    : reader.buildRowReader().projection(projection).build()) {
-                while (rows.hasNext()) {
-                    rows.next();
-                }
-            }
-        }
-
-        awaitEvents();
-
-        return events("jdk.SocketRead")
-                .mapToLong(e -> e.getLong("bytesRead"))
-                .sum();
-    }
 }


### PR DESCRIPTION
Fixes #453.

The bug is reproducible at a very low rate (<1/15,000 runs when I was able to reproduce it), and apparently it's **not** the HTTP request headers causing the inflated byte count we observed — it's extra `jdk.SocketRead` events fired from inside JDK HttpClient's NIO selector loop, specifically at `jdk.internal.net.http.SocketTube.readAvailable` on the `HttpClient-N-SelectorManager` thread.

## Investigation summary

I verified across three independent vantage points that the inflation lives below the application:

| Layer | Counter | Behavior |
|---|---|---|
| Server wire (TCP relay between `S3Source` and s3proxy) | `relayDown` | Deterministic — exactly 146,617 bytes for the one-column read every iteration. s3proxy sends what we asked for and nothing more. |
| Application (`S3InputFile`) | `networkBytesFetched` / `streamReadActualBytes` | Deterministic — exactly the requested bytes per read, no retries (`networkRequestCount` always 3). |
| JDK NIO socket reads | `jdk.SocketRead.bytesRead` | Occasionally inflated by ~15-100 KB. All extra events captured with stack traces showing only `jdk.internal.net.http.SocketTube.readAvailable` → `SequentialScheduler.runOrSchedule` → `InternalReadSubscription.signalReadable`. No Hardwood frames anywhere. |

Three plausible mechanisms remain at the JDK layer (TCP retransmits being observed as additional `SocketChannel.read()` events, eager NIO buffer fills that are discarded, or HttpClient internal subscriber-cancellation drains), but **none of them are reachable from Hardwood code** — every frame in the captured stacks is `jdk.internal.net.http.*`.

## Fix

Switched the projection test from `jdk.SocketRead` to the application-level counter `S3InputFile.networkBytesFetched()`. This counts bytes the reader actually requested (tail prefetch + every `readRange` length when it hits the network), which is what the test semantically wants to assert anyway. The assertion against `pageIndexFileSize` is kept — `networkBytesFetched` is fully deterministic at 145,758 bytes for the one-column read, giving ~24 KB of headroom against the 170,022 byte file size.

The other tests in the file still use JFR because they need socket-level signal to validate lazy-fetch / back-pressure / early-close behavior that isn't observable from the application counter.

## Test plan
- [x] `./mvnw -pl s3 verify` — all 147 tests pass
- [x] Stress test (`@RepeatedTest(10000)` locally) — 0 failures with the new assertion source