### PR TITLE
#560 Return S3InputFile from S3Source factory methods

### DIFF
--- a/cli/src/main/java/dev/hardwood/cli/dive/ParquetModel.java
+++ b/cli/src/main/java/dev/hardwood/cli/dive/ParquetModel.java
@@ -23,7 +23,6 @@ import dev.hardwood.internal.reader.ColumnIndexBuffers;
 import dev.hardwood.internal.reader.Dictionary;
 import dev.hardwood.internal.reader.DictionaryParser;
 import dev.hardwood.internal.reader.HardwoodContextImpl;
-import dev.hardwood.internal.reader.RangeBackedInputFile;
 import dev.hardwood.internal.reader.RowGroupIndexBuffers;
 import dev.hardwood.internal.thrift.ColumnIndexReader;
 import dev.hardwood.internal.thrift.OffsetIndexReader;
@@ -334,14 +333,10 @@ public final class ParquetModel implements AutoCloseable {
     }
 
     /// Network usage of the underlying [InputFile] for this session.
-    /// Returns `null` for local files; for [S3InputFile] (possibly
-    /// behind a [RangeBackedInputFile] decorator) returns a live
+    /// Returns `null` for local files; for [S3InputFile] returns a live
     /// snapshot of request count and bytes fetched since `open()`.
     public NetStats netStats() {
-        InputFile inner = inputFile instanceof RangeBackedInputFile rbf
-                ? rbf.delegate()
-                : inputFile;
-        if (inner instanceof S3InputFile s3) {
+        if (inputFile instanceof S3InputFile s3) {
             return new NetStats(s3.networkRequestCount(), s3.networkBytesFetched());
         }
         return null;

--- a/core/src/main/java/dev/hardwood/Hardwood.java
+++ b/core/src/main/java/dev/hardwood/Hardwood.java
@@ -51,7 +51,7 @@ public class Hardwood implements AutoCloseable {
     /// @param inputFiles the input files to read (must not be empty)
     /// @throws IOException if the first file cannot be opened or read
     /// @throws IllegalArgumentException if the list is empty
-    public ParquetFileReader openAll(List<InputFile> inputFiles) throws IOException {
+    public ParquetFileReader openAll(List<? extends InputFile> inputFiles) throws IOException {
         return ParquetFileReader.openAll(inputFiles, context);
     }
 

--- a/core/src/main/java/dev/hardwood/reader/ParquetFileReader.java
+++ b/core/src/main/java/dev/hardwood/reader/ParquetFileReader.java
@@ -100,16 +100,16 @@ public class ParquetFileReader implements AutoCloseable {
     /// is read from the first file and is assumed to be common across all
     /// files. Files are opened on demand by the iterator; the first file is
     /// opened eagerly so any I/O or metadata error surfaces immediately.
-    public static ParquetFileReader openAll(List<InputFile> inputFiles) throws IOException {
+    public static ParquetFileReader openAll(List<? extends InputFile> inputFiles) throws IOException {
         return openInternal(inputFiles, HardwoodContextImpl.create(), true);
     }
 
     /// Open multiple Parquet files with a shared context.
-    public static ParquetFileReader openAll(List<InputFile> inputFiles, HardwoodContext context) throws IOException {
+    public static ParquetFileReader openAll(List<? extends InputFile> inputFiles, HardwoodContext context) throws IOException {
         return openInternal(inputFiles, (HardwoodContextImpl) context, false);
     }
 
-    private static ParquetFileReader openInternal(List<InputFile> inputFiles, HardwoodContextImpl context,
+    private static ParquetFileReader openInternal(List<? extends InputFile> inputFiles, HardwoodContextImpl context,
                                                    boolean ownsContext) throws IOException {
         if (inputFiles == null || inputFiles.isEmpty()) {
             throw new IllegalArgumentException("At least one file must be provided");

--- a/docs/content/concepts/parquet-layout.md
+++ b/docs/content/concepts/parquet-layout.md
@@ -83,10 +83,11 @@ records each chunk's compressed and uncompressed size, codec, and statistics.
 !!! info "2 GB column-chunk limit"
     A column chunk is addressed within Hardwood as a single in-memory region, so each chunk must
     be at most 2 GB of *compressed* data — the limit is per chunk, not per file. Local
-    memory-mapped files may be arbitrarily large overall; the in-memory (`ByteBuffer`) and
-    object-store backends additionally cap the *whole file* at 2 GB. Datasets larger than that
-    are split across multiple files and read together — see
-    [Read Multiple Files as One Dataset](../how-to/multi-file.md).
+    memory-mapped files and S3-backed files may be arbitrarily large overall; the in-memory
+    (`ByteBuffer`) backend additionally caps the *whole file* at 2 GB, and the `dive` TUI caps
+    S3 files at 2 GB because its mmap-backed range cache uses `MappedByteBuffer`. For datasets
+    that don't fit a single supported file, split the data into multiple files at write time and
+    read them as one — see [Read Multiple Files as One Dataset](../how-to/multi-file.md).
 
 ### Page
 

--- a/docs/content/how-to/s3.md
+++ b/docs/content/how-to/s3.md
@@ -190,12 +190,12 @@ Note that without a `maxRows` limit, the reader fetches all projected (and filte
 
 ### Measuring Fetch Cost
 
-Each `S3InputFile` tracks the network I/O it has performed, which is useful for confirming that column projection, predicate pushdown, and `maxRows` actually reduced transfer — and for estimating S3 cost (GET requests plus bytes transferred). `S3Source.inputFile(...)` returns the `InputFile` supertype, so cast to `S3InputFile` to read the counters:
+Each `S3InputFile` tracks the network I/O it has performed, which is useful for confirming that column projection, predicate pushdown, and `maxRows` actually reduced transfer — and for estimating S3 cost (GET requests plus bytes transferred):
 
 ```java
 import dev.hardwood.s3.S3InputFile;
 
-try (S3InputFile in = (S3InputFile) source.inputFile("s3://my-bucket/data/trips.parquet");
+try (S3InputFile in = source.inputFile("s3://my-bucket/data/trips.parquet");
      ParquetFileReader reader = ParquetFileReader.open(in);
      RowReader rows = reader.rowReader()) {
     while (rows.hasNext()) {

--- a/docs/content/index.md
+++ b/docs/content/index.md
@@ -47,11 +47,12 @@ try (ParquetFileReader fileReader = ParquetFileReader.open(InputFile.of(path));
 
 Ready? [Install Hardwood](getting-started.md), then read [your first file end-to-end](tutorial/first-read.md).
 
-## Status
+## Status and Limitations
 
 This is Beta quality software, under active development.
 
-Reading from S3 or an in-memory `ByteBuffer` currently caps a file at 2 GB; split larger datasets across multiple files (local memory-mapped reads have no whole-file size limit). See [Parquet file layout](concepts/parquet-layout.md).
+The Hardwood library supports reading arbitrarily large Parquet files, provided individual column chunks are not larger than 2 GB (see [Parquet file layout](concepts/parquet-layout.md)).
+The interactive `dive` TUI currently caps S3 files at 2 GB.
 
 ## Roadmap
 

--- a/s3/src/main/java/dev/hardwood/s3/S3InputFile.java
+++ b/s3/src/main/java/dev/hardwood/s3/S3InputFile.java
@@ -11,10 +11,12 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.net.http.HttpResponse;
 import java.nio.ByteBuffer;
+import java.nio.file.Path;
 import java.util.concurrent.atomic.AtomicLong;
 
 import dev.hardwood.InputFile;
 import dev.hardwood.internal.FetchReason;
+import dev.hardwood.internal.reader.RangeBackedInputFile;
 import dev.hardwood.s3.internal.S3Api;
 
 /// [InputFile] backed by an object in Amazon S3 (or an S3-compatible service).
@@ -26,6 +28,13 @@ import dev.hardwood.s3.internal.S3Api;
 /// discovers the file length from the `Content-Range` response header
 /// and pre-fetches the Parquet footer (which sits at the end of the file) in
 /// the same round-trip — eliminating a separate HEAD request per file.
+///
+/// When the owning [S3Source] is configured with
+/// [RangeBacking#SPARSE_TEMPFILE], an internal mmap-backed range cache
+/// serves repeat reads of the same byte ranges without re-issuing HTTP
+/// requests. The cache is invisible at the API surface — the same
+/// counters ([#networkRequestCount], [#networkBytesFetched]) reflect
+/// only network traffic in either mode.
 ///
 /// Thread-safe once [#open()] has been called.
 public class S3InputFile implements InputFile {
@@ -45,15 +54,40 @@ public class S3InputFile implements InputFile {
     private long tailCacheOffset;
     private final AtomicLong networkRequestCount = new AtomicLong();
     private final AtomicLong networkBytesFetched = new AtomicLong();
+    /// Non-null iff the owning [S3Source] was configured with
+    /// [RangeBacking#SPARSE_TEMPFILE]. Wraps a private adapter that
+    /// exposes the bare S3 fetch path, so cache hits don't re-enter
+    /// [#readRange] (and thus don't double-count network counters).
+    private final RangeBackedInputFile cache;
 
     S3InputFile(S3Source source, String bucket, String key) {
         this.api = source.api();
         this.bucket = bucket;
         this.key = key;
+        Path tempDir = source.rangeBacking() == RangeBacking.SPARSE_TEMPFILE
+                ? source.tempDir()
+                : null;
+        this.cache = tempDir != null ? new RangeBackedInputFile(new BareFetcher(), tempDir) : null;
     }
 
     @Override
     public void open() throws IOException {
+        if (cache != null) {
+            cache.open();
+            return;
+        }
+        openBare();
+    }
+
+    @Override
+    public ByteBuffer readRange(long offset, int length) throws IOException {
+        if (cache != null) {
+            return cache.readRange(offset, length);
+        }
+        return readRangeBare(offset, length);
+    }
+
+    private void openBare() throws IOException {
         if (fileLength >= 0) {
             return;
         }
@@ -77,8 +111,7 @@ public class S3InputFile implements InputFile {
         logFetch("open-tail", tailCacheOffset, tail.length, requestNo, totalBytes);
     }
 
-    @Override
-    public ByteBuffer readRange(long offset, int length) throws IOException {
+    private ByteBuffer readRangeBare(long offset, int length) throws IOException {
         // Serve from the tail cache if the requested range falls within it
         if (tailCache != null && offset >= tailCacheOffset
                 && offset + length <= tailCacheOffset + tailCache.capacity()) {
@@ -135,8 +168,10 @@ public class S3InputFile implements InputFile {
     }
 
     @Override
-    public void close() {
-        // S3Source owns the HttpClient — nothing to close here
+    public void close() throws IOException {
+        if (cache != null) {
+            cache.close();
+        }
     }
 
     /// Number of HTTP requests issued against the object since [#open()].
@@ -190,5 +225,38 @@ public class S3InputFile implements InputFile {
         }
         return response.headers().firstValueAsLong("Content-Length")
                 .orElseThrow(() -> new IOException("Response missing both Content-Range and Content-Length headers"));
+    }
+
+    /// Bare-fetch adapter handed to the [RangeBackedInputFile] cache so
+    /// the cache delegates back into the enclosing [S3InputFile]'s
+    /// network path *without* recursing through [#readRange] (which
+    /// would short-circuit to the cache again). The adapter's
+    /// [#close()] is a no-op because the enclosing instance owns no
+    /// per-file resources to release.
+    private final class BareFetcher implements InputFile {
+
+        @Override
+        public void open() throws IOException {
+            openBare();
+        }
+
+        @Override
+        public ByteBuffer readRange(long offset, int length) throws IOException {
+            return readRangeBare(offset, length);
+        }
+
+        @Override
+        public long length() {
+            return S3InputFile.this.length();
+        }
+
+        @Override
+        public String name() {
+            return S3InputFile.this.name();
+        }
+
+        @Override
+        public void close() {
+        }
     }
 }

--- a/s3/src/main/java/dev/hardwood/s3/S3Source.java
+++ b/s3/src/main/java/dev/hardwood/s3/S3Source.java
@@ -16,8 +16,6 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
 
-import dev.hardwood.InputFile;
-import dev.hardwood.internal.reader.RangeBackedInputFile;
 import dev.hardwood.s3.internal.S3Api;
 
 /// A configured connection to an S3-compatible object store.
@@ -46,32 +44,29 @@ public final class S3Source implements Closeable {
         this.tempDir = tempDir;
     }
 
-    /// Creates an [InputFile] for the given bucket and key. Returns an
-    /// [S3InputFile] when range backing is [RangeBacking#NONE] (the
-    /// default); otherwise wraps that bare file in a
-    /// [RangeBackedInputFile] so repeated reads of the same byte range
-    /// hit the local mapping.
-    public InputFile inputFile(String bucket, String key) {
+    /// Creates an [S3InputFile] for the given bucket and key. When the
+    /// source is configured with [RangeBacking#SPARSE_TEMPFILE], the
+    /// returned file transparently caches fetched byte ranges in a
+    /// mmap-backed sparse temp file; the cache is an internal
+    /// implementation detail and does not change the returned type.
+    public S3InputFile inputFile(String bucket, String key) {
         Objects.requireNonNull(bucket, "bucket must not be null");
         Objects.requireNonNull(key, "key must not be null");
-        S3InputFile bare = new S3InputFile(this, bucket, key);
-        return rangeBacking == RangeBacking.SPARSE_TEMPFILE
-                ? new RangeBackedInputFile(bare, tempDir)
-                : bare;
+        return new S3InputFile(this, bucket, key);
     }
 
-    /// Creates an [InputFile] from an `s3://bucket/key` URI. See
+    /// Creates an [S3InputFile] from an `s3://bucket/key` URI. See
     /// [#inputFile(String, String)] for the [RangeBacking] policy.
-    public InputFile inputFile(String uri) {
+    public S3InputFile inputFile(String uri) {
         Objects.requireNonNull(uri, "uri must not be null");
         String[] parsed = parseS3Uri(uri);
         return inputFile(parsed[0], parsed[1]);
     }
 
-    /// Creates [InputFile] instances for multiple keys in the same bucket.
-    public List<InputFile> inputFilesInBucket(String bucket, String... keys) {
+    /// Creates [S3InputFile] instances for multiple keys in the same bucket.
+    public List<S3InputFile> inputFilesInBucket(String bucket, String... keys) {
         Objects.requireNonNull(bucket, "bucket must not be null");
-        List<InputFile> files = new ArrayList<>(keys.length);
+        List<S3InputFile> files = new ArrayList<>(keys.length);
         for (String key : keys) {
             Objects.requireNonNull(key, "key must not be null");
             files.add(inputFile(bucket, key));
@@ -79,9 +74,9 @@ public final class S3Source implements Closeable {
         return files;
     }
 
-    /// Creates [InputFile] instances from `s3://` URIs (may span buckets).
-    public List<InputFile> inputFiles(String... uris) {
-        List<InputFile> files = new ArrayList<>(uris.length);
+    /// Creates [S3InputFile] instances from `s3://` URIs (may span buckets).
+    public List<S3InputFile> inputFiles(String... uris) {
+        List<S3InputFile> files = new ArrayList<>(uris.length);
         for (String uri : uris) {
             Objects.requireNonNull(uri, "uri must not be null");
             files.add(inputFile(uri));
@@ -91,6 +86,14 @@ public final class S3Source implements Closeable {
 
     S3Api api() {
         return api;
+    }
+
+    RangeBacking rangeBacking() {
+        return rangeBacking;
+    }
+
+    Path tempDir() {
+        return tempDir;
     }
 
     @Override

--- a/s3/src/test/java/dev/hardwood/s3/S3InputFileLargeFileTest.java
+++ b/s3/src/test/java/dev/hardwood/s3/S3InputFileLargeFileTest.java
@@ -1,0 +1,123 @@
+/*
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Copyright The original authors
+ *
+ *  Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package dev.hardwood.s3;
+
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
+
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.testcontainers.containers.Container.ExecResult;
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/// Verifies that [S3InputFile] reads files larger than 2 GB from S3.
+///
+/// The file length, the tail cache offset, and every byte-range offset are
+/// `long`-typed in the bare network path, so an offset past
+/// [Integer#MAX_VALUE] resolves to the right bytes rather than wrapping. The
+/// 2 GB cap [RangeBackedInputFile] enforces only kicks in under
+/// [RangeBacking#SPARSE_TEMPFILE], which this test does *not* opt into.
+///
+/// The test object is sparse-truncated inside the s3proxy container so the
+/// 2 GB file costs kilobytes on disk and milliseconds to create.
+@Testcontainers
+class S3InputFileLargeFileTest {
+
+    private static final long TWO_GB = (long) Integer.MAX_VALUE + 1; // 2_147_483_648
+
+    private static final byte[] AT_ZERO = "START-OF-FILE---".getBytes(StandardCharsets.US_ASCII);
+    private static final byte[] STRADDLE = "STRADDLE-2GB-MRK".getBytes(StandardCharsets.US_ASCII);
+    private static final byte[] BEYOND = "WELL-BEYOND-2GB!".getBytes(StandardCharsets.US_ASCII);
+
+    private static final long STRADDLE_OFFSET = TWO_GB - 8;
+    private static final long BEYOND_OFFSET = TWO_GB + 4096;
+    /// Padded past `BEYOND_OFFSET + BEYOND.length` by more than the 64 KB
+    /// tail cache so the straddle and post-2 GB reads exercise the network
+    /// path — that's where the long-typed offset arithmetic lives.
+    private static final long FILE_SIZE = TWO_GB + 256 * 1024L + 16;
+    private static final String KEY = "large.bin";
+
+    @Container
+    static GenericContainer<?> s3 = S3ProxyContainers.filesystemBacked();
+
+    static S3Source source;
+
+    @BeforeAll
+    static void setup() throws Exception {
+        execOrFail("mkdir", "-p", "/data/" + S3ProxyContainers.BUCKET);
+        String objectPath = S3ProxyContainers.objectPath(KEY);
+        execOrFail("truncate", "-s", String.valueOf(FILE_SIZE), objectPath);
+        writeSentinel(objectPath, 0, AT_ZERO);
+        writeSentinel(objectPath, STRADDLE_OFFSET, STRADDLE);
+        writeSentinel(objectPath, BEYOND_OFFSET, BEYOND);
+
+        source = S3Source.builder()
+                .endpoint(S3ProxyContainers.endpoint(s3))
+                .pathStyle(true)
+                .credentials(S3Credentials.of(S3ProxyContainers.ACCESS_KEY, S3ProxyContainers.SECRET_KEY))
+                .build();
+    }
+
+    @AfterAll
+    static void tearDown() {
+        source.close();
+    }
+
+    @Test
+    void readsRegionsBeyondTwoGigabytes() throws Exception {
+        try (S3InputFile inputFile = source.inputFile(S3ProxyContainers.BUCKET, KEY)) {
+            inputFile.open();
+
+            // Whole-file length surfaces unchanged past Integer.MAX_VALUE.
+            assertThat(inputFile.length()).isEqualTo(FILE_SIZE);
+
+            assertThat(read(inputFile, 0, AT_ZERO.length)).isEqualTo(AT_ZERO);
+            assertThat(read(inputFile, STRADDLE_OFFSET, STRADDLE.length)).isEqualTo(STRADDLE);
+
+            // The decisive case: a start offset past Integer.MAX_VALUE,
+            // which an int cast on the offset would corrupt.
+            assertThat(read(inputFile, BEYOND_OFFSET, BEYOND.length)).isEqualTo(BEYOND);
+
+            // A hole reads back as zeros.
+            assertThat(read(inputFile, TWO_GB + 1024, 8)).containsOnly((byte) 0);
+        }
+    }
+
+    private static byte[] read(S3InputFile inputFile, long offset, int length) throws IOException {
+        ByteBuffer buffer = inputFile.readRange(offset, length);
+        byte[] out = new byte[length];
+        buffer.get(out);
+        return out;
+    }
+
+    private static void writeSentinel(String objectPath, long offset, byte[] bytes) throws Exception {
+        // dd's `seek` is in blocks of `bs`; with bs=1 it's a byte offset, and
+        // `conv=notrunc` preserves the surrounding sparse holes.
+        execOrFail("sh", "-c",
+                "printf '%s' '" + new String(bytes, StandardCharsets.US_ASCII) + "'"
+                        + " | dd of=" + objectPath
+                        + " bs=1 seek=" + offset
+                        + " count=" + bytes.length
+                        + " conv=notrunc status=none");
+    }
+
+    private static void execOrFail(String... command) throws Exception {
+        ExecResult result = s3.execInContainer(command);
+        if (result.getExitCode() != 0) {
+            throw new IllegalStateException("Command failed: " + String.join(" ", command)
+                    + "\nstdout: " + result.getStdout()
+                    + "\nstderr: " + result.getStderr());
+        }
+    }
+}

--- a/s3/src/test/java/dev/hardwood/s3/S3InputFileTest.java
+++ b/s3/src/test/java/dev/hardwood/s3/S3InputFileTest.java
@@ -236,7 +236,7 @@ class S3InputFileTest {
         // network — proving the counters increase past the open() baseline.
         // (A tiny fixture would fit entirely inside the tail cache and the
         // counters would correctly stay at 1.)
-        S3InputFile file = (S3InputFile) source.inputFile("test-bucket", "column_index_pushdown.parquet");
+        S3InputFile file = source.inputFile("test-bucket", "column_index_pushdown.parquet");
         try (ParquetFileReader reader = ParquetFileReader.open(file)) {
             long openRequests = file.networkRequestCount();
             long openBytes = file.networkBytesFetched();

--- a/s3/src/test/java/dev/hardwood/s3/S3RangeBackingTest.java
+++ b/s3/src/test/java/dev/hardwood/s3/S3RangeBackingTest.java
@@ -18,8 +18,6 @@ import org.testcontainers.junit.jupiter.Container;
 import org.testcontainers.junit.jupiter.Testcontainers;
 import org.testcontainers.utility.MountableFile;
 
-import dev.hardwood.InputFile;
-import dev.hardwood.internal.reader.RangeBackedInputFile;
 import dev.hardwood.reader.ColumnReader;
 import dev.hardwood.reader.ParquetFileReader;
 import dev.hardwood.reader.RowReader;
@@ -46,7 +44,6 @@ class S3RangeBackingTest {
     static Path cacheDir;
 
     static S3Source backedSource;
-    static S3Source bareSource;
 
     @BeforeAll
     static void setup() {
@@ -57,37 +54,16 @@ class S3RangeBackingTest {
                 .rangeBacking(RangeBacking.SPARSE_TEMPFILE)
                 .tempDir(cacheDir)
                 .build();
-        bareSource = S3Source.builder()
-                .endpoint(S3ProxyContainers.endpoint(s3))
-                .pathStyle(true)
-                .credentials(S3Credentials.of(S3ProxyContainers.ACCESS_KEY, S3ProxyContainers.SECRET_KEY))
-                .build();
     }
 
     @AfterAll
     static void tearDown() {
         backedSource.close();
-        bareSource.close();
-    }
-
-    @Test
-    void backedSourceWrapsInRangeBacked() {
-        InputFile file = backedSource.inputFile("test-bucket", "column_index_pushdown.parquet");
-        assertThat(file).isInstanceOf(RangeBackedInputFile.class);
-        assertThat(((RangeBackedInputFile) file).delegate()).isInstanceOf(S3InputFile.class);
-    }
-
-    @Test
-    void bareSourceReturnsBareS3InputFile() {
-        InputFile file = bareSource.inputFile("test-bucket", "column_index_pushdown.parquet");
-        assertThat(file).isInstanceOf(S3InputFile.class);
     }
 
     @Test
     void repeatReadAgainstSameRangeReducesHttpGets() throws Exception {
-        InputFile cached = backedSource.inputFile("test-bucket", "column_index_pushdown.parquet");
-        // Underlying S3InputFile to inspect network counters.
-        S3InputFile inner = (S3InputFile) ((RangeBackedInputFile) cached).delegate();
+        S3InputFile cached = backedSource.inputFile("test-bucket", "column_index_pushdown.parquet");
 
         try (ParquetFileReader reader = ParquetFileReader.open(cached);
                 ColumnReader col = reader.columnReader("id")) {
@@ -95,11 +71,11 @@ class S3RangeBackingTest {
                 // drain
             }
         }
-        long requestsAfterFirst = inner.networkRequestCount();
-        long bytesAfterFirst = inner.networkBytesFetched();
+        long requestsAfterFirst = cached.networkRequestCount();
+        long bytesAfterFirst = cached.networkBytesFetched();
         assertThat(requestsAfterFirst).isPositive();
 
-        long requestsBeforeSecond = inner.networkRequestCount();
+        long requestsBeforeSecond = cached.networkRequestCount();
         // Re-open + re-read against the *same* InputFile instance. The
         // range cache is alive, so byte ranges fetched on the first
         // pass should now be served from the local mmap.
@@ -109,22 +85,21 @@ class S3RangeBackingTest {
                 // drain
             }
         }
-        long requestsForSecond = inner.networkRequestCount() - requestsBeforeSecond;
+        long requestsForSecond = cached.networkRequestCount() - requestsBeforeSecond;
 
         assertThat(requestsForSecond)
                 .as("second pass should issue strictly fewer GETs than the first")
                 .isLessThan(requestsAfterFirst);
-        assertThat(inner.networkBytesFetched() - bytesAfterFirst)
+        assertThat(cached.networkBytesFetched() - bytesAfterFirst)
                 .as("second pass should fetch strictly fewer bytes than the first")
                 .isLessThan(bytesAfterFirst);
     }
 
     @Test
     void exactSameRangeReadTwiceHitsCache() throws Exception {
-        // Direct readRange() against the decorator: same offset/length
+        // Direct readRange() against the cached file: same offset/length
         // twice, the second goes to the mmap, no network call.
-        InputFile cached = backedSource.inputFile("test-bucket", "column_index_pushdown.parquet");
-        S3InputFile inner = (S3InputFile) ((RangeBackedInputFile) cached).delegate();
+        S3InputFile cached = backedSource.inputFile("test-bucket", "column_index_pushdown.parquet");
         cached.open();
 
         // Pick an offset that is outside the 64 KB tail cache so the
@@ -132,21 +107,20 @@ class S3RangeBackingTest {
         long offset = 1024;
         int length = 4096;
         cached.readRange(offset, length);
-        long requestsAfterFirst = inner.networkRequestCount();
-        long bytesAfterFirst = inner.networkBytesFetched();
+        long requestsAfterFirst = cached.networkRequestCount();
+        long bytesAfterFirst = cached.networkBytesFetched();
 
         cached.readRange(offset, length);
 
-        assertThat(inner.networkRequestCount())
+        assertThat(cached.networkRequestCount())
                 .as("exact-match repeat read must not issue a new HTTP GET")
                 .isEqualTo(requestsAfterFirst);
-        assertThat(inner.networkBytesFetched()).isEqualTo(bytesAfterFirst);
+        assertThat(cached.networkBytesFetched()).isEqualTo(bytesAfterFirst);
     }
 
     @Test
     void rowReaderRereadReducesHttpGets() throws Exception {
-        InputFile cached = backedSource.inputFile("test-bucket", "column_index_pushdown.parquet");
-        S3InputFile inner = (S3InputFile) ((RangeBackedInputFile) cached).delegate();
+        S3InputFile cached = backedSource.inputFile("test-bucket", "column_index_pushdown.parquet");
 
         try (ParquetFileReader reader = ParquetFileReader.open(cached);
                 RowReader rows = reader.rowReader()) {
@@ -154,8 +128,8 @@ class S3RangeBackingTest {
                 rows.next();
             }
         }
-        long after = inner.networkRequestCount();
-        long requestsBeforeSecond = inner.networkRequestCount();
+        long after = cached.networkRequestCount();
+        long requestsBeforeSecond = cached.networkRequestCount();
 
         try (ParquetFileReader reader = ParquetFileReader.open(cached);
                 RowReader rows = reader.rowReader()) {
@@ -163,7 +137,7 @@ class S3RangeBackingTest {
                 rows.next();
             }
         }
-        long requestsForSecond = inner.networkRequestCount() - requestsBeforeSecond;
+        long requestsForSecond = cached.networkRequestCount() - requestsBeforeSecond;
 
         assertThat(requestsForSecond)
                 .as("RowReader re-read should issue fewer GETs than the first read")

--- a/s3/src/test/java/dev/hardwood/s3/S3SelectiveReadJfrTest.java
+++ b/s3/src/test/java/dev/hardwood/s3/S3SelectiveReadJfrTest.java
@@ -217,7 +217,7 @@ public class S3SelectiveReadJfrTest extends AbstractJfrRecorderTest {
     void projectionTransfersFewerBytes() throws Exception {
         // page_index_test.parquet is 170 KB (> 64 KB tail cache), so column chunks
         // reads go to the network.
-        S3InputFile s3File = (S3InputFile) source.inputFile("test-bucket", PAGE_INDEX_FILE);
+        S3InputFile s3File = source.inputFile("test-bucket", PAGE_INDEX_FILE);
         try (ParquetFileReader reader = ParquetFileReader.open(s3File);
              RowReader rows = reader.buildRowReader().projection(ColumnProjection.columns("id")).build()) {
             while (rows.hasNext()) {


### PR DESCRIPTION
The previous shape forced every caller of `networkRequestCount()` / `networkBytesFetched()` to downcast, because under `RangeBacking.SPARSE_TEMPFILE` `S3Source.inputFile(...)` wrapped the bare file in an `InputFile`-typed `RangeBackedInputFile`. That wrapper was also implementation drift from `_designs/REMOTE_RANGE_BACKING.md`, which specifies the cache as internal to `S3InputFile`.

Composing the cache inside `S3InputFile` over a private adapter brings both into line: the factories return `S3InputFile` directly, the cache is invisible at the API surface, and the counters reflect only network traffic in either backing mode. `openAll` is widened to `List<? extends InputFile>` so the new typed list flows through without forcing callers to recast.