### PR TITLE
#541 Support skip combined with a filter as a logical OFFSET

### DIFF
--- a/_designs/ROW_BASED_SEEK.md
+++ b/_designs/ROW_BASED_SEEK.md
@@ -19,11 +19,14 @@ from row 0 and fetching everything in between.
 A new method on the existing `RowReaderBuilder`:
 
 ```java
-/// Begin reading from the given absolute row index. Earlier row groups
-/// are not opened — their pages are not fetched or decoded — so this
-/// is an O(1 RG) seek on remote backends.
+/// Skip rows before reading — SQL `OFFSET`. **Without a filter**, `skip(n)`
+/// is a physical absolute row index: earlier row groups are not opened —
+/// their pages are not fetched or decoded — so this is an O(1 RG) seek on
+/// remote backends. **With a filter**, `skip(n)` is a logical offset over
+/// the matched rows (see ROW_SELECTION_SEMANTICS.md / #541), and the O(1)
+/// seek does not apply — earlier groups are decoded to count matches.
 ///
-/// `skip == 0` is the no-op default. `skip == totalRows`
+/// `skip == 0` is the no-op default. `skip >= totalRows`
 /// produces an empty reader. Indexes into the *first* file's rows for
 /// multi-file readers; cross-file `skip` is out of scope. Mutually
 /// exclusive with [#tail]; composes with [#head] for a bounded
@@ -54,7 +57,12 @@ file).
 
 ## Implementation
 
-In `ParquetFileReader.buildRowReader(projection, filter, maxRows, skip)`:
+The physical seek below is the **no-filter** path. When a `FilterPredicate` is
+present, `skip` is instead a logical offset over the matched rows — earlier
+groups must be decoded to count matches — handled separately per
+[ROW_SELECTION_SEMANTICS.md](ROW_SELECTION_SEMANTICS.md) (#541).
+
+In `ParquetFileReader.buildRowReader(projection, filter, maxRows, skip)`, with no filter:
 
 1. If `skip == 0`, delegate to the existing path (no behaviour change).
 2. Otherwise, locate the target row group by walking cumulative
@@ -140,8 +148,8 @@ dedicated viewport window cache (#377) replaces them.
   at the start of RG 1 with no within-RG residue.
 - `ParquetReaderTest.skipComposesWithHead` — `skip(150).head(20)`
   yields exactly rows 150..169.
-- `ParquetReaderTest.skipAtTotalRowsYieldsEmpty` — boundary at
-  end-of-file.
+- `ParquetReaderTest.skipAtOrBeyondTotalRowsYieldsEmpty` — at and past
+  end-of-file (overshoot yields empty, not an error).
 - `ParquetReaderTest.skipRejectsNegative` and
   `skipAndTailAreMutuallyExclusive` cover the validation paths.
 - `DataPreviewIoTest` exercises the dive integration: jump-to-last-page

--- a/core/src/main/java/dev/hardwood/reader/ParquetFileReader.java
+++ b/core/src/main/java/dev/hardwood/reader/ParquetFileReader.java
@@ -240,7 +240,7 @@ public class ParquetFileReader implements AutoCloseable {
         // Apply the row-group predicate (e.g. byte-range) up front so `skip` indexes
         // into the kept sequence — a caller doing split-aware reading can seek inside *its*
         // split. Stats-based row-group dropping (via FilterPredicate) stays inside the
-        // RowGroupIterator, so its semantics under `skip` are unchanged from before.
+        // RowGroupIterator.
         List<RowGroup> filteredRowGroups = rowGroupFilter == null
                 ? firstFileMetaData.rowGroups()
                 : filterRowGroups(null, rowGroupFilter);
@@ -248,9 +248,24 @@ public class ParquetFileReader implements AutoCloseable {
         if (skip == 0L) {
             return buildRowReader(projection, filter, maxRows, filteredRowGroups);
         }
-        // Locate the row group containing `skip` by walking cumulative
-        // RowGroup.numRows() over the filtered list. After the loop, `cumulative`
-        // equals the total row count of `filteredRowGroups` if no target was found.
+
+        if (filter != null) {
+            // Logical OFFSET over the matched relation (SQL OFFSET), symmetric with
+            // head() being LIMIT (#538). Row-group statistics bound values, not match
+            // counts, so we cannot seek by physical row position: build over the full
+            // (row-group-filtered) relation, cap the underlying reader at `skip + head`
+            // matched rows, then discard the first `skip` matches. A `skip` past the end
+            // of the matched relation simply yields an exhausted (empty) reader.
+            long matchedCap = maxRows == 0 ? 0L : Math.addExact(maxRows, skip);
+            RowReader reader = buildRowReader(projection, filter, matchedCap, filteredRowGroups);
+            return discardLeadingRows(reader, skip);
+        }
+
+        // No filter: `skip` is a physical row offset. Locate the row group containing
+        // `skip` by walking cumulative RowGroup.numRows() over the filtered list, open
+        // from there, and discard the within-group residue — earlier row groups are
+        // never opened (O(1 row-group) seek). After the loop, `cumulative` equals the
+        // total row count of `filteredRowGroups` if no target was found.
         long cumulative = 0L;
         int targetRg = -1;
         long withinRg = 0L;
@@ -264,12 +279,8 @@ public class ParquetFileReader implements AutoCloseable {
             cumulative += rgRows;
         }
         if (targetRg < 0) {
-            if (skip > cumulative) {
-                throw new IllegalArgumentException(
-                        "skip " + skip
-                        + " exceeds the (row-group-filtered) total row count " + cumulative);
-            }
-            // skip == cumulative — empty reader.
+            // skip >= total rows — a SQL OFFSET past the end of the relation, so an
+            // empty reader (consistent with the filtered case overshooting the matches).
             return buildRowReader(projection, filter, maxRows, List.<RowGroup>of());
         }
         List<RowGroup> rowGroups = targetRg == 0
@@ -283,13 +294,34 @@ public class ParquetFileReader implements AutoCloseable {
         // Walk past the within-RG residue. These rows *are* decoded —
         // page-level skip via OffsetIndex (#381) would let us drop the
         // leading pages at the byte level instead.
-        for (long i = 0; i < withinRg; i++) {
-            if (!reader.hasNext()) {
-                break;
+        return discardLeadingRows(reader, withinRg);
+    }
+
+    /// Advances `reader` past its first `count` rows via `next()` and returns it,
+    /// positioned at the first row the caller should see. Used to apply both the
+    /// physical within-row-group residue (no-filter `skip`) and the logical `OFFSET`
+    /// (filtered `skip`). Stops early if the reader is exhausted before `count`. If
+    /// iteration fails, the partially built reader is closed before the error
+    /// propagates, so its worker pipeline never leaks.
+    private static RowReader discardLeadingRows(RowReader reader, long count) {
+        try {
+            for (long i = 0; i < count; i++) {
+                if (!reader.hasNext()) {
+                    break;
+                }
+                reader.next();
             }
-            reader.next();
+            return reader;
         }
-        return reader;
+        catch (RuntimeException e) {
+            try {
+                reader.close();
+            }
+            catch (RuntimeException closeException) {
+                e.addSuppressed(closeException);
+            }
+            throw e;
+        }
     }
 
     RowReader buildTailRowReader(ColumnProjection projection, long tailRows) {
@@ -513,9 +545,9 @@ public class ParquetFileReader implements AutoCloseable {
         /// Positive: return at most `tailRows` rows from the end.
         /// Zero (default): no limit. Mutually exclusive with `headRows`.
         private long tailRows;
-        /// Zero (default): start from row 0. Positive: skip rows before the
-        /// given absolute row index, opening only the row group(s) needed
-        /// to reach it. Mutually exclusive with `tailRows`.
+        /// Zero (default): start from row 0. Positive: SQL `OFFSET` — a physical
+        /// absolute row index without a filter, or a logical offset over matched
+        /// rows with one. Mutually exclusive with `tailRows`.
         private long skip;
 
         private RowReaderBuilder(ParquetFileReader fileReader) {
@@ -575,25 +607,23 @@ public class ParquetFileReader implements AutoCloseable {
             return this;
         }
 
-        /// Begin reading from the given absolute row index. Earlier row groups
-        /// are not opened — their pages are not fetched or decoded — so this
-        /// is an O(1 RG) seek on remote backends, in contrast to walking
-        /// `next()` from row 0.
+        /// Skip leading rows before reading — SQL `OFFSET`. Its meaning depends on
+        /// whether a [#filter(FilterPredicate)] is present:
         ///
-        /// **Cost within the target row group.** The reader still yields
-        /// rows from the row group's first row, then walks `next()`
-        /// `skip - rowGroupFirstRow` times to discard the leading
-        /// residue. Those residue rows *are* decoded — `skip` near
-        /// the end of a 1 M-row group walks ~1 M decoded `next()` calls.
-        /// Page-level skip via OffsetIndex is tracked as #381.
+        /// - **Without a filter:** a physical absolute row index. Earlier row groups
+        ///   are not opened — an O(1 row-group) seek on remote backends (the leading
+        ///   residue within the target row group is still decoded). `skip >= totalRows`
+        ///   yields an empty reader. Indexes into the *first* file's rows for multi-file
+        ///   readers.
+        /// - **With a filter:** a *logical* offset over the matched rows — discards the
+        ///   first `n` rows matching the predicate, symmetric with [#head] as `LIMIT`.
+        ///   The O(1) seek does not apply: the reader decodes earlier groups to count
+        ///   matches (groups proven non-matching by statistics are still pruned). A
+        ///   `skip` past the match count yields an empty reader, counting across *all*
+        ///   files in order.
         ///
-        /// `skip == 0` is the no-op default. `skip == totalRows`
-        /// produces an empty reader. `skip > totalRows` throws
-        /// [IllegalArgumentException] at `build()` time. Indexes into the
-        /// *first* file's rows for multi-file readers; cross-file
-        /// `skip` is out of scope. Mutually exclusive with [#tail] and with
-        /// [#filter(FilterPredicate)]; composes with [#head] for a bounded
-        /// `[skip, skip + maxRows)` window, and with
+        /// `skip == 0` is the no-op default. Mutually exclusive with [#tail]; composes
+        /// with [#head] (`skip(n).head(k)` is `OFFSET n LIMIT k`) and with
         /// [#filter(RowGroupPredicate)] over the kept row-group sequence.
         public RowReaderBuilder skip(long skip) {
             if (skip < 0) {
@@ -619,12 +649,6 @@ public class ParquetFileReader implements AutoCloseable {
             }
             if (tailRows > 0 && skip > 0) {
                 throw new IllegalArgumentException("tail and skip are mutually exclusive");
-            }
-            if (skip > 0 && filter != null) {
-                throw new IllegalArgumentException(
-                        "skip cannot be combined with a filter predicate: logical OFFSET "
-                                + "semantics over the filtered relation are not yet supported "
-                                + "(tracked in #541)");
             }
             if (tailRows > 0) {
                 return fileReader.buildTailRowReader(projection, tailRows);

--- a/core/src/main/java/dev/hardwood/reader/ParquetFileReader.java
+++ b/core/src/main/java/dev/hardwood/reader/ParquetFileReader.java
@@ -359,12 +359,7 @@ public class ParquetFileReader implements AutoCloseable {
             // mask gate (a nested-v1 column without an OffsetIndex). Decode
             // every leading row and discard it to preserve cross-column
             // row alignment.
-            for (long i = 0; i < skip; i++) {
-                if (!reader.hasNext()) {
-                    break;
-                }
-                reader.next();
-            }
+            return discardLeadingRows(reader, skip);
         }
         return reader;
     }

--- a/core/src/test/java/dev/hardwood/BuilderCombinationTest.java
+++ b/core/src/test/java/dev/hardwood/BuilderCombinationTest.java
@@ -49,8 +49,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 /// follow-up (a known bug in flight, or a legal-but-unverified interaction).
 ///
 /// The matrix is the live contract: adding a builder option means adding its rows here, and a
-/// behavior change (e.g. #540 turning `skip` + filter from BUILDS into REJECTED) makes the
-/// corresponding row fail until it is updated.
+/// behavior change makes the corresponding row fail until it is updated.
 class BuilderCombinationTest {
 
     private static final Path FIXTURE = Paths.get("src/test/resources/filter_pushdown_int.parquet");
@@ -134,9 +133,8 @@ class BuilderCombinationTest {
                 Combo.rejected("filterFP + tail",
                         b -> b.filter(FilterPredicate.gt("id", 150L)).tail(50),
                         "tail cannot be combined with a filter"),
-                Combo.rejected("filterFP + skip",
-                        b -> b.filter(FilterPredicate.gt("id", 150L)).skip(50),
-                        "skip cannot be combined with a filter"),
+                Combo.builds("filterFP + skip",
+                        b -> b.filter(FilterPredicate.gt("id", 150L)).skip(50)),
 
                 // ---- filter(RowGroupPredicate) × {…} ----
                 Combo.buildsPending("filterRGP + head",
@@ -156,9 +154,8 @@ class BuilderCombinationTest {
                         "tail and skip are mutually exclusive"),
 
                 // ---- key triples ----
-                Combo.rejected("filterFP + skip + head",
-                        b -> b.filter(FilterPredicate.gt("id", 150L)).skip(20).head(50),
-                        "skip cannot be combined with a filter"),
+                Combo.builds("filterFP + skip + head",
+                        b -> b.filter(FilterPredicate.gt("id", 150L)).skip(20).head(50)),
                 Combo.builds("filterRGP + skip + head",
                         b -> b.filter(RowGroupPredicate.byteRange(rg1Mid, fileLen)).skip(20).head(50)),
                 Combo.builds("projection + filterRGP + skip + head",
@@ -174,7 +171,7 @@ class BuilderCombinationTest {
             c.apply().accept(builder);
 
             if (c.expect() == Disposition.REJECTED) {
-                assertThatThrownBy(() -> builder.build())
+                assertThatThrownBy(builder::build)
                         .isInstanceOf(IllegalArgumentException.class)
                         .hasMessageContaining(c.rejectMessage());
                 return;
@@ -194,7 +191,7 @@ class BuilderCombinationTest {
 
     /// Multi-file boundary cells — `skip` indexes into the first file only and `tail` is
     /// single-file-only (throws) — need a multi-file fixture before they can be pinned.
-    /// Tracked by #577; left disabled so the gap is visible in test reports.
+    /// Tracked by #577; left disabled, so the gap is visible in test reports.
     @Test
     @Disabled("multi-file boundary cells need a multi-file fixture — see #577")
     void multiFileBoundaries() {

--- a/core/src/test/java/dev/hardwood/BuilderCombinationTest.java
+++ b/core/src/test/java/dev/hardwood/BuilderCombinationTest.java
@@ -189,13 +189,15 @@ class BuilderCombinationTest {
         }
     }
 
-    /// Multi-file boundary cells — `skip` indexes into the first file only and `tail` is
-    /// single-file-only (throws) — need a multi-file fixture before they can be pinned.
-    /// Tracked by #577; left disabled, so the gap is visible in test reports.
+    /// Multi-file boundary cells — physical `skip` (no filter) indexes into the first file
+    /// only, logical `skip` (with a filter) counts matches across *all* files in order, and
+    /// `tail` is single-file-only (throws) — all need a multi-file fixture before they can be
+    /// pinned. Tracked by #577; left disabled, so the gap is visible in test reports.
     @Test
     @Disabled("multi-file boundary cells need a multi-file fixture — see #577")
     void multiFileBoundaries() {
-        // skip + multi-file: indexes into the first file's rows only.
+        // physical skip + multi-file: indexes into the first file's rows only.
+        // filtered skip + multi-file: counts matched rows across all files in order.
         // tail + multi-file: currently UnsupportedOperationException.
     }
 }

--- a/core/src/test/java/dev/hardwood/DifferentialReadTest.java
+++ b/core/src/test/java/dev/hardwood/DifferentialReadTest.java
@@ -158,8 +158,15 @@ class DifferentialReadTest {
 
                 builds("filter + head", null, new Pred(Op.GT, 100), null, 20, null),
 
-                // --- known-wrong today; clearing the marker turns this into the fix's verifier ---
-                pending("#541", "filter + skip + head", new Pred(Op.GT, 100), 10, 20, null));
+                // --- #541: skip + filter as logical OFFSET over the matched relation ---
+                builds("filter + skip + head", null, new Pred(Op.GT, 100), 10, 20, null),
+                builds("filter + skip", null, new Pred(Op.GT, 100), 30, null, null),
+
+                // --- skip past the end of the relation: a SQL OFFSET overshoot yields empty,
+                //     both at the boundary (== 250 rows) and beyond, with and without a filter ---
+                builds("skip == total", null, null, 250, null, null),
+                builds("skip beyond total", null, null, 300, null, null),
+                builds("filter + skip beyond matches", null, new Pred(Op.GT, 100), 300, null, null));
     }
 
     static Stream<Arguments> cases() {

--- a/core/src/test/java/dev/hardwood/ParquetReaderTest.java
+++ b/core/src/test/java/dev/hardwood/ParquetReaderTest.java
@@ -469,18 +469,32 @@ class ParquetReaderTest {
     }
 
     @Test
-    void skipAndFilterPredicateAreRejected() throws Exception {
+    void skipWithFilterIsLogicalOffsetOverMatches() throws Exception {
+        // id 1..300. gtEq(id, 100) matches 100..300 (201 rows). skip(50) is a logical
+        // OFFSET over the matched relation: discard the first 50 matches (100..149) and
+        // yield the rest, 150..300 — not a physical 50-row seek (#541).
         Path parquetFile = Paths.get("src/test/resources/filter_pushdown_int.parquet");
 
-        try (ParquetFileReader reader = ParquetFileReader.open(InputFile.of(parquetFile))) {
-            assertThatThrownBy(() -> reader.buildRowReader()
-                    .projection(ColumnProjection.all())
-                    .skip(50)
-                    .filter(FilterPredicate.gtEq("id", 100L))
-                    .build())
-                    .isInstanceOf(IllegalArgumentException.class)
-                    .hasMessageContaining("skip")
-                    .hasMessageContaining("filter");
+        try (ParquetFileReader reader = ParquetFileReader.open(InputFile.of(parquetFile));
+             RowReader rows = reader.buildRowReader()
+                     .skip(50)
+                     .filter(FilterPredicate.gtEq("id", 100L))
+                     .build()) {
+            long firstId = -1;
+            long lastId = -1;
+            int count = 0;
+            while (rows.hasNext()) {
+                rows.next();
+                long id = rows.getLong("id");
+                if (firstId < 0) {
+                    firstId = id;
+                }
+                lastId = id;
+                count++;
+            }
+            assertThat(count).as("matches after skip(50)").isEqualTo(151);
+            assertThat(firstId).as("first matched id after skip(50)").isEqualTo(150L);
+            assertThat(lastId).as("last matched id").isEqualTo(300L);
         }
     }
 
@@ -558,12 +572,17 @@ class ParquetReaderTest {
     }
 
     @Test
-    void skipAtTotalRowsYieldsEmpty() throws Exception {
+    void skipAtOrBeyondTotalRowsYieldsEmpty() throws Exception {
+        // skip past the end of the file is a SQL OFFSET overshoot — an empty reader,
+        // not an error, at the boundary (== totalRows) and beyond (> totalRows).
         Path parquetFile = Paths.get("src/test/resources/filter_pushdown_int.parquet");
 
         try (ParquetFileReader reader = ParquetFileReader.open(InputFile.of(parquetFile))) {
             long total = reader.getFileMetaData().numRows();
             try (RowReader rows = reader.buildRowReader().skip(total).build()) {
+                assertThat(rows.hasNext()).isFalse();
+            }
+            try (RowReader rows = reader.buildRowReader().skip(total + 1000).build()) {
                 assertThat(rows.hasNext()).isFalse();
             }
         }

--- a/core/src/test/java/dev/hardwood/PredicatePushDownTest.java
+++ b/core/src/test/java/dev/hardwood/PredicatePushDownTest.java
@@ -291,6 +291,91 @@ class PredicatePushDownTest {
     }
 
     @Test
+    void testSkipWithFilterIsLogicalOffsetSpanningRowGroups() throws Exception {
+        // gt(id, 50) matches 51-300 (250 rows). skip(150) discards the first 150
+        // matches — 51-100 (RG1), 101-200 (RG2), crossing both boundaries — so reading
+        // resumes at the 151st match (id 201) and yields through id 300. The first 50
+        // matches live in RG1, which a physical seek would wrongly skip past.
+        try (ParquetFileReader reader = ParquetFileReader.open(InputFile.of(INT_FILE))) {
+            FilterPredicate filter = FilterPredicate.gt("id", 50L);
+
+            try (RowReader rows = reader.buildRowReader().skip(150).filter(filter).build()) {
+                List<Long> ids = new ArrayList<>();
+                while (rows.hasNext()) {
+                    rows.next();
+                    ids.add(rows.getLong("id"));
+                }
+                assertThat(ids).hasSize(100);
+                assertThat(ids.getFirst()).isEqualTo(201L);
+                assertThat(ids.getLast()).isEqualTo(300L);
+            }
+        }
+    }
+
+    @Test
+    void testSkipWithFilterAndHeadIsOffsetLimitOverMatches() throws Exception {
+        // OFFSET 150 LIMIT 5 over gt(id, 50): matches 51-300; skip the first 150
+        // matches (51-200, spanning RG1 and RG2), then return the next 5 -> 201-205.
+        try (ParquetFileReader reader = ParquetFileReader.open(InputFile.of(INT_FILE))) {
+            FilterPredicate filter = FilterPredicate.gt("id", 50L);
+
+            try (RowReader rows = reader.buildRowReader().skip(150).filter(filter).head(5).build()) {
+                List<Long> ids = new ArrayList<>();
+                while (rows.hasNext()) {
+                    rows.next();
+                    ids.add(rows.getLong("id"));
+                }
+                assertThat(ids).containsExactly(201L, 202L, 203L, 204L, 205L);
+            }
+        }
+    }
+
+    @Test
+    void testSkipWithFilterBeyondMatchCountYieldsEmpty() throws Exception {
+        // gt(id, 50) matches 250 rows; skip(1000) discards them all and yields an
+        // empty reader (SQL OFFSET past the result set), without throwing.
+        try (ParquetFileReader reader = ParquetFileReader.open(InputFile.of(INT_FILE))) {
+            FilterPredicate filter = FilterPredicate.gt("id", 50L);
+
+            try (RowReader rows = reader.buildRowReader().skip(1000).filter(filter).build()) {
+                assertThat(rows.hasNext()).isFalse();
+            }
+        }
+    }
+
+    @Test
+    void testSkipWithFilterAtExactMatchCountYieldsEmpty() throws Exception {
+        // gt(id, 50) matches exactly 250 rows; skip(250) discards all of them — the
+        // OFFSET == result-set-size boundary — yielding an empty reader.
+        try (ParquetFileReader reader = ParquetFileReader.open(InputFile.of(INT_FILE))) {
+            FilterPredicate filter = FilterPredicate.gt("id", 50L);
+
+            try (RowReader rows = reader.buildRowReader().skip(250).filter(filter).build()) {
+                assertThat(rows.hasNext()).isFalse();
+            }
+        }
+    }
+
+    @Test
+    void testSkipWithFilterOnNestedSchemaIsLogicalOffset() throws Exception {
+        // Record-level filtering on a nested schema routes through FilteredRowReader.
+        // RG2 holds id 4-6, RG3 id 7-9. gt(id, 4) matches 5,6,7,8,9; skip(2) discards
+        // the first two matches (5, 6) and yields 7, 8, 9, crossing the RG2/RG3 boundary.
+        try (ParquetFileReader reader = ParquetFileReader.open(InputFile.of(NESTED_FILE))) {
+            FilterPredicate filter = FilterPredicate.gt("id", 4);
+
+            try (RowReader rows = reader.buildRowReader().skip(2).filter(filter).build()) {
+                List<Integer> ids = new ArrayList<>();
+                while (rows.hasNext()) {
+                    rows.next();
+                    ids.add(rows.getInt("id"));
+                }
+                assertThat(ids).containsExactly(7, 8, 9);
+            }
+        }
+    }
+
+    @Test
     void testRowReaderFilterNoMatchReturnsZeroRows() throws Exception {
         try (ParquetFileReader reader = ParquetFileReader.open(InputFile.of(INT_FILE))) {
             FilterPredicate filter = FilterPredicate.eq("id", 999L);

--- a/core/src/test/java/dev/hardwood/RowGroupFilterTest.java
+++ b/core/src/test/java/dev/hardwood/RowGroupFilterTest.java
@@ -9,6 +9,7 @@ package dev.hardwood;
 
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.util.ArrayList;
 import java.util.List;
 
 import org.junit.jupiter.api.BeforeAll;
@@ -226,6 +227,30 @@ class RowGroupFilterTest {
             assertThat(rows.hasNext()).isTrue();
             rows.next();
             assertThat(rows.getLong("id")).isEqualTo(111L);
+        }
+    }
+
+    @Test
+    void rowReaderByteRangeFilterSkipAndHeadComposeByIntersection() throws Exception {
+        // RowGroupPredicate keeps rg1+rg2 (rows 101..300); the FilterPredicate gt(id, 150)
+        // matches 151..300 within those groups (150 matches). skip(50) discards the first 50
+        // matches (151..200), and head(5) caps the rest at 5 -> 201..205. This pins the full
+        // intersection: byteRange(...).filter(p).skip(n).head(k) counts over the matching rows
+        // within this reader's row groups, not over the file.
+        try (ParquetFileReader reader = ParquetFileReader.open(InputFile.of(FIXTURE));
+             RowReader rows = reader.buildRowReader()
+                     .projection(ColumnProjection.columns("id"))
+                     .filter(RowGroupPredicate.byteRange(rg1Mid, fileLen))
+                     .filter(FilterPredicate.gt("id", 150L))
+                     .skip(50)
+                     .head(5)
+                     .build()) {
+            List<Long> ids = new ArrayList<>();
+            while (rows.hasNext()) {
+                rows.next();
+                ids.add(rows.getLong("id"));
+            }
+            assertThat(ids).containsExactly(201L, 202L, 203L, 204L, 205L);
         }
     }
 

--- a/docs/content/concepts/row-selection.md
+++ b/docs/content/concepts/row-selection.md
@@ -1,0 +1,99 @@
+<!--
+
+     SPDX-License-Identifier: CC-BY-SA-4.0
+
+     Copyright The original authors
+
+     Licensed under the Creative Commons Attribution-ShareAlike 4.0 International License;
+     you may not use this file except in compliance with the License.
+     You may obtain a copy of the License at https://creativecommons.org/licenses/by-sa/4.0/
+
+-->
+# Row Selection
+
+You rarely want every row of a Parquet file. Hardwood gives a `RowReader` five controls for
+narrowing what comes back — `filter`, `head`, `tail`, `skip`, and the `byteRange` row-group
+predicate. They compose predictably once you hold one idea: **row selection counts over the
+result set, not over the file.** For the step-by-step recipes, see
+[Predicate Pushdown, Projection, Limits, and Splits](../how-to/query-controls.md).
+
+## Two questions: which rows, and where they live
+
+Selection has two independent axes, and each control belongs to exactly one of them.
+
+- **Which rows you want — the logical result.** A `FilterPredicate` (`WHERE`), and the
+  positional controls `head`, `tail`, and `skip`.
+- **Where data lives in the file — the physical layout.** `RowGroupPredicate.byteRange(...)`,
+  at row-group granularity. This is the lever for splitting a file across parallel readers, not
+  for shaping what a single reader returns.
+
+Keeping these apart is what makes the controls predictable: physical positioning is `byteRange`'s
+job, and nothing else's.
+
+## The result set
+
+The `FilterPredicate` defines a **result set** — the rows that match, in file order. The
+positional controls count over that result set, exactly like SQL clauses count over the rows that
+survive a `WHERE`:
+
+| Control   | SQL analogue | Meaning over the result set                          |
+|-----------|--------------|------------------------------------------------------|
+| `filter`  | `WHERE`      | the rows that match the predicate, in file order     |
+| `head(n)` | `LIMIT n`    | the first `n` matching rows                          |
+| `skip(n)` | `OFFSET n`   | discard the first `n` matching rows, keep the rest   |
+
+So `skip(n).head(k)` is `OFFSET n LIMIT k`: it returns at most `k` matching rows, starting after
+the first `n` matches. None of these count physical rows — a matching row sitting deep in the
+file is still the first row `head(1)` returns. (`tail` is not in this table because it cannot
+combine with a filter — see [Currently supported combinations](#currently-supported-combinations).)
+
+## The no-filter coincidence
+
+With **no filter**, every row matches, so the result set *is* the whole file and a logical
+position coincides with a physical one. That is the case where `skip(n)` can be a true seek:
+it begins at physical row `n`, and earlier row groups are never opened — an O(1-row-group) jump
+that fetches none of the bytes in between. `head(n)` is simply the first `n` rows of the file.
+
+Add a filter and the coincidence breaks. Row-group statistics bound the *values* in a group, not
+the *count* of rows that match, so the reader cannot know how many matches lie ahead without
+looking. `head` and `skip` then stream over the matched rows, decoding earlier groups to count
+them — though groups whose statistics prove no row can match are still skipped wholesale. This is
+why `skip(n)` is an O(1) seek without a filter but a forward scan with one: same control, but the
+relation it counts over changed.
+
+## Physical splitting is separate
+
+`byteRange(start, end)` keeps a row group when its midpoint falls in `[start, end)`. Across a
+partition of the file into disjoint ranges, every row group lands in exactly one — the basis for
+handing each parallel reader its own slice of the file. It composes with the logical controls by
+intersection: under `byteRange(...).filter(p).skip(n).head(k)`, the result set is the matching
+rows *within this reader's row groups*, and `skip`/`head` count over that.
+
+Reach for `byteRange` to decide *which bytes a reader owns*; reach for `filter`/`skip`/`head` to
+decide *which rows it returns*. Using `skip` to position a scan physically under a filter is the
+wrong tool — that is what `byteRange` is for.
+
+## Which do I reach for?
+
+| You want…                                          | Use                              |
+|----------------------------------------------------|----------------------------------|
+| the first `n` rows matching a predicate            | `filter(p).head(n)`              |
+| rows `n … n+k` of the matching rows                | `filter(p).skip(n).head(k)`      |
+| row `n` of the file, ignoring content              | `skip(n)` (no filter — a seek)   |
+| the last `n` rows of the file                      | `tail(n)` (no filter)            |
+| this reader to own a byte range of the file        | `filter(byteRange(a, b))`        |
+
+## Currently supported combinations
+
+`head`, `skip`, and `byteRange` each compose with a `FilterPredicate`; `head`/`skip` count over
+the matched rows. `tail` + filter is **not** supported and is rejected at `build()`: unlike the
+forward-streaming `head`/`skip`, the *last* `n` matching rows have no row-group-statistics
+shortcut, so it would require a reverse scan over the whole file. Until that lands, take the tail
+of the unfiltered file, or filter and keep the trailing matches yourself.
+
+## Further reading
+
+- [Predicate Pushdown, Projection, Limits, and Splits](../how-to/query-controls.md) — the
+  step-by-step guide for each control.
+- [How a Parquet File Is Laid Out](parquet-layout.md) — row groups, pages, and why statistics
+  let whole groups be skipped.

--- a/docs/content/how-to/query-controls.md
+++ b/docs/content/how-to/query-controls.md
@@ -247,7 +247,7 @@ try (ParquetFileReader fileReader = ParquetFileReader.open(InputFile.of(path));
 
 A row group is included if and only if its **midpoint** — the start of its first column chunk plus half of its on-disk compressed size — falls in `[start, end)`. This is the standard Hadoop-input-format split convention: across a partitioning of the file into disjoint byte ranges, every row group lands in exactly one range, regardless of where the split boundary falls inside the row group itself.
 
-**Granularity is row-group, not row.** A row group whose midpoint is in `[0, 1000)` is read in full, including any rows whose data extends beyond byte 1000. If you need true row-level windowing, combine `RowGroupPredicate` with [`RowReaderBuilder.skip(...)`](#seeking-to-an-absolute-row) and [`head(...)`](#row-limit).
+**Granularity is row-group, not row.** A row group whose midpoint is in `[0, 1000)` is read in full, including any rows whose data extends beyond byte 1000. If you need true row-level windowing, combine `RowGroupPredicate` with [`RowReaderBuilder.skip(...)`](#skipping-rows-skip) and [`head(...)`](#row-limit).
 
 `RowGroupPredicate` composes with [`FilterPredicate`](#predicate-pushdown-filter) via intersection — both apply, and a row group is read if and only if it passes both:
 
@@ -290,12 +290,14 @@ try (ParquetFileReader fileReader = ParquetFileReader.open(InputFile.of(path));
 
 Tail mode cannot currently be combined with a filter predicate — the set of matching rows is not known from row-group statistics alone, so the reader cannot identify which row groups cover the last N matching rows without scanning the whole file. It is also mutually exclusive with `skip(long)`.
 
-### Seeking to an Absolute Row
+### Skipping Rows (`skip`)
 
-The `skip(long)` builder method begins iteration at an arbitrary absolute row index. Earlier row groups are not opened — their pages are not fetched or decoded — making this an O(1 row group) seek on remote backends, in contrast to walking `next()` from row 0.
+The `skip(long)` builder method is SQL `OFFSET`: it discards leading rows before reading. What "leading rows" means depends on whether a filter is present — see [Row Selection](../concepts/row-selection.md) for the model.
+
+**Without a filter,** `skip(n)` is a physical absolute row index. Earlier row groups are not opened — their pages are not fetched or decoded — making this an O(1 row group) seek on remote backends, in contrast to walking `next()` from row 0.
 
 ```java
-// Read rows starting at row 1,000,000 — earlier row groups are skipped.
+// Read rows starting at row 1,000,000 — earlier row groups are not opened.
 try (ParquetFileReader fileReader = ParquetFileReader.open(InputFile.of(path));
      RowReader rowReader = fileReader.buildRowReader().skip(1_000_000).build()) {
 
@@ -306,23 +308,25 @@ try (ParquetFileReader fileReader = ParquetFileReader.open(InputFile.of(path));
 }
 ```
 
-Compose with `head(N)` for a bounded `[skip, skip + N)` window:
+`skip == 0` is the no-op default. `skip >= totalRows` produces an empty reader (a SQL `OFFSET` past the end of the file). Within the target row group, the reader still decodes the leading residue rows and discards them via `next()`; page-level skip via the OffsetIndex is tracked separately.
+
+!!! warning "Multi-file readers: first file only"
+    For the no-filter (physical) case, `skip(N)` indexes into the **first** file's rows only — it does not seek across file boundaries. To skip whole files, omit them from the input list; to skip within a non-first file, open it separately.
+
+**With a filter,** `skip(n)` is a *logical* offset over the matched rows — it discards the first `n` rows that match the predicate and returns the rest, exactly like SQL `OFFSET` after a `WHERE`. The O(1 row-group seek does **not** apply: row-group statistics bound min/max values, not match *counts*, so the reader decodes earlier groups to count matches (groups whose statistics prove no match are still pruned). A `skip` past the number of matching rows yields an empty reader rather than throwing.
 
 ```java
-// Read rows [1_000_000, 1_000_050).
+// Skip the first 150 rows matching the predicate, then read the next 20.
+// OFFSET 150 LIMIT 20 over the filtered relation.
 try (ParquetFileReader fileReader = ParquetFileReader.open(InputFile.of(path));
      RowReader rowReader = fileReader.buildRowReader()
-             .skip(1_000_000)
-             .head(50)
+             .filter(FilterPredicate.gt("age", 21))
+             .skip(150)
+             .head(20)
              .build()) {
     // ...
 }
 ```
 
-`skip == 0` is the no-op default. `skip == totalRows` produces an empty reader; `skip > totalRows` throws `IllegalArgumentException`. Mutually exclusive with `tail(N)` and with `filter(FilterPredicate)` — a logical `OFFSET` over the filtered relation is not yet supported, so the combination is rejected at `build()` time. `skip(N)` composes with `filter(RowGroupPredicate)` (e.g. `byteRange`), indexing into the kept row-group sequence.
-
-!!! warning "Multi-file readers: first file only"
-    For multi-file readers, `skip(N)` indexes into the **first** file's rows only — it does not seek across file boundaries. To skip whole files, omit them from the input list; to skip within a non-first file, open it separately.
-
-Within the target row group, the reader still decodes the leading residue rows and discards them via `next()`. Page-level skip via the OffsetIndex is tracked separately.
+Compose `skip` with `head` for a bounded window — `skip(n).head(k)` returns at most `k` rows starting after the first `n` (physical rows without a filter, matched rows with one). `skip(N)` also composes with `filter(RowGroupPredicate)` (e.g. `byteRange`), indexing into the kept row-group sequence. `skip` is mutually exclusive with `tail`.
 

--- a/docs/content/how-to/query-controls.md
+++ b/docs/content/how-to/query-controls.md
@@ -313,7 +313,7 @@ try (ParquetFileReader fileReader = ParquetFileReader.open(InputFile.of(path));
 !!! warning "Multi-file readers: first file only"
     For the no-filter (physical) case, `skip(N)` indexes into the **first** file's rows only — it does not seek across file boundaries. To skip whole files, omit them from the input list; to skip within a non-first file, open it separately.
 
-**With a filter,** `skip(n)` is a *logical* offset over the matched rows — it discards the first `n` rows that match the predicate and returns the rest, exactly like SQL `OFFSET` after a `WHERE`. The O(1 row-group seek does **not** apply: row-group statistics bound min/max values, not match *counts*, so the reader decodes earlier groups to count matches (groups whose statistics prove no match are still pruned). A `skip` past the number of matching rows yields an empty reader rather than throwing.
+**With a filter,** `skip(n)` is a *logical* offset over the matched rows — it discards the first `n` rows that match the predicate and returns the rest, exactly like SQL `OFFSET` after a `WHERE`. The O(1 row-group) seek does **not** apply: row-group statistics bound min/max values, not match *counts*, so the reader decodes earlier groups to count matches (groups whose statistics prove no match are still pruned). A `skip` past the number of matching rows yields an empty reader rather than throwing.
 
 ```java
 // Skip the first 150 rows matching the predicate, then read the next 20.

--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -36,6 +36,7 @@ nav:
     - How a Parquet File Is Laid Out: concepts/parquet-layout.md
     - The Concurrency Model: concepts/concurrency-model.md
     - RowReader vs. ColumnReader: concepts/reader-models.md
+    - Row Selection: concepts/row-selection.md
     - Compatibility Philosophy: concepts/compatibility-philosophy.md
   - Reference:
     - Configuration: reference/configuration.md


### PR DESCRIPTION
Heyy, this PR resolves #541 

This makes skip a logical OFFSET over the matched relation, symmetric with head() as LIMIT (#538): when a filter is present the reader scans the full row-group-filtered relation, caps at skip + head matches, and discards the first skip matches, so skip(n).filter(p).head(k) reads "OFFSET n LIMIT k" over the rows matching p. Without a filter, skip stays the physical O(1-row-group) seek.

- A skip past the end now yields an empty reader in both modes rather than throwing in the no-filter case — a SQL OFFSET overshoot returns nothing, and this aligns the code with the ROW_BASED_SEEK design, which already specified empty for skip >= totalRows
- The two residue walks (physical and logical) are unified in discardLeadingRows, which closes the partially built reader if iteration fails so its worker pipeline cannot leak. 
- The DuckDB differential harness gains the skip + filter and overshoot cases (its pending #541 marker is cleared), confirming hardwood agrees with SQL OFFSET semantics, including that OFFSET past the end returns empty without error. 
- The reader-facing model is documented in the new concepts/row-selection.md.

## Checklist

- [x] Build via `./mvnw clean verify` passes
- [x] The commit message is prefixed with the issue key ("#123 Adding support for...")
- [x] Code changes are covered by tests
- [x] If this PR adds or changes user-facing behaviour, `docs/` has been updated
