### PR TITLE
#570 Document float total-order, qualify legacy-list compatibility

### DIFF
--- a/core/src/main/java/dev/hardwood/reader/FilterPredicate.java
+++ b/core/src/main/java/dev/hardwood/reader/FilterPredicate.java
@@ -58,6 +58,25 @@ import java.util.UUID;
 /// parquet-java's `notEq`, which treats `null <> v` as true and therefore
 /// includes null rows. To reproduce parquet-java's behavior in Hardwood, write
 /// the null-inclusion explicitly: `or(notEq("x", v), isNull("x"))`.
+///
+/// ## Float and double comparisons
+///
+/// Predicates on `float` and `double` columns use the [Float#compare] /
+/// [Double#compare] total order, not IEEE 754 equality. Two consequences
+/// matter in practice:
+///
+/// - `-0.0` is strictly less than `+0.0`. `eq(0.0)` matches only `+0.0`
+///   values; to match either zero, use `or(eq(0.0), eq(-0.0))`.
+/// - `NaN` sorts above every finite value. `eq(NaN)` matches only `NaN`
+///   (whereas IEEE `NaN == anything` is always false). `lt` and `ltEq` against
+///   any value never match `NaN` rows; `gt` and `gtEq` against a finite value
+///   always include `NaN` rows.
+///
+/// Predicate pushdown is defensive against non-conformant writers: if a
+/// column's statistics carry `NaN` as `min` or `max` (forbidden by the
+/// Parquet spec, but produced by older / buggy writers), the bound is
+/// treated as no-bound and pruning is skipped on that side — matching rows
+/// are never dropped.
 public sealed interface FilterPredicate
         permits FilterPredicate.IntColumnPredicate,
                 FilterPredicate.LongColumnPredicate,

--- a/docs/content/concepts/compatibility-philosophy.md
+++ b/docs/content/concepts/compatibility-philosophy.md
@@ -26,10 +26,10 @@ Two goals are in tension, and Hardwood resolves them on different axes:
 
 - **Read what's out there.** Parquet files in the wild were written by many tools across many
   years — parquet-mr, Arrow, Spark, Hive, PyArrow — using legacy encodings, deprecated types,
-  and annotations that newer specs dropped. Hardwood reads these transparently: legacy 2-level
-  list encodings, INT96 timestamps, the legacy `converted_type` annotations that predate the
-  modern logical-type union, `NULL`-typed columns, FLOAT16. On the *input* side, Hardwood is
-  liberal — if parquet-java can read it, Hardwood aims to.
+  and annotations that newer specs dropped. Hardwood reads these transparently: most legacy
+  list-encoding variants, INT96 timestamps, the legacy `converted_type` annotations that
+  predate the modern logical-type union, `NULL`-typed columns, FLOAT16. On the *input* side,
+  Hardwood is liberal — if parquet-java can read it, Hardwood aims to.
 - **Don't silently produce wrong results.** On the *semantic* side, where a behavior is a matter
   of correctness rather than file compatibility, Hardwood chooses the well-defined answer even
   when that diverges from parquet-java's historical behavior. This follows the project's

--- a/docs/content/how-to/query-controls.md
+++ b/docs/content/how-to/query-controls.md
@@ -81,6 +81,26 @@ FilterPredicate filter = FilterPredicate.or(
 !!! note "Divergence from parquet-java"
     parquet-java's `notEq` treats `null <> v` as true and therefore includes null rows, which breaks the SQL identity above. Hardwood applies uniform SQL three-valued-logic semantics across all comparison operators. To reproduce parquet-java's behavior, make the null-inclusion explicit: `or(notEq("x", v), isNull("x"))`.
 
+### Float and Double Comparisons
+
+Predicates on `float` and `double` columns use the `Float.compare` / `Double.compare` total order, not IEEE 754 equality. Two consequences matter in practice:
+
+- `-0.0` is strictly less than `+0.0`. `eq(0.0)` matches only `+0.0` values; to match either zero, use `or(eq(0.0), eq(-0.0))`.
+- `NaN` sorts above every finite value. `eq(Float.NaN)` matches only `NaN` (whereas IEEE `NaN == anything` is always false). `lt` and `ltEq` against any value never match `NaN` rows; `gt` and `gtEq` against a finite value always include `NaN` rows.
+
+```java
+// Match any NaN row
+FilterPredicate anyNaN = FilterPredicate.eq("score", Double.NaN);
+
+// Match both signed zeros
+FilterPredicate anyZero = FilterPredicate.or(
+    FilterPredicate.eq("ratio", 0.0),
+    FilterPredicate.eq("ratio", -0.0)
+);
+```
+
+Row-group and page-level pushdown is defensive against non-conformant writers: if a column's statistics carry `NaN` as `min` or `max` (forbidden by the Parquet spec, but produced by older or buggy writers), that bound is treated as no-bound and the row group / page is not pruned on its account.
+
 ### Logical Type Support
 
 Factory methods are provided for common Parquet logical types, handling the physical


### PR DESCRIPTION
Closes #570 (plus a drive-by fix for a #568 build fallout).

## Summary

- **`docs/content/how-to/query-controls.md`**: new "Float and Double Comparisons" subsection — documents that `eq` / `lt` / etc. on `float` and `double` use the `Float.compare` / `Double.compare` total order (`-0.0` strictly less than `+0.0`; `NaN` sorts above every finite value), with worked examples for "match any NaN" and "match either signed zero", and notes that NaN bounds in column statistics are treated as no-bound by pushdown (the #566 defence).
- **`core/src/main/java/dev/hardwood/reader/FilterPredicate.java`**: the same contract on the class-level JavaDoc so the contract is discoverable from the API.
- **`docs/content/concepts/compatibility-philosophy.md`**: "legacy 2-level list encodings" → "most legacy list-encoding variants" — the LIST backward-compat rule 3 case (#567) is open for 1.1, so the original phrasing over-promised.
- **`row-reader.md` TIMESTAMP guidance** (the third #570 bullet) already landed in #584 with #568; no edit needed here.
- **Drive-by `#568` commit**: `RecordFilterMicroBenchmark`'s anonymous `RowReader` test doubles missed the new `getLocalTimestamp` override added by #584, so the benchmark module no longer compiled under `-Pperformance-test`. Two-line fix to match the other unsupported-operation stubs.

## Test plan

- [x] `mkdocs build --strict` — clean.
- [x] `./mvnw -pl :hardwood-core -am -DskipTests compile` — clean (validates the JavaDoc `///` syntax).
- [x] `./mvnw -pl :hardwood-performance-testing-micro-benchmarks -am -DskipTests -Pperformance-test compile` — clean with the benchmark fix; failed on `main` without it.
- [ ] CI on this PR.