### PR TITLE
#561 Configure japicmp for all published modules with a unified report

### DIFF
--- a/.github/workflows/main-build.yml
+++ b/.github/workflows/main-build.yml
@@ -368,10 +368,10 @@ jobs:
         run: |
           JAPICMP_OLD_VERSION="$(sed -n 's/^Latest version: \([^,]*\),.*/\1/p' README.md)"
           echo "Comparing against ${JAPICMP_OLD_VERSION}"
-          ./mvnw -ntp -B package japicmp:cmp -pl :hardwood-core -DskipTests -Djapicmp.oldVersion="${JAPICMP_OLD_VERSION}"
+          tools/api-report.sh "${JAPICMP_OLD_VERSION}"
 
       - name: 'Upload API change report'
         uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f  # v7 — https://github.com/actions/upload-artifact/releases/tag/v7
         with:
           name: japicmp-report
-          path: core/target/japicmp/
+          path: target/japicmp/

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -82,7 +82,7 @@ jobs:
         uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f  # v7 — https://github.com/actions/upload-artifact/releases/tag/v7
         with:
           name: japicmp-report
-          path: core/target/japicmp/
+          path: japicmp-report/
 
       - name: 'JReleaser output'
         if: always()

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 #Maven
 target/
+japicmp-report/
 pom.xml.tag
 pom.xml.releaseBackup
 pom.xml.versionsBackup

--- a/README.md
+++ b/README.md
@@ -190,13 +190,16 @@ See [RELEASING.md](RELEASING.md).
 
 ### API Change Report
 
-To generate an API change report comparing the current build against a previous release:
+To generate an API change report across all published modules (`hardwood-core`, `hardwood-avro`, `hardwood-s3`, `hardwood-aws-auth`):
 
 ```shell
-./mvnw package japicmp:cmp -pl :hardwood-core -DskipTests -Djapicmp.oldVersion=<PREVIOUS_VERSION>
+tools/api-report.sh <PREVIOUS_VERSION>                  # HEAD (snapshot) vs <PREVIOUS_VERSION>
+tools/api-report.sh <PREVIOUS_VERSION> <LATER_VERSION>  # compare two published versions
 ```
 
-The `package` phase is needed to build the current jar before comparing. The report is written to `core/target/japicmp/`. Internal packages (`dev.hardwood.internal`) are excluded. This is run automatically during releases.
+In the default (single-argument) form the script installs the snapshot jars and compares HEAD against `<PREVIOUS_VERSION>`. With both arguments the build step is skipped and both sides are resolved from the Maven repository — useful to diff arbitrary released pairs (e.g. `Beta2` against `CR1`).
+
+The script writes a unified `target/japicmp/api-report.diff` (text) and `target/japicmp/api-report.html` (one document with a TOC linking to per-module sections). Per-module reports also land under `target/japicmp/<artifactId>/` (HTML / Markdown / XML / diff). Internal packages (`dev.hardwood.internal`) are excluded. This is run automatically during releases.
 
 ## Performance
 

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -183,32 +183,6 @@
           </execution>
         </executions>
       </plugin>
-      <!-- API change report (run manually: mvn japicmp:cmp -Djapicmp.oldVersion=...) -->
-      <plugin>
-        <groupId>com.github.siom79.japicmp</groupId>
-        <artifactId>japicmp-maven-plugin</artifactId>
-        <configuration>
-          <oldVersion>
-            <dependency>
-              <groupId>${project.groupId}</groupId>
-              <artifactId>${project.artifactId}</artifactId>
-              <version>${japicmp.oldVersion}</version>
-              <type>jar</type>
-            </dependency>
-          </oldVersion>
-          <newVersion>
-            <file>
-              <path>${project.build.directory}/${project.build.finalName}.jar</path>
-            </file>
-          </newVersion>
-          <parameter>
-            <onlyModified>true</onlyModified>
-            <excludes>
-              <exclude>dev.hardwood.internal</exclude>
-            </excludes>
-          </parameter>
-        </configuration>
-      </plugin>
     </plugins>
   </build>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -67,6 +67,7 @@
     <auto-service.version>1.1.1</auto-service.version>
     <error-prone.version>2.49.0</error-prone.version>
     <hadoop.version>3.4.3</hadoop.version>
+    <japicmp.newVersion>${project.version}</japicmp.newVersion>
     <java.version>21</java.version>
     <java.version.build>25</java.version.build>
     <maven.compiler.parameters>true</maven.compiler.parameters>
@@ -107,6 +108,31 @@
           <groupId>com.github.siom79.japicmp</groupId>
           <artifactId>japicmp-maven-plugin</artifactId>
           <version>0.25.4</version>
+          <configuration>
+            <oldVersion>
+              <dependency>
+                <groupId>${project.groupId}</groupId>
+                <artifactId>${project.artifactId}</artifactId>
+                <version>${japicmp.oldVersion}</version>
+                <type>jar</type>
+              </dependency>
+            </oldVersion>
+            <newVersion>
+              <dependency>
+                <groupId>${project.groupId}</groupId>
+                <artifactId>${project.artifactId}</artifactId>
+                <version>${japicmp.newVersion}</version>
+                <type>jar</type>
+              </dependency>
+            </newVersion>
+            <parameter>
+              <onlyModified>true</onlyModified>
+              <excludes>
+                <exclude>dev.hardwood.internal</exclude>
+              </excludes>
+            </parameter>
+            <outputDirectory>${maven.multiModuleProjectDirectory}/target/japicmp/${project.artifactId}</outputDirectory>
+          </configuration>
         </plugin>
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>

--- a/release.sh
+++ b/release.sh
@@ -98,12 +98,7 @@ git checkout -b "release/${RELEASE_VERSION}"
 
 echo "Generating API change report..."
 JAPICMP_OLD_VERSION="$(sed -n 's/^Latest version: \([^,]*\),.*/\1/p' README.md)"
-# -am brings up everything in hardwood-core's reactor dependency graph
-# (hardwood-test-support and the BOMs), but not hardwood-error-prone-checks: it is
-# wired as an annotationProcessorPath, not a project dependency, so it stays
-# invisible to the reactor and must be installed into the local repo first.
-./mvnw -ntp -B install -pl :hardwood-error-prone-checks -DskipTests
-./mvnw -ntp -B package japicmp:cmp -pl :hardwood-core -am -DskipTests -Djapicmp.oldVersion="${JAPICMP_OLD_VERSION}"
+tools/api-report.sh "${JAPICMP_OLD_VERSION}"
 
 # -- Update README versions and date -----------------------------------------
 

--- a/release.sh
+++ b/release.sh
@@ -99,6 +99,11 @@ git checkout -b "release/${RELEASE_VERSION}"
 echo "Generating API change report..."
 JAPICMP_OLD_VERSION="$(sed -n 's/^Latest version: \([^,]*\),.*/\1/p' README.md)"
 tools/api-report.sh "${JAPICMP_OLD_VERSION}"
+# release:prepare's preparationGoals ("clean verify") will wipe target/ shortly,
+# so move the report outside target/ to keep it for upload-artifact. The
+# release.yml workflow reads from japicmp-report/.
+rm -rf japicmp-report
+cp -r target/japicmp japicmp-report
 
 # -- Update README versions and date -----------------------------------------
 

--- a/tools/api-report.sh
+++ b/tools/api-report.sh
@@ -1,0 +1,135 @@
+#!/usr/bin/env bash
+#
+#  SPDX-License-Identifier: Apache-2.0
+#
+#  Copyright The original authors
+#
+#  Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+#
+
+# Run japicmp across the four published modules and concatenate the per-module
+# reports into a unified text diff and a unified HTML.
+#
+# Usage: tools/api-report.sh <oldVersion> [<newVersion>]
+#   e.g. tools/api-report.sh 1.0.0.CR1               # HEAD (snapshot) vs 1.0.0.CR1
+#        tools/api-report.sh 1.0.0.Beta2 1.0.0.CR1   # compare two published versions
+#
+# When <newVersion> is omitted, the local snapshot is installed and used as the
+# new side. When it is supplied, both sides are resolved from the Maven
+# repository and no build is needed.
+#
+# Outputs:
+#   target/japicmp/api-report.diff           — concatenated per-module diffs
+#   target/japicmp/api-report.html           — single HTML with TOC + module sections
+#   target/japicmp/<artifactId>/*.{html,diff,md,xml}  — per-module reports
+
+set -euo pipefail
+
+if [ $# -lt 1 ] || [ $# -gt 2 ]; then
+  echo "Usage: $0 <oldVersion> [<newVersion>]" >&2
+  echo "Examples:" >&2
+  echo "  $0 1.0.0.CR1" >&2
+  echo "  $0 1.0.0.Beta2 1.0.0.CR1" >&2
+  exit 2
+fi
+
+OLD="$1"
+NEW="${2:-}"
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+cd "$ROOT"
+
+MODULES=":hardwood-core,:hardwood-avro,:hardwood-s3,:hardwood-aws-auth"
+ARTIFACTS=(hardwood-core hardwood-avro hardwood-s3 hardwood-aws-auth)
+
+if [ -z "$NEW" ]; then
+  CAPTION="HEAD vs $OLD"
+  # error-prone-checks is wired as an annotationProcessorPath, not a project
+  # dependency, so it stays invisible to the reactor and must be installed into
+  # the local repo first. The four modules are then installed (not just
+  # packaged) so japicmp can resolve their snapshot dependencies
+  # cross-invocation.
+  echo "Installing error-prone-checks and module JARs..."
+  ./mvnw -ntp -pl :hardwood-error-prone-checks -DskipTests install -q
+  ./mvnw -ntp -pl "$MODULES" -am -DskipTests install -q
+else
+  CAPTION="$NEW vs $OLD"
+  echo "Comparing published $NEW against $OLD — skipping local build."
+fi
+
+echo "Running japicmp..."
+if [ -z "$NEW" ]; then
+  ./mvnw -ntp -pl "$MODULES" japicmp:cmp -Djapicmp.oldVersion="$OLD" -q
+else
+  ./mvnw -ntp -pl "$MODULES" japicmp:cmp \
+    -Djapicmp.oldVersion="$OLD" -Djapicmp.newVersion="$NEW" -q
+fi
+
+REPORT_DIR="$ROOT/target/japicmp"
+mkdir -p "$REPORT_DIR"
+UNIFIED_DIFF="$REPORT_DIR/api-report.diff"
+UNIFIED_HTML="$REPORT_DIR/api-report.html"
+GENERATED="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+
+# Per-module file paths. The plugin names report files after the execution id
+# (default-cli when invoked from the command line). Glob to stay robust if the
+# goal ever gets bound to a phase with a different id.
+diff_for() { ls "$REPORT_DIR/$1"/*.diff 2>/dev/null | head -1; }
+html_for() { ls "$REPORT_DIR/$1"/*.html 2>/dev/null | head -1; }
+
+# --- text diff ----------------------------------------------------------------
+{
+  echo "Hardwood API report"
+  echo "  $CAPTION"
+  echo "  generated $GENERATED"
+  for artifact in "${ARTIFACTS[@]}"; do
+    diff_file=$(diff_for "$artifact")
+    echo
+    echo "=================================================="
+    echo " $artifact"
+    echo "=================================================="
+    if [ -n "$diff_file" ] && [ -f "$diff_file" ]; then
+      cat "$diff_file"
+    else
+      echo "(no diff produced — japicmp goal did not run for this module)"
+    fi
+  done
+} > "$UNIFIED_DIFF"
+
+# --- HTML ---------------------------------------------------------------------
+# Reuse one per-module HTML's <head> as a style template (japicmp embeds its
+# CSS there); add a table of contents under the page heading, then splice each
+# module's <body> content under an <h1 id="<artifact>"> banner.
+template=$(html_for "${ARTIFACTS[0]}")
+if [ -n "$template" ] && [ -f "$template" ]; then
+  {
+    sed -n '1,/<\/head>/p' "$template" \
+      | sed "s|<title>.*</title>|<title>Hardwood API report — $CAPTION</title>|"
+    echo "<body>"
+    echo "<h1>Hardwood API report</h1>"
+    echo "<p>$CAPTION &mdash; generated $GENERATED</p>"
+    echo "<ul>"
+    for artifact in "${ARTIFACTS[@]}"; do
+      echo "  <li><a href=\"#$artifact\">$artifact</a></li>"
+    done
+    echo "</ul>"
+    for artifact in "${ARTIFACTS[@]}"; do
+      html_file=$(html_for "$artifact")
+      echo "<hr>"
+      echo "<h1 id=\"$artifact\">$artifact</h1>"
+      if [ -n "$html_file" ] && [ -f "$html_file" ]; then
+        # Body content, without the wrapping <body>/</body> tags.
+        sed -n '/<body>/,/<\/body>/p' "$html_file" | sed '1d;$d'
+      else
+        echo "<p>(no HTML report produced)</p>"
+      fi
+    done
+    echo "</body>"
+    echo "</html>"
+  } > "$UNIFIED_HTML"
+fi
+
+echo
+echo "Wrote unified reports:"
+echo "  $UNIFIED_DIFF"
+[ -f "$UNIFIED_HTML" ] && echo "  $UNIFIED_HTML"
+echo "Per-module reports:   $REPORT_DIR/<artifact>/*.{html,diff,md,xml}"


### PR DESCRIPTION
Closes #561.

## Summary

- Move japicmp's full plugin configuration into the parent pom's `pluginManagement` (which previously managed only the version). The four published modules — `hardwood-core`, `hardwood-avro`, `hardwood-s3`, `hardwood-aws-auth` — now inherit the same `onlyModified` + `dev.hardwood.internal` excludes shape without per-module duplication, and `core/pom.xml` loses the 26 lines it used to carry.
- Add `tools/api-report.sh <PREVIOUS_VERSION>` — installs the snapshot jars (including the annotation-processor-only `hardwood-error-prone-checks`), runs `japicmp:cmp` against each of the four modules, and concatenates the per-module diffs into one `target/japicmp/api-report.diff` with section headers. Per-module HTML / Markdown / XML / diff land under `target/japicmp/<artifactId>/`.
- `README.md` "API Change Report" section now documents the new script.
- `release.sh` replaces its inline core-only japicmp invocation with a single call to `tools/api-report.sh`, so a release captures the avro/s3/aws-auth surfaces too.

Wiring japicmp into the `verify` lifecycle is separable per the issue body and is **not** part of this PR — manual invocation only.

## Test plan

- [x] `tools/api-report.sh 1.0.0.CR1` from a purged-M2 state — all four per-module diffs produced; unified `target/japicmp/api-report.diff` populated (~105 lines, four `==`-headed sections; real findings against the published `1.0.0.CR1` jars).
- [x] `./mvnw license:check` — clean (script carries the project header).
- [ ] Reviewer: verify `release.sh` change reads correctly against the rest of the release flow.