### PR TITLE
#457 Drain-side filtering: support OR and mixed AND/OR compounds

### DIFF
--- a/_designs/DRAIN_SIDE_RECORD_FILTERING.md
+++ b/_designs/DRAIN_SIDE_RECORD_FILTERING.md
@@ -26,12 +26,7 @@ Eligible queries take the drain-side path; ineligible queries fall back to `Filt
 
 ## Eligibility
 
-A `ResolvedPredicate` is **eligible** iff:
-
-- It is either a single column-local leaf, or `ResolvedPredicate.And(children)` whose children are all column-local leaves, and
-- Every leaf has `(type, op)` supported by `BatchFilterCompiler`.
-
-Multiple leaves on the same projected column are allowed and compose via `AndBatchMatcher` (see below).
+A `ResolvedPredicate` is **eligible** iff every leaf in the tree is column-local and supported, and no column appears in more than one independent subtree. `And` and `Or` may nest freely.
 
 A leaf is **column-local** iff:
 
@@ -39,17 +34,27 @@ A leaf is **column-local** iff:
 - Its column maps to a non-negative projected index, and
 - Its `(type, op)` is one of: `long` / `double` / `int` / `float` × `{EQ, NOT_EQ, LT, LT_EQ, GT, GT_EQ}`, `boolean` × `{EQ, NOT_EQ}`, `IntIn` / `LongIn`, `IsNull` / `IsNotNull`.
 
-`Or`, `Not`, intermediate-struct paths, geospatial predicates, `Binary*` leaves, and any leaf on a fragment-less column make the entire query non-eligible. Multiple leaves on the same column (e.g. `id >= x AND id <= y`) are folded into a single `AndBatchMatcher` per column that runs both children and word-AND merges their bitmaps. A dedicated fused range matcher would be tighter, but the general composite already moves the `range` shape onto the drain-side path.
+`Not` is lowered to leaf-level operator inversion at resolution time (`ResolvedPredicate.negate`, De Morgan for compounds), so the batch compiler only sees `And` / `Or`. Intermediate-struct paths, geospatial predicates, `Binary*` leaves, and any leaf on a fragment-less column make the entire query non-eligible.
 
-Per-column composition is enforced positionally: `BatchFilterCompiler.tryCompile` allocates a `ColumnBatchMatcher[]` slot per projected column index and folds any further leaf for that column into an `AndBatchMatcher` over the existing slot occupant:
+The compiler walks the predicate tree bottom-up:
 
-```java
-result[projected] = result[projected] == null
-        ? matcher
-        : new AndBatchMatcher(result[projected], matcher);
-```
+- A subtree that lives entirely on one projected column collapses into a single `ColumnBatchMatcher` slot. Same-column leaves under an `And` chain through `AndBatchMatcher`; under an `Or` they chain through `OrBatchMatcher`. `id >= x AND id <= y` and `id < -5 OR id > 5` both end up as one composite in one column slot.
+- A subtree that spans multiple columns produces a `MergePlan` (`And` / `Or`) whose children are either `MergePlan.Column(projectedIndex)` references — for child subtrees that resolved to a single column — or nested merge plans.
 
-`AndBatchMatcher` runs both children against the same batch, writing the first child's bits into the caller's `outWords` and the second into a per-instance scratch buffer, then word-ANDs the active range. The composite is type-agnostic — both children handle their own `batch.values` cast.
+`tryCompile` returns a `CompiledBatchFilter(columnMatchers[], mergePlan)`: per-projected-column matcher slots (workers populate `Batch.matches` from these) plus a `MergePlan` the consumer walks to merge the per-column bitmaps. A subtree where the **same** column appears across two independent siblings (e.g. `(a > 5 AND b > 5) OR (a < 0 AND b < 0)`, where column `a` would need two different per-row predicates encoded in one `matches` array) is rejected — the per-column matcher model cannot represent it.
+
+### Why `Or` is safe under "definitely matches" semantics
+
+Each matcher emits bit `i` set iff row `i` **definitely** satisfies the leaf (NULL → unset). For `WHERE A OR B` under SQL three-valued logic, the row should be included iff `A OR B` is definitely true:
+
+| A     | B     | `A OR B` (SQL) | `def(A) \| def(B)` |
+|-------|-------|----------------|-------------------:|
+| true  | true  | true           | 1 ✓                |
+| true  | null  | true           | 1 ✓                |
+| false | null  | null → exclude | 0 ✓                |
+| null  | null  | null → exclude | 0 ✓                |
+
+Word-wise OR of the existing per-leaf bitmaps is the correct combine for both `OrBatchMatcher` (within one column) and the `MergePlan.Or` consumer walk (across columns) — no auxiliary null tracking, no extra passes.
 
 There is no separate leaf-count gate. The v1 prototype carried an `if (leaves.size() < 2) return null;` short-circuit on the theory that single-fragment queries pay drain-side overhead with no parallelism payoff; in practice the single-leaf drain-side path is within noise of the compiled path on the end-to-end benchmark (see the `single` row in the table below) and strictly wins once a matcher gains a vectorised body, so the gate was removed.
 
@@ -63,7 +68,7 @@ Sealed interface representing a per-column fragment over a single batch:
 public sealed interface ColumnBatchMatcher
         permits LongBatchMatcher, DoubleBatchMatcher, IntBatchMatcher,
                 FloatBatchMatcher, BooleanBatchMatcher, NullBatchMatcher,
-                AndBatchMatcher {
+                AndBatchMatcher, OrBatchMatcher {
     void test(BatchExchange.Batch batch, long[] outWords);
 }
 ```
@@ -110,7 +115,7 @@ Key shape choices:
 - **Hoisted `literal`, `recordCount`, `fullWords`, `tail`.** The inner `for (b = 0; b < 64; b++)` is a constant-bound loop that the JIT unrolls.
 - **`nulls == null` specialised outside the per-word loops.** One branch per call, not per element.
 
-NULL semantics: each fragment writes "definitely matches" — false on NULL. Word-wise AND of per-column matches gives SQL three-valued AND because any `unknown` conjunct unsets the bit. This contract does not generalise to OR-spanning-columns; that case is excluded by the eligibility rule.
+NULL semantics: each fragment writes "definitely matches" — false on NULL. Word-wise AND of per-column matches gives SQL three-valued AND because any `unknown` conjunct unsets the bit; the same contract handles OR cleanly via word-wise OR (see the truth table under [Eligibility](#why-or-is-safe-under-definitely-matches-semantics)).
 
 `Null*BatchMatcher` short-circuits the per-bit loop entirely — `IsNullBatchMatcher.test` bulk-copies `nulls.toLongArray()`; `IsNotNullBatchMatcher.test` bulk-inverts the same. Like the typed matchers, bits past `recordCount` are left as-is and filtered by the consumer's `bit < limit` check.
 
@@ -132,50 +137,41 @@ Cost is paid on the drain thread, on hot data, in parallel with peer drains. Whe
 
 ---
 
-## Intersection and iteration in `FlatRowReader`
+## Combine and iteration in `FlatRowReader`
 
-`FlatRowReader.create` calls `BatchFilterCompiler.tryCompile`. A non-null result drives the drain-side path; otherwise the existing branch (`FilteredRowReader` if a filter is set, plain reader if not) is used.
+`FlatRowReader.create` calls `BatchFilterCompiler.tryCompile`. A non-null `CompiledBatchFilter` drives the drain-side path; otherwise the existing branch (`FilteredRowReader` if a filter is set, plain reader if not) is used.
 
 The reader gains:
 
 - `long[] combinedWords` — the per-batch combined match mask.
-- `int[] fragmentColumns` — the projected indices of columns with a fragment, computed once at construction. Iterating this array in the hot path avoids the per-batch null check on `Batch.matches`.
+- `MergePlan mergePlan` — the consumer-side plan returned by the compiler. A top-level `MergePlan.Column` is the single-column fast path; everything else is evaluated by a shared evaluator (below).
+- `MergePlanEvaluator mergeEvaluator` — owns the depth-indexed scratch pool used by compound subtrees. Constructed once per reader; reused across all batches (zero allocations after warm-up).
+- `long[][] perColumnMatches` — preallocated `long[columnCount][]` whose entries are reseated each batch from `previousBatches[i].matches` and passed to the evaluator. Avoids coupling `MergePlanEvaluator` to the reader's `BatchExchange.Batch` type.
 
 `loadNextBatch`, after polling all column batches and when `drainSide` is true, calls `intersectMatches`:
 
 ```java
 private void intersectMatches() {
-    BatchExchange.Batch[] batches = previousBatches;
-
-    // Single-column fast path: nothing to AND-merge. Alias the batch's matches
-    // directly; no copy, no owned combinedWords buffer needed.
-    if (filteredColumns.length == 1) {
-        combinedWords = batches[filteredColumns[0]].matches;
+    // Single-column fast path: alias the batch's matches array directly.
+    // No copy, no evaluator call, no owned combinedWords buffer needed.
+    if (mergePlan instanceof MergePlan.Column c) {
+        combinedWords = previousBatches[c.projectedIndex()].matches;
         return;
     }
-
-    int activeWords = (batchSize + 63) >>> 6;
-    long[] combined = combinedWords;
-    long[] first = batches[filteredColumns[0]].matches;
-    System.arraycopy(first, 0, combined, 0, activeWords);
-
-    // Track an OR across merged words: as soon as a highly-selective column
-    // drives the intersection to all-zero, skip the remaining columns'
-    // AND-passes — the batch is already known to produce no rows.
-    for (int col = 1; col < filteredColumns.length; col++) {
-        long[] matches = batches[filteredColumns[col]].matches;
-        long anyBit = 0L;
-        for (int w = 0; w < activeWords; w++) {
-            long merged = combined[w] & matches[w];
-            combined[w] = merged;
-            anyBit |= merged;
-        }
-        if (anyBit == 0L) {
-            return;
-        }
+    // Multi-column: snapshot per-column matches references for this batch
+    // (one pointer per column — references shared, no data copied), then
+    // hand off to the shared evaluator.
+    for (int i = 0; i < columnCount; i++) {
+        perColumnMatches[i] = previousBatches[i].matches;
     }
+    int activeWords = (batchSize + 63) >>> 6;
+    mergeEvaluator.eval(mergePlan, combinedWords, activeWords, perColumnMatches);
 }
 ```
+
+`MergePlanEvaluator.eval` is a recursive walk: a `Column` node arraycopies the column's bitmap into the output; an `And` node merges its children word-wise with the same all-zero short-circuit the previous shape used (skipping later children once the intersection collapses); an `Or` node word-ORs. Column children of an And/Or bypass scratch and merge directly from their `matches` array; only compound children get a depth-indexed scratch buffer. Sibling frames at the same depth reuse one buffer (their lives don't overlap), but a frame at depth+1 gets a distinct buffer (depth's is still in use). Pool entries persist across calls.
+
+The evaluator is also used by `DrainSideOracleTest`'s drain-side path so the two implementations of the merge semantics can't drift; the oracle's independence comes from the **per-row** compile path (`RecordFilterCompiler` + `RowMatcher.test`), not from a duplicate evaluator.
 
 Only the words covering `[0, batchSize)` are touched — bits past `batchSize` are not read by the consumer (`nextSetBit` is bounded), so leaving them stale is safe and avoids the trailing zero-fill the original shape paid every batch.
 
@@ -289,24 +285,6 @@ One read of `vals[]`, one bitmap, no intersect. Strictly cheaper than two single
 **Payoff.** Unlocks the `Page+record`-shaped predicate (the most common compound after match-all in real workloads — `id BETWEEN a AND b AND value op c`). The benchmark's `range` row should move from the "fallback" pile into the "drain wins" pile.
 
 **Difficulty.** Low. Two new matcher classes plus a grouping pass in `BatchFilterCompiler.tryCompile`. No changes to drain plumbing or intersect logic.
-
-### Cross-column `Or` (`or`, `nested`)
-
-**Why it falls back today.** Two stacked reasons:
-
-1. **Intersect helper is AND-only.** `FlatRowReader.intersectMatches` does `combined[w] &= m[w]`. A cross-column OR would need word-wise `|`. The structural change is small but the helper currently has no notion of "this query is an OR."
-2. **Bitmap can't represent NULL distinctly.** Each `BatchMatcher` writes "definitely matches" — bit unset means either "doesn't match" or "is null." That's correct for AND (SQL `null ∧ x` is false; an unset bit gives the same result). For OR it's wrong: `null ∨ true` is `true`, but the bitmap encoding can't distinguish a null 0-bit from a non-match 0-bit, so cross-column OR would silently drop rows that should pass via the non-null disjunct.
-
-**What to build.** Either:
-
-- **Two-bit-per-row encoding**: alongside `matches`, carry `notNull` per column. Word-wise: `combined = (notNull0 & matches0) | (notNull1 & matches1)`. Doubles the bitmap memory and adds one AND per column per word, but expressively complete.
-- **Per-column tri-state**: `matches` semantics flip to "true / false / unknown," with separate `definitelyTrue` / `definitelyFalse` long[]s. Cleaner three-valued semantics, but invasive — every matcher writes two outputs.
-
-The simpler path is `notNullWords` per column (which the codebase wants anyway for autovectorisation reasons — see below) plus a `BatchScan` that knows the predicate tree shape and chooses `&` vs `|` per node.
-
-**Payoff.** Unlocks `or` and any `nested` shape with column-spanning OR. The compiled per-row path's main remaining moat.
-
-**Difficulty.** Medium. The intersect change is mechanical; the NULL fix is plumbing across every matcher and the `Batch` type. Has to land on top of the `notNullWords` migration to be efficient.
 
 ### `BitSet nulls` → `long[] notNullWords`
 

--- a/core/src/main/java/dev/hardwood/internal/predicate/BatchFilterCompiler.java
+++ b/core/src/main/java/dev/hardwood/internal/predicate/BatchFilterCompiler.java
@@ -7,7 +7,12 @@
  */
 package dev.hardwood.internal.predicate;
 
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Map;
+import java.util.Set;
 import java.util.function.IntUnaryOperator;
 
 import dev.hardwood.internal.predicate.matcher.booleans.BooleanEqBatchMatcher;
@@ -43,104 +48,188 @@ import dev.hardwood.internal.predicate.matcher.nulls.IsNullBatchMatcher;
 import dev.hardwood.reader.FilterPredicate;
 import dev.hardwood.schema.FileSchema;
 
-/// Compiles an eligible [ResolvedPredicate] into per-column [ColumnBatchMatcher] fragments
-/// for drain-side evaluation in [dev.hardwood.internal.reader.FlatColumnWorker].
+/// Compiles an eligible [ResolvedPredicate] into a [CompiledBatchFilter]:
+/// per-column [ColumnBatchMatcher] fragments plus a [MergePlan] describing
+/// how the consumer (in [dev.hardwood.internal.reader.FlatRowReader]) combines
+/// the per-column bitmaps into one per-batch survivor mask.
 ///
-/// Eligibility is **all-or-nothing** per query:
+/// Eligibility:
 ///
-/// - A single column-local leaf with a supported `(type, op)`, OR
-/// - `ResolvedPredicate.And(children)` where every child is a column-local leaf.
+/// - Every leaf must be a supported `(type, op)` whose column is a **top-level**
+///   projected field.
+/// - `And`/`Or` may nest, as long as no single column appears in more than one
+///   independent subtree. Same-column leaves under a single shared `And`/`Or`
+///   fold into a per-column [AndBatchMatcher] / [OrBatchMatcher] composite — the
+///   same mechanism that handles `id >= x AND id <= y` today.
 ///
-/// Any other shape (`Or`, `Not`, intermediate-struct paths, unsupported `(type, op)`)
-/// returns `null`. The caller falls back to the existing
-/// [dev.hardwood.internal.reader.FilteredRowReader] path on `null`. Multiple leaves on
-/// the same column compose into an [AndBatchMatcher] in the same slot.
-///
-/// Supported `(type, op)` pairs:
-/// - `long` / `double` / `int` / `float` × `{EQ, NOT_EQ, LT, LT_EQ, GT, GT_EQ}`
-/// - `boolean` × `{EQ, NOT_EQ}`
-/// - `IntIn` / `LongIn`
-/// - `IsNull` / `IsNotNull`
+/// Anything else (intermediate-struct paths, `BinaryPredicate`,
+/// `GeospatialPredicate`, unsupported `(type, op)`) returns `null` and the
+/// caller falls back to [dev.hardwood.internal.reader.FilteredRowReader].
 public final class BatchFilterCompiler {
 
     private BatchFilterCompiler() {}
 
-    /// Returns a per-column matcher array (indexed by **projected** column index)
-    /// or `null` if the predicate is not eligible.
-    ///
-    /// @param predicate resolved predicate tree
-    /// @param schema the file schema (for top-level path checks)
-    /// @param topLevelFieldIndex maps a file column index to the projected
-    ///     column index, or `-1` if the column is not addressable as a top-level
-    ///     projected leaf
-    public static ColumnBatchMatcher[] tryCompile(ResolvedPredicate predicate, FileSchema schema,
+    /// Returns a [CompiledBatchFilter] or `null` if the predicate is not eligible.
+    public static CompiledBatchFilter tryCompile(ResolvedPredicate predicate, FileSchema schema,
             IntUnaryOperator topLevelFieldIndex) {
-        List<ResolvedPredicate> leaves = flattenAnd(predicate);
-        if (leaves == null) {
+        // Shared scratch array — threaded through every recursive `compile` call
+        // and populated in-place as subtrees commit their per-column matchers.
+        // Not a "result" of any subtree; it lives here, so its lifetime is one
+        // tryCompile invocation.
+        ColumnBatchMatcher[] matchers = new ColumnBatchMatcher[schema.getColumnCount()];
+        Result r = compile(predicate, schema, topLevelFieldIndex, matchers);
+        if (r == null) {
             return null;
         }
-
-        int leavesSize = leaves.size();
-        int[] projectedIdx = new int[leavesSize];
-        int maxProjected = -1;
-
-        for (int i = 0; i < leavesSize; i++) {
-            ResolvedPredicate leaf = leaves.get(i);
-
-            int fileIdx = leafColumnIndex(leaf);
-            if (fileIdx == -1 || !isTopLevel(schema, fileIdx)) {
-                return null;
-            }
-
-            int projected = topLevelFieldIndex.applyAsInt(fileIdx);
-            if (projected < 0 || !isSupported(leaf)) {
-                return null;
-            }
-
-            projectedIdx[i] = projected;
-
-            if (projected > maxProjected) {
-                maxProjected = projected;
-            }
+        // Single-column top-level result: the matcher is still "held" — commit
+        // it and wrap as a one-leaf MergePlan. (Mixed-column results committed
+        // their matchers and built their plan during recursion.)
+        if (r.columnIndex >= 0) {
+            matchers[r.columnIndex] = r.columnMatcher;
+            r.mergePlan = new MergePlan.Column(r.columnIndex);
         }
-
-        ColumnBatchMatcher[] result = new ColumnBatchMatcher[maxProjected + 1];
-
-        for (int i = 0; i < leavesSize; i++) {
-            int projected = projectedIdx[i];
-            ColumnBatchMatcher matcher = compileLeaf(leaves.get(i));
-
-            // Multiple leaves on the same column (e.g. `id >= x AND id <= y`)
-            // compose into a single AND-merged matcher kept in the same slot.
-            result[projected] = result[projected] == null
-                    ? matcher
-                    : new AndBatchMatcher(result[projected], matcher);
-        }
-        return result;
+        return new CompiledBatchFilter(matchers, r.mergePlan);
     }
 
-    /// `ResolvedPredicate.And` is canonicalized to a flat list of children at
-    /// construction time (see [ResolvedPredicate.And]), so a nested `And` here
-    /// would indicate a broken invariant. `Or` children remain a bail-out — the
-    /// batch path only supports column-local conjunctions.
-    private static List<ResolvedPredicate> flattenAnd(ResolvedPredicate predicate) {
-        if (predicate instanceof ResolvedPredicate.And(List<ResolvedPredicate> children)) {
-            for (ResolvedPredicate child : children) {
-                if (child instanceof ResolvedPredicate.And) {
-                    throw new IllegalStateException(
-                            "ResolvedPredicate.And must be flat; found nested And child");
-                }
-                if (child instanceof ResolvedPredicate.Or) {
-                    return null;
-                }
-            }
-            return children;
+    /// A subtree compile result. Carries one of two mutually exclusive states,
+    /// keyed by [#columnIndex]:
+    ///
+    /// - `columnIndex >= 0`: the whole subtree lives on one projected column.
+    ///   [#columnMatcher] is its composite matcher, **not yet committed** to the
+    ///   `matchers[]` scratch array — the caller decides whether to fold it
+    ///   further with siblings or commit it. [#mergePlan] is `null`.
+    /// - `columnIndex == -1`: the subtree spans multiple columns. Its
+    ///   per-column matchers were committed to `matchers[]` during recursion,
+    ///   and [#mergePlan] is the plan the consumer walks to combine the
+    ///   per-column bitmaps. [#columns] lists the columns the subtree touches
+    ///   (used by the parent to detect cross-sibling column conflicts).
+    private static final class Result {
+        int columnIndex = -1;
+        ColumnBatchMatcher columnMatcher;
+        MergePlan mergePlan;
+        Set<Integer> columns;
+    }
+
+    private static Result compile(ResolvedPredicate p, FileSchema schema, IntUnaryOperator projection,
+            ColumnBatchMatcher[] matchers) {
+        if (p instanceof ResolvedPredicate.And and) {
+            return compileCompound(and.children(), false, schema, projection, matchers);
         }
-        if (predicate instanceof ResolvedPredicate.Or
-                || predicate instanceof ResolvedPredicate.GeospatialPredicate) {
+        if (p instanceof ResolvedPredicate.Or or) {
+            return compileCompound(or.children(), true, schema, projection, matchers);
+        }
+        return compileLeaf(p, schema, projection);
+    }
+
+    private static Result compileLeaf(ResolvedPredicate leaf, FileSchema schema, IntUnaryOperator projection) {
+        int fileIdx = leafColumnIndex(leaf);
+        if (fileIdx == -1 || !isTopLevel(schema, fileIdx) || !isSupported(leaf)) {
             return null;
         }
-        return List.of(predicate);
+        int projected = projection.applyAsInt(fileIdx);
+        if (projected < 0) {
+            return null;
+        }
+        Result r = new Result();
+        r.columnIndex = projected;
+        r.columnMatcher = leafMatcher(leaf);
+        return r;
+    }
+
+    private static ColumnBatchMatcher fold(boolean isOr, ColumnBatchMatcher a, ColumnBatchMatcher b) {
+        return isOr ? new OrBatchMatcher(a, b) : new AndBatchMatcher(a, b);
+    }
+
+    private static Result compileCompound(List<ResolvedPredicate> children, boolean isOr,
+            FileSchema schema, IntUnaryOperator projection, ColumnBatchMatcher[] matchers) {
+        int n = children.size();
+        if (n == 1) {
+            return compile(children.getFirst(), schema, projection, matchers);
+        }
+        // Compile each child and track whether every child so far is single-column
+        // on the same column. `sharedColumnIndex` ends >= 0 iff that holds for all
+        // children — the same-column fast path below.
+        Result[] childResults = new Result[n];
+        int sharedColumnIndex = -1;
+        for (int i = 0; i < n; i++) {
+            Result cr = compile(children.get(i), schema, projection, matchers);
+            if (cr == null) {
+                return null;
+            }
+            childResults[i] = cr;
+            if (i == 0) {
+                sharedColumnIndex = cr.columnIndex;
+            }
+            else if (cr.columnIndex != sharedColumnIndex) {
+                sharedColumnIndex = -1;
+            }
+        }
+
+        Result out = new Result();
+
+        if (sharedColumnIndex >= 0) {
+            // Same column throughout — fold every child's matcher into one
+            // composite, held on the Result without committing to matchers[].
+            // The parent decides whether to fold further or finally commit.
+            ColumnBatchMatcher composite = childResults[0].columnMatcher;
+            for (int i = 1; i < n; i++) {
+                composite = fold(isOr, composite, childResults[i].columnMatcher);
+            }
+            out.columnIndex = sharedColumnIndex;
+            out.columnMatcher = composite;
+            return out;
+        }
+
+        // Mixed columns: build the MergePlan child list. Same-column single
+        // siblings under this And/Or (e.g. `id >= x AND id <= y AND value < z`)
+        // fold into one per-column composite matcher and contribute a single
+        // MergePlan.Column entry. Mixed-column children already committed their
+        // matchers during recursion; we just splice their sub-plans in. Two
+        // mixed-column siblings claiming the same column, or a single-column
+        // bucket whose column was already claimed elsewhere, both reject —
+        // `Batch.matches[c]` can hold only one per-row bitmap.
+        Map<Integer, ColumnBatchMatcher> singleColumnBuckets = new LinkedHashMap<>(n);
+        Set<Integer> touchedColumns = new HashSet<>(n);
+        List<Result> mixedResults = new ArrayList<>(n);
+        for (Result cr : childResults) {
+            if (cr.columnIndex >= 0) {
+                singleColumnBuckets.merge(cr.columnIndex, cr.columnMatcher,
+                        (existing, next) -> fold(isOr, existing, next));
+            }
+            else {
+                for (int c : cr.columns) {
+                    if (!touchedColumns.add(c)) {
+                        // Two mixed siblings both touch this column.
+                        return null;
+                    }
+                }
+                mixedResults.add(cr);
+            }
+        }
+
+        // Commit single-column buckets to matchers[] and assemble the merge
+        // plan's children. `matchers[c] != null` covers both within-compound
+        // collisions (a mixed sibling already committed `c`) and ancestor-side
+        // collisions.
+        MergePlan[] planChildren = new MergePlan[singleColumnBuckets.size() + mixedResults.size()];
+        int idx = 0;
+        for (Map.Entry<Integer, ColumnBatchMatcher> bucket : singleColumnBuckets.entrySet()) {
+            int c = bucket.getKey();
+            if (matchers[c] != null) {
+                return null;
+            }
+            matchers[c] = bucket.getValue();
+            touchedColumns.add(c);
+            planChildren[idx++] = new MergePlan.Column(c);
+        }
+        for (Result cr : mixedResults) {
+            planChildren[idx++] = cr.mergePlan;
+        }
+        out.mergePlan = isOr
+                ? new MergePlan.Or(planChildren)
+                : new MergePlan.And(planChildren);
+        out.columns = touchedColumns;
+        return out;
     }
 
     private static int leafColumnIndex(ResolvedPredicate leaf) {
@@ -178,7 +267,7 @@ public final class BatchFilterCompiler {
         };
     }
 
-    private static ColumnBatchMatcher compileLeaf(ResolvedPredicate leaf) {
+    private static ColumnBatchMatcher leafMatcher(ResolvedPredicate leaf) {
         return switch (leaf) {
             case ResolvedPredicate.LongPredicate p -> switch (p.op()) {
                 case GT -> new LongGtBatchMatcher(p.value());
@@ -216,7 +305,7 @@ public final class BatchFilterCompiler {
                 case EQ -> new BooleanEqBatchMatcher(p.value());
                 case NOT_EQ -> new BooleanNotEqBatchMatcher(p.value());
                 default -> throw new IllegalStateException(
-                        "Unsupported boolean operator reached compileLeaf: " + p.op()
+                        "Unsupported boolean operator reached leafMatcher: " + p.op()
                                 + " — isSupported should have rejected this");
             };
             case ResolvedPredicate.IntInPredicate p -> new IntInBatchMatcher(p.values());
@@ -224,7 +313,7 @@ public final class BatchFilterCompiler {
             case ResolvedPredicate.IsNullPredicate p -> new IsNullBatchMatcher();
             case ResolvedPredicate.IsNotNullPredicate p -> new IsNotNullBatchMatcher();
             default -> throw new IllegalStateException(
-                    "Unsupported predicate type reached compileLeaf: " + leaf.getClass().getSimpleName()
+                    "Unsupported predicate type reached leafMatcher: " + leaf.getClass().getSimpleName()
                             + " — isSupported should have rejected this");
         };
     }

--- a/core/src/main/java/dev/hardwood/internal/predicate/ColumnBatchMatcher.java
+++ b/core/src/main/java/dev/hardwood/internal/predicate/ColumnBatchMatcher.java
@@ -22,7 +22,7 @@ import dev.hardwood.internal.reader.BatchExchange;
 /// `(batch.recordCount + 63) >>> 6`.
 public sealed interface ColumnBatchMatcher
         permits LongBatchMatcher, DoubleBatchMatcher, IntBatchMatcher, FloatBatchMatcher,
-        BooleanBatchMatcher, NullBatchMatcher, AndBatchMatcher {
+        BooleanBatchMatcher, NullBatchMatcher, AndBatchMatcher, OrBatchMatcher {
 
     void test(BatchExchange.Batch batch, long[] outWords);
 }

--- a/core/src/main/java/dev/hardwood/internal/predicate/CompiledBatchFilter.java
+++ b/core/src/main/java/dev/hardwood/internal/predicate/CompiledBatchFilter.java
@@ -1,0 +1,20 @@
+/*
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Copyright The original authors
+ *
+ *  Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package dev.hardwood.internal.predicate;
+
+/// Result of compiling an eligible [ResolvedPredicate] for the drain-side
+/// filter path.
+///
+/// - `columnMatchers[i]` is the [ColumnBatchMatcher] installed on projected
+///   column `i`, or `null` if the column has no filter contribution. Workers
+///   run this matcher against every published batch.
+/// - `mergePlan` is the consumer-side [MergePlan] walked by
+///   [dev.hardwood.internal.reader.FlatRowReader] to combine the per-column
+///   bitmaps into one per-batch survivor mask.
+public record CompiledBatchFilter(ColumnBatchMatcher[] columnMatchers, MergePlan mergePlan) {
+}

--- a/core/src/main/java/dev/hardwood/internal/predicate/MergePlan.java
+++ b/core/src/main/java/dev/hardwood/internal/predicate/MergePlan.java
@@ -1,0 +1,47 @@
+/*
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Copyright The original authors
+ *
+ *  Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package dev.hardwood.internal.predicate;
+
+/// Plan describing how to merge per-column
+/// [BatchExchange.Batch#matches][dev.hardwood.internal.reader.BatchExchange.Batch#matches]
+/// bitmaps into a single per-batch combined survivor mask.
+///
+/// Produced by [BatchFilterCompiler] alongside the per-column
+/// [ColumnBatchMatcher] array. A [Column] node references the projected index
+/// of a column whose worker emitted a `matches` array; [And] and [Or] combine
+/// children word-wise.
+///
+/// Each leaf column appears in at most one [Column] node — same-column leaves
+/// are pre-composed into [AndBatchMatcher] / [OrBatchMatcher] inside the
+/// per-column matcher, so the plan only encodes cross-column structure.
+public sealed interface MergePlan {
+
+    /// Common parent for [And] and [Or]: a compound with [MergePlan] children
+    /// that may themselves be compounds.
+    sealed interface Compound extends MergePlan {
+        MergePlan[] children();
+    }
+
+    record Column(int projectedIndex) implements MergePlan {}
+
+    record And(MergePlan[] children) implements Compound {
+        public And {
+            if (children.length < 2) {
+                throw new IllegalArgumentException("And requires at least two children");
+            }
+        }
+    }
+
+    record Or(MergePlan[] children) implements Compound {
+        public Or {
+            if (children.length < 2) {
+                throw new IllegalArgumentException("Or requires at least two children");
+            }
+        }
+    }
+}

--- a/core/src/main/java/dev/hardwood/internal/predicate/MergePlanEvaluator.java
+++ b/core/src/main/java/dev/hardwood/internal/predicate/MergePlanEvaluator.java
@@ -1,0 +1,142 @@
+/*
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Copyright The original authors
+ *
+ *  Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package dev.hardwood.internal.predicate;
+
+/// Evaluates a [MergePlan] against a set of per-column bitmaps, writing the
+/// combined survivor bitmap into a caller-supplied output buffer.
+///
+/// One instance owns a depth-indexed scratch pool: each recursion level of an
+/// And/Or merge gets its own scratch buffer, so sibling frames at the same
+/// depth share a buffer (their lives don't overlap) while a frame at depth+1
+/// gets a distinct buffer (the depth's buffer is still in use). Pool entries
+/// persist across calls — zero per-call allocations after warm-up.
+///
+/// The same instance is used by [dev.hardwood.internal.reader.FlatRowReader]
+/// on the hot path and by `DrainSideOracleTest` to verify equivalence with the
+/// per-row compile path.
+public final class MergePlanEvaluator {
+
+    private final int wordsLen;
+    private long[][] scratchPool;
+
+    /// @param wordsLen size of every output and scratch buffer in `long`s
+    ///         (= max-possible `activeWords`).
+    public MergePlanEvaluator(int wordsLen) {
+        this.wordsLen = wordsLen;
+    }
+
+    /// Evaluates `plan` and writes the result into `out` over its first
+    /// `activeWords` words (positions past `activeWords` are not touched).
+    ///
+    /// @param plan the merge plan
+    /// @param out destination buffer; must have length `>= wordsLen`
+    /// @param activeWords number of valid words for this call (`<= wordsLen`)
+    /// @param perColumn per-column bitmaps indexed by projected column index;
+    ///         each entry must be non-null and have length `>= activeWords`
+    ///         for any column referenced by `plan`
+    public void eval(MergePlan plan, long[] out, int activeWords, long[][] perColumn) {
+        evalNode(plan, out, 0, activeWords, perColumn);
+    }
+
+    private void evalNode(MergePlan node, long[] out, int depth, int activeWords, long[][] perColumn) {
+        switch (node) {
+            case MergePlan.Column c -> System.arraycopy(perColumn[c.projectedIndex()], 0, out, 0, activeWords);
+            case MergePlan.And a -> evalAnd(a.children(), out, depth, activeWords, perColumn);
+            case MergePlan.Or o -> evalOr(o.children(), out, depth, activeWords, perColumn);
+        }
+    }
+
+    /// AND of children writing to `out`. Column children merge directly from
+    /// their bitmap; compound children write into a depth-indexed scratch
+    /// buffer first. The last sibling skips the all-zero-detection accumulator
+    /// since there is nothing after it to short-circuit.
+    private void evalAnd(MergePlan[] children, long[] out, int depth, int activeWords, long[][] perColumn) {
+        writeFirstChild(children[0], out, depth, activeWords, perColumn);
+        int n = children.length;
+        long[] scratch = null;
+        for (int i = 1; i < n; i++) {
+            MergePlan child = children[i];
+            long[] src;
+            if (child instanceof MergePlan.Column cc) {
+                src = perColumn[cc.projectedIndex()];
+            }
+            else {
+                if (scratch == null) scratch = scratchAt(depth);
+                evalNode(child, scratch, depth + 1, activeWords, perColumn);
+                src = scratch;
+            }
+            if (i == n - 1) {
+                for (int w = 0; w < activeWords; w++) out[w] &= src[w];
+            }
+            else {
+                long anyBit = 0L;
+                for (int w = 0; w < activeWords; w++) {
+                    long merged = out[w] & src[w];
+                    out[w] = merged;
+                    anyBit |= merged;
+                }
+                if (anyBit == 0L) return;
+            }
+        }
+    }
+
+    /// OR of children writing to `out`. Mirror of [#evalAnd] without short-circuit.
+    private void evalOr(MergePlan[] children, long[] out, int depth, int activeWords, long[][] perColumn) {
+        writeFirstChild(children[0], out, depth, activeWords, perColumn);
+        int n = children.length;
+        long[] scratch = null;
+        for (int i = 1; i < n; i++) {
+            MergePlan child = children[i];
+            long[] src;
+            if (child instanceof MergePlan.Column cc) {
+                src = perColumn[cc.projectedIndex()];
+            }
+            else {
+                if (scratch == null) scratch = scratchAt(depth);
+                evalNode(child, scratch, depth + 1, activeWords, perColumn);
+                src = scratch;
+            }
+            for (int w = 0; w < activeWords; w++) out[w] |= src[w];
+        }
+    }
+
+    /// Writes the first child of an And/Or into `out`, inlining the Column
+    /// case to skip one recursive call frame.
+    private void writeFirstChild(MergePlan first, long[] out, int depth, int activeWords, long[][] perColumn) {
+        if (first instanceof MergePlan.Column c) {
+            System.arraycopy(perColumn[c.projectedIndex()], 0, out, 0, activeWords);
+        }
+        else {
+            evalNode(first, out, depth, activeWords, perColumn);
+        }
+    }
+
+    /// Returns the scratch buffer for the given recursion depth, allocating
+    /// (and growing the pool) on demand.
+    private long[] scratchAt(int depth) {
+        long[][] pool = scratchPool;
+        if (pool == null || depth >= pool.length) {
+            int newLen = pool == null ? 4 : pool.length * 2;
+            while (newLen <= depth) {
+                newLen *= 2;
+            }
+            long[][] grown = new long[newLen][];
+            if (pool != null) {
+                System.arraycopy(pool, 0, grown, 0, pool.length);
+            }
+            scratchPool = grown;
+            pool = grown;
+        }
+        long[] buf = pool[depth];
+        if (buf == null) {
+            buf = new long[wordsLen];
+            pool[depth] = buf;
+        }
+        return buf;
+    }
+}

--- a/core/src/main/java/dev/hardwood/internal/predicate/OrBatchMatcher.java
+++ b/core/src/main/java/dev/hardwood/internal/predicate/OrBatchMatcher.java
@@ -1,0 +1,49 @@
+/*
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Copyright The original authors
+ *
+ *  Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package dev.hardwood.internal.predicate;
+
+import dev.hardwood.internal.reader.BatchExchange;
+
+/// Composes two [ColumnBatchMatcher]s evaluated against the same column and
+/// word-OR merges their bit masks. Used when an eligible subtree has multiple
+/// leaves on a single column joined by `Or` (e.g. `id < -5 OR id > 5`).
+///
+/// Under the "definitely matches, nulls excluded" semantics of
+/// [ColumnBatchMatcher], a bitwise OR across leaves is equivalent to SQL
+/// three-valued disjunction: a row survives iff at least one leaf definitely
+/// matches it.
+///
+/// Both children must be valid matchers for the column's batch — the composite
+/// is type-agnostic and delegates the `batch.values` cast to each child. The
+/// scratch buffer is allocated lazily on the first [#test] call and reused
+/// across batches; the matcher is intended to be called sequentially by a
+/// single drain thread.
+public final class OrBatchMatcher implements ColumnBatchMatcher {
+
+    private final ColumnBatchMatcher first;
+    private final ColumnBatchMatcher second;
+    private long[] scratch;
+
+    public OrBatchMatcher(ColumnBatchMatcher first, ColumnBatchMatcher second) {
+        this.first = first;
+        this.second = second;
+    }
+
+    @Override
+    public void test(BatchExchange.Batch batch, long[] outWords) {
+        if (scratch == null || scratch.length < outWords.length) {
+            scratch = new long[outWords.length];
+        }
+        first.test(batch, outWords);
+        second.test(batch, scratch);
+        int activeWords = (batch.recordCount + 63) >>> 6;
+        for (int i = 0; i < activeWords; i++) {
+            outWords[i] |= scratch[i];
+        }
+    }
+}

--- a/core/src/main/java/dev/hardwood/internal/reader/FlatRowReader.java
+++ b/core/src/main/java/dev/hardwood/internal/reader/FlatRowReader.java
@@ -19,6 +19,9 @@ import dev.hardwood.internal.ExceptionContext;
 import dev.hardwood.internal.conversion.LogicalTypeConverter;
 import dev.hardwood.internal.predicate.BatchFilterCompiler;
 import dev.hardwood.internal.predicate.ColumnBatchMatcher;
+import dev.hardwood.internal.predicate.CompiledBatchFilter;
+import dev.hardwood.internal.predicate.MergePlan;
+import dev.hardwood.internal.predicate.MergePlanEvaluator;
 import dev.hardwood.internal.predicate.RecordFilterCompiler;
 import dev.hardwood.internal.predicate.ResolvedPredicate;
 import dev.hardwood.internal.predicate.RowMatcher;
@@ -82,16 +85,25 @@ public final class FlatRowReader implements RowReader {
     // Drain-side filter path: when drainSide is true, iterate via nextSetBit over
     // combinedWords. When false, the original rowIndex++ path is taken.
     private final boolean drainSide;
-    /// AND-merged per-row matches for the current batch. `null` when `!drainSide`.
-    /// Multi-column case: an owned buffer filled by [#intersectMatches]. Single-column
-    /// case: aliased per batch to the underlying [BatchExchange.Batch#matches] array
-    /// (no copy needed — there is nothing to intersect).
+    /// Combined per-row matches for the current batch. `null` when `!drainSide`.
+    /// Multi-column case: an owned buffer that [#intersectMatches] hands to
+    /// [#mergeEvaluator] for in-place population. Single-column case
+    /// (`mergePlan instanceof MergePlan.Column`): aliased per batch to the
+    /// underlying [BatchExchange.Batch#matches] array (no copy, no evaluator
+    /// call — there is nothing to combine).
     private long[] combinedWords;
-    /// Projected indices of columns that have a [ColumnBatchMatcher] column-filter installed.
-    /// Iterating this array in [#intersectMatches] avoids per-column null checks
-    /// on `Batch.matches` and skips columns without columnFilters entirely. `null`
-    /// when `!drainSide`.
-    private final int[] filteredColumns;
+    /// Plan describing how to merge the per-column [BatchExchange.Batch#matches]
+    /// bitmaps into [#combinedWords]. `null` when `!drainSide`.
+    private final MergePlan mergePlan;
+    /// Evaluator that walks [#mergePlan] each batch. Owns the scratch pool;
+    /// reused across batches (zero allocations after warm-up). `null` when the
+    /// single-column fast path applies (no merge to do).
+    private final MergePlanEvaluator mergeEvaluator;
+    /// Per-column matches bitmaps for the current batch, indexed by projected
+    /// column index. Repopulated each batch from `previousBatches[i].matches`;
+    /// passed to [#mergeEvaluator]. `null` when the single-column fast path
+    /// applies.
+    private final long[][] perColumnMatches;
     private int pendingRowIndex = -1;
     /// Exclusive upper bound of the current run of consecutive-1 bits in
     /// [#combinedWords] starting at or before `rowIndex + 1`. While
@@ -106,7 +118,7 @@ public final class FlatRowReader implements RowReader {
 
     public FlatRowReader(BatchExchange<BatchExchange.Batch>[] exchanges, FlatColumnWorker[] columnWorkers,
                          FileSchema fileSchema, ProjectedSchema projectedSchema,
-                         boolean drainSide, int wordsLen, int[] filteredColumns) {
+                         boolean drainSide, int wordsLen, MergePlan mergePlan) {
         this.exchanges = exchanges;
         this.columnWorkers = columnWorkers;
         this.columnCount = exchanges.length;
@@ -116,13 +128,15 @@ public final class FlatRowReader implements RowReader {
         this.flatValidity = new long[columnCount][];
         this.previousBatches = new BatchExchange.Batch[columnCount];
         this.drainSide = drainSide;
-        // Multi-column drain needs a private buffer for the AND-merged words.
-        // Single-column drain aliases the batch's matches array directly (see
-        // intersectMatches) so no allocation is needed here.
-        this.combinedWords = drainSide && filteredColumns != null && filteredColumns.length > 1
-                ? new long[wordsLen]
-                : null;
-        this.filteredColumns = filteredColumns;
+        // Multi-column drain needs a private buffer for the combined words plus
+        // an evaluator that owns the depth-indexed scratch pool. A top-level
+        // Column aliases the batch's matches array directly (see
+        // intersectMatches) so neither buffer nor evaluator is needed.
+        boolean needsOwnedBuffer = drainSide && !(mergePlan instanceof MergePlan.Column);
+        this.combinedWords = needsOwnedBuffer ? new long[wordsLen] : null;
+        this.mergePlan = mergePlan;
+        this.mergeEvaluator = needsOwnedBuffer ? new MergePlanEvaluator(wordsLen) : null;
+        this.perColumnMatches = needsOwnedBuffer ? new long[columnCount][] : null;
 
         // Build name-to-index map and cache column metadata
         this.nameToIndex = new StringToIntMap(columnCount);
@@ -170,10 +184,11 @@ public final class FlatRowReader implements RowReader {
 
         // Try the drain-side path first. tryCompile returns null for any non-eligible
         // predicate; null falls through to the existing FilteredRowReader path below.
-        ColumnBatchMatcher[] columnBatchMatchers = null;
+        CompiledBatchFilter compiledFilter = null;
         if (filter != null) {
-            columnBatchMatchers = BatchFilterCompiler.tryCompile(filter, schema, projectedSchema::toProjectedIndex);
+            compiledFilter = BatchFilterCompiler.tryCompile(filter, schema, projectedSchema::toProjectedIndex);
         }
+        ColumnBatchMatcher[] columnBatchMatchers = compiledFilter != null ? compiledFilter.columnMatchers() : null;
         boolean drainSide = columnBatchMatchers != null;
         final int wordsLen = (batchSize + 63) >>> 6;
 
@@ -211,26 +226,13 @@ public final class FlatRowReader implements RowReader {
             worker.start();
         }
 
-        int[] filteredColumns = null;
-        if (drainSide) {
-            int len = columnBatchMatchers.length;
-            int[] tmp = new int[len];
-            int idx = 0;
-
-            for (int i = 0; i < len; i++) {
-                if (columnBatchMatchers[i] != null) {
-                    tmp[idx++] = i;
-                }
-            }
-
-            filteredColumns = Arrays.copyOf(tmp, idx);
-        }
-        if (filteredColumns == null || filteredColumns.length == 0) {
+        MergePlan mergePlan = compiledFilter != null ? compiledFilter.mergePlan() : null;
+        if (mergePlan == null) {
             drainSide = false;
         }
 
         FlatRowReader reader = new FlatRowReader(buffers, workers, schema, projectedSchema,
-                drainSide, wordsLen, filteredColumns);
+                drainSide, wordsLen, mergePlan);
         reader.initialize();
 
         if (drainSide) {
@@ -746,54 +748,33 @@ public final class FlatRowReader implements RowReader {
         return true;
     }
 
-    /// Intersects per-column [BatchExchange.Batch.matches] arrays into [combinedWords]
-    /// for the rows currently held by this reader.
+    /// Combines per-column [BatchExchange.Batch.matches] arrays into [combinedWords]
+    /// by delegating to [#mergeEvaluator].
     ///
-    /// Iterates only the columns recorded in [#filteredColumns] (built once at
-    /// construction time), so there is no per-batch null check on `Batch.matches`.
     /// Only the words covering `[0, batchSize)` are touched — bits past
     /// `batchSize` are not read by the consumer (`nextSetBit` is bounded by
     /// `batchSize`), so leaving them stale is safe and avoids the trailing
     /// zero-fill the previous shape paid every batch.
     ///
-    /// **Single-column fast path**: when only one column has a matcher there is
-    /// nothing to AND-merge, so [combinedWords] is aliased directly to the batch's
-    /// own `matches` array — no copy, no owned buffer. The alias is reseated each
-    /// batch; the array stays valid until the batch is recycled in the next
-    /// [#loadNextBatch].
+    /// **Single-column fast path**: when the whole predicate is a single
+    /// [MergePlan.Column] there is nothing to merge, so [combinedWords] is
+    /// aliased directly to the batch's own `matches` array — no copy, no owned
+    /// buffer, no evaluator call. The alias is reseated each batch; the array
+    /// stays valid until the batch is recycled in the next [#loadNextBatch].
     private void intersectMatches() {
-        BatchExchange.Batch[] batches = previousBatches;
-
-        if (filteredColumns.length == 1) {
-            combinedWords = batches[filteredColumns[0]].matches;
+        if (mergePlan instanceof MergePlan.Column c) {
+            combinedWords = previousBatches[c.projectedIndex()].matches;
             return;
         }
-
-        int activeWords = (batchSize + 63) >>> 6;
-        long[] combined = combinedWords;
-
-        // First column: bulk copy the words covering the active range.
-        long[] first = batches[filteredColumns[0]].matches;
-        System.arraycopy(first, 0, combined, 0, activeWords);
-
-        // Remaining columns: word-wise AND-merge. Track an OR across the merged
-        // words so we can bail out the moment a highly selective column drives
-        // the intersection to all-zero — skipping the remaining columns'
-        // AND-passes when the batch is already known to produce no rows.
-        for (int col = 1; col < filteredColumns.length; col++) {
-            long[] matches = batches[filteredColumns[col]].matches;
-            long anyBit = 0L;
-
-            for (int wIndex = 0; wIndex < activeWords; wIndex++) {
-                long merged = combined[wIndex] & matches[wIndex];
-                combined[wIndex] = merged;
-                anyBit |= merged;
-            }
-
-            if (anyBit == 0L) {
-                return;
-            }
+        // Snapshot per-column matches references for this batch and hand off
+        // to the shared evaluator. The same long[] entry from previousBatches
+        // gets read back; the indirection is one columnCount-sized assignment
+        // per batch — negligible vs. the per-row merge work.
+        for (int i = 0; i < columnCount; i++) {
+            perColumnMatches[i] = previousBatches[i].matches;
         }
+        int activeWords = (batchSize + 63) >>> 6;
+        mergeEvaluator.eval(mergePlan, combinedWords, activeWords, perColumnMatches);
     }
 
     // ==================== Close ====================

--- a/core/src/test/java/dev/hardwood/internal/predicate/BatchFilterCompilerTest.java
+++ b/core/src/test/java/dev/hardwood/internal/predicate/BatchFilterCompilerTest.java
@@ -28,6 +28,12 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 
 class BatchFilterCompilerTest {
 
+    private static ColumnBatchMatcher[] compileMatchers(ResolvedPredicate predicate, FileSchema schema,
+            IntUnaryOperator projection) {
+        CompiledBatchFilter compiled = BatchFilterCompiler.tryCompile(predicate, schema, projection);
+        return compiled == null ? null : compiled.columnMatchers();
+    }
+
     private static FileSchema schema(SchemaElement... columns) {
         SchemaElement root = new SchemaElement("root", null, null, null, columns.length,
                 null, null, null, null, null);
@@ -53,7 +59,7 @@ class BatchFilterCompilerTest {
                 new ResolvedPredicate.DoublePredicate(1, Operator.LT, 500.0)
         ));
 
-        ColumnBatchMatcher[] result = BatchFilterCompiler.tryCompile(
+        ColumnBatchMatcher[] result = compileMatchers(
                 predicate, schema, IntUnaryOperator.identity());
 
         assertNotNull(result);
@@ -67,7 +73,7 @@ class BatchFilterCompilerTest {
         FileSchema schema = schema(leaf("id", PhysicalType.INT64));
         ResolvedPredicate predicate = new ResolvedPredicate.LongPredicate(0, Operator.GT, 5L);
 
-        ColumnBatchMatcher[] result = BatchFilterCompiler.tryCompile(
+        ColumnBatchMatcher[] result = compileMatchers(
                 predicate, schema, IntUnaryOperator.identity());
 
         assertNotNull(result);
@@ -80,7 +86,7 @@ class BatchFilterCompilerTest {
         FileSchema schema = schema(leaf("flag", PhysicalType.BOOLEAN));
         ResolvedPredicate predicate = new ResolvedPredicate.BooleanPredicate(0, Operator.EQ, true);
 
-        ColumnBatchMatcher[] result = BatchFilterCompiler.tryCompile(
+        ColumnBatchMatcher[] result = compileMatchers(
                 predicate, schema, IntUnaryOperator.identity());
 
         assertNotNull(result);
@@ -93,7 +99,7 @@ class BatchFilterCompilerTest {
         FileSchema schema = schema(leaf("id", PhysicalType.INT64));
         ResolvedPredicate predicate = new ResolvedPredicate.LongInPredicate(0, new long[]{1L, 2L, 3L});
 
-        ColumnBatchMatcher[] result = BatchFilterCompiler.tryCompile(
+        ColumnBatchMatcher[] result = compileMatchers(
                 predicate, schema, IntUnaryOperator.identity());
 
         assertNotNull(result);
@@ -106,7 +112,7 @@ class BatchFilterCompilerTest {
         FileSchema schema = schema(leaf("id", PhysicalType.INT64));
         ResolvedPredicate predicate = new ResolvedPredicate.IsNullPredicate(0);
 
-        ColumnBatchMatcher[] result = BatchFilterCompiler.tryCompile(
+        ColumnBatchMatcher[] result = compileMatchers(
                 predicate, schema, IntUnaryOperator.identity());
 
         assertNotNull(result);
@@ -116,16 +122,6 @@ class BatchFilterCompilerTest {
 
     @Nested
     class IneligibleShapes {
-
-        @Test
-        void or_atRoot_returnsNull() {
-            FileSchema schema = longDoubleSchema();
-            ResolvedPredicate predicate = new ResolvedPredicate.Or(List.of(
-                    new ResolvedPredicate.LongPredicate(0, Operator.GT, 5L),
-                    new ResolvedPredicate.DoublePredicate(1, Operator.LT, 500.0)
-            ));
-            assertNull(BatchFilterCompiler.tryCompile(predicate, schema, IntUnaryOperator.identity()));
-        }
 
         @Test
         void andWithNestedAnd_isFlattenedAndCompiles() {
@@ -138,23 +134,10 @@ class BatchFilterCompilerTest {
                             new ResolvedPredicate.DoublePredicate(1, Operator.LT, 500.0)
                     ))
             ));
-            ColumnBatchMatcher[] result = BatchFilterCompiler.tryCompile(
+            ColumnBatchMatcher[] result = compileMatchers(
                     predicate, schema, IntUnaryOperator.identity());
             assertNotNull(result);
             assertEquals(2, result.length);
-        }
-
-        @Test
-        void andWithOrChild_returnsNull() {
-            FileSchema schema = longDoubleSchema();
-            ResolvedPredicate predicate = new ResolvedPredicate.And(List.of(
-                    new ResolvedPredicate.LongPredicate(0, Operator.GT, 5L),
-                    new ResolvedPredicate.Or(List.of(
-                            new ResolvedPredicate.DoublePredicate(1, Operator.LT, 500.0),
-                            new ResolvedPredicate.DoublePredicate(1, Operator.GT, 1000.0)
-                    ))
-            ));
-            assertNull(BatchFilterCompiler.tryCompile(predicate, schema, IntUnaryOperator.identity()));
         }
 
         @Test
@@ -213,10 +196,116 @@ class BatchFilterCompilerTest {
                 new ResolvedPredicate.LongPredicate(0, Operator.GT_EQ, 5L),
                 new ResolvedPredicate.LongPredicate(0, Operator.LT_EQ, 100L)
         ));
-        ColumnBatchMatcher[] result = BatchFilterCompiler.tryCompile(
+        ColumnBatchMatcher[] result = compileMatchers(
                 predicate, schema, IntUnaryOperator.identity());
         assertNotNull(result);
         assertEquals(1, result.length);
         assertInstanceOf(AndBatchMatcher.class, result[0]);
+    }
+
+    @Test
+    void twoLeavesOnSameColumn_underOr_composeIntoOrMatcher() {
+        // Same-column OR: `id < -5 OR id > 5` folds into a single OrBatchMatcher
+        // in one column slot, and the MergePlan is a single Column node.
+        FileSchema schema = schema(leaf("id", PhysicalType.INT64));
+        ResolvedPredicate predicate = new ResolvedPredicate.Or(List.of(
+                new ResolvedPredicate.LongPredicate(0, Operator.LT, -5L),
+                new ResolvedPredicate.LongPredicate(0, Operator.GT, 5L)
+        ));
+        CompiledBatchFilter result = BatchFilterCompiler.tryCompile(
+                predicate, schema, IntUnaryOperator.identity());
+        assertNotNull(result);
+        assertEquals(1, result.columnMatchers().length);
+        assertInstanceOf(OrBatchMatcher.class, result.columnMatchers()[0]);
+        assertInstanceOf(MergePlan.Column.class, result.mergePlan());
+    }
+
+    @Test
+    void orOfLongAndDoubleLeaves_compilesAsOr() {
+        FileSchema schema = longDoubleSchema();
+        ResolvedPredicate predicate = new ResolvedPredicate.Or(List.of(
+                new ResolvedPredicate.LongPredicate(0, Operator.GT, 5L),
+                new ResolvedPredicate.DoublePredicate(1, Operator.LT, 500.0)
+        ));
+        CompiledBatchFilter result = BatchFilterCompiler.tryCompile(
+                predicate, schema, IntUnaryOperator.identity());
+        assertNotNull(result);
+        assertInstanceOf(LongBatchMatcher.class, result.columnMatchers()[0]);
+        assertInstanceOf(DoubleBatchMatcher.class, result.columnMatchers()[1]);
+        assertInstanceOf(MergePlan.Or.class, result.mergePlan());
+    }
+
+    @Test
+    void andOfLeafAndOrOnDistinctColumn_compilesAsMixedTree() {
+        // `id > 5 AND (value < 0 OR value > 1000)` — the OR subtree is fully
+        // contained on the `value` column and folds into a single OrBatchMatcher
+        // slot, while the outer AND becomes a MergePlan.And.
+        FileSchema schema = longDoubleSchema();
+        ResolvedPredicate predicate = new ResolvedPredicate.And(List.of(
+                new ResolvedPredicate.LongPredicate(0, Operator.GT, 5L),
+                new ResolvedPredicate.Or(List.of(
+                        new ResolvedPredicate.DoublePredicate(1, Operator.LT, 0.0),
+                        new ResolvedPredicate.DoublePredicate(1, Operator.GT, 1000.0)
+                ))
+        ));
+        CompiledBatchFilter result = BatchFilterCompiler.tryCompile(
+                predicate, schema, IntUnaryOperator.identity());
+        assertNotNull(result);
+        assertInstanceOf(LongBatchMatcher.class, result.columnMatchers()[0]);
+        assertInstanceOf(OrBatchMatcher.class, result.columnMatchers()[1]);
+        assertInstanceOf(MergePlan.And.class, result.mergePlan());
+    }
+
+    @Test
+    void andWithSingleMixedChild_compilesAsThatChildsCombine() {
+        // ResolvedPredicate.And/Or accept a single child (only empty is rejected).
+        // A 1-child And wrapping a mixed-column Or is semantically the Or itself;
+        // ensure the compiler unwraps rather than producing a 1-element compound
+        // (which throws "requires at least two children").
+        FileSchema schema = longDoubleSchema();
+        ResolvedPredicate predicate = new ResolvedPredicate.And(List.of(
+                new ResolvedPredicate.Or(List.of(
+                        new ResolvedPredicate.LongPredicate(0, Operator.GT, 5L),
+                        new ResolvedPredicate.DoublePredicate(1, Operator.LT, 0.0)))
+        ));
+        CompiledBatchFilter result = BatchFilterCompiler.tryCompile(
+                predicate, schema, IntUnaryOperator.identity());
+        assertNotNull(result);
+        assertInstanceOf(MergePlan.Or.class, result.mergePlan());
+    }
+
+    @Test
+    void andWithSingleSameColumnChild_compilesAsSingleColumn() {
+        // 1-child And wrapping a same-column Or (`id < -5 OR id > 5`) should
+        // unwrap to that subtree's single-column composite — no MergePlan.And
+        // wrapper, since it would have only one child.
+        FileSchema schema = schema(leaf("id", PhysicalType.INT64));
+        ResolvedPredicate predicate = new ResolvedPredicate.And(List.of(
+                new ResolvedPredicate.Or(List.of(
+                        new ResolvedPredicate.LongPredicate(0, Operator.LT, -5L),
+                        new ResolvedPredicate.LongPredicate(0, Operator.GT, 5L)))
+        ));
+        CompiledBatchFilter result = BatchFilterCompiler.tryCompile(
+                predicate, schema, IntUnaryOperator.identity());
+        assertNotNull(result);
+        assertInstanceOf(OrBatchMatcher.class, result.columnMatchers()[0]);
+        assertInstanceOf(MergePlan.Column.class, result.mergePlan());
+    }
+
+    @Test
+    void columnAppearingInTwoSiblingSubtrees_returnsNull() {
+        // (a > 5 AND b > 5) OR (a < 0 AND b < 0): column `a` lives in both OR
+        // branches. The per-column matcher model can't carry two distinct
+        // predicates for `a`, so the compile rejects.
+        FileSchema schema = longDoubleSchema();
+        ResolvedPredicate predicate = new ResolvedPredicate.Or(List.of(
+                new ResolvedPredicate.And(List.of(
+                        new ResolvedPredicate.LongPredicate(0, Operator.GT, 5L),
+                        new ResolvedPredicate.DoublePredicate(1, Operator.GT, 5.0))),
+                new ResolvedPredicate.And(List.of(
+                        new ResolvedPredicate.LongPredicate(0, Operator.LT, 0L),
+                        new ResolvedPredicate.DoublePredicate(1, Operator.LT, 0.0)))
+        ));
+        assertNull(BatchFilterCompiler.tryCompile(predicate, schema, IntUnaryOperator.identity()));
     }
 }

--- a/core/src/test/java/dev/hardwood/internal/predicate/DrainSideOracleTest.java
+++ b/core/src/test/java/dev/hardwood/internal/predicate/DrainSideOracleTest.java
@@ -206,6 +206,80 @@ class DrainSideOracleTest {
         assertSurvivorsAgree(p, w);
     }
 
+    // ---------- OR / mixed AND-OR coverage ----------
+
+    @Test
+    void orSameColumn_bothWaysAgree() {
+        Workload w = workload(0x05A1ECE);
+        ResolvedPredicate p = new ResolvedPredicate.Or(List.of(
+                new ResolvedPredicate.LongPredicate(COL_ID, Operator.LT, -5L),
+                new ResolvedPredicate.LongPredicate(COL_ID, Operator.GT, 5L)
+        ));
+        assertSurvivorsAgree(p, w);
+    }
+
+    @ParameterizedTest(name = "or(id {0} 100, value {1} 0.5)")
+    @MethodSource("opPairs")
+    void orOfLongAndDouble_bothWaysAgree(Operator opA, Operator opB) {
+        Workload w = workload(0x07ED7);
+        ResolvedPredicate p = new ResolvedPredicate.Or(List.of(
+                new ResolvedPredicate.LongPredicate(COL_ID, opA, 100L),
+                new ResolvedPredicate.DoublePredicate(COL_VALUE, opB, 0.5)
+        ));
+        assertSurvivorsAgree(p, w);
+    }
+
+    @Test
+    void orOfIntAndBoolean_bothWaysAgree() {
+        Workload w = workload(0x017E50);
+        ResolvedPredicate p = new ResolvedPredicate.Or(List.of(
+                new ResolvedPredicate.IntPredicate(COL_TAG, Operator.GT, 0),
+                new ResolvedPredicate.BooleanPredicate(COL_FLAG, Operator.EQ, true)
+        ));
+        assertSurvivorsAgree(p, w);
+    }
+
+    @Test
+    void andOfLeafAndOrOnDistinctColumn_bothWaysAgree() {
+        // `id > 0 AND (value < 0 OR value > 0.5)` — exercises mixed AND/OR with
+        // the OR subtree folding into a same-column OrBatchMatcher.
+        Workload w = workload(0xA10C04);
+        ResolvedPredicate p = new ResolvedPredicate.And(List.of(
+                new ResolvedPredicate.LongPredicate(COL_ID, Operator.GT, 0L),
+                new ResolvedPredicate.Or(List.of(
+                        new ResolvedPredicate.DoublePredicate(COL_VALUE, Operator.LT, 0.0),
+                        new ResolvedPredicate.DoublePredicate(COL_VALUE, Operator.GT, 0.5)
+                ))
+        ));
+        assertSurvivorsAgree(p, w);
+    }
+
+    @Test
+    void orOfAndAndLeafOnDistinctColumns_bothWaysAgree() {
+        // `(id > 0 AND value > 0) OR tag < 0` — cross-column AND inside an OR
+        // beside a leaf on a third column; the MergePlan is Or(And(...), leaf).
+        Workload w = workload(0x07AC1);
+        ResolvedPredicate p = new ResolvedPredicate.Or(List.of(
+                new ResolvedPredicate.And(List.of(
+                        new ResolvedPredicate.LongPredicate(COL_ID, Operator.GT, 0L),
+                        new ResolvedPredicate.DoublePredicate(COL_VALUE, Operator.GT, 0.0))),
+                new ResolvedPredicate.IntPredicate(COL_TAG, Operator.LT, 0)
+        ));
+        assertSurvivorsAgree(p, w);
+    }
+
+    @Test
+    void orWithIsNotNullSibling_bothWaysAgree() {
+        // Mixes a null-check leaf into the OR — the matcher and MergePlan
+        // both have to respect "definitely matches" semantics.
+        Workload w = workload(0x05077);
+        ResolvedPredicate p = new ResolvedPredicate.Or(List.of(
+                new ResolvedPredicate.LongPredicate(COL_ID, Operator.EQ, 100L),
+                new ResolvedPredicate.IsNullPredicate(COL_VALUE)
+        ));
+        assertSurvivorsAgree(p, w);
+    }
+
     private static Stream<Arguments> opPairs() {
         Operator[] ops = Operator.values();
         List<Arguments> pairs = new ArrayList<>();
@@ -244,9 +318,9 @@ class DrainSideOracleTest {
     }
 
     private static BitSet drainSideSurvivors(ResolvedPredicate predicate, Workload w) {
-        ColumnBatchMatcher[] fragments = BatchFilterCompiler.tryCompile(predicate, w.schema,
+        CompiledBatchFilter compiled = BatchFilterCompiler.tryCompile(predicate, w.schema,
                 w.projection::toProjectedIndex);
-        if (fragments == null) {
+        if (compiled == null) {
             // Predicate not eligible for drain-side compilation. Callers in this file
             // intentionally use eligible predicates, so `assertSurvivorsAgree` will
             // fail loudly on a null return rather than silently skipping.
@@ -254,31 +328,25 @@ class DrainSideOracleTest {
         }
 
         int wordsLen = (N + 63) >>> 6;
-        long[] combined = new long[wordsLen];
-        boolean initialised = false;
-        for (int col = 0; col < fragments.length; col++) {
-            ColumnBatchMatcher m = fragments[col];
+        long[][] perColumn = new long[compiled.columnMatchers().length][];
+        for (int col = 0; col < compiled.columnMatchers().length; col++) {
+            ColumnBatchMatcher m = compiled.columnMatchers()[col];
             if (m == null) {
                 continue;
             }
-            BatchExchange.Batch batch = w.batch(col);
             long[] colWords = new long[wordsLen];
-            m.test(batch, colWords);
-            if (!initialised) {
-                System.arraycopy(colWords, 0, combined, 0, wordsLen);
-                initialised = true;
-            }
-            else {
-                for (int wi = 0; wi < wordsLen; wi++) {
-                    combined[wi] &= colWords[wi];
-                }
-            }
+            m.test(w.batch(col), colWords);
+            perColumn[col] = colWords;
         }
-        if (!initialised) {
-            // No fragments installed — universal "all-ones" up to N.
-            for (int i = 0; i < N; i++) {
-                combined[i >>> 6] |= 1L << i;
-            }
+
+        long[] combined = new long[wordsLen];
+        MergePlan plan = compiled.mergePlan();
+        if (plan instanceof MergePlan.Column c) {
+            // Mirror the production single-column fast path (aliasing).
+            System.arraycopy(perColumn[c.projectedIndex()], 0, combined, 0, wordsLen);
+        }
+        else {
+            new MergePlanEvaluator(wordsLen).eval(plan, combined, wordsLen, perColumn);
         }
 
         BitSet out = new BitSet(N);

--- a/performance-testing/end-to-end/src/test/java/dev/hardwood/perf/RecordFilterBenchmarkTest.java
+++ b/performance-testing/end-to-end/src/test/java/dev/hardwood/perf/RecordFilterBenchmarkTest.java
@@ -26,6 +26,7 @@ import org.junit.jupiter.api.Test;
 import dev.hardwood.InputFile;
 import dev.hardwood.internal.predicate.BatchFilterCompiler;
 import dev.hardwood.internal.predicate.ColumnBatchMatcher;
+import dev.hardwood.internal.predicate.CompiledBatchFilter;
 import dev.hardwood.internal.predicate.FilterPredicateResolver;
 import dev.hardwood.internal.predicate.ResolvedPredicate;
 import dev.hardwood.reader.FilterPredicate;
@@ -163,6 +164,21 @@ class RecordFilterBenchmarkTest {
                         FilterPredicate.lt("value", 500.0)),
                 runs);
 
+        Run mixedAndOr = timeFilter(
+                // Outer AND narrows by `flag`, inner OR picks rows from either
+                // end of the `id`/`tag` distributions — three distinct columns
+                // so all branches stay drain-eligible. Roughly:
+                //   flag!=false: ~50%
+                //   (id<N/4 OR tag<25): id<N/4 is exactly 25%, tag<25 ~25% uniform,
+                //                       independent OR ≈ 43.75%
+                //   combined AND: ~22%
+                FilterPredicate.and(
+                        FilterPredicate.notEq("flag", false),
+                        FilterPredicate.or(
+                                FilterPredicate.lt("id", (long) (TOTAL_ROWS / 4)),
+                                FilterPredicate.lt("tag", 25))),
+                runs);
+
         Run rangeDup = timeFilter(
                 // Same-column range on `id` is not drain-eligible (duplicate column).
                 FilterPredicate.and(
@@ -203,7 +219,9 @@ class RecordFilterBenchmarkTest {
         System.out.println();
         printResults("Empty result (id<0 AND value<+inf)", empty, runs);
         System.out.println();
-        printResults("OR fallback (id<0 OR value<500)", orFilter, runs);
+        printResults("OR (id<0 OR value<500)", orFilter, runs);
+        System.out.println();
+        printResults("Mixed AND/OR (flag!=false AND (id<N/4 OR tag<25))", mixedAndOr, runs);
         System.out.println();
         printResults("Range+value (id BETWEEN 1M..2M)", rangeDup, runs);
         System.out.println();
@@ -243,6 +261,8 @@ class RecordFilterBenchmarkTest {
         assertThat(empty.rows[0]).isEqualTo(0L);
         // OR: id<0 is empty so the result is the value<500 half.
         assertThat(orFilter.rows[0]).isBetween((long) (TOTAL_ROWS * 0.4), (long) (TOTAL_ROWS * 0.6));
+        // Mixed AND/OR: expected ~22%; allow 15-30% to absorb tag's random jitter.
+        assertThat(mixedAndOr.rows[0]).isBetween((long) (TOTAL_ROWS * 0.15), (long) (TOTAL_ROWS * 0.30));
         assertThat(rangeDup.rows[0]).isEqualTo(1_000_000L);
         // intIn: 5 of 100 values, expect ~5%.
         assertThat(intIn.rows[0]).isBetween((long) (TOTAL_ROWS * 0.03), (long) (TOTAL_ROWS * 0.07));
@@ -284,12 +304,12 @@ class RecordFilterBenchmarkTest {
         }
         ResolvedPredicate resolved = FilterPredicateResolver.resolve(filter, schema);
         ProjectedSchema projected = ProjectedSchema.create(schema, ColumnProjection.all());
-        ColumnBatchMatcher[] matchers = BatchFilterCompiler.tryCompile(
+        CompiledBatchFilter compiled = BatchFilterCompiler.tryCompile(
                 resolved, schema, projected::toProjectedIndex);
-        if (matchers == null) {
+        if (compiled == null) {
             return PATH_CONSUMER;
         }
-        for (ColumnBatchMatcher matcher : matchers) {
+        for (ColumnBatchMatcher matcher : compiled.columnMatchers()) {
             if (matcher != null) {
                 return PATH_DRAIN;
             }

--- a/performance-testing/micro-benchmarks/src/main/java/dev/hardwood/benchmarks/RecordFilterMicroBenchmark.java
+++ b/performance-testing/micro-benchmarks/src/main/java/dev/hardwood/benchmarks/RecordFilterMicroBenchmark.java
@@ -32,6 +32,8 @@ import org.openjdk.jmh.infra.Blackhole;
 
 import dev.hardwood.internal.predicate.BatchFilterCompiler;
 import dev.hardwood.internal.predicate.ColumnBatchMatcher;
+import dev.hardwood.internal.predicate.CompiledBatchFilter;
+import dev.hardwood.internal.predicate.MergePlanEvaluator;
 import dev.hardwood.internal.predicate.RecordFilterCompiler;
 import dev.hardwood.internal.predicate.ResolvedPredicate;
 import dev.hardwood.internal.predicate.RowMatcher;
@@ -85,11 +87,14 @@ public class RecordFilterMicroBenchmark {
     private StructAccessor[] rows;
     private RowMatcher compiled;
 
-    // Drain-side state — populated for eligible shapes (single, and2). null otherwise.
-    private ColumnBatchMatcher[] drainFragments;
+    // Drain-side state — populated whenever the predicate is drain-eligible.
+    private CompiledBatchFilter drainCompiled;
     private BatchExchange.Batch[] drainBatches;
     private long[] drainCombined;
-    private long[] drainColumnScratch; // reused per-column matches workspace
+    // Per-column match bitmaps, indexed by projected column; entries for
+    // columns with no matcher stay null. Reused across invocations.
+    private long[][] drainPerColumnMatches;
+    private MergePlanEvaluator drainMergeEvaluator;
 
     @Setup
     public void setup() {
@@ -99,13 +104,20 @@ public class RecordFilterMicroBenchmark {
         compiled = RecordFilterCompiler.compile(predicate, schema);
 
         ProjectedSchema projection = ProjectedSchema.create(schema, ColumnProjection.all());
-        drainFragments = BatchFilterCompiler.tryCompile(predicate, schema,
+        drainCompiled = BatchFilterCompiler.tryCompile(predicate, schema,
                 projection::toProjectedIndex);
-        if (drainFragments != null) {
-            drainBatches = buildDrainBatches(rows, drainFragments.length);
+        if (drainCompiled != null) {
+            ColumnBatchMatcher[] fragments = drainCompiled.columnMatchers();
+            drainBatches = buildDrainBatches(rows, fragments.length);
             int wordsLen = (BATCH_SIZE + 63) >>> 6;
             drainCombined = new long[wordsLen];
-            drainColumnScratch = new long[wordsLen];
+            drainPerColumnMatches = new long[fragments.length][];
+            for (int c = 0; c < fragments.length; c++) {
+                if (fragments[c] != null) {
+                    drainPerColumnMatches[c] = new long[wordsLen];
+                }
+            }
+            drainMergeEvaluator = new MergePlanEvaluator(wordsLen);
         }
     }
 
@@ -118,41 +130,35 @@ public class RecordFilterMicroBenchmark {
         }
     }
 
-    /// Drain-side variant: per-column [ColumnBatchMatcher] writes a long[] of matches,
-    /// the columns are intersected, surviving rows are iterated via
+    /// Drain-side variant: mirrors the production pipeline — per-column
+    /// [ColumnBatchMatcher]s write per-column long[] match bitmaps, then the
+    /// shared [MergePlanEvaluator] combines them via the compiled [MergePlan]
+    /// into one survivor mask. Surviving rows are then iterated via
     /// `Long.numberOfTrailingZeros`. Single-threaded — measures codegen quality
     /// against the value array, isolated from the parallelism story which
     /// requires the full reader pipeline.
     ///
-    /// Skipped (no-op) for shapes that are not eligible (`or2`, `nested`, `intIn*`,
-    /// and `and3`/`and4` because they include an INT32 leaf).
+    /// Skipped (no-op) only when the predicate isn't drain-eligible at all
+    /// (`BatchFilterCompiler.tryCompile` returns `null`).
     @Benchmark
     public void drainSide(Blackhole bh) {
-        ColumnBatchMatcher[] fragments = drainFragments;
-        if (fragments == null) {
-            return; // shape not eligible — see class javadoc.
+        CompiledBatchFilter cf = drainCompiled;
+        if (cf == null) {
+            return;
         }
+        ColumnBatchMatcher[] fragments = cf.columnMatchers();
         BatchExchange.Batch[] batches = drainBatches;
-        long[] combined = drainCombined;
-        long[] scratch = drainColumnScratch;
-
-        boolean initialised = false;
-        for (int col = 0; col < fragments.length; col++) {
-            ColumnBatchMatcher m = fragments[col];
-            if (m == null) {
-                continue;
-            }
-            m.test(batches[col], scratch);
-            if (!initialised) {
-                System.arraycopy(scratch, 0, combined, 0, combined.length);
-                initialised = true;
-            }
-            else {
-                for (int wi = 0; wi < combined.length; wi++) {
-                    combined[wi] &= scratch[wi];
-                }
+        long[][] perColumn = drainPerColumnMatches;
+        for (int c = 0; c < fragments.length; c++) {
+            ColumnBatchMatcher m = fragments[c];
+            if (m != null) {
+                m.test(batches[c], perColumn[c]);
             }
         }
+        long[] combined = drainCombined;
+        int activeWords = (BATCH_SIZE + 63) >>> 6;
+        drainMergeEvaluator.eval(cf.mergePlan(), combined, activeWords, perColumn);
+
         // Iterate surviving rows. Each call to Blackhole defeats DCE.
         int n = BATCH_SIZE;
         int rowIdx = -1;


### PR DESCRIPTION
## Summary

- Extends `BatchFilterCompiler` from "column-local AND of leaves" to any nesting of `And`/`Or` over column-local leaves. Same-column subtrees fold into one per-column composite (`AndBatchMatcher` / new `OrBatchMatcher`); cross-column subtrees become a `MergePlan` (`Column` leaf + sealed `Compound` with `And`/`Or` records) for the consumer to walk. `tryCompile` now returns a `CompiledBatchFilter(columnMatchers[], mergePlan)`.
- Adds `MergePlanEvaluator` — single owner of the merge semantics, used by `FlatRowReader.intersectMatches` on the hot path and by `DrainSideOracleTest` to verify equivalence with the per-row compile path. Depth-indexed scratch pool, zero allocations per batch after warm-up; Column children of an And/Or bypass scratch entirely.
- Two independent siblings claiming the same column (`(a > 5 AND b > 5) OR (a < 0 AND b < 0)` with `a` in both branches) are still rejected — the per-column matcher model can't represent two different per-row predicates on one column.
- Design doc rewritten to reflect the new IR / consumer-side wiring; old `CombineNode` / `evalCombine` / `combineActiveWords` identifiers removed throughout.

Closes #457.

## Test plan

- [x] `./mvnw -pl core test -Dtest='BatchFilterCompilerTest,DrainSideOracleTest,DrainSideRowReaderTest'` — 112 tests pass.
- [x] Full `./mvnw verify -pl '!parquet-testing-runner'` — BUILD SUCCESS.
- [x] `DrainSideOracleTest` covers every supported `(type, op)` pair plus cross-type AND/OR combinations and mixed shapes (`And(Or(...), leaf)`, `Or(And(...), leaf)`, `Or` with `IsNull`/`IsNotNull` siblings).
- [x] `BatchFilterCompilerTest` adds positive assertions for same-column OR folding, mixed AND/OR over distinct columns, and 1-child compound unwrapping; negative assertion for the same-column-across-siblings rejection.
- [x] `./mvnw test -Pperformance-test -pl performance-testing/end-to-end -Dtest=RecordFilterBenchmarkTest -Dperf.runs=5` — `or`-shape rows now report `drain` rather than `fallback (or)`.