### PR TITLE
#553 Document that ColumnReader hands out fresh, non-reused batch arrays

### DIFF
--- a/core/src/main/java/dev/hardwood/reader/ColumnReader.java
+++ b/core/src/main/java/dev/hardwood/reader/ColumnReader.java
@@ -55,6 +55,17 @@ import dev.hardwood.schema.FileSchema;
 /// distinguishes empty from null at REPEATED layers (validity carries the
 /// null bit).
 ///
+/// **Array ownership.** Every array and [Validity] handed back by an
+/// accessor ([#getInts()], [#getLongs()], [#getLayerOffsets(int)],
+/// [#getLeafValidity()], and the rest) belongs to the current batch and is
+/// freshly allocated by the [#nextBatch()] call that produced it. A later
+/// [#nextBatch()] never reuses or overwrites an array returned for an
+/// earlier batch — so a returned array may be kept and read after the reader
+/// has advanced, including handed off to another thread for processing. The
+/// reader itself is still a single-threaded cursor: only one consumer thread
+/// may call [#nextBatch()]. (The capacity-sizing note on [#getBinaryValues()]
+/// is about array *length*, not reuse; that buffer is fresh per batch too.)
+///
 /// **This API is [Experimental]:** the shape of the batch accessors and
 /// layer representation may change in future releases without prior
 /// deprecation.

--- a/docs/content/concepts/concurrency-model.md
+++ b/docs/content/concepts/concurrency-model.md
@@ -69,7 +69,10 @@ shared pool matters, since all the files draw on the same workers. See
 - **Drive one reader from one thread.** A `RowReader` / `ColumnReader` / `ColumnReaders` instance
   is a stateful cursor meant to be advanced by a single consumer thread. The concurrency is
   *internal* — you do not, and should not, call `next()` / `nextBatch()` on the same reader from
-  multiple threads.
+  multiple threads. This restricts advancing the cursor, not the data it returns: a `ColumnReader`
+  allocates fresh batch arrays on every `nextBatch()` and never reuses them later, so you can fan a
+  batch's arrays out to other threads for processing while the consumer thread moves on (see
+  [Column-Oriented Reading](../how-to/column-reader.md#retaining-and-handing-off-batch-arrays)).
 - **For your own parallelism, read in parallel at the file or row-group grain.** To use more
   than one consumer thread, give each its own reader over a different file, or partition one file
   across readers by byte range with

--- a/docs/content/how-to/column-reader.md
+++ b/docs/content/how-to/column-reader.md
@@ -95,6 +95,22 @@ try (ColumnReaders columns = parquet.buildColumnReaders(
 
 `ColumnReaders.nextBatch()` advances every underlying reader once and returns `false` when any reader is exhausted — partial advancement isn't possible because all readers consume from a shared `RowGroupIterator`. The aligned record count is exposed via `ColumnReaders.getRecordCount()`. As a defensive guard, mismatched per-reader record counts throw `IllegalStateException`. Single-column consumers, or callers that need fine-grained per-reader cadence, can still call `ColumnReader.nextBatch()` directly on the readers returned by `getColumnReader(...)`.
 
+### Retaining and Handing Off Batch Arrays
+
+The arrays and `Validity` objects returned by the accessors belong to the current batch and are freshly allocated on each `nextBatch()`. A later `nextBatch()` never reuses or overwrites an array returned for an earlier batch, so you can keep a returned array and process it after advancing — including by handing it to another thread:
+
+```java
+while (columns.nextBatch()) {
+    int count = columns.getRecordCount();
+    long[]   v0 = columns.getColumnReader("passenger_count").getLongs();
+    double[] v1 = columns.getColumnReader("trip_distance").getDoubles();
+    double[] v2 = columns.getColumnReader("fare_amount").getDoubles();
+    Thread.ofPlatform().start(() -> process(count, v0, v1, v2));
+}
+```
+
+The reader stays a single-threaded cursor: only the loop thread calls `nextBatch()`. It is the *returned arrays* that are detached and safe to read elsewhere, not the reader. (For `getBinaryValues()` the byte buffer is capacity-sized — see above — but it too is fresh per batch.)
+
 ### Nested and Repeated Columns
 
 #### Navigating nested groups in the schema


### PR DESCRIPTION
Closes #553.

`ColumnReader` runs its `BatchExchange` in *detaching* mode: every `nextBatch()` allocates a fresh user-facing array and never recycles one it has already handed out. So the arrays and `Validity` objects returned by the batch accessors survive a subsequent `nextBatch()` and may be retained — or fanned out to other threads — while the consumer advances. That guarantee was previously undocumented, so callers (see #553) had no way to rely on it.

This change documents the contract without altering behavior:

- **`ColumnReader` Javadoc** — a class-level *Array ownership* paragraph covering all accessors, scoped to `ColumnReader` (it does not claim the same for the row-oriented readers, which recycle). Notes that the `getBinaryValues()` capacity-sizing is about array *length*, not reuse.
- **`how-to/column-reader.md`** — a "Retaining and Handing Off Batch Arrays" section showing the thread hand-off pattern from the issue.
- **`concepts/concurrency-model.md`** — clarifies that the "drive one reader from one thread" rule binds advancing the cursor, not processing the data it returns.

🤖 Generated with [Claude Code](https://claude.com/claude-code)