### PR TITLE
#530 Rewrite performance-testing POM versions during release

### DIFF
--- a/performance-testing/pom.xml
+++ b/performance-testing/pom.xml
@@ -23,6 +23,13 @@
   <name>Hardwood Performance Testing</name>
   <description>Performance testing modules for Hardwood</description>
 
+  <properties>
+    <!-- Never published to Maven Central; these modules are only in the release
+         reactor so release:prepare rewrites their versions consistently with the
+         rest of the build. Inherited by all performance-testing submodules. -->
+    <maven.deploy.skip>true</maven.deploy.skip>
+  </properties>
+
   <dependencyManagement>
     <dependencies>
       <dependency>

--- a/performance-testing/test-data-setup/pom.xml
+++ b/performance-testing/test-data-setup/pom.xml
@@ -22,11 +22,22 @@
   <name>Hardwood Performance Test Data Setup</name>
   <description>Downloads and manages test data files for performance testing</description>
 
+  <properties>
+    <!-- Whether to skip fetching the (multi-gigabyte) test data sets. The quick
+         profile below flips this to true so that -Dquick builds this module
+         without downloading, e.g. during release:prepare which only needs the
+         POM versions rewritten, not the performance tests run. -->
+    <testdata.download.skip>false</testdata.download.skip>
+  </properties>
+
   <build>
     <plugins>
       <plugin>
         <groupId>org.codehaus.mojo</groupId>
         <artifactId>exec-maven-plugin</artifactId>
+        <configuration>
+          <skip>${testdata.download.skip}</skip>
+        </configuration>
         <executions>
           <execution>
             <id>download-test-data</id>
@@ -64,4 +75,20 @@
       </plugin>
     </plugins>
   </build>
+
+  <profiles>
+    <!-- -Dquick skips non-essential plugins for fast compile-only builds; the
+         test data download is one such non-essential step here. -->
+    <profile>
+      <id>quick</id>
+      <activation>
+        <property>
+          <name>quick</name>
+        </property>
+      </activation>
+      <properties>
+        <testdata.download.skip>true</testdata.download.skip>
+      </properties>
+    </profile>
+  </profiles>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -547,7 +547,7 @@
             <configuration>
               <tagNameFormat>v@{project.version}</tagNameFormat>
               <goals>deploy</goals>
-              <arguments>-ntp -B -DskipTests</arguments>
+              <arguments>-ntp -B -Dquick</arguments>
               <scmCommentPrefix>[release] </scmCommentPrefix>
               <scmReleaseCommitComment>@{prefix} Releasing version @{releaseLabel}</scmReleaseCommitComment>
               <scmDevelopmentCommitComment>@{prefix} Bump for next development cycle</scmDevelopmentCommitComment>

--- a/release.sh
+++ b/release.sh
@@ -118,14 +118,21 @@ git commit -m "[release] Update versions for ${RELEASE_VERSION}"
 # -- Prepare and perform release ---------------------------------------------
 
 echo "Running Maven release:prepare release:perform..."
-./mvnw -ntp -B -Prelease release:prepare release:perform \
+# -Pperformance-test puts the performance-testing modules into the reactor that
+# release:prepare rewrites, so the release tag carries the release version in
+# their POMs too (otherwise they stay at 1.X-SNAPSHOT and the tag can't be built
+# with -Pperformance-test). The release plugin forwards the active profiles to
+# its forked verify/deploy builds, so these modules get built too: -Dquick keeps
+# the build compile-only (skips tests, QA plugins, and the multi-gigabyte data
+# download), and <maven.deploy.skip> in their POMs keeps them out of Maven Central.
+./mvnw -ntp -B -Prelease -Pperformance-test release:prepare release:perform \
   -DreleaseVersion="${RELEASE_VERSION}" \
   -DdevelopmentVersion="${DEVELOPMENT_VERSION}" \
   -Dresume=false \
   -DpushChanges=false \
   -DlocalCheckout=true \
-  -DpreparationGoals="clean verify -DskipTests" \
-  -Darguments="-DskipTests"
+  -DpreparationGoals="clean verify -Dquick" \
+  -Darguments="-Dquick"
 
 # Restore the cli_release_tag placeholder value to 1.0-early-access so main's
 # HEAD points at the rolling early-access binaries. The release tag (created


### PR DESCRIPTION
The performance-testing modules were contributed to the reactor only by the performance-test profile, which release.sh never activates. release:prepare therefore left their parent at 1.X-SNAPSHOT while the rest of the tag moved to the release version, so a checkout of the tag could not be built with -Pperformance-test (non-resolvable parent POM). This is the same class of defect #230 fixed for the non-deployed modules, which it missed.

Activating -Pperformance-test for the release puts these modules into the reactor release:prepare rewrites. Because the release plugin forwards the active profiles to its forked verify/deploy builds, the modules are also built and would otherwise be deployed and would fetch their multi-gigabyte data sets: maven.deploy.skip keeps them off Maven Central, and switching the release build to the project's -Dquick scheme makes it compile-only (no tests, no QA, and the data download is now gated behind the quick profile).