### PR TITLE
#566 Defend float/double pruning against NaN min/max in statistics

### DIFF
--- a/core/src/main/java/dev/hardwood/internal/predicate/StatisticsFilterSupport.java
+++ b/core/src/main/java/dev/hardwood/internal/predicate/StatisticsFilterSupport.java
@@ -93,6 +93,13 @@ final class StatisticsFilterSupport {
     }
 
     static boolean canDropFloat(FilterPredicate.Operator op, float value, float min, float max) {
+        // The Parquet spec forbids writing NaN to statistics min/max, but older / buggy writers
+        // have produced such bounds. NaN sorts above every finite value in Float.compare's total
+        // order, so applying the range checks below would silently prune row groups / pages that
+        // hold matching finite rows. Treat NaN bounds as no-bound and never prune.
+        if (Float.isNaN(min) || Float.isNaN(max)) {
+            return false;
+        }
         return switch (op) {
             case EQ -> Float.compare(value, min) < 0 || Float.compare(value, max) > 0;
             case NOT_EQ -> Float.compare(min, max) == 0 && Float.compare(value, min) == 0;
@@ -104,6 +111,9 @@ final class StatisticsFilterSupport {
     }
 
     static boolean canDropDouble(FilterPredicate.Operator op, double value, double min, double max) {
+        if (Double.isNaN(min) || Double.isNaN(max)) {
+            return false;
+        }
         return switch (op) {
             case EQ -> Double.compare(value, min) < 0 || Double.compare(value, max) > 0;
             case NOT_EQ -> Double.compare(min, max) == 0 && Double.compare(value, min) == 0;

--- a/core/src/test/java/dev/hardwood/internal/predicate/NaNStatisticsFilterTest.java
+++ b/core/src/test/java/dev/hardwood/internal/predicate/NaNStatisticsFilterTest.java
@@ -1,0 +1,91 @@
+/*
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Copyright The original authors
+ *
+ *  Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package dev.hardwood.internal.predicate;
+
+import java.util.stream.Stream;
+
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.EnumSource;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import dev.hardwood.reader.FilterPredicate.Operator;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/// Regression tests for #566: float/double predicate pruning must not drop matching rows
+/// when row-group / page statistics carry `NaN` in `min` or `max`.
+///
+/// The Parquet spec forbids writing `NaN` to `min`/`max`, but older or buggy writers have
+/// emitted such values. A conformant reader must treat a `NaN` bound as unusable for
+/// pruning (parquet-mr does the same).
+class NaNStatisticsFilterTest {
+
+    @ParameterizedTest(name = "double {0} with NaN min")
+    @EnumSource(Operator.class)
+    void doubleNaNMinNeverDrops(Operator op) {
+        assertThat(StatisticsFilterSupport.canDropDouble(op, 1.0, Double.NaN, 10.0))
+                .as("NaN min must be treated as no-bound and never prune")
+                .isFalse();
+    }
+
+    @ParameterizedTest(name = "double {0} with NaN max")
+    @EnumSource(Operator.class)
+    void doubleNaNMaxNeverDrops(Operator op) {
+        assertThat(StatisticsFilterSupport.canDropDouble(op, 1.0, -10.0, Double.NaN))
+                .as("NaN max must be treated as no-bound and never prune")
+                .isFalse();
+    }
+
+    @ParameterizedTest(name = "double {0} with NaN min and max")
+    @EnumSource(Operator.class)
+    void doubleNaNBothNeverDrops(Operator op) {
+        assertThat(StatisticsFilterSupport.canDropDouble(op, 1.0, Double.NaN, Double.NaN))
+                .isFalse();
+    }
+
+    @ParameterizedTest(name = "float {0} with NaN min")
+    @EnumSource(Operator.class)
+    void floatNaNMinNeverDrops(Operator op) {
+        assertThat(StatisticsFilterSupport.canDropFloat(op, 1.0f, Float.NaN, 10.0f))
+                .as("NaN min must be treated as no-bound and never prune")
+                .isFalse();
+    }
+
+    @ParameterizedTest(name = "float {0} with NaN max")
+    @EnumSource(Operator.class)
+    void floatNaNMaxNeverDrops(Operator op) {
+        assertThat(StatisticsFilterSupport.canDropFloat(op, 1.0f, -10.0f, Float.NaN))
+                .as("NaN max must be treated as no-bound and never prune")
+                .isFalse();
+    }
+
+    @ParameterizedTest(name = "float {0} with NaN min and max")
+    @EnumSource(Operator.class)
+    void floatNaNBothNeverDrops(Operator op) {
+        assertThat(StatisticsFilterSupport.canDropFloat(op, 1.0f, Float.NaN, Float.NaN))
+                .isFalse();
+    }
+
+    /// Sanity check that non-NaN stats still prune as before — guarding against an
+    /// overly broad fix that disables pruning for finite values too.
+    @ParameterizedTest(name = "double {0}({1}) on [{2},{3}] expectDrop={4}")
+    @MethodSource
+    void doubleFiniteStillPrunes(Operator op, double value, double min, double max, boolean expectDrop) {
+        assertThat(StatisticsFilterSupport.canDropDouble(op, value, min, max)).isEqualTo(expectDrop);
+    }
+
+    static Stream<Arguments> doubleFiniteStillPrunes() {
+        return Stream.of(
+                Arguments.of(Operator.LT,    0.0, 1.0, 10.0, true),  // all values >= 1 → drop
+                Arguments.of(Operator.LT,    5.0, 1.0, 10.0, false), // some values < 5 possible
+                Arguments.of(Operator.GT,   20.0, 1.0, 10.0, true),  // all values <= 10 → drop
+                Arguments.of(Operator.EQ,  100.0, 1.0, 10.0, true),  // 100 out of [1,10] → drop
+                Arguments.of(Operator.EQ,    5.0, 1.0, 10.0, false));
+    }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -330,6 +330,8 @@
                     <exclude>.venv/**</exclude>
                     <exclude>.docker-venv/**</exclude>
                     <exclude>_tmp/**</exclude>
+                    <exclude>japicmp-report/**</exclude>
+                    <exclude>**/__pycache__/**</exclude>
                     <exclude>.release-env</exclude>
                     <exclude>LICENSE.txt</exclude>
                     <exclude>etc/license-cc-by-sa.txt</exclude>


### PR DESCRIPTION
## Summary

Closes #566.

`StatisticsFilterSupport.canDropFloat` / `canDropDouble` compared against statistics min/max via `Float.compare` / `Double.compare`. Those comparators implement a *total* order in which `NaN` ranks above every finite value, so when a column's stats `min` (or `max`) was `NaN` — which the spec forbids but older/buggy writers have produced — predicates resolved against the NaN side silently pruned row groups and pages that held finite matches:

- **Unsafe directions** (with NaN `min`): `LT`, `LT_EQ`, `EQ` → predicate `min >= value` ended up true → page pruned even though it contained `< value`.
- **Safe by accident** (with NaN `max`): `GT`, `GT_EQ` happened to land on the right side of the comparison and did not prune.

The fix treats a NaN bound as "no bound" — short-circuits both methods to return `false` when either `min` or `max` is NaN. This matches parquet-mr's defensive behavior. Severity in the conformance audit (#565) flagged this as the highest: silent data loss.

The PR also adds two patterns to the `license-maven-plugin` excludes — `japicmp-report/**` and `**/__pycache__/**`. Both are gitignored byproducts (japicmp HTML reports from the #561 plumbing, Python bytecode caches from `tools/`); without the excludes, `./mvnw verify` aborts on the next run after either directory has been generated once in the workspace.

## Test plan

- [x] Failing test first: `NaNStatisticsFilterTest` parameterized across all six operators × {NaN min, NaN max, NaN both} × {float, double}, plus sanity cases that finite bounds still prune. 12 of the 41 cases failed pre-fix (LT/LT_EQ/EQ with NaN min, all six with NaN-both — for each of float and double); all 41 pass post-fix.
- [x] `./mvnw -pl core test` — 1272 tests pass.
- [x] `./mvnw -pl avro,cli,s3,parquet-java-compat,integration-test test` — green.
- [x] `./mvnw -N license:check` with stale `japicmp-report/` and `__pycache__/` present — passes (without the new excludes it would fail with "Missing header").
- [ ] CI on this PR.

Pre-existing failures in `parquet-testing-runner` (`fixed_length_byte_array.parquet` decoding error, missing `target/parquet-testing/` fixtures) reproduce on `main` with this change reverted and are unrelated.