### PR TITLE
#512 Configurable read batch size for ColumnReader / ColumnReaders.

### DIFF
--- a/.claude/skills/hardwood-review/references/checklist.md
+++ b/.claude/skills/hardwood-review/references/checklist.md
@@ -187,8 +187,9 @@ These items should ideally be caught by linting / checkstyle, not manual review.
 - **How:** Read the diff for `dev\.hardwood\.\S+\.\S+\(` patterns mid-method.
 
 ### F4. DRY within the same class/package
-- **Rule:** Repeated logic gets a private helper. Repeated *classes* (e.g. N near-identical matcher classes) need a justification before merging — generally codegen or a shared helper beats hand-duplication, even when "JIT specialization" is the stated reason.
-- **Why:** Maintenance multiplier. Today's 28 hand-duplicated matchers become tomorrow's 56 vector-API + scalar matchers.
+- **Rule:** *Substantial* repeated logic gets a private helper. Repeated *classes* (e.g. N near-identical matcher classes) need a justification before merging — generally codegen or a shared helper beats hand-duplication, even when "JIT specialization" is the stated reason.
+- **Floor — do NOT flag below this.** A short guard or boilerplate fragment (a 1–3 line argument-validation check, a null-check, a trivial throw) duplicated across **2** call sites is *fine* — extracting a helper for it costs more readability than it saves. The maintainer has explicitly called this out as noise. Flag duplication only when **either** the repeated block is non-trivial (real branching/computation, not a one-line guard) **or** it appears at **3+** sites. When in doubt below this floor, drop the finding — don't even demote it to a nit.
+- **Why:** Maintenance multiplier. Today's 28 hand-duplicated matchers become tomorrow's 56 vector-API + scalar matchers. But a twice-duplicated `if (x <= 0) throw ...` is not a maintenance multiplier — it's the cheapest possible code to keep in sync.
 - **How:** When 3+ new files share >70% of their structure, flag it. Ask the author to A/B against a shared helper before locking in the pattern. **Note:** DRY at this scale is an implementation-semantics concern, not a style nit — promote it.
 
 ### F5. Base class restraint

--- a/core/src/main/java/dev/hardwood/reader/ColumnReader.java
+++ b/core/src/main/java/dev/hardwood/reader/ColumnReader.java
@@ -626,21 +626,24 @@ public class ColumnReader implements AutoCloseable {
     /// filtering. `filter` may be `null`.
     static ColumnReader create(String columnName, FileSchema schema,
                                InputFile inputFile, List<RowGroup> rowGroups,
-                               HardwoodContextImpl context, ResolvedPredicate filter) {
-        return create(schema.getColumn(columnName), schema, inputFile, rowGroups, context, filter);
+                               HardwoodContextImpl context, ResolvedPredicate filter,
+                               int batchSize) {
+        return create(schema.getColumn(columnName), schema, inputFile, rowGroups, context, filter, batchSize);
     }
 
     /// Create a ColumnReader for a column by index with optional page-level
     /// filtering. `filter` may be `null`.
     static ColumnReader create(int columnIndex, FileSchema schema,
                                InputFile inputFile, List<RowGroup> rowGroups,
-                               HardwoodContextImpl context, ResolvedPredicate filter) {
-        return create(schema.getColumn(columnIndex), schema, inputFile, rowGroups, context, filter);
+                               HardwoodContextImpl context, ResolvedPredicate filter,
+                               int batchSize) {
+        return create(schema.getColumn(columnIndex), schema, inputFile, rowGroups, context, filter, batchSize);
     }
 
     private static ColumnReader create(ColumnSchema columnSchema, FileSchema schema,
                                        InputFile inputFile, List<RowGroup> rowGroups,
-                                       HardwoodContextImpl context, ResolvedPredicate filter) {
+                                       HardwoodContextImpl context, ResolvedPredicate filter,
+                                       int batchSize) {
         ProjectedSchema projectedSchema = ProjectedSchema.create(schema,
                 ColumnProjection.columns(columnSchema.fieldPath().toString()));
 
@@ -649,7 +652,7 @@ public class ColumnReader implements AutoCloseable {
         rowGroupIterator.setFirstFile(schema, rowGroups);
         rowGroupIterator.initialize(projectedSchema, filter);
 
-        return createFromIterator(columnSchema, schema, rowGroupIterator, context, 0, rowGroupIterator);
+        return createFromIterator(columnSchema, schema, rowGroupIterator, context, 0, rowGroupIterator, batchSize);
     }
 
     /// Creates a ColumnReader from a pre-configured RowGroupIterator.
@@ -663,7 +666,8 @@ public class ColumnReader implements AutoCloseable {
                                            RowGroupIterator rowGroupIterator,
                                            HardwoodContextImpl context,
                                            int projectedColumnIndex,
-                                           RowGroupIterator ownedIterator) {
+                                           RowGroupIterator ownedIterator,
+                                           int batchSize) {
         NestedLevelComputer.Layers layers = NestedLevelComputer.computeLayers(
                 schema.getRootNode(), columnSchema.columnIndex());
         boolean nested = layers.count() > 0 || columnSchema.maxRepetitionLevel() > 0;
@@ -674,11 +678,11 @@ public class ColumnReader implements AutoCloseable {
             BatchExchange<NestedBatch> nestedBuf = BatchExchange.detaching(
                     columnSchema.name(), () -> {
                         NestedBatch b = new NestedBatch();
-                        b.values = BatchExchange.allocateArray(columnSchema, DEFAULT_BATCH_SIZE);
+                        b.values = BatchExchange.allocateArray(columnSchema, batchSize);
                         return b;
                     });
             NestedColumnWorker nestedWorker = new NestedColumnWorker(
-                    pageSource, nestedBuf, columnSchema, DEFAULT_BATCH_SIZE,
+                    pageSource, nestedBuf, columnSchema, batchSize,
                     context.decompressorFactory(), context.executor(), 0,
                     layers);
             nestedWorker.start();
@@ -688,11 +692,11 @@ public class ColumnReader implements AutoCloseable {
             BatchExchange<BatchExchange.Batch> flatBuf = BatchExchange.detaching(
                     columnSchema.name(), () -> {
                         BatchExchange.Batch b = new BatchExchange.Batch();
-                        b.values = BatchExchange.allocateArray(columnSchema, DEFAULT_BATCH_SIZE);
+                        b.values = BatchExchange.allocateArray(columnSchema, batchSize);
                         return b;
                     });
             FlatColumnWorker flatWorker = new FlatColumnWorker(
-                    pageSource, flatBuf, columnSchema, DEFAULT_BATCH_SIZE,
+                    pageSource, flatBuf, columnSchema, batchSize,
                     context.decompressorFactory(), context.executor(), 0, null);
             flatWorker.start();
             return ColumnReader.forFlat(columnSchema, flatBuf, flatWorker, ownedIterator);

--- a/core/src/main/java/dev/hardwood/reader/ColumnReader.java
+++ b/core/src/main/java/dev/hardwood/reader/ColumnReader.java
@@ -61,7 +61,9 @@ import dev.hardwood.schema.ProjectedSchema;
 @Experimental
 public class ColumnReader implements AutoCloseable {
 
-    static final int DEFAULT_BATCH_SIZE = 262_144;
+    /// The default maximum number of records returned per batch when no batch
+    /// size is configured via `batchSize(int)` on the reader builders.
+    public static final int DEFAULT_BATCH_SIZE = 262_144;
 
     private final ColumnSchema column;
     private final boolean nested;

--- a/core/src/main/java/dev/hardwood/reader/ColumnReaders.java
+++ b/core/src/main/java/dev/hardwood/reader/ColumnReaders.java
@@ -52,7 +52,8 @@ public class ColumnReaders implements AutoCloseable {
     ColumnReaders(HardwoodContextImpl context,
                   RowGroupIterator rowGroupIterator,
                   FileSchema schema,
-                  ProjectedSchema projectedSchema) {
+                  ProjectedSchema projectedSchema,
+                  int batchSize) {
         int projectedColumnCount = projectedSchema.getProjectedColumnCount();
         this.readersByName = new LinkedHashMap<>(projectedColumnCount);
         this.readersByIndex = new ColumnReader[projectedColumnCount];
@@ -62,7 +63,7 @@ public class ColumnReaders implements AutoCloseable {
             ColumnSchema columnSchema = schema.getColumn(originalIndex);
 
             ColumnReader reader = ColumnReader.createFromIterator(
-                    columnSchema, schema, rowGroupIterator, context, i, null);
+                    columnSchema, schema, rowGroupIterator, context, i, null, batchSize);
 
             readersByName.put(columnSchema.fieldPath().toString(), reader);
             readersByIndex[i] = reader;

--- a/core/src/main/java/dev/hardwood/reader/ParquetFileReader.java
+++ b/core/src/main/java/dev/hardwood/reader/ParquetFileReader.java
@@ -359,41 +359,42 @@ public class ParquetFileReader implements AutoCloseable {
     }
 
     ColumnReader buildColumnReader(String columnName, FilterPredicate filter) {
-        return buildColumnReader(columnName, filter, null);
+        return buildColumnReader(columnName, filter, null, ColumnReader.DEFAULT_BATCH_SIZE);
     }
 
     ColumnReader buildColumnReader(
-            String columnName, FilterPredicate filter, RowGroupPredicate rowGroupFilter) {
+            String columnName, FilterPredicate filter, RowGroupPredicate rowGroupFilter, int batchSize) {
         ensureSingleFile("columnReader(String)");
         InputFile inputFile = inputFiles.get(0);
         ResolvedPredicate resolved = filter != null
                 ? FilterPredicateResolver.resolve(filter, schema) : null;
         List<RowGroup> rowGroups = filterRowGroups(resolved, rowGroupFilter);
-        return ColumnReader.create(columnName, schema, inputFile, rowGroups, context, resolved);
+        return ColumnReader.create(columnName, schema, inputFile, rowGroups, context, resolved, batchSize);
     }
 
     ColumnReader buildColumnReader(int columnIndex, FilterPredicate filter) {
-        return buildColumnReader(columnIndex, filter, null);
+        return buildColumnReader(columnIndex, filter, null, ColumnReader.DEFAULT_BATCH_SIZE);
     }
 
     ColumnReader buildColumnReader(
-            int columnIndex, FilterPredicate filter, RowGroupPredicate rowGroupFilter) {
+            int columnIndex, FilterPredicate filter, RowGroupPredicate rowGroupFilter, int batchSize) {
         ensureSingleFile("columnReader(int)");
         InputFile inputFile = inputFiles.get(0);
         ResolvedPredicate resolved = filter != null
                 ? FilterPredicateResolver.resolve(filter, schema) : null;
         List<RowGroup> rowGroups = filterRowGroups(resolved, rowGroupFilter);
-        return ColumnReader.create(columnIndex, schema, inputFile, rowGroups, context, resolved);
+        return ColumnReader.create(columnIndex, schema, inputFile, rowGroups, context, resolved, batchSize);
     }
 
     ColumnReaders buildColumnReaders(ColumnProjection projection, FilterPredicate filter) {
-        return buildColumnReaders(projection, filter, null);
+        return buildColumnReaders(projection, filter, null, ColumnReader.DEFAULT_BATCH_SIZE);
     }
 
     ColumnReaders buildColumnReaders(
             ColumnProjection projection,
             FilterPredicate filter,
-            RowGroupPredicate rowGroupFilter) {
+            RowGroupPredicate rowGroupFilter,
+            int batchSize) {
         ResolvedPredicate resolved = filter != null
                 ? FilterPredicateResolver.resolve(filter, schema) : null;
         List<RowGroup> rowGroups = filterRowGroups(resolved, rowGroupFilter);
@@ -402,7 +403,7 @@ public class ParquetFileReader implements AutoCloseable {
         iterator.setFirstFile(schema, rowGroups);
         ProjectedSchema projected = iterator.initialize(projection, resolved);
         rowGroupIterators.add(iterator);
-        return new ColumnReaders(context, iterator, schema, projected);
+        return new ColumnReaders(context, iterator, schema, projected, batchSize);
     }
 
     private void ensureSingleFile(String op) {
@@ -642,6 +643,7 @@ public class ParquetFileReader implements AutoCloseable {
         private final boolean byName;
         private FilterPredicate filter;
         private RowGroupPredicate rowGroupFilter;
+        private int batchSize = ColumnReader.DEFAULT_BATCH_SIZE;
 
         private ColumnReaderBuilder(ParquetFileReader fileReader, String columnName) {
             this.fileReader = fileReader;
@@ -672,11 +674,21 @@ public class ParquetFileReader implements AutoCloseable {
             return this;
         }
 
+        /// Set the maximum number of records to return in each batch.
+        /// Default: [ColumnReader#DEFAULT_BATCH_SIZE].
+        public ColumnReaderBuilder batchSize(int batchSize) {
+            if (batchSize <= 0) {
+                throw new IllegalArgumentException("batchSize must be positive: " + batchSize);
+            }
+            this.batchSize = batchSize;
+            return this;
+        }
+
         public ColumnReader build() {
             if (byName) {
-                return fileReader.buildColumnReader(columnName, filter, rowGroupFilter);
+                return fileReader.buildColumnReader(columnName, filter, rowGroupFilter, batchSize);
             }
-            return fileReader.buildColumnReader(columnIndex, filter, rowGroupFilter);
+            return fileReader.buildColumnReader(columnIndex, filter, rowGroupFilter, batchSize);
         }
     }
 
@@ -701,6 +713,7 @@ public class ParquetFileReader implements AutoCloseable {
         private final ColumnProjection projection;
         private FilterPredicate filter;
         private RowGroupPredicate rowGroupFilter;
+        private int batchSize = ColumnReader.DEFAULT_BATCH_SIZE;
 
         private ColumnReadersBuilder(ParquetFileReader fileReader, ColumnProjection projection) {
             if (projection == null) {
@@ -725,8 +738,18 @@ public class ParquetFileReader implements AutoCloseable {
             return this;
         }
 
+        /// Set the maximum number of records to return in each batch for all columns.
+        /// Default: [ColumnReader#DEFAULT_BATCH_SIZE].
+        public ColumnReadersBuilder batchSize(int batchSize) {
+            if (batchSize <= 0) {
+                throw new IllegalArgumentException("batchSize must be positive: " + batchSize);
+            }
+            this.batchSize = batchSize;
+            return this;
+        }
+
         public ColumnReaders build() {
-            return fileReader.buildColumnReaders(projection, filter, rowGroupFilter);
+            return fileReader.buildColumnReaders(projection, filter, rowGroupFilter, batchSize);
         }
     }
 

--- a/core/src/test/java/dev/hardwood/ColumnReadersTest.java
+++ b/core/src/test/java/dev/hardwood/ColumnReadersTest.java
@@ -128,6 +128,22 @@ class ColumnReadersTest {
     }
 
     @Test
+    void testBatchSizeRejectsNonPositive() throws Exception {
+        Path filePath = Paths.get("src/test/resources/filter_pushdown_int.parquet");
+
+        try (Hardwood hardwood = Hardwood.create();
+             ParquetFileReader parquet = hardwood.openAll(InputFile.ofPaths(List.of(filePath)))) {
+
+            assertThatThrownBy(() -> parquet.buildColumnReaders(ColumnProjection.columns("id", "value")).batchSize(0))
+                    .isInstanceOf(IllegalArgumentException.class)
+                    .hasMessageContaining("batchSize must be positive");
+            assertThatThrownBy(() -> parquet.buildColumnReaders(ColumnProjection.columns("id", "value")).batchSize(-1))
+                    .isInstanceOf(IllegalArgumentException.class)
+                    .hasMessageContaining("batchSize must be positive");
+        }
+    }
+
+    @Test
     void testUnknownColumnNameThrows() throws Exception {
         Path filePath = Paths.get("src/test/resources/plain_uncompressed.parquet");
 

--- a/core/src/test/java/dev/hardwood/ColumnReadersTest.java
+++ b/core/src/test/java/dev/hardwood/ColumnReadersTest.java
@@ -105,6 +105,29 @@ class ColumnReadersTest {
     }
 
     @Test
+    void testSmallBatchSize() throws Exception {
+        Path filePath = Paths.get("src/test/resources/filter_pushdown_int.parquet");
+
+        try (Hardwood hardwood = Hardwood.create();
+             ParquetFileReader parquet = hardwood.openAll(InputFile.ofPaths(List.of(filePath)));
+             ColumnReaders columns = parquet.buildColumnReaders(ColumnProjection.columns("id", "value"))
+                     .batchSize(50)
+                     .build()) {
+
+            int totalRows = 0;
+            int batches = 0;
+            while (columns.nextBatch()) {
+                int count = columns.getRecordCount();
+                assertThat(count).isLessThanOrEqualTo(50);
+                totalRows += count;
+                batches++;
+            }
+            assertThat(totalRows).isEqualTo(300);
+            assertThat(batches).isEqualTo(6); // 300 / 50
+        }
+    }
+
+    @Test
     void testUnknownColumnNameThrows() throws Exception {
         Path filePath = Paths.get("src/test/resources/plain_uncompressed.parquet");
 

--- a/core/src/test/java/dev/hardwood/ParquetReaderTest.java
+++ b/core/src/test/java/dev/hardwood/ParquetReaderTest.java
@@ -208,6 +208,29 @@ class ParquetReaderTest {
     }
 
     @Test
+    void testSmallBatchSize() throws Exception {
+        Path filePath = Paths.get("src/test/resources/filter_pushdown_int.parquet");
+
+        try (Hardwood hardwood = Hardwood.create();
+             ParquetFileReader parquet = hardwood.open(InputFile.of(filePath));
+             ColumnReader reader = parquet.buildColumnReader("id")
+                     .batchSize(10)
+                     .build()) {
+
+            int totalRows = 0;
+            int batches = 0;
+            while (reader.nextBatch()) {
+                int count = reader.getRecordCount();
+                assertThat(count).isLessThanOrEqualTo(10);
+                totalRows += count;
+                batches++;
+            }
+            assertThat(totalRows).isEqualTo(300);
+            assertThat(batches).isEqualTo(30); // 300 / 10
+        }
+    }
+
+    @Test
     void testColumnReaderByIndex() throws Exception {
         Path parquetFile = Paths.get("src/test/resources/plain_uncompressed.parquet");
 

--- a/core/src/test/java/dev/hardwood/ParquetReaderTest.java
+++ b/core/src/test/java/dev/hardwood/ParquetReaderTest.java
@@ -231,6 +231,47 @@ class ParquetReaderTest {
     }
 
     @Test
+    void testBatchSizeRejectsNonPositive() throws Exception {
+        Path filePath = Paths.get("src/test/resources/filter_pushdown_int.parquet");
+
+        try (Hardwood hardwood = Hardwood.create();
+             ParquetFileReader parquet = hardwood.open(InputFile.of(filePath))) {
+
+            assertThatThrownBy(() -> parquet.buildColumnReader("id").batchSize(0))
+                    .isInstanceOf(IllegalArgumentException.class)
+                    .hasMessageContaining("batchSize must be positive");
+            assertThatThrownBy(() -> parquet.buildColumnReader("id").batchSize(-1))
+                    .isInstanceOf(IllegalArgumentException.class)
+                    .hasMessageContaining("batchSize must be positive");
+        }
+    }
+
+    @Test
+    void testSmallBatchSizeNestedColumn() throws Exception {
+        // `scores` is a repeated (list) column, exercising the nested worker's
+        // batch-size handling, where a record spans a variable number of leaf values.
+        Path filePath = Paths.get("src/test/resources/filter_pushdown_list.parquet");
+
+        try (Hardwood hardwood = Hardwood.create();
+             ParquetFileReader parquet = hardwood.open(InputFile.of(filePath));
+             ColumnReader reader = parquet.buildColumnReader("scores.list.element")
+                     .batchSize(2)
+                     .build()) {
+
+            int totalRows = 0;
+            int batches = 0;
+            while (reader.nextBatch()) {
+                int count = reader.getRecordCount();
+                assertThat(count).isLessThanOrEqualTo(2);
+                totalRows += count;
+                batches++;
+            }
+            assertThat(totalRows).isEqualTo(9);
+            assertThat(batches).isEqualTo(5); // ceil(9 / 2)
+        }
+    }
+
+    @Test
     void testColumnReaderByIndex() throws Exception {
         Path parquetFile = Paths.get("src/test/resources/plain_uncompressed.parquet");
 

--- a/docs/content/how-to/column-reader.md
+++ b/docs/content/how-to/column-reader.md
@@ -47,7 +47,7 @@ The [Validity](/api/latest/dev/hardwood/reader/Validity.html) type wraps the und
 
 Typed accessors are available for each fixed-width physical type: `getInts()`, `getLongs()`, `getFloats()`, `getDoubles()`, `getBooleans()`. For varlength leaves (`BINARY`, `FIXED_LEN_BYTE_ARRAY`, `INT96`) the primary accessors are `getBinaryValues()` (a `byte[]` buffer) plus `getBinaryOffsets()` (a sentinel-suffixed `int[]` of length `getValueCount() + 1`); the byte slice for value `i` is `[offsets[i], offsets[i+1])`. The convenience accessors `getBinaries()` and `getStrings()` materialise one `byte[]` or `String` per leaf — useful for low-volume / debug paths but allocate per-row, so hot loops should read the buffers directly.
 
-Column readers can also be created by index via `columnReader(int columnIndex)`. To attach a filter, use the builder form: `reader.buildColumnReader("id").filter(predicate).build()`.
+Column readers can also be created by index via `columnReader(int columnIndex)`. To attach a filter or customize the batch size, use the builder form: `reader.buildColumnReader("id").filter(predicate).batchSize(1024).build()`.
 
 ### Reading Multiple Columns
 
@@ -79,6 +79,17 @@ try (ParquetFileReader parquet = ParquetFileReader.open(InputFile.of(path));
             fareAmount += v2[i];
         }
     }
+}
+```
+
+To customize the batch size for all columns, use `.batchSize(int)` on the builder:
+
+```java
+try (ColumnReaders columns = parquet.buildColumnReaders(
+             ColumnProjection.columns("passenger_count", "trip_distance", "fare_amount"))
+        .batchSize(2048)
+        .build()) {
+    // ...
 }
 ```
 


### PR DESCRIPTION
closes #512

  - #512 Implemented configurable batch sizes via `.batchSize(int)` in `ColumnReaderBuilder` and `ColumnReadersBuilder`.
  - Updated `ColumnReader` and `ColumnReaders` to propagate and honor custom batch sizes.
  - Added Javadocs and updated documentation in `docs/content/` to explain usage and memory/throughput trade-offs.
  - Integrated permanent unit tests in `ParquetReaderTest` and `ColumnReadersTest` to verify batch boundary correctness.

## Checklist

- [x] Build via `./mvnw clean verify` passes
- [x] The commit message is prefixed with the issue key ("#512")
- [x] Code changes are covered by tests
- [x] If this PR adds or changes user-facing behaviour, `docs/` has been updated
