### PR TITLE
#540 Reject skip + FilterPredicate at build()

### DIFF
--- a/core/src/main/java/dev/hardwood/reader/ParquetFileReader.java
+++ b/core/src/main/java/dev/hardwood/reader/ParquetFileReader.java
@@ -591,9 +591,10 @@ public class ParquetFileReader implements AutoCloseable {
         /// produces an empty reader. `skip > totalRows` throws
         /// [IllegalArgumentException] at `build()` time. Indexes into the
         /// *first* file's rows for multi-file readers; cross-file
-        /// `skip` is out of scope. Mutually exclusive with [#tail];
-        /// composes with [#head] for a bounded
-        /// `[skip, skip + maxRows)` window.
+        /// `skip` is out of scope. Mutually exclusive with [#tail] and with
+        /// [#filter(FilterPredicate)]; composes with [#head] for a bounded
+        /// `[skip, skip + maxRows)` window, and with
+        /// [#filter(RowGroupPredicate)] over the kept row-group sequence.
         public RowReaderBuilder skip(long skip) {
             if (skip < 0) {
                 throw new IllegalArgumentException("skip must be non-negative: " + skip);
@@ -618,6 +619,12 @@ public class ParquetFileReader implements AutoCloseable {
             }
             if (tailRows > 0 && skip > 0) {
                 throw new IllegalArgumentException("tail and skip are mutually exclusive");
+            }
+            if (skip > 0 && filter != null) {
+                throw new IllegalArgumentException(
+                        "skip cannot be combined with a filter predicate: logical OFFSET "
+                                + "semantics over the filtered relation are not yet supported "
+                                + "(tracked in #541)");
             }
             if (tailRows > 0) {
                 return fileReader.buildTailRowReader(projection, tailRows);

--- a/core/src/test/java/dev/hardwood/ParquetReaderTest.java
+++ b/core/src/test/java/dev/hardwood/ParquetReaderTest.java
@@ -18,6 +18,7 @@ import dev.hardwood.metadata.FileMetaData;
 import dev.hardwood.metadata.PhysicalType;
 import dev.hardwood.metadata.RepetitionType;
 import dev.hardwood.reader.ColumnReader;
+import dev.hardwood.reader.FilterPredicate;
 import dev.hardwood.reader.LayerKind;
 import dev.hardwood.reader.ParquetFileReader;
 import dev.hardwood.reader.RowReader;
@@ -462,8 +463,24 @@ class ParquetReaderTest {
         Path parquetFile = Paths.get("src/test/resources/filter_pushdown_int.parquet");
 
         try (ParquetFileReader reader = ParquetFileReader.open(InputFile.of(parquetFile))) {
-            assertThatThrownBy(() -> reader.buildRowReader().projection(ColumnProjection.all()).filter(dev.hardwood.reader.FilterPredicate.gt("id", 0L)).tail(10L).build())
+            assertThatThrownBy(() -> reader.buildRowReader().projection(ColumnProjection.all()).filter(FilterPredicate.gt("id", 0L)).tail(10L).build())
                     .isInstanceOf(IllegalArgumentException.class);
+        }
+    }
+
+    @Test
+    void skipAndFilterPredicateAreRejected() throws Exception {
+        Path parquetFile = Paths.get("src/test/resources/filter_pushdown_int.parquet");
+
+        try (ParquetFileReader reader = ParquetFileReader.open(InputFile.of(parquetFile))) {
+            assertThatThrownBy(() -> reader.buildRowReader()
+                    .projection(ColumnProjection.all())
+                    .skip(50)
+                    .filter(FilterPredicate.gtEq("id", 100L))
+                    .build())
+                    .isInstanceOf(IllegalArgumentException.class)
+                    .hasMessageContaining("skip")
+                    .hasMessageContaining("filter");
         }
     }
 

--- a/docs/content/how-to/query-controls.md
+++ b/docs/content/how-to/query-controls.md
@@ -319,7 +319,7 @@ try (ParquetFileReader fileReader = ParquetFileReader.open(InputFile.of(path));
 }
 ```
 
-`skip == 0` is the no-op default. `skip == totalRows` produces an empty reader; `skip > totalRows` throws `IllegalArgumentException`. Mutually exclusive with `tail(N)`.
+`skip == 0` is the no-op default. `skip == totalRows` produces an empty reader; `skip > totalRows` throws `IllegalArgumentException`. Mutually exclusive with `tail(N)` and with `filter(FilterPredicate)` — a logical `OFFSET` over the filtered relation is not yet supported, so the combination is rejected at `build()` time. `skip(N)` composes with `filter(RowGroupPredicate)` (e.g. `byteRange`), indexing into the kept row-group sequence.
 
 !!! warning "Multi-file readers: first file only"
     For multi-file readers, `skip(N)` indexes into the **first** file's rows only — it does not seek across file boundaries. To skip whole files, omit them from the input list; to skip within a non-first file, open it separately.


### PR DESCRIPTION
skip(n) walks physical RowGroup.numRows() to locate the starting group, then calls reader.next() to consume the within-group residue. On a filtered reader, next() steps over *matched* rows, so the offset is counted physically across row-group boundaries but logically inside the target group, and any matches in fully-skipped leading groups vanish from the count.

Logical OFFSET semantics over the filtered relation are out of scope for the 1.0.0.Final milestone (tracked in #541), and the matched-row head() fix in #538 perturbs this path. Rejecting the combination keeps that fix contained and follows the fail-early principle — better an IllegalArgumentException at build() than a silently wrong row set. skip + RowGroupPredicate stays supported: kept row groups are returned in full, so physical and logical indexing agree.