### PR TITLE
#493 Handle new bad_data/ARROW-GH-47662.parquet from upstream parquet-testing

### DIFF
--- a/parquet-testing-runner/src/test/java/dev/hardwood/testing/BadDataHandlingTest.java
+++ b/parquet-testing-runner/src/test/java/dev/hardwood/testing/BadDataHandlingTest.java
@@ -91,6 +91,14 @@ class BadDataHandlingTest {
     }
 
     @Test
+    void rejectArrowGH47662() throws IOException {
+        // Schema declares flba_field as required fixed_len_byte_array(4) with
+        // 1000 values, but the page data runs out at value 92.
+        assertBadDataRejected("ARROW-GH-47662.parquet",
+                "[ARROW-GH-47662.parquet] Unexpected EOF while reading fixed-length byte array");
+    }
+
+    @Test
     void rejectCorruptChecksum() throws IOException {
         // Intentionally corrupted CRC checksums in data pages.
         // The CRC IOException is wrapped in UncheckedIOException with file context

--- a/parquet-testing-runner/src/test/java/dev/hardwood/testing/Utils.java
+++ b/parquet-testing-runner/src/test/java/dev/hardwood/testing/Utils.java
@@ -68,7 +68,6 @@ public class Utils {
             "hadoop_lz4_compressed.parquet", // Empty field name in schema
 
             // parquet-java Avro reader decoding issues
-            "fixed_length_byte_array.parquet", // ParquetDecodingException
             "large_string_map.brotli.parquet", // ParquetDecodingException (block -1)
             "non_hadoop_lz4_compressed.parquet", // ParquetDecodingException (block -1)
             "nation.dict-malformed.parquet", // EOF error (intentionally malformed)
@@ -108,7 +107,8 @@ public class Utils {
             "ARROW-RS-GH-6229-LEVELS.parquet",
             "ARROW-GH-41317.parquet",
             "ARROW-GH-41321.parquet",
-            "ARROW-GH-45185.parquet"
+            "ARROW-GH-45185.parquet",
+            "ARROW-GH-47662.parquet"
     );
 
     /// Returns a GitHub issue reference blocking row-level nested comparison for


### PR DESCRIPTION
## Summary

- Add `ARROW-GH-47662.parquet` to `Utils.SKIPPED_FILES` so `ParquetComparisonTest` no longer errors on the newly-added intentionally-malformed fixture
- Add `rejectArrowGH47662()` to `BadDataHandlingTest` to lock in Hardwood's clean EOF rejection (`[ARROW-GH-47662.parquet] Unexpected EOF while reading fixed-length byte array`)
- Remove `fixed_length_byte_array.parquet` from the skip list — upstream PR fixed the schema (`flba_field` is now `optional`), so parquet-java reads it and the comparison passes

## Context

`apache/parquet-testing` PR [#111](https://github.com/apache/parquet-testing/pull/111) (commit `fa255df`, 2026-05-20) reshuffled the FLBA fixture: the corrected file kept the original path, and the previously-broken version moved to `bad_data/ARROW-GH-47662.parquet`. Because `ParquetTestingRepoCloner` does an unpinned shallow clone, the next `clean verify` picked both up — but our skip list and `BadDataHandlingTest` were unaware. The failure surfaced as a parquet-java decoding exception during comparison; Hardwood itself was already rejecting the file correctly with a clear EOF, just without an assertion to defend it.

See #493 for the full investigation. A follow-up to pin `ParquetTestingRepoCloner` to a specific upstream SHA is worth considering separately — that would make the failure mode deterministic instead of depending on wall-clock state of `apache/parquet-testing` HEAD.

## Test plan

- [x] `./mvnw -pl parquet-testing-runner -am test -Dtest='ParquetComparisonTest,BadDataHandlingTest'` → ParquetComparisonTest 420 run / 60 skipped / 0 errors; BadDataHandlingTest 13 run / 0 errors

Fixes #493