### PR TITLE
#533 Keep CLI-only dependencies out of the published BOM

### DIFF
--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -50,41 +50,6 @@
 
   <dependencyManagement>
     <dependencies>
-      <!-- TamboUI (TUI library; the upstream tamboui-bom omits widgets/tui, pin directly) -->
-      <dependency>
-        <groupId>dev.tamboui</groupId>
-        <artifactId>tamboui-core</artifactId>
-        <version>0.2.0</version>
-      </dependency>
-      <dependency>
-        <groupId>dev.tamboui</groupId>
-        <artifactId>tamboui-widgets</artifactId>
-        <version>0.2.0</version>
-      </dependency>
-      <dependency>
-        <groupId>dev.tamboui</groupId>
-        <artifactId>tamboui-tui</artifactId>
-        <version>0.2.0</version>
-      </dependency>
-      <dependency>
-        <groupId>dev.tamboui</groupId>
-        <artifactId>tamboui-jline3-backend</artifactId>
-        <version>0.2.0</version>
-      </dependency>
-
-      <!-- JLine — sub-modules (not the fat bundle) so native-image doesn't try to
-           parse the JNA / Jansi provider factories that reference libs we don't ship. -->
-      <dependency>
-        <groupId>org.jline</groupId>
-        <artifactId>jline-terminal</artifactId>
-        <version>3.25.1</version>
-      </dependency>
-      <dependency>
-        <groupId>org.jline</groupId>
-        <artifactId>jline-terminal-jni</artifactId>
-        <version>3.25.1</version>
-      </dependency>
-
       <!-- Hardwood modules -->
       <dependency>
         <groupId>dev.hardwood</groupId>

--- a/cli/pom.xml
+++ b/cli/pom.xml
@@ -71,6 +71,49 @@
         <type>pom</type>
         <scope>import</scope>
       </dependency>
+
+      <!-- ASCII table rendering for command output -->
+      <dependency>
+        <groupId>com.github.freva</groupId>
+        <artifactId>ascii-table</artifactId>
+        <version>1.8.0</version>
+      </dependency>
+
+      <!-- TamboUI (TUI library for the `dive` subcommand; the upstream tamboui-bom
+           omits widgets/tui, pin directly) -->
+      <dependency>
+        <groupId>dev.tamboui</groupId>
+        <artifactId>tamboui-core</artifactId>
+        <version>0.2.0</version>
+      </dependency>
+      <dependency>
+        <groupId>dev.tamboui</groupId>
+        <artifactId>tamboui-widgets</artifactId>
+        <version>0.2.0</version>
+      </dependency>
+      <dependency>
+        <groupId>dev.tamboui</groupId>
+        <artifactId>tamboui-tui</artifactId>
+        <version>0.2.0</version>
+      </dependency>
+      <dependency>
+        <groupId>dev.tamboui</groupId>
+        <artifactId>tamboui-jline3-backend</artifactId>
+        <version>0.2.0</version>
+      </dependency>
+
+      <!-- JLine — sub-modules (not the fat bundle) so native-image doesn't try to
+           parse the JNA / Jansi provider factories that reference libs we don't ship. -->
+      <dependency>
+        <groupId>org.jline</groupId>
+        <artifactId>jline-terminal</artifactId>
+        <version>3.25.1</version>
+      </dependency>
+      <dependency>
+        <groupId>org.jline</groupId>
+        <artifactId>jline-terminal-jni</artifactId>
+        <version>3.25.1</version>
+      </dependency>
     </dependencies>
   </dependencyManagement>
 

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -34,6 +34,13 @@
     <dependencies>
       <dependency>
         <groupId>dev.hardwood</groupId>
+        <artifactId>hardwood-bom</artifactId>
+        <version>${project.version}</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
+      <dependency>
+        <groupId>dev.hardwood</groupId>
         <artifactId>hardwood-test-bom</artifactId>
         <version>${project.version}</version>
         <type>pom</type>

--- a/pom.xml
+++ b/pom.xml
@@ -73,36 +73,6 @@
     <project.build.outputTimestamp>2026-05-31T18:50:14Z</project.build.outputTimestamp>
   </properties>
 
-  <dependencyManagement>
-    <dependencies>
-      <dependency>
-        <groupId>org.xerial.snappy</groupId>
-        <artifactId>snappy-java</artifactId>
-        <version>1.1.10.8</version>
-      </dependency>
-      <dependency>
-        <groupId>com.github.luben</groupId>
-        <artifactId>zstd-jni</artifactId>
-        <version>1.5.7-6</version>
-      </dependency>
-      <dependency>
-        <groupId>at.yawk.lz4</groupId>
-        <artifactId>lz4-java</artifactId>
-        <version>1.8.1</version>
-      </dependency>
-      <dependency>
-        <groupId>com.aayushatharva.brotli4j</groupId>
-        <artifactId>brotli4j</artifactId>
-        <version>1.20.0</version>
-      </dependency>
-      <dependency>
-        <groupId>com.github.freva</groupId>
-        <artifactId>ascii-table</artifactId>
-        <version>1.8.0</version>
-      </dependency>
-    </dependencies>
-  </dependencyManagement>
-
   <build>
     <!-- Keep alphabetic order -->
     <pluginManagement>


### PR DESCRIPTION
The published BOM exists to align versions for Hardwood library users. Its flatten configuration resolves the effective dependency management, so anything declared in the parent pom's dependencyManagement is baked into the released BOM too — not just what the BOM module lists directly.

That had two consequences. The CLI-only TUI stack (TamboUI, the JLine sub-modules) and ascii-table were imposed on library users who never pull the CLI; they now live in the cli module's own dependencyManagement, reachable by the one module that needs them and invisible to the BOM.

And the optional compression libraries, while legitimately consumer-facing, were declared both in the BOM and in the parent (whence core and friends inherited them), leaving two places to sync. They had already drifted — the parent pinned lz4-java 1.8.1 while the BOM advertised 1.10.1, so the build tested against a different version than users were told to use. The compression versions now live only in the BOM, which core imports like the other modules already do, making the BOM a single curated artifact rather than a duplicate of parent state (#534).