### PR TITLE
#543 rename firstrow to skip

### DIFF
--- a/_designs/CROSS_COLUMN_COALESCING.md
+++ b/_designs/CROSS_COLUMN_COALESCING.md
@@ -150,11 +150,11 @@ Bytes-on-the-wire don't change; request count and per-RG latency do.
 - With **#370** (per-column-worker over-fetch): the worker behaviour is
   unchanged; coalescing happens at plan-build time, before workers
   start. #370's fix and this one are orthogonal.
-- With **#361** / **#377** (firstRow seek + dive window): unchanged.
+- With **#361** / **#377** (skip seek + dive window): unchanged.
   The window's refill path issues `readPreviewPage` which goes through
   the same iterator/plan code; coalescing applies transparently.
 - With **#381** (page-level skip via OffsetIndex when seeking with
-  firstRow): page drops introduce intra-column gaps and trigger the
+  skip): page drops introduce intra-column gaps and trigger the
   conservative "no coalescing for filtered columns" rule. The two
   features compose by partitioning each RG into coalesced (fully-read)
   and per-column (filtered) sub-plans.

--- a/_designs/PREVIEW_WINDOW.md
+++ b/_designs/PREVIEW_WINDOW.md
@@ -69,7 +69,7 @@ doesn't depend on row group sizes.
 ## Bounded cursor — the `head(count)` rule
 
 Each `ParquetModel.readPreviewPage(firstRow, count, …)` call builds
-the cursor with `firstRow(firstRow).head(count)`, where `count` is
+the cursor with `skip(firstRow).head(count)`, where `count` is
 the row count the caller passed. That bound is load-bearing: without
 it, the per-column workers in the v2 pipeline race many row groups
 ahead of what the consumer asks for (#370). The queued pre-fetch

--- a/_designs/ROW_BASED_SEEK.md
+++ b/_designs/ROW_BASED_SEEK.md
@@ -23,28 +23,28 @@ A new method on the existing `RowReaderBuilder`:
 /// are not opened — their pages are not fetched or decoded — so this
 /// is an O(1 RG) seek on remote backends.
 ///
-/// `firstRow == 0` is the no-op default. `firstRow == totalRows`
+/// `skip == 0` is the no-op default. `skip == totalRows`
 /// produces an empty reader. Indexes into the *first* file's rows for
-/// multi-file readers; cross-file `firstRow` is out of scope. Mutually
+/// multi-file readers; cross-file `skip` is out of scope. Mutually
 /// exclusive with [#tail]; composes with [#head] for a bounded
-/// `[firstRow, firstRow + maxRows)` window.
-public RowReaderBuilder firstRow(long firstRow)
+/// `[skip, skip + maxRows)` window.
+public RowReaderBuilder skip(long skip)
 ```
 
 Composes with existing builder methods:
 
 ```java
 // Read rows [N, end) of the file, no projection, no filter
-file.buildRowReader().firstRow(N).build();
+file.buildRowReader().skip(N).build();
 
 // Read rows [N, N+M) — bounded window
-file.buildRowReader().firstRow(N).head(M).build();
+file.buildRowReader().skip(N).head(M).build();
 
 // Same with projection + filter
 file.buildRowReader()
         .projection(ColumnProjection.columns("id", "name"))
         .filter(FilterPredicate.gt("id", 100))
-        .firstRow(500)
+        .skip(500)
         .head(50)
         .build();
 ```
@@ -54,13 +54,13 @@ file).
 
 ## Implementation
 
-In `ParquetFileReader.buildRowReader(projection, filter, maxRows, firstRow)`:
+In `ParquetFileReader.buildRowReader(projection, filter, maxRows, skip)`:
 
-1. If `firstRow == 0`, delegate to the existing path (no behaviour change).
+1. If `skip == 0`, delegate to the existing path (no behaviour change).
 2. Otherwise, locate the target row group by walking cumulative
    `RowGroup.numRows()` from the first file's row-group list. Compute
-   `withinRg = firstRow - rowGroupFirstRow(targetRg)`.
-3. If `firstRow >= totalRows`, return an empty reader (`rowGroups.subList(end, end)`).
+   `withinRg = skip - rowGroupFirstRow(targetRg)`.
+3. If `skip >= totalRows`, return an empty reader (`rowGroups.subList(end, end)`).
 4. Open a reader scoped to `rowGroups.subList(targetRg, end)`. Apply
    `head(maxRowsAdjusted)` where `maxRowsAdjusted = maxRows + withinRg` (the
    `head` budget bounds *yielded* rows, and the within-RG skip yields rows
@@ -76,9 +76,9 @@ Against a multi-row-group file on remote storage:
 
 | Action | Before | After |
 |---|---|---|
-| `firstRow(0)` | Open from row 0 | Same (no-op) |
-| `firstRow(N)` where N is in row group K | Walk row 0 → N, fetching all of row groups 0..K | Skip directly to row group K, fetch only its bytes |
-| `firstRow(totalRows)` | Walk to end (full file) | Empty reader (no fetches) |
+| `skip(0)` | Open from row 0 | Same (no-op) |
+| `skip(N)` where N is in row group K | Walk row 0 → N, fetching all of row groups 0..K | Skip directly to row group K, fetch only its bytes |
+| `skip(totalRows)` | Walk to end (full file) | Empty reader (no fetches) |
 
 ## Dive wiring
 
@@ -87,7 +87,7 @@ fresh `RowReader` on every call:
 
 ```java
 try (RowReader cursor = reader.buildRowReader()
-        .firstRow(firstRow)
+        .skip(firstRow)
         .head(count)
         .build()) {
     while (read < count && cursor.hasNext()) {
@@ -103,7 +103,7 @@ the dive viewport window cache (#377) absorbs all within-buffer
 navigation, so cross-call cursor reuse would buy nothing while
 risking the "phantom fetch" issue (#370) where an unbounded cursor's
 worker pool drains long after the user moved on. `head(count)` caps
-each cursor to exactly the rows asked for; combined with `firstRow`,
+each cursor to exactly the rows asked for; combined with `skip`,
 the cursor is scoped to the target row group onwards and never
 fetches earlier ones.
 
@@ -124,7 +124,7 @@ dedicated viewport window cache (#377) replaces them.
 - **Page-level seek for files without OffsetIndex.** Synthesising
   page-location info from a header walk is #378.
 
-- **Multi-file `firstRow`.** Indexes into the first file's rows only.
+- **Multi-file `skip`.** Indexes into the first file's rows only.
   Cross-file (e.g. "row N across the concatenated dataset") is a separate
   problem and not on the roadmap.
 
@@ -134,16 +134,16 @@ dedicated viewport window cache (#377) replaces them.
 
 ## Testing
 
-- `ParquetReaderTest.firstRowSkipsEarlierRowGroups` — `firstRow(150)` on a
+- `ParquetReaderTest.skipSeeksPastEarlierRowGroups` — `skip(150)` on a
   3-RG file (100 rows each) yields the right rows starting at id 151.
-- `ParquetReaderTest.firstRowAtRowGroupBoundary` — `firstRow(100)` lands
+- `ParquetReaderTest.skipAtRowGroupBoundary` — `skip(100)` lands
   at the start of RG 1 with no within-RG residue.
-- `ParquetReaderTest.firstRowComposesWithHead` — `firstRow(150).head(20)`
+- `ParquetReaderTest.skipComposesWithHead` — `skip(150).head(20)`
   yields exactly rows 150..169.
-- `ParquetReaderTest.firstRowAtTotalRowsYieldsEmpty` — boundary at
+- `ParquetReaderTest.skipAtTotalRowsYieldsEmpty` — boundary at
   end-of-file.
-- `ParquetReaderTest.firstRowRejectsNegative` and
-  `firstRowAndTailAreMutuallyExclusive` cover the validation paths.
+- `ParquetReaderTest.skipRejectsNegative` and
+  `skipAndTailAreMutuallyExclusive` cover the validation paths.
 - `DataPreviewIoTest` exercises the dive integration: jump-to-last-page
   yields the right rows AND reads less than half the file's bytes;
   forward intra-RG steps reuse the cursor; backward seek rebuilds within

--- a/_designs/ROW_SELECTION_SEMANTICS.md
+++ b/_designs/ROW_SELECTION_SEMANTICS.md
@@ -1,0 +1,81 @@
+# Design: row selection semantics
+
+**Status: In progress.** Tracking issues: #538 (`head` + filter), #540 / #541
+(`skip` + filter), #542 (`tail` + filter), #543 (`firstRow` → `skip` rename).
+The reader-facing counterpart is `docs/content/concepts/row-selection.md`.
+
+## Scope
+
+How the row-selection controls on `RowReaderBuilder` — `head`, `tail`, `skip` —
+relate to the two filtering mechanisms — the row-level `FilterPredicate` and the
+group-level `RowGroupPredicate` (e.g. `byteRange`). The goal is a single model
+under which the controls compose predictably, so a caller can reason about
+`skip(a).filter(p).head(b)` without knowing the file's row-group structure or
+the filter's selectivity.
+
+## The model: two axes
+
+Row selection has two independent axes.
+
+**Physical layout** — *where data lives in the file* — is addressed only through
+`RowGroupPredicate`, at row-group granularity. `byteRange(start, end)` keeps a
+row group if and only if its midpoint falls in `[start, end)`. Across a
+partition of the file into disjoint byte ranges, every row group lands in
+exactly one range — this is the work-splitting lever for parallel readers.
+
+**Logical result** — *which rows the caller wants* — is addressed by `head`,
+`tail`, `skip`, and the row-level `FilterPredicate`.
+
+The **surviving relation** is the set of rows in the row groups kept by the
+`RowGroupPredicate`, intersected with the rows matching the `FilterPredicate`,
+in file order.
+
+## The one rule
+
+`head`, `tail`, and `skip` count over the surviving relation, in file order:
+
+- `skip(n)` discards the first `n` rows of the relation (SQL `OFFSET`).
+- `head(n)` keeps at most the first `n` rows (SQL `LIMIT`).
+- `tail(n)` keeps at most the last `n` rows.
+
+There is no second mode. The controls always count over the relation; they do
+not switch between "physical" and "logical" behavior.
+
+When no `FilterPredicate` is present, every row of the kept row groups is in the
+relation, so a logical offset coincides with a physical row position:
+`skip(n)` begins at physical row `n` and remains an O(1-row-group) seek — earlier
+row groups are never opened. With a `FilterPredicate`, the controls count matched
+rows and that coincidence breaks: row-group statistics bound min/max values, not
+match *counts*, so the reader must decode earlier groups in order to count
+matches (groups whose statistics prove no match can still be pruned).
+
+## Composition
+
+`RowGroupPredicate` and `FilterPredicate` compose by intersection — a row is in
+the relation only if its row group is kept *and* the row matches. The logical
+controls then count over that intersection. So `byteRange(...).skip(n)` skips `n`
+rows *within the split*, and `byteRange(...).filter(p).head(n)` returns the first
+`n` rows of the split that match `p`.
+
+| Control      | No `FilterPredicate`                                              | With `FilterPredicate`                                                  |
+|--------------|------------------------------------------------------------------|------------------------------------------------------------------------|
+| `skip(n)`    | begin at physical row `n`; earlier row groups not opened (O(1 RG) | discard the first `n` matched rows; earlier groups scanned to count     |
+| `head(n)`    | first `n` rows                                                   | first `n` matched rows                                                  |
+| `tail(n)`    | last `n` rows                                                    | last `n` matched rows (deferred — see #542)                            |
+| `byteRange`  | selects row groups by byte range (the split)                    | intersects: a group is read iff it is in range and not statistics-pruned |
+
+## Non-goals
+
+- **Physical-row addressing under a filter.** There is no API that takes a
+  physical absolute row number when a `FilterPredicate` is present. Physical
+  positioning is row-group granular via `byteRange`; a checkpoint/resume point is
+  expressed as a `(byteRange, logical offset)` pair, not a physical row index.
+
+- **Sub-row-group physical splitting.** `byteRange` is row-group granular,
+  matching the I/O unit. Finer physical partitioning is not offered.
+
+- **`tail` + filter (for now).** Tracked as #542 and deferred past 1.0. Unlike
+  the forward-streaming `head`/`skip`, the last `n` matched rows have no
+  row-group-statistics shortcut, so it requires a reverse scan or a sliding
+  window over a full forward scan. Until then `tail` + filter is rejected at
+  `build()`.

--- a/cli/src/main/java/dev/hardwood/cli/dive/ParquetModel.java
+++ b/cli/src/main/java/dev/hardwood/cli/dive/ParquetModel.java
@@ -372,7 +372,7 @@ public final class ParquetModel implements AutoCloseable {
     public void readPreviewPage(long firstRow, int pageSize, java.util.function.Consumer<RowReader> consumer)
             throws IOException {
         try (RowReader cursor = reader.buildRowReader()
-                .firstRow(firstRow)
+                .skip(firstRow)
                 .head(pageSize)
                 .build()) {
             int read = 0;

--- a/core/src/main/java/dev/hardwood/reader/ParquetFileReader.java
+++ b/core/src/main/java/dev/hardwood/reader/ParquetFileReader.java
@@ -236,19 +236,19 @@ public class ParquetFileReader implements AutoCloseable {
     }
 
     RowReader buildRowReader(ColumnProjection projection, FilterPredicate filter,
-                             RowGroupPredicate rowGroupFilter, long maxRows, long firstRow) {
-        // Apply the row-group predicate (e.g. byte-range) up front so `firstRow` indexes
+                             RowGroupPredicate rowGroupFilter, long maxRows, long skip) {
+        // Apply the row-group predicate (e.g. byte-range) up front so `skip` indexes
         // into the kept sequence — a caller doing split-aware reading can seek inside *its*
         // split. Stats-based row-group dropping (via FilterPredicate) stays inside the
-        // RowGroupIterator, so its semantics under `firstRow` are unchanged from before.
+        // RowGroupIterator, so its semantics under `skip` are unchanged from before.
         List<RowGroup> filteredRowGroups = rowGroupFilter == null
                 ? firstFileMetaData.rowGroups()
                 : filterRowGroups(null, rowGroupFilter);
 
-        if (firstRow == 0L) {
+        if (skip == 0L) {
             return buildRowReader(projection, filter, maxRows, filteredRowGroups);
         }
-        // Locate the row group containing `firstRow` by walking cumulative
+        // Locate the row group containing `skip` by walking cumulative
         // RowGroup.numRows() over the filtered list. After the loop, `cumulative`
         // equals the total row count of `filteredRowGroups` if no target was found.
         long cumulative = 0L;
@@ -256,20 +256,20 @@ public class ParquetFileReader implements AutoCloseable {
         long withinRg = 0L;
         for (int i = 0; i < filteredRowGroups.size(); i++) {
             long rgRows = filteredRowGroups.get(i).numRows();
-            if (firstRow < cumulative + rgRows) {
+            if (skip < cumulative + rgRows) {
                 targetRg = i;
-                withinRg = firstRow - cumulative;
+                withinRg = skip - cumulative;
                 break;
             }
             cumulative += rgRows;
         }
         if (targetRg < 0) {
-            if (firstRow > cumulative) {
+            if (skip > cumulative) {
                 throw new IllegalArgumentException(
-                        "firstRow " + firstRow
+                        "skip " + skip
                         + " exceeds the (row-group-filtered) total row count " + cumulative);
             }
-            // firstRow == cumulative — empty reader.
+            // skip == cumulative — empty reader.
             return buildRowReader(projection, filter, maxRows, List.<RowGroup>of());
         }
         List<RowGroup> rowGroups = targetRg == 0
@@ -516,7 +516,7 @@ public class ParquetFileReader implements AutoCloseable {
         /// Zero (default): start from row 0. Positive: skip rows before the
         /// given absolute row index, opening only the row group(s) needed
         /// to reach it. Mutually exclusive with `tailRows`.
-        private long firstRow;
+        private long skip;
 
         private RowReaderBuilder(ParquetFileReader fileReader) {
             this.fileReader = fileReader;
@@ -541,8 +541,8 @@ public class ParquetFileReader implements AutoCloseable {
         /// Default: read every row group. Combines with [#filter(FilterPredicate)] via
         /// intersection: a row group is read if and only if it passes both.
         ///
-        /// Composes with [#head(long)] and [#firstRow(long)] over the *filtered* row-group
-        /// sequence — `firstRow(N)` skips `N` rows of the kept set, `head(N)` caps at `N`
+        /// Composes with [#head(long)] and [#skip(long)] over the *filtered* row-group
+        /// sequence — `skip(N)` skips `N` rows of the kept set, `head(N)` caps at `N`
         /// rows of the kept set. Mutually exclusive with [#tail(long)] (tail mode requires
         /// a known total row count, which row-group filtering invalidates).
         public RowReaderBuilder filter(RowGroupPredicate rowGroupFilter) {
@@ -562,7 +562,7 @@ public class ParquetFileReader implements AutoCloseable {
         /// Limit to the last `tailRows` rows. Row groups that do not overlap
         /// the tail are skipped entirely, so pages for earlier row groups are
         /// never fetched or decoded — useful on remote backends. Mutually
-        /// exclusive with [#head], [#filter], and [#firstRow]. Single-file only.
+        /// exclusive with [#head], [#filter], and [#skip]. Single-file only.
         public RowReaderBuilder tail(long tailRows) {
             if (tailRows <= 0) {
                 throw new IllegalArgumentException("tail row count must be positive: " + tailRows);
@@ -578,23 +578,23 @@ public class ParquetFileReader implements AutoCloseable {
         ///
         /// **Cost within the target row group.** The reader still yields
         /// rows from the row group's first row, then walks `next()`
-        /// `firstRow - rowGroupFirstRow` times to discard the leading
-        /// residue. Those residue rows *are* decoded — `firstRow` near
+        /// `skip - rowGroupFirstRow` times to discard the leading
+        /// residue. Those residue rows *are* decoded — `skip` near
         /// the end of a 1 M-row group walks ~1 M decoded `next()` calls.
         /// Page-level skip via OffsetIndex is tracked as #381.
         ///
-        /// `firstRow == 0` is the no-op default. `firstRow == totalRows`
-        /// produces an empty reader. `firstRow > totalRows` throws
+        /// `skip == 0` is the no-op default. `skip == totalRows`
+        /// produces an empty reader. `skip > totalRows` throws
         /// [IllegalArgumentException] at `build()` time. Indexes into the
         /// *first* file's rows for multi-file readers; cross-file
-        /// `firstRow` is out of scope. Mutually exclusive with [#tail];
+        /// `skip` is out of scope. Mutually exclusive with [#tail];
         /// composes with [#head] for a bounded
-        /// `[firstRow, firstRow + maxRows)` window.
-        public RowReaderBuilder firstRow(long firstRow) {
-            if (firstRow < 0) {
-                throw new IllegalArgumentException("firstRow must be non-negative: " + firstRow);
+        /// `[skip, skip + maxRows)` window.
+        public RowReaderBuilder skip(long skip) {
+            if (skip < 0) {
+                throw new IllegalArgumentException("skip must be non-negative: " + skip);
             }
-            this.firstRow = firstRow;
+            this.skip = skip;
             return this;
         }
 
@@ -612,14 +612,14 @@ public class ParquetFileReader implements AutoCloseable {
                                 + "tail mode requires a known total row count, which row-group "
                                 + "filtering invalidates");
             }
-            if (tailRows > 0 && firstRow > 0) {
-                throw new IllegalArgumentException("tail and firstRow are mutually exclusive");
+            if (tailRows > 0 && skip > 0) {
+                throw new IllegalArgumentException("tail and skip are mutually exclusive");
             }
             if (tailRows > 0) {
                 return fileReader.buildTailRowReader(projection, tailRows);
             }
             return fileReader.buildRowReader(
-                    projection, filter, rowGroupFilter, headRows, firstRow);
+                    projection, filter, rowGroupFilter, headRows, skip);
         }
     }
 

--- a/core/src/test/java/dev/hardwood/ParquetReaderTest.java
+++ b/core/src/test/java/dev/hardwood/ParquetReaderTest.java
@@ -468,12 +468,12 @@ class ParquetReaderTest {
     }
 
     @Test
-    void firstRowSkipsEarlierRowGroups() throws Exception {
+    void skipSeeksPastEarlierRowGroups() throws Exception {
         // filter_pushdown_int.parquet: 3 row groups of 100 rows each — id 1..100, 101..200, 201..300.
         Path parquetFile = Paths.get("src/test/resources/filter_pushdown_int.parquet");
 
         try (ParquetFileReader reader = ParquetFileReader.open(InputFile.of(parquetFile));
-             RowReader rows = reader.buildRowReader().firstRow(150).build()) {
+             RowReader rows = reader.buildRowReader().skip(150).build()) {
             long firstId = -1;
             long lastId = -1;
             int count = 0;
@@ -486,21 +486,21 @@ class ParquetReaderTest {
                 lastId = id;
                 count++;
             }
-            // firstRow=150 lands inside RG 1 (rows 100..199, ids 101..200)
+            // skip=150 lands inside RG 1 (rows 100..199, ids 101..200)
             // at within-RG offset 50 → first id yielded is 151.
-            assertThat(count).as("rows from firstRow=150").isEqualTo(150);
-            assertThat(firstId).as("first id at firstRow=150").isEqualTo(151L);
+            assertThat(count).as("rows from skip=150").isEqualTo(150);
+            assertThat(firstId).as("first id at skip=150").isEqualTo(151L);
             assertThat(lastId).as("last id at file end").isEqualTo(300L);
         }
     }
 
     @Test
-    void firstRowAtRowGroupBoundary() throws Exception {
-        // firstRow=100 lands at the exact start of RG 1.
+    void skipAtRowGroupBoundary() throws Exception {
+        // skip=100 lands at the exact start of RG 1.
         Path parquetFile = Paths.get("src/test/resources/filter_pushdown_int.parquet");
 
         try (ParquetFileReader reader = ParquetFileReader.open(InputFile.of(parquetFile));
-             RowReader rows = reader.buildRowReader().firstRow(100).build()) {
+             RowReader rows = reader.buildRowReader().skip(100).build()) {
             int count = 0;
             long firstId = -1;
             while (rows.hasNext()) {
@@ -516,12 +516,12 @@ class ParquetReaderTest {
     }
 
     @Test
-    void firstRowComposesWithHead() throws Exception {
-        // firstRow=150 + head(20) → rows 150..169 → ids 151..170.
+    void skipComposesWithHead() throws Exception {
+        // skip=150 + head(20) → rows 150..169 → ids 151..170.
         Path parquetFile = Paths.get("src/test/resources/filter_pushdown_int.parquet");
 
         try (ParquetFileReader reader = ParquetFileReader.open(InputFile.of(parquetFile));
-             RowReader rows = reader.buildRowReader().firstRow(150).head(20).build()) {
+             RowReader rows = reader.buildRowReader().skip(150).head(20).build()) {
             long firstId = -1;
             long lastId = -1;
             int count = 0;
@@ -541,33 +541,33 @@ class ParquetReaderTest {
     }
 
     @Test
-    void firstRowAtTotalRowsYieldsEmpty() throws Exception {
+    void skipAtTotalRowsYieldsEmpty() throws Exception {
         Path parquetFile = Paths.get("src/test/resources/filter_pushdown_int.parquet");
 
         try (ParquetFileReader reader = ParquetFileReader.open(InputFile.of(parquetFile))) {
             long total = reader.getFileMetaData().numRows();
-            try (RowReader rows = reader.buildRowReader().firstRow(total).build()) {
+            try (RowReader rows = reader.buildRowReader().skip(total).build()) {
                 assertThat(rows.hasNext()).isFalse();
             }
         }
     }
 
     @Test
-    void firstRowRejectsNegative() throws Exception {
+    void skipRejectsNegative() throws Exception {
         Path parquetFile = Paths.get("src/test/resources/filter_pushdown_int.parquet");
 
         try (ParquetFileReader reader = ParquetFileReader.open(InputFile.of(parquetFile))) {
-            assertThatThrownBy(() -> reader.buildRowReader().firstRow(-1).build())
+            assertThatThrownBy(() -> reader.buildRowReader().skip(-1).build())
                     .isInstanceOf(IllegalArgumentException.class);
         }
     }
 
     @Test
-    void firstRowAndTailAreMutuallyExclusive() throws Exception {
+    void skipAndTailAreMutuallyExclusive() throws Exception {
         Path parquetFile = Paths.get("src/test/resources/filter_pushdown_int.parquet");
 
         try (ParquetFileReader reader = ParquetFileReader.open(InputFile.of(parquetFile))) {
-            assertThatThrownBy(() -> reader.buildRowReader().firstRow(100).tail(10L).build())
+            assertThatThrownBy(() -> reader.buildRowReader().skip(100).tail(10L).build())
                     .isInstanceOf(IllegalArgumentException.class);
         }
     }

--- a/core/src/test/java/dev/hardwood/RowGroupFilterTest.java
+++ b/core/src/test/java/dev/hardwood/RowGroupFilterTest.java
@@ -214,14 +214,14 @@ class RowGroupFilterTest {
     }
 
     @Test
-    void rowReaderFirstRowIndexesIntoFilteredSequence() throws Exception {
-        // RowGroupPredicate keeps rg1+rg2 (rows 101..300 in id order). firstRow(10) skips
+    void rowReaderSkipIndexesIntoFilteredSequence() throws Exception {
+        // RowGroupPredicate keeps rg1+rg2 (rows 101..300 in id order). skip(10) skips
         // 10 rows of the kept set, so we resume at id 111.
         try (ParquetFileReader reader = ParquetFileReader.open(InputFile.of(FIXTURE));
              RowReader rows = reader.buildRowReader()
                      .projection(ColumnProjection.columns("id"))
                      .filter(RowGroupPredicate.byteRange(rg1Mid, fileLen))
-                     .firstRow(10)
+                     .skip(10)
                      .build()) {
             assertThat(rows.hasNext()).isTrue();
             rows.next();

--- a/docs/content/how-to/query-controls.md
+++ b/docs/content/how-to/query-controls.md
@@ -247,7 +247,7 @@ try (ParquetFileReader fileReader = ParquetFileReader.open(InputFile.of(path));
 
 A row group is included if and only if its **midpoint** — the start of its first column chunk plus half of its on-disk compressed size — falls in `[start, end)`. This is the standard Hadoop-input-format split convention: across a partitioning of the file into disjoint byte ranges, every row group lands in exactly one range, regardless of where the split boundary falls inside the row group itself.
 
-**Granularity is row-group, not row.** A row group whose midpoint is in `[0, 1000)` is read in full, including any rows whose data extends beyond byte 1000. If you need true row-level windowing, combine `RowGroupPredicate` with [`RowReaderBuilder.firstRow(...)`](#seeking-to-an-absolute-row) and [`head(...)`](#row-limit).
+**Granularity is row-group, not row.** A row group whose midpoint is in `[0, 1000)` is read in full, including any rows whose data extends beyond byte 1000. If you need true row-level windowing, combine `RowGroupPredicate` with [`RowReaderBuilder.skip(...)`](#seeking-to-an-absolute-row) and [`head(...)`](#row-limit).
 
 `RowGroupPredicate` composes with [`FilterPredicate`](#predicate-pushdown-filter) via intersection — both apply, and a row group is read if and only if it passes both:
 
@@ -266,7 +266,7 @@ ColumnReader col = fileReader.buildColumnReader("price")
         RowGroupPredicate.byteRange(otherStart, otherEnd)))
 ```
 
-The same `filter(RowGroupPredicate)` overload is available on `RowReaderBuilder` and `ColumnReadersBuilder`. On `RowReaderBuilder`, `firstRow(N)` and `head(N)` index over the *row-group-filtered* sequence — `firstRow(N)` skips `N` rows of the kept set, `head(N)` caps reading at `N` rows of the kept set. Combining `RowGroupPredicate` with `tail(N)` is rejected: tail mode requires a known total row count, which row-group filtering invalidates.
+The same `filter(RowGroupPredicate)` overload is available on `RowReaderBuilder` and `ColumnReadersBuilder`. On `RowReaderBuilder`, `skip(N)` and `head(N)` index over the *row-group-filtered* sequence — `skip(N)` skips `N` rows of the kept set, `head(N)` caps reading at `N` rows of the kept set. Combining `RowGroupPredicate` with `tail(N)` is rejected: tail mode requires a known total row count, which row-group filtering invalidates.
 
 ### Empty ranges
 
@@ -288,16 +288,16 @@ try (ParquetFileReader fileReader = ParquetFileReader.open(InputFile.of(path));
 }
 ```
 
-Tail mode cannot currently be combined with a filter predicate — the set of matching rows is not known from row-group statistics alone, so the reader cannot identify which row groups cover the last N matching rows without scanning the whole file. It is also mutually exclusive with `firstRow(long)`.
+Tail mode cannot currently be combined with a filter predicate — the set of matching rows is not known from row-group statistics alone, so the reader cannot identify which row groups cover the last N matching rows without scanning the whole file. It is also mutually exclusive with `skip(long)`.
 
 ### Seeking to an Absolute Row
 
-The `firstRow(long)` builder method begins iteration at an arbitrary absolute row index. Earlier row groups are not opened — their pages are not fetched or decoded — making this an O(1 row group) seek on remote backends, in contrast to walking `next()` from row 0.
+The `skip(long)` builder method begins iteration at an arbitrary absolute row index. Earlier row groups are not opened — their pages are not fetched or decoded — making this an O(1 row group) seek on remote backends, in contrast to walking `next()` from row 0.
 
 ```java
 // Read rows starting at row 1,000,000 — earlier row groups are skipped.
 try (ParquetFileReader fileReader = ParquetFileReader.open(InputFile.of(path));
-     RowReader rowReader = fileReader.buildRowReader().firstRow(1_000_000).build()) {
+     RowReader rowReader = fileReader.buildRowReader().skip(1_000_000).build()) {
 
     while (rowReader.hasNext()) {
         rowReader.next();
@@ -306,23 +306,23 @@ try (ParquetFileReader fileReader = ParquetFileReader.open(InputFile.of(path));
 }
 ```
 
-Compose with `head(N)` for a bounded `[firstRow, firstRow + N)` window:
+Compose with `head(N)` for a bounded `[skip, skip + N)` window:
 
 ```java
 // Read rows [1_000_000, 1_000_050).
 try (ParquetFileReader fileReader = ParquetFileReader.open(InputFile.of(path));
      RowReader rowReader = fileReader.buildRowReader()
-             .firstRow(1_000_000)
+             .skip(1_000_000)
              .head(50)
              .build()) {
     // ...
 }
 ```
 
-`firstRow == 0` is the no-op default. `firstRow == totalRows` produces an empty reader; `firstRow > totalRows` throws `IllegalArgumentException`. Mutually exclusive with `tail(N)`.
+`skip == 0` is the no-op default. `skip == totalRows` produces an empty reader; `skip > totalRows` throws `IllegalArgumentException`. Mutually exclusive with `tail(N)`.
 
 !!! warning "Multi-file readers: first file only"
-    For multi-file readers, `firstRow(N)` indexes into the **first** file's rows only — it does not seek across file boundaries. To skip whole files, omit them from the input list; to skip within a non-first file, open it separately.
+    For multi-file readers, `skip(N)` indexes into the **first** file's rows only — it does not seek across file boundaries. To skip whole files, omit them from the input list; to skip within a non-first file, open it separately.
 
 Within the target row group, the reader still decodes the leading residue rows and discards them via `next()`. Page-level skip via the OffsetIndex is tracked separately.
 


### PR DESCRIPTION
I think `skip()` is a better name for what this method does, avoiding the "physical" semantics suggested by `firstRow()`. Also adding a design doc for putting a system behind #538, #541, #542.