### PR TITLE
#534 update deps

### DIFF
--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -86,17 +86,17 @@
       <dependency>
         <groupId>com.github.luben</groupId>
         <artifactId>zstd-jni</artifactId>
-        <version>1.5.7-6</version>
+        <version>1.5.7-9</version>
       </dependency>
       <dependency>
         <groupId>at.yawk.lz4</groupId>
         <artifactId>lz4-java</artifactId>
-        <version>1.10.1</version>
+        <version>1.11.0</version>
       </dependency>
       <dependency>
         <groupId>com.aayushatharva.brotli4j</groupId>
         <artifactId>brotli4j</artifactId>
-        <version>1.20.0</version>
+        <version>1.23.0</version>
       </dependency>
     </dependencies>
   </dependencyManagement>

--- a/test-bom/pom.xml
+++ b/test-bom/pom.xml
@@ -44,22 +44,22 @@
       <dependency>
         <groupId>org.apache.logging.log4j</groupId>
         <artifactId>log4j-api</artifactId>
-        <version>2.24.3</version>
+        <version>2.25.4</version>
       </dependency>
       <dependency>
         <groupId>org.apache.logging.log4j</groupId>
         <artifactId>log4j-core</artifactId>
-        <version>2.24.3</version>
+        <version>2.25.4</version>
       </dependency>
       <dependency>
         <groupId>org.apache.logging.log4j</groupId>
         <artifactId>log4j-jpl</artifactId>
-        <version>2.24.3</version>
+        <version>2.25.4</version>
       </dependency>
       <dependency>
         <groupId>org.apache.logging.log4j</groupId>
         <artifactId>log4j-slf4j2-impl</artifactId>
-        <version>2.24.3</version>
+        <version>2.25.4</version>
       </dependency>
 
       <!-- Parquet reference implementation -->


### PR DESCRIPTION
Staying conservative here; just updating the optional compression libs to the latest (as they are in the BOM) and log4j has a CVE.