### PR TITLE
#256 Copy heap-backed decompressor input into native memory

### DIFF
--- a/core/src/main/java22/dev/hardwood/internal/compression/libdeflate/LibdeflateDecompressor.java
+++ b/core/src/main/java22/dev/hardwood/internal/compression/libdeflate/LibdeflateDecompressor.java
@@ -23,6 +23,7 @@ import dev.hardwood.internal.compression.Decompressor;
 /// Performance: libdeflate is typically 2-4x faster than zlib for decompression.
 public final class LibdeflateDecompressor implements Decompressor {
 
+    private static final ThreadLocal<MemorySegment> NATIVE_INPUT = new ThreadLocal<>();
     private static final ThreadLocal<MemorySegment> NATIVE_OUTPUT = new ThreadLocal<>();
     private static final ThreadLocal<MemorySegment> IN_SIZE_PTR = new ThreadLocal<>();
     private static final ThreadLocal<MemorySegment> OUT_SIZE_PTR = new ThreadLocal<>();
@@ -42,8 +43,18 @@ public final class LibdeflateDecompressor implements Decompressor {
 
             int compressedSize = compressed.remaining();
 
+            // The FFM downcall requires a native MemorySegment for its pointer
+            // arguments. A direct buffer already maps to native memory, but a
+            // heap-backed buffer (e.g. ByteBuffer.allocate) yields a heap
+            // segment that the downcall rejects, so copy it into a reusable
+            // native scratch segment first.
             MemorySegment input = MemorySegment.ofBuffer(compressed);
-            MemorySegment output = borrowNativeOutput(uncompressedSize);
+            if (!compressed.isDirect()) {
+                MemorySegment scratch = borrowNative(NATIVE_INPUT, compressedSize);
+                MemorySegment.copy(input, 0, scratch, 0, compressedSize);
+                input = scratch;
+            }
+            MemorySegment output = borrowNative(NATIVE_OUTPUT, uncompressedSize);
             MemorySegment actualInSizePtr = borrowSizePtr(IN_SIZE_PTR);
             MemorySegment actualOutSizePtr = borrowSizePtr(OUT_SIZE_PTR);
 
@@ -94,11 +105,11 @@ public final class LibdeflateDecompressor implements Decompressor {
         }
     }
 
-    private static MemorySegment borrowNativeOutput(int minSize) {
-        MemorySegment seg = NATIVE_OUTPUT.get();
+    private static MemorySegment borrowNative(ThreadLocal<MemorySegment> tl, int minSize) {
+        MemorySegment seg = tl.get();
         if (seg == null || seg.byteSize() < minSize) {
             seg = Arena.ofAuto().allocate(minSize);
-            NATIVE_OUTPUT.set(seg);
+            tl.set(seg);
         }
         return seg;
     }

--- a/core/src/test/java/dev/hardwood/internal/compression/libdeflate/LibdeflateDecompressorIT.java
+++ b/core/src/test/java/dev/hardwood/internal/compression/libdeflate/LibdeflateDecompressorIT.java
@@ -86,6 +86,40 @@ class LibdeflateDecompressorIT {
     }
 
     @Test
+    void decompressHeapBackedInput() throws Exception {
+        byte[] original = "Heap-backed input for libdeflate".getBytes();
+        byte[] compressed = gzipCompress(original);
+
+        LibdeflateDecompressor decompressor = new LibdeflateDecompressor(pool);
+        ByteBuffer buffer = createHeapBuffer(compressed);
+
+        byte[] result = decompressor.decompress(buffer, original.length);
+
+        assertThat(result).startsWith(original);
+    }
+
+    @Test
+    void decompressHeapBackedInputAtNonZeroPosition() throws Exception {
+        // The real heap-backed sources (ByteBufferInputFile slices, reassembled
+        // S3 chunks) hand the decompressor a buffer positioned partway into its
+        // backing array. The native copy must honour position/remaining, not
+        // start at the array's offset 0.
+        byte[] original = "Heap-backed input at a non-zero position".getBytes();
+        byte[] compressed = gzipCompress(original);
+
+        int prefix = 7;
+        ByteBuffer buffer = ByteBuffer.allocate(prefix + compressed.length);
+        buffer.position(prefix);
+        buffer.put(compressed);
+        buffer.position(prefix);
+
+        LibdeflateDecompressor decompressor = new LibdeflateDecompressor(pool);
+        byte[] result = decompressor.decompress(buffer, original.length);
+
+        assertThat(result).startsWith(original);
+    }
+
+    @Test
     void decompressConcatenatedGzipMembers() throws Exception {
         byte[] part1 = "First GZIP member".getBytes();
         byte[] part2 = "Second GZIP member".getBytes();
@@ -130,5 +164,9 @@ class LibdeflateDecompressorIT {
         direct.put(data);
         direct.flip();
         return direct;
+    }
+
+    private static ByteBuffer createHeapBuffer(byte[] data) {
+        return ByteBuffer.wrap(data);
     }
 }


### PR DESCRIPTION
Hey, this PR is resolving #256, finally, not a complex thing, I went with the first proposed approach, fixing it on the decompressor side

## Checklist

- [x] Build via `./mvnw clean verify` passes
- [x] The commit message is prefixed with the issue key ("#123 Adding support for...")
- [x] Code changes are covered by tests
- [x] If this PR adds or changes user-facing behaviour, `docs/` has been updated
