### PR TITLE
#75 Support local Parquet files larger than 2 GB

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,11 @@ try (ParquetFileReader fileReader = ParquetFileReader.open(InputFile.of(path));
 
 See the [Getting Started](https://hardwood.dev/latest/getting-started/) guide for detailed setup instructions.
 
+## Limitations
+
+- **Local files** (memory-mapped via `InputFile.of(Path)`) may be arbitrarily large; each individual column chunk must be at most 2 GB of compressed data.
+- **In-memory** (`InputFile.of(ByteBuffer)`) and **object-store** sources are limited to 2 GB per file. Split larger datasets across multiple files and read them with `Hardwood.openAll(...)` or `ParquetFileReader.openAll(...)`.
+
 ---
 
 ## Repository Documentation

--- a/_designs/LARGE_FILE_PER_REGION_MAPPING.md
+++ b/_designs/LARGE_FILE_PER_REGION_MAPPING.md
@@ -1,0 +1,191 @@
+# Per-region mapping for large local files
+
+**Status: Implemented**
+
+## Context
+
+`MappedInputFile` memory-maps the entire file into a single `MappedByteBuffer` in `open()`. Because `MappedByteBuffer` addresses bytes with `int` offsets, this caps a local file at `Integer.MAX_VALUE` (2 GB). `MappedInputFile.open()` enforces the cap with an explicit `IOException` ("File too large … Maximum supported file size is 2 GB."), so oversized files fail early rather than overflowing.
+
+The cap is whole-file, but the data structure that genuinely needs to fit in 2 GB is far smaller: an individual fetched region (a column chunk, a coalesced page group, or a row-group index region). A file with many normal-sized row groups should be readable even when its total size exceeds 2 GB.
+
+The goal is to support local files larger than 2 GB by mapping **per region** instead of mapping the whole file at once, while:
+
+1. Keeping the Java 21 baseline — no Foreign Memory API, no multi-release-JAR gating.
+2. Preserving today's performance for the common (≤ 2 GB) case — a single whole-file mapping with zero-copy slices.
+3. Preserving the fail-early guarantee: any single region that cannot be addressed with an `int` length throws, never overflows silently.
+
+## Approach
+
+`FileChannel.map(MapMode, long position, long size)` already accepts a `long` position on Java 21; only `size` is `int`-bounded. A region anywhere in a file of any size can therefore be mapped directly, as long as that region is itself ≤ 2 GB. `readRange(long offset, int length)` already passes the region's `length` as an `int`, and every caller derives that `int` via `Math.toIntExact` — so the per-region size bound is already established and already fails loud.
+
+`MappedInputFile` becomes a hybrid keyed on file size:
+
+- **File ≤ 2 GB** — map the whole file once in `open()` (today's behavior, unchanged). `readRange` returns zero-copy slices of that mapping.
+- **File > 2 GB** — keep the `FileChannel` open and map each `readRange` on demand via `channel.map(READ_ONLY, offset, length)`. Each mapping covers exactly the requested region; nothing straddles a boundary, so no stitching or copying is needed. The returned `MappedByteBuffer` is itself the region (its position 0 corresponds to `offset`); the JDK handles page-alignment of the underlying mapping internally.
+
+A non-page-aligned `position` is supported by `FileChannel.map`; the returned buffer is still a zero-copy view of the requested range.
+
+## MappedInputFile implementation
+
+```java
+public class MappedInputFile implements InputFile {
+
+    private final Path path;
+    private final String name;
+
+    // ≤ 2 GB: whole-file mapping, channel closed eagerly after open().
+    private MappedByteBuffer wholeFile;
+
+    // > 2 GB: channel kept open for lazy per-region mapping.
+    private FileChannel channel;
+    private long size;
+
+    @Override
+    public void open() throws IOException {
+        if (wholeFile != null || channel != null) {
+            return; // idempotent
+        }
+        FileChannel ch = FileChannel.open(path, StandardOpenOption.READ);
+        boolean keepOpen = false;
+        try {
+            long fileSize = ch.size();
+            if (fileSize > Integer.MAX_VALUE) {
+                channel = ch;        // stays open for per-region mapping
+                size = fileSize;
+                keepOpen = true;
+            } else {
+                wholeFile = mapRegion(ch, 0, fileSize); // emits FileMappingEvent
+            }
+        } finally {
+            if (!keepOpen) {
+                ch.close();          // whole-file mode (or failure): channel not needed
+            }
+        }
+    }
+
+    @Override
+    public ByteBuffer readRange(long offset, int length) throws IOException {
+        if (wholeFile != null) {
+            return wholeFile.slice(Math.toIntExact(offset), length);
+        }
+        if (channel == null) {
+            throw new IllegalStateException("File not opened: " + name);
+        }
+        return mapRegion(channel, offset, length); // length is already int-bounded
+    }
+
+    @Override
+    public long length() {
+        if (wholeFile != null) {
+            return wholeFile.capacity();
+        }
+        if (channel == null) {
+            throw new IllegalStateException("File not opened: " + name);
+        }
+        return size;
+    }
+
+    @Override
+    public void close() throws IOException {
+        // Whole-file mode: channel already closed in open(); mapping released by GC.
+        // Per-region mode: close the channel held open for lazy mapping.
+        if (channel != null) {
+            channel.close();
+            channel = null;
+        }
+    }
+}
+```
+
+`mapRegion` centralizes `channel.map(READ_ONLY, offset, length)` plus the `FileMappingEvent` JFR event (`file`, `offset`, `size`). In whole-file mode it fires once for the whole file; in per-region mode it fires once per region, which gives finer-grained mapping telemetry for large files.
+
+### Lifecycle
+
+In per-region mode the `FileChannel` is held open for the lifetime of the `InputFile` and closed in `close()`. The per-region `MappedByteBuffer`s remain valid after the channel is closed and are released by GC, matching the whole-file mode's reliance on GC for unmapping. `InputFile.close()` is already called by the framework (reader for single-file, `FileManager` for multi-file), so no caller changes are required.
+
+### Concurrency
+
+`InputFile` must be safe for concurrent use once opened. In whole-file mode, concurrent `slice` calls on a shared mapping are already safe. In per-region mode, each `readRange` calls `channel.map` independently; `FileChannel` is thread-safe for `map`, and no mutable state is shared across calls. After `open()` completes, the `wholeFile`/`channel`/`size` fields are only read, never written.
+
+## Limits and fail-early guarantees
+
+The 2 GB whole-file guard in `open()` is removed. The binding limit moves from the file as a whole to the individual fetched region, and is already enforced fail-loud:
+
+- `readRange` takes an `int length`. Every caller computes it via `Math.toIntExact` — `RowGroupIndexBuffers` (index region), `SharedRegion` / `ChunkHandle` (coalesced column data), and the chunk-size logic in `SequentialFetchPlan`. A region whose length would exceed `Integer.MAX_VALUE` throws `ArithmeticException` at that computation, before any mapping is attempted.
+
+The binding limit is **per column chunk**: a local file may be arbitrarily large, and a row group as a whole may exceed 2 GB, but each individual column chunk must be ≤ 2 GB (compressed). This is exactly the granularity the read path enforces:
+
+- `SequentialFetchPlan.build` narrows the chunk's `totalCompressedSize` with `Math.toIntExact(columnChunk.metaData().totalCompressedSize())`, then splits it into bounded sub-reads. A column chunk up to `Integer.MAX_VALUE` bytes is read normally; one beyond that throws `ArithmeticException`.
+- `IndexedFetchPlan` reads page group by page group, and a page's `compressedPageSize` is an `int32` in the Parquet format — so a 2 GB column chunk is read as many sub-2 GB ranges regardless of the fetch plan.
+
+Row-group index regions are also read as single ranges and so must be ≤ 2 GB, but that is metadata and effectively never a concern. The user-facing limit should be stated as the real one: **column chunks up to 2 GB for local files**, not a per-file limit.
+
+The two narrowing casts that previously relied on the whole-file guard for safety are hardened to `Math.toIntExact` (`MappedInputFile.readRange` whole-file slice, `ByteBufferInputFile.readRange`). They cannot overflow given their invariants, but `Math.toIntExact` enforces the invariant at the cast site rather than depending on a guard elsewhere, per the project's downcast rule.
+
+## Scope boundaries
+
+These backends keep a 2 GB-per-file limit and are unchanged:
+
+- **`ByteBufferInputFile`** — a single `ByteBuffer`'s capacity is inherently `int`-bounded, so in-memory data cannot exceed 2 GB. The limit is intrinsic to the in-memory representation.
+- **`RangeBackedInputFile` / `S3InputFile`** — the range-backing temp file is mapped whole (`READ_WRITE`) and the gap-fill logic is `int`-positioned throughout. Object-store reads keep the 2 GB-per-file limit, with the existing early `IOException` from `RangeBackedInputFile`.
+
+Lifting the object-store path to per-region backing is out of scope and tracked separately.
+
+## Public API and documentation impact
+
+No public API signatures change — `InputFile.readRange`/`length` are already `long`-typed, and the `InputFile` contract already permits returned buffers to be independent mappings rather than slices of one mapping.
+
+Documentation that states the limit must change to describe the new end state, and should spell out the real (per-column-chunk) limit rather than understate it:
+
+- `core/src/main/java/dev/hardwood/reader/ParquetFileReader.java` — the "**Limitation:**" javadoc: local (memory-mapped) files may be arbitrarily large; each column chunk must be at most 2 GB (compressed). The per-file 2 GB limit remains only for in-memory `ByteBuffer` and object-store sources.
+- `docs/content/index.md` — replace the "2 GB single-file limit" warning: for local files, individual column chunks (not files) are limited to 2 GB; in-memory `ByteBuffer` and object-store sources keep the 2 GB-per-file limit.
+
+## File change summary
+
+### Modified
+
+| File | Change |
+|------|--------|
+| `core/src/main/java/dev/hardwood/internal/reader/MappedInputFile.java` | Hybrid whole-file / per-region mapping in a single class; remove 2 GB guard; keep channel open in per-region mode; close it in `close()` |
+| `core/src/main/java/dev/hardwood/reader/ParquetFileReader.java` | Update the limitation javadoc |
+| `docs/content/index.md` | Update the 2 GB limit warning |
+
+### New tests
+
+| File | Change |
+|------|--------|
+| `core/src/test/java/dev/hardwood/MappedInputFileLargeFileTest.java` | Sparse-file mapping primitive test (see Verification) |
+| `parquet-testing-runner/src/test/java/dev/hardwood/testing/LargeFileReadTest.java` | Opt-in end-to-end >2 GB read |
+
+### Hardened (already applied)
+
+| File | Change |
+|------|--------|
+| `core/src/main/java/dev/hardwood/internal/reader/MappedInputFile.java` | Whole-file slice cast `(int) offset` → `Math.toIntExact(offset)` |
+| `core/src/main/java/dev/hardwood/internal/reader/ByteBufferInputFile.java` | `(int) offset` → `Math.toIntExact(offset)` |
+
+## Verification
+
+Two tiers of tests, matching the two distinct risks.
+
+### Mapping primitive (core, runs in CI)
+
+`MappedInputFileLargeFileTest` exercises the long-offset per-region branch directly, without Parquet:
+
+- Build a temp file just over 2 GB by seeking past the 2 GB mark and writing known sentinel bytes (a sparse hole precedes the sentinel, so the file costs kilobytes and milliseconds on a sparse-capable filesystem — Linux ext4/xfs/tmpfs, the CI environment). `@TempDir` deletes it afterwards.
+- Write sentinels at offset 0, straddling the 2 GB boundary, and well beyond it.
+- Assert `open()` no longer rejects the file, `length()` returns the full size, and `readRange` returns the correct bytes at each offset — including offsets and ranges that cross or exceed `Integer.MAX_VALUE`.
+
+This is the high-value test: long-offset slicing is the only genuinely new behavior, and this proves it deterministically and cheaply.
+
+### End-to-end (parquet-testing-runner, opt-in)
+
+`LargeFileReadTest` proves a real >2 GB Parquet file reads correctly through the full stack. It is gated with `@Tag("large")` and `@EnabledIfSystemProperty(named = "hardwood.largeFileTests", matches = "true")`, so it is skipped by default and runs only when explicitly enabled (multi-GB generation is slow). It lives in `parquet-testing-runner`, the only module with both parquet-java's writer (`ExampleParquetWriter`) and `hardwood-core` on the test classpath.
+
+- Write a file just over 2 GB with `ExampleParquetWriter` into `@TempDir` (single `int64` column, sequential ids, loop until `writer.getDataSize()` exceeds the threshold).
+- Open it with Hardwood — this alone reads the footer at an offset beyond 2 GB.
+- Read the last rows via `buildRowReader().tail(n)`, which fetches the final row group's column chunk (located past the 2 GB mark) and validates the ids — targeted end-to-end coverage of the per-region path without iterating the whole file.
+
+### Build
+
+`./mvnw verify -pl core` — existing mmap behavior for ≤ 2 GB files is unchanged; the new primitive test passes.

--- a/core/src/main/java/dev/hardwood/internal/reader/ByteBufferInputFile.java
+++ b/core/src/main/java/dev/hardwood/internal/reader/ByteBufferInputFile.java
@@ -30,7 +30,7 @@ public class ByteBufferInputFile implements InputFile {
 
     @Override
     public ByteBuffer readRange(long offset, int length) {
-        return buffer.slice((int) offset, length);
+        return buffer.slice(Math.toIntExact(offset), length);
     }
 
     @Override

--- a/core/src/main/java/dev/hardwood/internal/reader/MappedInputFile.java
+++ b/core/src/main/java/dev/hardwood/internal/reader/MappedInputFile.java
@@ -15,17 +15,43 @@ import java.nio.file.Path;
 import java.nio.file.StandardOpenOption;
 
 import dev.hardwood.InputFile;
+import dev.hardwood.internal.ExceptionContext;
 import dev.hardwood.jfr.FileMappingEvent;
 
 /// [InputFile] backed by a memory-mapped file.
 ///
-/// Starts in an unopened state. [#open()] memory-maps the entire file;
-/// [#readRange] then returns zero-copy slices of the mapping.
+/// Starts in an unopened state. [#open()] inspects the file size and selects
+/// one of two backing strategies:
+///
+/// - **Files up to 2 GB** are mapped in their entirety; [#readRange] returns
+///   zero-copy slices of the single mapping.
+/// - **Files larger than 2 GB** cannot be addressed by a single
+///   [MappedByteBuffer] (its offsets are `int`). The [FileChannel] is kept open
+///   and each [#readRange] maps just the requested region on demand. A single
+///   requested region must still fit in an `int` length — in practice a column
+///   chunk, page group, or row-group index region, each at most 2 GB — but the
+///   file as a whole may be arbitrarily large.
+///
+/// **Interruption (larger-than-2 GB path only).** That path keeps the
+/// [FileChannel] open across reads, and `FileChannel` is an `InterruptibleChannel`:
+/// interrupting a thread while it is inside [#readRange] — or entering one with its
+/// interrupt flag already set — closes the channel for every reader, after which
+/// reads fail with `ClosedChannelException`. Callers that cancel reads by
+/// interrupting the reading thread (for example `Future.cancel(true)`) must not do
+/// so against a larger-than-2 GB file they intend to keep reading. The up-to-2 GB
+/// path is unaffected: its channel is closed before any read, so reads are pure
+/// mapped-memory slices with no channel operation to interrupt.
 public class MappedInputFile implements InputFile {
 
     private final Path path;
     private final String name;
-    private MappedByteBuffer mapping;
+
+    /// Whole-file mode (file ≤ 2 GB): single mapping; the channel is closed eagerly in [#open()].
+    private MappedByteBuffer wholeFile;
+
+    /// Per-region mode (file > 2 GB): channel kept open for lazy per-region mapping.
+    private FileChannel channel;
+    private long size;
 
     public MappedInputFile(Path path) {
         this.path = path;
@@ -34,42 +60,68 @@ public class MappedInputFile implements InputFile {
 
     @Override
     public void open() throws IOException {
-        if (mapping != null) {
+        if (wholeFile != null || channel != null) {
             return;
         }
-        try (FileChannel channel = FileChannel.open(path, StandardOpenOption.READ)) {
-            long fileSize = channel.size();
+        FileChannel ch = FileChannel.open(path, StandardOpenOption.READ);
+        boolean keepOpen = false;
+        try {
+            long fileSize = ch.size();
             if (fileSize > Integer.MAX_VALUE) {
-                throw new IOException("File too large: " + path + " (" + (fileSize / (1024 * 1024)) +
-                        " MB). Maximum supported file size is 2 GB.");
+                channel = ch;
+                size = fileSize;
+                keepOpen = true;
             }
-
-            FileMappingEvent event = new FileMappingEvent();
-            event.begin();
-
-            mapping = channel.map(FileChannel.MapMode.READ_ONLY, 0, fileSize);
-
-            event.file = name;
-            event.offset = 0;
-            event.size = fileSize;
-            event.commit();
+            else {
+                wholeFile = map(ch, 0L, fileSize);
+            }
+        }
+        finally {
+            if (!keepOpen) {
+                // Whole-file mode: the mapping survives channel close, released by GC.
+                // Failure: release the channel we just opened.
+                ch.close();
+            }
         }
     }
 
     @Override
-    public ByteBuffer readRange(long offset, int length) {
-        if (mapping == null) {
+    public ByteBuffer readRange(long offset, int length) throws IOException {
+        long fileBytes;
+        if (wholeFile != null) {
+            fileBytes = wholeFile.capacity();
+        }
+        else if (channel != null) {
+            fileBytes = size;
+        }
+        else {
             throw new IllegalStateException("File not opened: " + name);
         }
-        return mapping.slice((int) offset, length);
+
+        // Validate explicitly: FileChannel.map does not reject a region past EOF
+        // (it would map beyond the file and SIGBUS on access), unlike ByteBuffer.slice.
+        // The comparison is written to avoid overflow when offset + length wraps.
+        if (offset < 0 || length < 0 || offset > fileBytes - length) {
+            throw new IndexOutOfBoundsException(ExceptionContext.filePrefix(name)
+                    + "readRange(" + offset + ", " + length
+                    + ") out of bounds (" + fileBytes + " bytes)");
+        }
+
+        if (wholeFile != null) {
+            return wholeFile.slice(Math.toIntExact(offset), length);
+        }
+        return map(channel, offset, length);
     }
 
     @Override
     public long length() {
-        if (mapping == null) {
+        if (wholeFile != null) {
+            return wholeFile.capacity();
+        }
+        if (channel == null) {
             throw new IllegalStateException("File not opened: " + name);
         }
-        return mapping.capacity();
+        return size;
     }
 
     @Override
@@ -78,8 +130,28 @@ public class MappedInputFile implements InputFile {
     }
 
     @Override
-    public void close() {
-        // The file channel is closed eagerly in open() after mapping.
-        // The MappedByteBuffer remains valid and is released by GC.
+    public void close() throws IOException {
+        // Whole-file mode: channel was closed eagerly in open(); the mapping is released by GC.
+        // Per-region mode: close the channel held open for lazy mapping.
+        if (channel != null) {
+            channel.close();
+            channel = null;
+        }
+    }
+
+    /// Maps a single region of the file and emits a [FileMappingEvent]. The region
+    /// length is bounded by the `int` argument from [#readRange]; the offset is a
+    /// `long`, so regions beyond the 2 GB mark in a large file map correctly.
+    private MappedByteBuffer map(FileChannel ch, long offset, long length) throws IOException {
+        FileMappingEvent event = new FileMappingEvent();
+        event.begin();
+
+        MappedByteBuffer region = ch.map(FileChannel.MapMode.READ_ONLY, offset, length);
+
+        event.file = name;
+        event.offset = offset;
+        event.size = length;
+        event.commit();
+        return region;
     }
 }

--- a/core/src/main/java/dev/hardwood/internal/reader/RowGroupIndexBuffers.java
+++ b/core/src/main/java/dev/hardwood/internal/reader/RowGroupIndexBuffers.java
@@ -12,6 +12,7 @@ import java.nio.ByteBuffer;
 import java.util.List;
 
 import dev.hardwood.InputFile;
+import dev.hardwood.internal.ExceptionContext;
 import dev.hardwood.metadata.ColumnChunk;
 import dev.hardwood.metadata.RowGroup;
 
@@ -69,7 +70,13 @@ public class RowGroupIndexBuffers {
             return new RowGroupIndexBuffers(result);
         }
 
-        ByteBuffer indexRegion = inputFile.readRange(minOffset, Math.toIntExact(maxEnd - minOffset));
+        long indexRegionSize = maxEnd - minOffset;
+        if (indexRegionSize > Integer.MAX_VALUE) {
+            throw new IOException(ExceptionContext.filePrefix(inputFile.name())
+                    + "Row-group index region too large (" + indexRegionSize
+                    + " bytes) — split the file into smaller row groups");
+        }
+        ByteBuffer indexRegion = inputFile.readRange(minOffset, Math.toIntExact(indexRegionSize));
 
         for (int i = 0; i < allColumns.size(); i++) {
             ColumnChunk col = allColumns.get(i);

--- a/core/src/main/java/dev/hardwood/reader/ParquetFileReader.java
+++ b/core/src/main/java/dev/hardwood/reader/ParquetFileReader.java
@@ -51,9 +51,10 @@ import dev.hardwood.schema.ProjectedSchema;
 /// }
 /// ```
 ///
-/// **Limitation:** When using the default memory-mapped [InputFile],
-/// individual files must be at most 2 GB ([Integer#MAX_VALUE] bytes).
-/// Larger datasets should be split across multiple files.
+/// **Limitation:** When using the default memory-mapped [InputFile], the file
+/// itself may be arbitrarily large, but each individual column chunk must be at
+/// most 2 GB ([Integer#MAX_VALUE] bytes) of compressed data. The in-memory and
+/// object-store backends have a 2 GB limit on the whole file.
 public class ParquetFileReader implements AutoCloseable {
 
     private final List<InputFile> inputFiles;

--- a/core/src/test/java/dev/hardwood/MappedInputFileLargeFileTest.java
+++ b/core/src/test/java/dev/hardwood/MappedInputFileLargeFileTest.java
@@ -1,0 +1,85 @@
+/*
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Copyright The original authors
+ *
+ *  Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package dev.hardwood;
+
+import java.io.IOException;
+import java.io.RandomAccessFile;
+import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Path;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/// Tests that [InputFile#of(Path)] reads files larger than 2 GB by mapping each
+/// requested region on demand, rather than mapping the whole file at once.
+///
+/// The temp file exceeds [Integer#MAX_VALUE] but is sparse: only the pages holding
+/// the sentinel bytes are materialized, so on a sparse-capable filesystem (Linux
+/// ext4/xfs/tmpfs) it costs kilobytes and a few milliseconds.
+class MappedInputFileLargeFileTest {
+
+    private static final long TWO_GB = (long) Integer.MAX_VALUE + 1; // 2_147_483_648
+
+    @Test
+    void readsRegionsBeyondTwoGigabytes(@TempDir Path tmpDir) throws Exception {
+        Path file = tmpDir.resolve("large.bin");
+
+        byte[] atZero = "START-OF-FILE---".getBytes(StandardCharsets.US_ASCII);   // 16 bytes
+        byte[] straddle = "STRADDLE-2GB-MRK".getBytes(StandardCharsets.US_ASCII); // 16 bytes
+        byte[] beyond = "WELL-BEYOND-2GB!".getBytes(StandardCharsets.US_ASCII);   // 16 bytes
+
+        long straddleOffset = TWO_GB - 8;     // the [straddleOffset, +16) region crosses the 2 GB mark
+        long beyondOffset = TWO_GB + 4096;    // start offset itself exceeds Integer.MAX_VALUE
+        long fileSize = beyondOffset + beyond.length;
+
+        try (RandomAccessFile raf = new RandomAccessFile(file.toFile(), "rw")) {
+            raf.setLength(fileSize);          // sparse: holes consume no blocks
+            raf.seek(0);
+            raf.write(atZero);
+            raf.seek(straddleOffset);
+            raf.write(straddle);
+            raf.seek(beyondOffset);
+            raf.write(beyond);
+        }
+
+        try (InputFile inputFile = InputFile.of(file)) {
+            inputFile.open();
+
+            // The whole-file 2 GB guard is gone: a >2 GB file opens and reports its full size.
+            assertThat(inputFile.length()).isEqualTo(fileSize);
+
+            assertThat(read(inputFile, 0, atZero.length)).isEqualTo(atZero);
+            assertThat(read(inputFile, straddleOffset, straddle.length)).isEqualTo(straddle);
+
+            // The decisive case: a start offset past Integer.MAX_VALUE, which an int cast would corrupt.
+            assertThat(read(inputFile, beyondOffset, beyond.length)).isEqualTo(beyond);
+
+            // A hole reads back as zeros.
+            assertThat(read(inputFile, TWO_GB + 1024, 8)).containsOnly((byte) 0);
+
+            // A range past EOF fails cleanly with file context, rather than SIGBUS-ing
+            // when the per-region mapping is touched.
+            assertThatThrownBy(() -> inputFile.readRange(fileSize, 16))
+                    .isInstanceOf(IndexOutOfBoundsException.class)
+                    .hasMessageContaining("large.bin");
+            assertThatThrownBy(() -> inputFile.readRange(fileSize - 4, 16))
+                    .isInstanceOf(IndexOutOfBoundsException.class);
+        }
+    }
+
+    private static byte[] read(InputFile inputFile, long offset, int length) throws IOException {
+        ByteBuffer buffer = inputFile.readRange(offset, length);
+        byte[] out = new byte[length];
+        buffer.get(out);
+        return out;
+    }
+}

--- a/docs/content/index.md
+++ b/docs/content/index.md
@@ -53,8 +53,8 @@ See [Getting Started](getting-started.md) for installation and setup.
 
 This is Beta quality software, under active development.
 
-!!! warning "2 GB single-file limit"
-    Individual Parquet files must currently be at most **2 GB**. Larger datasets should be split across multiple files and read by passing a list of `InputFile`s to `Hardwood.openAll(...)` or `ParquetFileReader.openAll(...)`. Tracked as [#75](https://github.com/hardwood-hq/hardwood/issues/75).
+!!! warning "2 GB column-chunk limit"
+    For local (memory-mapped) files, the file itself may be arbitrarily large, but each individual **column chunk** must be at most **2 GB** of compressed data. The in-memory (`ByteBuffer`) and object-store backends have a 2 GB limit on the whole file; for those, larger datasets should be split across multiple files and read by passing a list of `InputFile`s to `Hardwood.openAll(...)` or `ParquetFileReader.openAll(...)`. Tracked as [#75](https://github.com/hardwood-hq/hardwood/issues/75).
 
 ## Roadmap
 

--- a/parquet-testing-runner/src/test/java/dev/hardwood/testing/LargeFileReadTest.java
+++ b/parquet-testing-runner/src/test/java/dev/hardwood/testing/LargeFileReadTest.java
@@ -1,0 +1,92 @@
+/*
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Copyright The original authors
+ *
+ *  Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package dev.hardwood.testing;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import org.apache.hadoop.conf.Configuration;
+import org.apache.parquet.example.data.Group;
+import org.apache.parquet.example.data.simple.SimpleGroupFactory;
+import org.apache.parquet.hadoop.ParquetWriter;
+import org.apache.parquet.hadoop.example.ExampleParquetWriter;
+import org.apache.parquet.hadoop.metadata.CompressionCodecName;
+import org.apache.parquet.schema.MessageType;
+import org.apache.parquet.schema.MessageTypeParser;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.EnabledIfSystemProperty;
+import org.junit.jupiter.api.io.TempDir;
+
+import dev.hardwood.InputFile;
+import dev.hardwood.reader.ParquetFileReader;
+import dev.hardwood.reader.RowReader;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/// End-to-end read of a Parquet file larger than 2 GB, proving the per-region
+/// memory mapping (#75) works through the full read stack.
+///
+/// Opt-in: generating a multi-GB file is slow and disk-heavy, so this runs only
+/// with `-Dhardwood.largeFileTests=true`.
+@Tag("large")
+@EnabledIfSystemProperty(named = "hardwood.largeFileTests", matches = "true")
+class LargeFileReadTest {
+
+    private static final long TWO_GB = (long) Integer.MAX_VALUE + 1;
+
+    @Test
+    void readsFileLargerThanTwoGigabytes(@TempDir Path tmpDir) throws Exception {
+        Path output = tmpDir.resolve("large.parquet");
+        MessageType schema = MessageTypeParser.parseMessageType("message m { required int64 id; }");
+
+        long written = 0;
+        try (ParquetWriter<Group> writer = ExampleParquetWriter
+                .builder(new org.apache.hadoop.fs.Path(output.toUri()))
+                .withConf(new Configuration())
+                .withType(schema)
+                .withCompressionCodec(CompressionCodecName.UNCOMPRESSED)
+                .withDictionaryEncoding(false) // PLAIN: ~8 bytes/row, so the file reliably exceeds 2 GB
+                .build()) {
+            SimpleGroupFactory factory = new SimpleGroupFactory(schema);
+            while (writer.getDataSize() <= TWO_GB + (64L << 20)) {
+                for (int i = 0; i < 1_000_000; i++) {
+                    writer.write(factory.newGroup().append("id", written));
+                    written++;
+                }
+            }
+        }
+
+        long fileSize = Files.size(output);
+        System.out.printf("LargeFileReadTest: wrote %,d rows, on-disk size %,d bytes (%.2f GB)%n",
+                written, fileSize, fileSize / (double) (1L << 30));
+        assertThat(fileSize)
+                .as("on-disk file size must exceed 2 GB (%,d bytes), was %,d", TWO_GB, fileSize)
+                .isGreaterThan(TWO_GB);
+
+        try (ParquetFileReader reader = ParquetFileReader.open(InputFile.of(output))) {
+            // Reading the footer alone exercises a read at an offset beyond 2 GB.
+            assertThat(reader.getFileMetaData().numRows()).isEqualTo(written);
+
+            // The final rows live in the last row group, located past the 2 GB mark,
+            // so reading them fetches a column-chunk region beyond Integer.MAX_VALUE.
+            int tail = 5;
+            try (RowReader rowReader = reader.buildRowReader().tail(tail).build()) {
+                long expected = written - tail;
+                int seen = 0;
+                while (rowReader.hasNext()) {
+                    rowReader.next();
+                    assertThat(rowReader.getLong("id")).isEqualTo(expected);
+                    expected++;
+                    seen++;
+                }
+                assertThat(seen).isEqualTo(tail);
+            }
+        }
+    }
+}


### PR DESCRIPTION
MappedInputFile mapped the whole file into a single MappedByteBuffer, whose int offsets capped a local file at 2 GB and forced an early rejection of anything larger. The structure that must actually fit in an int-addressable mapping is far smaller — a single column chunk — so the whole-file cap was needlessly restrictive.

For files above 2 GB, map each requested region on demand (keeping the channel open) instead of mapping the whole file; files at or below 2 GB keep the single whole-file mapping so the common path is unchanged. The binding limit becomes 2 GB per column chunk, which the read path already enforces fail-loud via Math.toIntExact on each region length. The two narrowing offset casts are hardened to Math.toIntExact so the invariant holds at the cast site rather than relying on a distant guard.

In-memory and object-store backends keep the 2 GB-per-file limit, tracked as a follow-up.