### PR TITLE
#588 Harden taxi-data download against rate limiting and cache poisoning

### DIFF
--- a/.github/workflows/performance.yml
+++ b/.github/workflows/performance.yml
@@ -33,6 +33,11 @@ on:
 # the test-data-setup module on cache miss) and the perf test both honor
 # `perf.start` / `perf.end`; keeping the cache key aligned ensures we don't
 # silently widen the window when the cache is regenerated.
+#
+# The taxi-data cache is restored and saved as separate steps so that the save
+# only runs when the job succeeds. Actions cache entries are immutable, so a
+# partial dataset persisted by a failed download would otherwise freeze under
+# this key forever and break every later run (issue #588).
 env:
   PERF_START: '2023-01'
   PERF_END: '2025-12'
@@ -63,8 +68,9 @@ jobs:
             maven-${{ runner.os }}-${{ github.job }}-
             maven-${{ runner.os }}-
 
-      - name: 'Cache taxi data'
-        uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7  # v5 — https://github.com/actions/cache/releases/tag/v5
+      - name: 'Restore taxi data cache'
+        id: taxi-data-cache
+        uses: actions/cache/restore@668228422ae6a00e4ad889ee87cd7109ec5666a7  # v5 — https://github.com/actions/cache/releases/tag/v5
         with:
           path: performance-testing/test-data-setup/target/tlc-trip-record-data/
           key: taxi-data-${{ env.PERF_START }}-to-${{ env.PERF_END }}
@@ -89,3 +95,13 @@ jobs:
           PERF_RUNS: ${{ inputs.perf_runs || '5' }}
           TESTS: ${{ inputs.tests || 'FlatPerformanceTest,NestedPerformanceTest' }}
         run: ./mvnw -B verify -Pperformance-test -pl :hardwood-performance-testing -amd -Dperf.start="$PERF_START" -Dperf.end="$PERF_END" -Dperf.runs="$PERF_RUNS" -Dtest="$TESTS" -Dsurefire.failIfNoSpecifiedTests=false
+
+      # Persist the taxi data only on success, and only when we actually had to
+      # download it (a restore hit needs no re-save). This prevents a partial
+      # dataset from a failed download being frozen under the immutable key.
+      - name: 'Save taxi data cache'
+        if: success() && steps.taxi-data-cache.outputs.cache-hit != 'true'
+        uses: actions/cache/save@668228422ae6a00e4ad889ee87cd7109ec5666a7  # v5 — https://github.com/actions/cache/releases/tag/v5
+        with:
+          path: performance-testing/test-data-setup/target/tlc-trip-record-data/
+          key: taxi-data-${{ env.PERF_START }}-to-${{ env.PERF_END }}

--- a/performance-testing/test-data-setup/pom.xml
+++ b/performance-testing/test-data-setup/pom.xml
@@ -22,6 +22,19 @@
   <name>Hardwood Performance Test Data Setup</name>
   <description>Downloads and manages test data files for performance testing</description>
 
+  <dependencies>
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.assertj</groupId>
+      <artifactId>assertj-core</artifactId>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
+
   <properties>
     <!-- Whether to skip fetching the (multi-gigabyte) test data sets. The quick
          profile below flips this to true so that -Dquick builds this module

--- a/performance-testing/test-data-setup/src/main/java/dev/hardwood/testdata/TaxiDataDownloader.java
+++ b/performance-testing/test-data-setup/src/main/java/dev/hardwood/testdata/TaxiDataDownloader.java
@@ -12,13 +12,22 @@ import java.net.URI;
 import java.net.http.HttpClient;
 import java.net.http.HttpRequest;
 import java.net.http.HttpResponse;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.time.YearMonth;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Set;
 
 /// Downloads NYC Yellow Taxi Trip Records for performance testing.
+///
+/// The trip-data files are served from a CloudFront distribution that rate-limits and, for
+/// shared cloud egress IPs, intermittently blocks bulk fetches with `403`/`429` responses. To
+/// survive that, every download is retried with exponential back-off, requests are throttled to
+/// avoid tripping the limiter, and a non-recoverable failure throws with the response status,
+/// the distinguishing headers (`server`, `x-cache`, `x-amzn-waf-action`, …) and a snippet of the
+/// error body so the cause (WAF block vs. missing object vs. throttling) is visible in the log.
 public final class TaxiDataDownloader {
 
     private static final String BASE_URL = "https://d37ci6vzurychx.cloudfront.net/trip-data/";
@@ -26,6 +35,37 @@ public final class TaxiDataDownloader {
     public static final YearMonth DEFAULT_START = YearMonth.of(2016, 1);
     public static final YearMonth DEFAULT_END = YearMonth.of(2025, 12);
     public static final Path DATA_DIR = Path.of("target/tlc-trip-record-data");
+
+    /// Total attempts per file before giving up (1 initial try + retries).
+    private static final int MAX_ATTEMPTS = 5;
+    /// Base back-off between retries; doubled each attempt and capped at [#MAX_BACKOFF_MILLIS].
+    private static final long BASE_BACKOFF_MILLIS = 2_000L;
+    private static final long MAX_BACKOFF_MILLIS = 60_000L;
+    /// Polite delay inserted between consecutive file downloads to stay under the rate limit.
+    private static final long THROTTLE_MILLIS = 1_000L;
+    /// Cap on the error-body snippet captured for diagnostics.
+    private static final int MAX_LOGGED_BODY = 2_000;
+
+    /// HTTP statuses worth retrying: throttling/WAF (`403`, `429`) and transient server errors.
+    /// A `404` is a genuinely absent object and is not retried.
+    private static final Set<Integer> RETRYABLE_STATUSES = Set.of(403, 429, 500, 502, 503, 504);
+
+    /// Performs a single HTTP GET, writing the body to `target`, and reports the [Outcome].
+    @FunctionalInterface
+    interface Fetcher {
+        Outcome fetch(String url, Path target) throws IOException;
+    }
+
+    /// Suspends the current thread; abstracted so retry/back-off timing is testable without waiting.
+    @FunctionalInterface
+    interface Sleeper {
+        void sleep(long millis) throws InterruptedException;
+    }
+
+    /// Result of one download attempt: the HTTP status, bytes written on success, and a
+    /// human-readable `detail` (headers + error-body snippet) populated on failure.
+    record Outcome(int status, long bytes, String detail) {
+    }
 
     public static void main(String[] args) throws IOException {
         Path dataDir = getDataDirFromProperty();
@@ -77,20 +117,77 @@ public final class TaxiDataDownloader {
 
     private static void downloadRange(Path dataDir, YearMonth start, YearMonth end) throws IOException {
         Files.createDirectories(dataDir);
-        for (YearMonth ym = start; !ym.isAfter(end); ym = ym.plusMonths(1)) {
-            String filename = formatFilename(ym);
-            Path target = dataDir.resolve(filename);
-            if (!Files.exists(target)) {
-                downloadFile(BASE_URL + filename, target);
-            }
-        }
-    }
-
-    private static void downloadFile(String url, Path target) throws IOException {
-        System.out.println("Downloading: " + url);
         HttpClient client = HttpClient.newBuilder()
                 .followRedirects(HttpClient.Redirect.NORMAL)
                 .build();
+        Fetcher fetcher = (url, target) -> httpGet(client, url, target);
+        Sleeper sleeper = Thread::sleep;
+
+        boolean firstDownload = true;
+        for (YearMonth ym = start; !ym.isAfter(end); ym = ym.plusMonths(1)) {
+            String filename = formatFilename(ym);
+            Path target = dataDir.resolve(filename);
+            if (Files.exists(target)) {
+                continue;
+            }
+            if (!firstDownload) {
+                throttle(sleeper);
+            }
+            firstDownload = false;
+            System.out.println("Downloading: " + BASE_URL + filename);
+            downloadWithRetry(fetcher, sleeper, BASE_URL + filename, target, MAX_ATTEMPTS);
+        }
+    }
+
+    /// Downloads `url` into `target`, retrying retryable failures with exponential back-off.
+    /// Throws once a non-retryable status is seen or the attempts are exhausted, including the
+    /// last response's diagnostics in the message.
+    static void downloadWithRetry(Fetcher fetcher, Sleeper sleeper, String url, Path target, int maxAttempts)
+            throws IOException {
+        for (int attempt = 1; attempt <= maxAttempts; attempt++) {
+            Outcome outcome = fetcher.fetch(url, target);
+            if (outcome.status() == 200 && outcome.bytes() > 0) {
+                System.out.println("  Downloaded: " + outcome.bytes() + " bytes");
+                return;
+            }
+            deleteQuietly(target);
+            System.out.println("  Attempt " + attempt + "/" + maxAttempts + " failed: status "
+                    + outcome.status() + describe(outcome));
+            if (!isRetryable(outcome) || attempt == maxAttempts) {
+                throw new IOException("Download failed for " + url + " after " + attempt
+                        + " attempt(s); last status " + outcome.status() + describe(outcome));
+            }
+            long delay = backoffMillis(attempt);
+            System.out.println("  Retrying in " + delay + " ms");
+            try {
+                sleeper.sleep(delay);
+            }
+            catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+                throw new IOException("Download interrupted while backing off for " + url, e);
+            }
+        }
+        throw new IOException("Download failed for " + url + ": exhausted " + maxAttempts + " attempts");
+    }
+
+    /// A `200` that produced no bytes is treated as a transient hiccup and retried; otherwise the
+    /// status code decides.
+    static boolean isRetryable(Outcome outcome) {
+        if (outcome.status() == 200) {
+            return outcome.bytes() == 0;
+        }
+        return RETRYABLE_STATUSES.contains(outcome.status());
+    }
+
+    static long backoffMillis(int attempt) {
+        long shifted = BASE_BACKOFF_MILLIS << (attempt - 1);
+        if (shifted <= 0 || shifted > MAX_BACKOFF_MILLIS) {
+            return MAX_BACKOFF_MILLIS;
+        }
+        return shifted;
+    }
+
+    private static Outcome httpGet(HttpClient client, String url, Path target) throws IOException {
         HttpRequest request = HttpRequest.newBuilder()
                 .uri(URI.create(url))
                 .header("User-Agent", "Wget")
@@ -98,20 +195,70 @@ public final class TaxiDataDownloader {
                 .build();
         try {
             HttpResponse<Path> response = client.send(request, HttpResponse.BodyHandlers.ofFile(target));
-            if (response.statusCode() != 200) {
-                Files.deleteIfExists(target);
-                throw new IOException("Download failed with status " + response.statusCode() + " for " + url);
+            int status = response.statusCode();
+            if (status == 200) {
+                return new Outcome(200, Files.size(target), null);
             }
-            if (Files.size(target) == 0) {
-                Files.deleteIfExists(target);
-                throw new IOException("Download produced an empty file for " + url);
-            }
-            System.out.println("  Downloaded: " + Files.size(target) + " bytes");
+            return new Outcome(status, 0, describeFailure(response, target));
         }
         catch (InterruptedException e) {
-            Files.deleteIfExists(target);
             Thread.currentThread().interrupt();
             throw new IOException("Download interrupted for " + url, e);
+        }
+    }
+
+    /// Builds a diagnostic string from the response headers that distinguish a WAF/edge block
+    /// from an origin (S3) denial, plus a snippet of the error body written to `target`.
+    private static String describeFailure(HttpResponse<Path> response, Path target) throws IOException {
+        StringBuilder sb = new StringBuilder();
+        appendHeader(sb, response, "server");
+        appendHeader(sb, response, "x-cache");
+        appendHeader(sb, response, "x-amz-cf-id");
+        appendHeader(sb, response, "x-amzn-waf-action");
+        appendHeader(sb, response, "retry-after");
+        String body = readBodySnippet(target);
+        if (!body.isBlank()) {
+            sb.append("body=").append(body);
+        }
+        return sb.toString().strip();
+    }
+
+    private static void appendHeader(StringBuilder sb, HttpResponse<?> response, String name) {
+        response.headers().firstValue(name).ifPresent(value -> sb.append(name).append('=').append(value).append("; "));
+    }
+
+    private static String readBodySnippet(Path target) throws IOException {
+        if (!Files.exists(target)) {
+            return "";
+        }
+        byte[] bytes = Files.readAllBytes(target);
+        int length = Math.min(bytes.length, MAX_LOGGED_BODY);
+        return new String(bytes, 0, length, StandardCharsets.UTF_8).replaceAll("\\s+", " ").strip();
+    }
+
+    private static String describe(Outcome outcome) {
+        if (outcome.detail() == null || outcome.detail().isBlank()) {
+            return "";
+        }
+        return " (" + outcome.detail() + ")";
+    }
+
+    private static void throttle(Sleeper sleeper) throws IOException {
+        try {
+            sleeper.sleep(THROTTLE_MILLIS);
+        }
+        catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new IOException("Interrupted while throttling between downloads", e);
+        }
+    }
+
+    private static void deleteQuietly(Path target) {
+        try {
+            Files.deleteIfExists(target);
+        }
+        catch (IOException e) {
+            System.out.println("  Warning: could not delete partial file " + target + ": " + e.getMessage());
         }
     }
 

--- a/performance-testing/test-data-setup/src/test/java/dev/hardwood/testdata/TaxiDataDownloaderTest.java
+++ b/performance-testing/test-data-setup/src/test/java/dev/hardwood/testdata/TaxiDataDownloaderTest.java
@@ -1,0 +1,130 @@
+/*
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Copyright The original authors
+ *
+ *  Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package dev.hardwood.testdata;
+
+import java.io.IOException;
+import java.nio.file.Path;
+import java.util.ArrayDeque;
+import java.util.ArrayList;
+import java.util.Deque;
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+
+import dev.hardwood.testdata.TaxiDataDownloader.Outcome;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class TaxiDataDownloaderTest {
+
+    private static final Path TARGET = Path.of("target/does-not-matter.parquet");
+
+    /// Records the requested sleep durations instead of actually waiting.
+    private static final class RecordingSleeper implements TaxiDataDownloader.Sleeper {
+        private final List<Long> delays = new ArrayList<>();
+
+        @Override
+        public void sleep(long millis) {
+            delays.add(millis);
+        }
+    }
+
+    /// Replays a queued sequence of outcomes, one per attempt.
+    private static TaxiDataDownloader.Fetcher fetcherReturning(Outcome... outcomes) {
+        Deque<Outcome> queue = new ArrayDeque<>(List.of(outcomes));
+        return (url, target) -> queue.poll();
+    }
+
+    @Test
+    void succeedsOnFirstAttemptWithoutSleeping() throws IOException {
+        RecordingSleeper sleeper = new RecordingSleeper();
+
+        TaxiDataDownloader.downloadWithRetry(
+                fetcherReturning(new Outcome(200, 1234, null)), sleeper, "http://x", TARGET, 5);
+
+        assertThat(sleeper.delays).isEmpty();
+    }
+
+    @Test
+    void retriesRetryableStatusThenSucceeds() throws IOException {
+        RecordingSleeper sleeper = new RecordingSleeper();
+
+        TaxiDataDownloader.downloadWithRetry(
+                fetcherReturning(
+                        new Outcome(503, 0, "server=AmazonS3"),
+                        new Outcome(403, 0, "x-amzn-waf-action=BLOCK"),
+                        new Outcome(200, 999, null)),
+                sleeper, "http://x", TARGET, 5);
+
+        // Two failures before success => two back-offs, doubling each time.
+        assertThat(sleeper.delays).containsExactly(2_000L, 4_000L);
+    }
+
+    @Test
+    void retriesEmptyBodyResponses() throws IOException {
+        RecordingSleeper sleeper = new RecordingSleeper();
+
+        TaxiDataDownloader.downloadWithRetry(
+                fetcherReturning(new Outcome(200, 0, null), new Outcome(200, 42, null)),
+                sleeper, "http://x", TARGET, 5);
+
+        assertThat(sleeper.delays).containsExactly(2_000L);
+    }
+
+    @Test
+    void failsFastOnNonRetryableStatus() {
+        RecordingSleeper sleeper = new RecordingSleeper();
+
+        assertThatThrownBy(() -> TaxiDataDownloader.downloadWithRetry(
+                fetcherReturning(new Outcome(404, 0, "server=AmazonS3; body=NoSuchKey")),
+                sleeper, "http://x", TARGET, 5))
+                .isInstanceOf(IOException.class)
+                .hasMessageContaining("404")
+                .hasMessageContaining("after 1 attempt");
+
+        assertThat(sleeper.delays).isEmpty();
+    }
+
+    @Test
+    void givesUpAfterMaxAttemptsOnPersistentFailure() {
+        RecordingSleeper sleeper = new RecordingSleeper();
+
+        assertThatThrownBy(() -> TaxiDataDownloader.downloadWithRetry(
+                fetcherReturning(
+                        new Outcome(403, 0, "x-amzn-waf-action=BLOCK"),
+                        new Outcome(403, 0, "x-amzn-waf-action=BLOCK"),
+                        new Outcome(403, 0, "x-amzn-waf-action=BLOCK")),
+                sleeper, "http://x", TARGET, 3))
+                .isInstanceOf(IOException.class)
+                .hasMessageContaining("after 3 attempt")
+                .hasMessageContaining("x-amzn-waf-action=BLOCK");
+
+        // Slept between attempts 1->2 and 2->3, but not after the final failure.
+        assertThat(sleeper.delays).containsExactly(2_000L, 4_000L);
+    }
+
+    @Test
+    void backoffGrowsExponentiallyAndIsCapped() {
+        assertThat(TaxiDataDownloader.backoffMillis(1)).isEqualTo(2_000L);
+        assertThat(TaxiDataDownloader.backoffMillis(2)).isEqualTo(4_000L);
+        assertThat(TaxiDataDownloader.backoffMillis(3)).isEqualTo(8_000L);
+        assertThat(TaxiDataDownloader.backoffMillis(10)).isEqualTo(60_000L);
+        assertThat(TaxiDataDownloader.backoffMillis(40)).isEqualTo(60_000L);
+    }
+
+    @Test
+    void classifiesStatusesForRetry() {
+        assertThat(TaxiDataDownloader.isRetryable(new Outcome(403, 0, null))).isTrue();
+        assertThat(TaxiDataDownloader.isRetryable(new Outcome(429, 0, null))).isTrue();
+        assertThat(TaxiDataDownloader.isRetryable(new Outcome(503, 0, null))).isTrue();
+        assertThat(TaxiDataDownloader.isRetryable(new Outcome(404, 0, null))).isFalse();
+        assertThat(TaxiDataDownloader.isRetryable(new Outcome(200, 0, null))).isTrue();
+        assertThat(TaxiDataDownloader.isRetryable(new Outcome(200, 5, null))).isFalse();
+    }
+}


### PR DESCRIPTION
The performance test data download repeatedly broke CI with a 403 on the newest month. The file existed (published months earlier); the runner was denied. Two stacked causes: the NYC TLC CloudFront distribution rate-limits and IP-blocks shared cloud egress so a bulk fetch from a runner can be refused, and the workflow cached partial datasets under an immutable key, so a single failed download froze a missing month into the cache for every later run.

Retry non-fatal responses (403/429/5xx) with exponential back-off, throttle between files to stay under the limiter, and on a non-recoverable failure surface the status, distinguishing headers and an error-body snippet so the cause is visible in the log instead of being discarded. Split the cache into restore/save steps that only persist on success, so a partial dataset can no longer be frozen under the immutable key.