### PR TITLE
#538 Cap matched rows, not scanned rows, for head() with a filter

### DIFF
--- a/core/src/main/java/dev/hardwood/internal/reader/ColumnWorker.java
+++ b/core/src/main/java/dev/hardwood/internal/reader/ColumnWorker.java
@@ -98,6 +98,9 @@ public abstract class ColumnWorker<B> implements AutoCloseable {
     // === In-flight decode tasks (tracked so close() can await them) ===
     private final Set<CompletableFuture<Void>> inFlightDecodes = ConcurrentHashMap.newKeySet();
 
+    /// Sentinel for the `maxRows` / row-limit contract meaning "no limit".
+    static final long UNLIMITED = 0L;
+
     // === Drain assembly state (drain thread only) ===
     final long maxRows;
     long totalRowsAssembled;

--- a/core/src/main/java/dev/hardwood/internal/reader/FilteredRowReader.java
+++ b/core/src/main/java/dev/hardwood/internal/reader/FilteredRowReader.java
@@ -21,7 +21,10 @@ import dev.hardwood.row.PqMap;
 import dev.hardwood.row.PqStruct;
 import dev.hardwood.row.PqVariant;
 
-/// Filtered wrapper around any [RowReader] that skips non-matching rows.
+/// Filtered wrapper around any [RowReader] that skips non-matching rows. When
+/// constructed with a positive `maxMatches`, also caps the number of matching
+/// rows returned (SQL `LIMIT` over the filtered relation); [ColumnWorker#UNLIMITED]
+/// disables the cap.
 public final class FilteredRowReader implements RowReader {
 
     private final RowReader delegate;

--- a/core/src/main/java/dev/hardwood/internal/reader/FilteredRowReader.java
+++ b/core/src/main/java/dev/hardwood/internal/reader/FilteredRowReader.java
@@ -26,16 +26,24 @@ public final class FilteredRowReader implements RowReader {
 
     private final RowReader delegate;
     private final RowMatcher matcher;
+    /// Cap on matching rows returned (SQL LIMIT over the filtered relation).
+    /// [ColumnWorker#UNLIMITED] means no cap.
+    private final long maxMatches;
 
     private boolean hasMatch;
+    private long matchesReturned;
 
-    FilteredRowReader(RowReader delegate, RowMatcher matcher) {
+    FilteredRowReader(RowReader delegate, RowMatcher matcher, long maxMatches) {
         this.delegate = delegate;
         this.matcher = matcher;
+        this.maxMatches = maxMatches;
     }
 
     @Override
     public boolean hasNext() {
+        if (maxMatches != ColumnWorker.UNLIMITED && matchesReturned >= maxMatches) {
+            return false;
+        }
         if (hasMatch) {
             return true;
         }
@@ -55,6 +63,7 @@ public final class FilteredRowReader implements RowReader {
             throw new java.util.NoSuchElementException("No matching row available. Call hasNext() first.");
         }
         hasMatch = false;
+        matchesReturned++;
     }
 
     // ==================== Delegation ====================

--- a/core/src/main/java/dev/hardwood/internal/reader/FlatRowReader.java
+++ b/core/src/main/java/dev/hardwood/internal/reader/FlatRowReader.java
@@ -111,6 +111,13 @@ public final class FlatRowReader implements RowReader {
     /// single-column fast path applies.
     private final int[] referencedColumns;
     private int pendingRowIndex = -1;
+    /// Drain-side cap on the number of *matching* rows yielded (SQL LIMIT over
+    /// the filtered relation). [ColumnWorker#UNLIMITED] means no cap. Enforced
+    /// only on the drain-side path — the FilteredRowReader wrapper and the worker
+    /// handle the other paths.
+    private final long maxMatchedRows;
+    /// Count of matching rows yielded so far on the drain-side path.
+    private long matchedRowsYielded;
     /// Exclusive upper bound of the current run of consecutive-1 bits in
     /// [#combinedWords] starting at or before `rowIndex + 1`. While
     /// `rowIndex + 1 < runEndExclusive`, [#hasNext] can advance without
@@ -124,7 +131,8 @@ public final class FlatRowReader implements RowReader {
 
     public FlatRowReader(BatchExchange<BatchExchange.Batch>[] exchanges, FlatColumnWorker[] columnWorkers,
                          FileSchema fileSchema, ProjectedSchema projectedSchema,
-                         boolean drainSide, int wordsLen, MergePlan mergePlan) {
+                         boolean drainSide, int wordsLen, MergePlan mergePlan, long maxMatchedRows) {
+        this.maxMatchedRows = maxMatchedRows;
         this.exchanges = exchanges;
         this.columnWorkers = columnWorkers;
         this.columnCount = exchanges.length;
@@ -178,7 +186,9 @@ public final class FlatRowReader implements RowReader {
     /// @param projectedSchema the projected column schema
     /// @param context the hardwood context
     /// @param filter resolved predicate, or `null` for no filtering
-    /// @param maxRows maximum rows (0 = unlimited), enforced by [ColumnWorker] drain
+    /// @param maxRows maximum rows (0 = unlimited). Without a filter this caps scanned
+    ///                rows at the [ColumnWorker] drain. With a filter it caps *matching*
+    ///                rows (SQL LIMIT), enforced over matches by the reader or wrapper.
     /// @return a [FlatRowReader] or [FilteredRowReader]
     public static RowReader create(RowGroupIterator rowGroupIterator,
                                    FileSchema schema,
@@ -188,6 +198,12 @@ public final class FlatRowReader implements RowReader {
                                    long maxRows) {
         int batchSize = BatchSizing.computeOptimalBatchSize(projectedSchema);
         int projectedColumnCount = projectedSchema.getProjectedColumnCount();
+
+        // A row-level filter changes what `maxRows` counts: under SQL LIMIT
+        // semantics the cap is on *matching* rows, not scanned rows. Let the
+        // workers scan unbounded and enforce the cap over matches downstream —
+        // either in the drain-side reader or in the FilteredRowReader wrapper.
+        long workerMaxRows = filter != null ? ColumnWorker.UNLIMITED : maxRows;
 
         // Try the drain-side path first. tryCompile returns null for any non-eligible
         // predicate; null falls through to the existing FilteredRowReader path below.
@@ -225,7 +241,7 @@ public final class FlatRowReader implements RowReader {
             ColumnBatchMatcher columnFilter = allocateMatches ? columnBatchMatchers[i] : null;
             FlatColumnWorker worker = new FlatColumnWorker(
                     pageSource, buffer, columnSchema, batchSize,
-                    context.decompressorFactory(), context.executor(), maxRows,
+                    context.decompressorFactory(), context.executor(), workerMaxRows,
                     columnFilter);
 
             buffers[i] = buffer;
@@ -238,8 +254,12 @@ public final class FlatRowReader implements RowReader {
             drainSide = false;
         }
 
+        // On the drain-side path filtering happens here, so the reader itself caps
+        // matched rows. On the FilteredRowReader path the wrapper caps; on the
+        // no-filter path the worker already capped scanned == matched rows.
+        long readerMatchLimit = drainSide ? maxRows : ColumnWorker.UNLIMITED;
         FlatRowReader reader = new FlatRowReader(buffers, workers, schema, projectedSchema,
-                drainSide, wordsLen, mergePlan);
+                drainSide, wordsLen, mergePlan, readerMatchLimit);
         reader.initialize();
 
         if (drainSide) {
@@ -252,7 +272,7 @@ public final class FlatRowReader implements RowReader {
             // a top-level field, and the reader's `getInt(int)` etc. take a
             // projected leaf-column index. Map directly through the projection.
             RowMatcher matcher = RecordFilterCompiler.compile(filter, schema, projectedSchema::toProjectedIndex);
-            return new FilteredRowReader(reader, matcher);
+            return new FilteredRowReader(reader, matcher, maxRows);
         }
         return reader;
     }
@@ -266,6 +286,10 @@ public final class FlatRowReader implements RowReader {
             return false;
         }
         if (drainSide) {
+            if (maxMatchedRows != ColumnWorker.UNLIMITED && matchedRowsYielded >= maxMatchedRows) {
+                exhausted = true;
+                return false;
+            }
             if (pendingRowIndex >= 0) {
                 return true;
             }
@@ -301,6 +325,7 @@ public final class FlatRowReader implements RowReader {
             }
             rowIndex = pendingRowIndex;
             pendingRowIndex = -1;
+            matchedRowsYielded++;
         }
         else {
             rowIndex++;

--- a/core/src/main/java/dev/hardwood/internal/reader/NestedRowReader.java
+++ b/core/src/main/java/dev/hardwood/internal/reader/NestedRowReader.java
@@ -92,7 +92,9 @@ public final class NestedRowReader implements RowReader {
     /// @param projectedSchema the projected column schema
     /// @param context the hardwood context
     /// @param filter resolved predicate, or `null` for no filtering
-    /// @param maxRows maximum rows (0 = unlimited), enforced by [ColumnWorker] drain
+    /// @param maxRows maximum rows (0 = unlimited). Without a filter this caps scanned
+    ///                rows at the [ColumnWorker] drain. With a filter it caps *matching*
+    ///                rows (SQL LIMIT), enforced over matches by the FilteredRowReader wrapper.
     /// @return a [NestedRowReader] or [FilteredRowReader]
     public static RowReader create(RowGroupIterator rowGroupIterator,
                             FileSchema schema,
@@ -102,6 +104,9 @@ public final class NestedRowReader implements RowReader {
                             long maxRows) {
         int batchSize = BatchSizing.computeOptimalBatchSize(projectedSchema);
         int projectedColumnCount = projectedSchema.getProjectedColumnCount();
+        // With a row-level filter, `maxRows` caps *matching* rows (SQL LIMIT), so the
+        // workers scan unbounded, and the FilteredRowReader wrapper enforces the cap.
+        long workerMaxRows = filter != null ? ColumnWorker.UNLIMITED : maxRows;
         NestedColumnWorker[] workers = new NestedColumnWorker[projectedColumnCount];
         @SuppressWarnings("unchecked")
         BatchExchange<NestedBatch>[] buffers = new BatchExchange[projectedColumnCount];
@@ -122,7 +127,7 @@ public final class NestedRowReader implements RowReader {
                     schema.getRootNode(), columnSchema.columnIndex());
             NestedColumnWorker worker = new NestedColumnWorker(
                     pageSource, buffer, columnSchema, batchSize,
-                    context.decompressorFactory(), context.executor(), maxRows,
+                    context.decompressorFactory(), context.executor(), workerMaxRows,
                     layers);
 
             buffers[i] = buffer;
@@ -140,7 +145,7 @@ public final class NestedRowReader implements RowReader {
             // (or `-1` for nested-leaf columns and unprojected fields).
             int[] topLevelLookup = buildTopLevelFieldIndexLookup(schema, projectedSchema);
             RowMatcher matcher = RecordFilterCompiler.compile(filter, schema, col -> topLevelLookup[col]);
-            return new FilteredRowReader(reader, matcher);
+            return new FilteredRowReader(reader, matcher, maxRows);
         }
         return reader;
     }

--- a/core/src/main/java/dev/hardwood/internal/reader/RowGroupIterator.java
+++ b/core/src/main/java/dev/hardwood/internal/reader/RowGroupIterator.java
@@ -488,9 +488,7 @@ public class RowGroupIterator {
                     continue;
                 }
 
-                if (perRgMaxRows > 0) {
-                    neededPages = truncateToMaxRows(neededPages, perRgMaxRows);
-                }
+                neededPages = truncateToMaxRows(neededPages, perRgMaxRows);
 
                 // Coalesce needed pages within this column into page groups,
                 // bridging small gaps but splitting on large ones.
@@ -790,8 +788,13 @@ public class RowGroupIterator {
         return true;
     }
 
-    /// Truncates a page list to cover at most `maxRows` rows.
+    /// Truncates a page list to cover at most `maxRows` rows. `maxRows <= 0`
+    /// means "no row bound" and returns every page unchanged — the same
+    /// `0 = unlimited` convention used throughout the fetch path.
     private static List<NeededPage> truncateToMaxRows(List<NeededPage> pages, long maxRows) {
+        if (maxRows <= 0) {
+            return pages;
+        }
         List<NeededPage> truncated = new ArrayList<>();
         for (NeededPage page : pages) {
             if (page.location().firstRowIndex() >= maxRows) {
@@ -804,18 +807,17 @@ public class RowGroupIterator {
 
     /// Per-row-group remainder of the iterator-wide `maxRows` budget.
     ///
-    /// Returns `0` when `maxRows` is unset (no limit). When a filter predicate
-    /// is active the prior-row-count sum can't be correlated with matching
-    /// rows, so the global `maxRows` is returned as a conservative bound.
-    /// Otherwise returns `max(0, maxRows - workItem.rowsConsumedBefore())`,
+    /// Returns `0` (no fetch-side truncation) when `maxRows` is unset, or when a
+    /// filter predicate is active: `head(N)` then caps *matching* rows (SQL
+    /// LIMIT), so a matching row can sit past the first `N` scanned rows and
+    /// every surviving page must remain fetchable. Statistics pushdown still
+    /// prunes pages and row groups, and the matched-row cap is enforced at the
+    /// reader. Without a filter, returns `max(0, maxRows - workItem.rowsConsumedBefore())`,
     /// which naturally trims the last partially-needed row group's fetch plan
     /// while being a no-op (all pages kept) for fully-needed earlier ones.
     private long perRgMaxRows(WorkItem workItem) {
-        if (maxRows <= 0) {
+        if (maxRows <= 0 || filterPredicate != null) {
             return 0;
-        }
-        if (filterPredicate != null) {
-            return maxRows;
         }
         return Math.max(0, maxRows - workItem.rowsConsumedBefore());
     }

--- a/core/src/main/java/dev/hardwood/internal/reader/RowGroupIterator.java
+++ b/core/src/main/java/dev/hardwood/internal/reader/RowGroupIterator.java
@@ -448,8 +448,9 @@ public class RowGroupIterator {
         // `PageLocation.firstRowIndex` and `SequentialFetchPlan.valuesRead`
         // are both row-group-local (reset to 0 each RG), so passing the global
         // maxRows would fail to truncate anything in non-first row groups and
-        // over-fetch the last partially-needed RG. With a filter active the
-        // match count is unpredictable, so we fall back to the global value.
+        // over-fetch the last partially-needed RG. With a filter active `head(N)`
+        // caps matching rows (SQL LIMIT), so no fetch-side truncation applies —
+        // perRgMaxRows returns 0 and the matched-row cap is enforced at the reader.
         long perRgMaxRows = perRgMaxRows(workItem);
 
         FetchPlan[] plans = new FetchPlan[projectedCount];

--- a/core/src/main/java/dev/hardwood/reader/ParquetFileReader.java
+++ b/core/src/main/java/dev/hardwood/reader/ParquetFileReader.java
@@ -550,7 +550,11 @@ public class ParquetFileReader implements AutoCloseable {
             return this;
         }
 
-        /// Limit to the first `maxRows` rows. Mutually exclusive with [#tail].
+        /// Limit to the first `maxRows` rows. When combined with [#filter(FilterPredicate)],
+        /// the cap is on the number of *matching* rows, not the number scanned — the
+        /// reader keeps scanning until `maxRows` rows satisfy the predicate or the input
+        /// is exhausted (SQL `LIMIT` over the filtered relation). Mutually exclusive with
+        /// [#tail].
         public RowReaderBuilder head(long maxRows) {
             if (maxRows <= 0) {
                 throw new IllegalArgumentException("head row count must be positive: " + maxRows);

--- a/core/src/test/java/dev/hardwood/PredicatePushDownTest.java
+++ b/core/src/test/java/dev/hardwood/PredicatePushDownTest.java
@@ -38,6 +38,11 @@ class PredicatePushDownTest {
     /// id (required) = [0, 9999], value (nullable) = [1000, 10999], sorted. Many pages
     /// of ~128 values each so per-page skipping is observable.
     private static final Path INLINE_STATS_FILE = Paths.get("src/test/resources/inline_page_stats.parquet");
+    /// One row group, 10000 rows, sorted id [0,9999] across ~10 pages, with a
+    /// ColumnIndex/OffsetIndex (Parquet v2). Exercises the page-index fetch path
+    /// (per-page pruning + `truncateToMaxRows`) as opposed to the sequential
+    /// inline-stats path of [#INLINE_STATS_FILE].
+    private static final Path COLUMN_INDEX_FILE = Paths.get("src/test/resources/column_index_pushdown.parquet");
 
     // ==================== ColumnReader with Filter ====================
 
@@ -165,6 +170,122 @@ class PredicatePushDownTest {
                     assertThat(rows.getString("label")).startsWith("rg1_");
                 }
                 assertThat(totalRows).isEqualTo(100);
+            }
+        }
+    }
+
+    @Test
+    void testHeadWithFilterLimitsMatchingRows() throws Exception {
+        // RG1 holds id 1-100. gt(id, 50) keeps 51-100; the first 50 scanned rows
+        // (id 1-50) do not match. head(5) must yield the first five *matching*
+        // rows (id 51-55), not stop after scanning five rows and return nothing.
+        try (ParquetFileReader reader = ParquetFileReader.open(InputFile.of(INT_FILE))) {
+            FilterPredicate filter = FilterPredicate.gt("id", 50L);
+
+            try (RowReader rows = reader.buildRowReader().filter(filter).head(5).build()) {
+                List<Long> ids = new ArrayList<>();
+                while (rows.hasNext()) {
+                    rows.next();
+                    ids.add(rows.getLong("id"));
+                }
+                assertThat(ids).containsExactly(51L, 52L, 53L, 54L, 55L);
+            }
+        }
+    }
+
+    @Test
+    void testHeadWithFilterAfterLeadingRowGroupsPruned() throws Exception {
+        // gtEq(id, 201) drops RG1 (1-100) and RG2 (101-200) by row-group statistics;
+        // RG3 holds 201-300. head(60) must return the first 60 matching rows (201-260),
+        // confirming the matched-row cap counts from the first surviving row group.
+        try (ParquetFileReader reader = ParquetFileReader.open(InputFile.of(INT_FILE))) {
+            FilterPredicate filter = FilterPredicate.gtEq("id", 201L);
+
+            try (RowReader rows = reader.buildRowReader().filter(filter).head(60).build()) {
+                List<Long> ids = new ArrayList<>();
+                while (rows.hasNext()) {
+                    rows.next();
+                    ids.add(rows.getLong("id"));
+                }
+                assertThat(ids).hasSize(60);
+                assertThat(ids.getFirst()).isEqualTo(201L);
+                assertThat(ids.getLast()).isEqualTo(260L);
+            }
+        }
+    }
+
+    @Test
+    void testHeadWithFilterFewerMatchesThanLimit() throws Exception {
+        // eq(id, 75) matches a single row;
+        try (ParquetFileReader reader = ParquetFileReader.open(InputFile.of(INT_FILE))) {
+            FilterPredicate filter = FilterPredicate.eq("id", 75L);
+
+            try (RowReader rows = reader.buildRowReader().filter(filter).head(100).build()) {
+                List<Long> ids = new ArrayList<>();
+                while (rows.hasNext()) {
+                    rows.next();
+                    ids.add(rows.getLong("id"));
+                }
+                assertThat(ids).containsExactly(75L);
+            }
+        }
+    }
+
+    @Test
+    void testHeadWithFilterOnNestedSchemaLimitsMatchingRows() throws Exception {
+        // Record-level filtering on a nested schema routes through FilteredRowReader.
+        // RG2 holds id 4-6; gt(id, 4) skips id 4 and matches 5, 6. head(2) must yield
+        // the first two matches (id 5, 6), not scan two rows and return only id 5.
+        try (ParquetFileReader reader = ParquetFileReader.open(InputFile.of(NESTED_FILE))) {
+            FilterPredicate filter = FilterPredicate.gt("id", 4);
+
+            try (RowReader rows = reader.buildRowReader().filter(filter).head(2).build()) {
+                List<Integer> ids = new ArrayList<>();
+                while (rows.hasNext()) {
+                    rows.next();
+                    ids.add(rows.getInt("id"));
+                }
+                assertThat(ids).containsExactly(5, 6);
+            }
+        }
+    }
+
+    @Test
+    void testHeadWithFilterAcrossManyPagesWithinRowGroup() throws Exception {
+        // INLINE_STATS_FILE: one row group, id sorted 0-9999 across many ~small pages,
+        // no page index (sequential fetch path). gt(id, 1000) matches 1001-9999; the
+        // first match sits far past the first scanned page, so a scanned-row fetch
+        // bound must NOT truncate it away. head(5) must yield id 1001-1005.
+        try (ParquetFileReader reader = ParquetFileReader.open(InputFile.of(INLINE_STATS_FILE))) {
+            FilterPredicate filter = FilterPredicate.gt("id", 1000L);
+
+            try (RowReader rows = reader.buildRowReader().filter(filter).head(5).build()) {
+                List<Long> ids = new ArrayList<>();
+                while (rows.hasNext()) {
+                    rows.next();
+                    ids.add(rows.getLong("id"));
+                }
+                assertThat(ids).containsExactly(1001L, 1002L, 1003L, 1004L, 1005L);
+            }
+        }
+    }
+
+    @Test
+    void testHeadWithFilterAcrossManyPagesWithPageIndex() throws Exception {
+        // COLUMN_INDEX_FILE: one row group, id sorted 0-9999 across ~10 pages, with a
+        // ColumnIndex/OffsetIndex. gt(id, 5000) prunes the leading pages by page stats;
+        // the surviving pages all start well past row 5, so the page-index fetch path
+        // must not truncate them to the first head() rows. head(5) -> id 5001-5005.
+        try (ParquetFileReader reader = ParquetFileReader.open(InputFile.of(COLUMN_INDEX_FILE))) {
+            FilterPredicate filter = FilterPredicate.gt("id", 5000L);
+
+            try (RowReader rows = reader.buildRowReader().filter(filter).head(5).build()) {
+                List<Long> ids = new ArrayList<>();
+                while (rows.hasNext()) {
+                    rows.next();
+                    ids.add(rows.getLong("id"));
+                }
+                assertThat(ids).containsExactly(5001L, 5002L, 5003L, 5004L, 5005L);
             }
         }
     }


### PR DESCRIPTION
This PR resolves #538, capping on matched row instead of scanned, for head + filter

With a filter present, the workers now scan unbounded, and the cap is enforced over matches: the drain-side reader counts yielded matches, and the FilteredRowReader wrapper counts returned matches on the indexed and nested paths. 

The fetch layer also drops its scanned-position bounds when a filter is active (perRgMaxRows returns 0), so every statistics-surviving page stays fetchable; row-group and page pushdown remain the only pruning. 

The no-filter path is unchanged: the worker and fetch planner keep bounding scanned rows, where scanned equals yielded.


## Checklist

- [x] Build via `./mvnw clean verify` passes
- [x] The commit message is prefixed with the issue key ("#123 Adding support for...")
- [x] Code changes are covered by tests
- [ ] If this PR adds or changes user-facing behaviour, `docs/` has been updated
