### PR TITLE
#582 Upgrade parquet-java reference impl to 1.17.1

### DIFF
--- a/parquet-testing-runner/src/test/java/dev/hardwood/testing/Utils.java
+++ b/parquet-testing-runner/src/test/java/dev/hardwood/testing/Utils.java
@@ -8,6 +8,7 @@
 package dev.hardwood.testing;
 
 import java.io.IOException;
+import java.math.BigDecimal;
 import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
@@ -267,7 +268,14 @@ public class Utils {
                 compareMap(context, resolved.getValueType(), (Map<?, ?>) refValue, map);
             }
             default -> {
-                Object actualValue = getLeafValue(actual, fieldName, resolved);
+                // parquet-java's Avro reader applies the DECIMAL logical-type conversion
+                // to INT32/INT64-backed decimals, surfacing a BigDecimal. Hardwood's row
+                // API exposes the same via getDecimal(), so read it that way and compare
+                // BigDecimal-to-BigDecimal. (BYTE_ARRAY/FIXED-backed decimals are read as
+                // raw bytes on both sides, so refValue is not a BigDecimal for those.)
+                Object actualValue = refValue instanceof BigDecimal
+                        ? actual.getDecimal(fieldName)
+                        : getLeafValue(actual, fieldName, resolved);
                 compareLeafValues(context, refValue, actualValue);
             }
         }
@@ -381,9 +389,36 @@ public class Utils {
         else if (comparableRef instanceof byte[] refBytes) {
             assertThat((byte[]) comparableActual).as(context).isEqualTo(refBytes);
         }
+        else if (comparableRef instanceof BigDecimal refDecimal) {
+            assertDecimalMatches(context, refDecimal, comparableActual);
+        }
         else {
             assertThat(comparableActual).as(context).isEqualTo(comparableRef);
         }
+    }
+
+    /// Compare a reference [BigDecimal] (produced by parquet-java's Avro reader
+    /// for INT32/INT64-backed decimals) against the Hardwood-side value. The two
+    /// read APIs surface decimals differently:
+    ///
+    /// - The row API (`StructAccessor#getDecimal`) decodes the logical type and
+    ///   hands back a [BigDecimal], compared directly here.
+    /// - The column API ([dev.hardwood.reader.ColumnReader]) is the physical layer
+    ///   and exposes only the raw unscaled `int`/`long`; the scaled value is
+    ///   reconstructed using the reference's scale before comparing.
+    ///
+    /// Both arms compare with [java.math.BigDecimal#compareTo] semantics so that
+    /// equal values with differing scales (e.g. `1.0` vs `1.00`) still match.
+    private static void assertDecimalMatches(String context, BigDecimal expected, Object actual) {
+        if (actual instanceof BigDecimal actualDecimal) {
+            assertThat(actualDecimal).as(context).isEqualByComparingTo(expected);
+            return;
+        }
+        assertThat(actual)
+                .as(context + " (decimal unscaled value)")
+                .isInstanceOf(Number.class);
+        BigDecimal reconstructed = BigDecimal.valueOf(((Number) actual).longValue(), expected.scale());
+        assertThat(reconstructed).as(context).isEqualByComparingTo(expected);
     }
 
     /// Compare an Avro collection against a Hardwood [PqList] element-by-element.
@@ -964,6 +999,9 @@ public class Utils {
         }
         else if (expected instanceof byte[] refBytes) {
             assertThat((byte[]) actual).as(context).isEqualTo(refBytes);
+        }
+        else if (expected instanceof BigDecimal refDecimal) {
+            assertDecimalMatches(context, refDecimal, actual);
         }
         else {
             assertThat(actual).as(context).isEqualTo(expected);

--- a/test-bom/pom.xml
+++ b/test-bom/pom.xml
@@ -66,12 +66,12 @@
       <dependency>
         <groupId>org.apache.parquet</groupId>
         <artifactId>parquet-hadoop</artifactId>
-        <version>1.16.0</version>
+        <version>1.17.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.parquet</groupId>
         <artifactId>parquet-avro</artifactId>
-        <version>1.16.0</version>
+        <version>1.17.1</version>
       </dependency>
 
       <!-- Git cloning -->


### PR DESCRIPTION
Closes #582.

Bumps the parquet-java reference implementation used by `hardwood-parquet-testing-runner` from **1.16.0** to **1.17.1** (`parquet-hadoop` + `parquet-avro` in `test-bom/pom.xml`), keeping the differential comparison meaningful against the current release ahead of `1.0.0.Final`.

### Decimal handling in the comparison harness

The bump surfaced a long-standing gap in the harness rather than a Hardwood regression. parquet-avro 1.17 fixed [GH-3149](https://github.com/apache/parquet-java/issues/3149) (via [#3306](https://github.com/apache/parquet-java/pull/3306)): the Avro reader now respects the DECIMAL annotation on **INT32/INT64**-backed columns and returns a `BigDecimal`, where 1.16 dropped the scale and returned the raw primitive (e.g. `23.4` read as `234`).

The row-level comparison previously read these columns via `getInt`/`getLong`, so it never exercised Hardwood's decimal API at all — it merely happened to match the old, buggy primitive. It now:

- **Row path** — reads decimals through `StructAccessor.getDecimal` and compares `BigDecimal`-to-`BigDecimal`, actually validating Hardwood's decimal support against the (now spec-correct) reference.
- **Column path** — keeps comparing against the reconstructed scaled value, since `ColumnReader` is the physical layer and deliberately exposes only the unscaled `int`/`long`.

Detection is reference-driven (`refValue instanceof BigDecimal`): the GH-3149 fix is scoped to INT32/INT64 only, so BYTE_ARRAY/FIXED-backed decimals are still read as raw bytes on both sides and correctly stay on the existing byte path.

All 570 runner tests pass (62 skipped, unchanged).