### PR TITLE
#585 Move look-it-up docs from how-to guides into reference and concepts

### DIFF
--- a/docs/content/concepts/nested-columns.md
+++ b/docs/content/concepts/nested-columns.md
@@ -1,0 +1,103 @@
+<!--
+
+     SPDX-License-Identifier: CC-BY-SA-4.0
+
+     Copyright The original authors
+
+     Licensed under the Creative Commons Attribution-ShareAlike 4.0 International License;
+     you may not use this file except in compliance with the License.
+     You may obtain a copy of the License at https://creativecommons.org/licenses/by-sa/4.0/
+
+-->
+# The Layer Model
+
+`ColumnReader` hands you a column as flat, typed primitive arrays. For a nested column — a struct
+field, a list, a map, or any combination — those flat arrays need extra structure to say which
+leaf values belong to which record, and where the nulls and empty containers sit. The **layer
+model** is how `ColumnReader` expresses that structure without boxing or per-row objects. This page
+explains the model; for worked code against it, see
+[Column-Oriented Reading](../how-to/column-reader.md).
+
+## Layers
+
+`ColumnReader` exposes a column's schema chain as a sequence of **layers**. Each non-leaf node
+along the chain contributes zero or one layer:
+
+| Schema node | Contributes layer? | Layer kind |
+|---|---|---|
+| `REQUIRED` group | no | — |
+| `OPTIONAL` group (struct) | yes | `STRUCT` |
+| `LIST` / `MAP`-annotated group | yes — exactly one | `REPEATED` |
+
+Layers are numbered `0..getLayerCount() - 1` outermost-to-innermost, and the leaf is queried
+separately. A flat column reports `getLayerCount() == 0`.
+
+For each layer, two buffers describe the items at that layer:
+
+- `getLayerValidity(k)` — a [Validity](/api/latest/dev/hardwood/reader/Validity.html) indexed by
+  item position; `isNull(i)` / `isNotNull(i)` answer the per-item question, `hasNulls()` is the
+  O(1) fast-path gate. Returns the shared `Validity.NO_NULLS` singleton when no item at layer `k`
+  is null in this batch.
+- `getLayerOffsets(k)` — sentinel-suffixed offsets of length `count(k) + 1` into the next inner
+  layer's items (or, for the innermost layer, into the leaf-value array). Only valid when
+  `getLayerKind(k) == REPEATED`; throws on a `STRUCT` layer.
+
+The leaf has its own `getLeafValidity()` (also a `Validity`).
+
+## Empty versus null containers
+
+The four states of a `LIST` / `MAP` container fall out cleanly from offsets and validity:
+
+| Logical value | `getLayerValidity` | `offsets[r+1] - offsets[r]` |
+|---|---|---|
+| `null`           | `isNull(r)`    | `0` |
+| `[]`             | `isNotNull(r)` | `0` |
+| `[null]`         | `isNotNull(r)` | `1`, leaf validity says null |
+| `[v]`            | `isNotNull(r)` | `1`, leaf validity says not null |
+
+Empty-vs-null is the offsets diff; the validity bit picks out null. No empty-marker bitmap is
+needed.
+
+## STRUCT keeps cardinality, REPEATED expands it
+
+Two rules govern how item counts flow down the chain:
+
+1. **STRUCT keeps cardinality.** Items at layer `k+1` equal items at layer `k`. STRUCT layers
+   carry validity, no offsets.
+2. **REPEATED expands cardinality.** Items at layer `k+1` equal `getLayerOffsets(k)[count(k)]`.
+   REPEATED layers carry both validity and offsets.
+
+The leaf array and `getLayerOffsets` carry **real items only** — phantom slots from null/empty
+parents at any `REPEATED` layer are excluded. `getValueCount()` returns the real leaf count.
+`STRUCT` layers do not expand or contract the item stream; only `REPEATED` layers add cardinality,
+via their offsets.
+
+Those two rules generate the layer shape of any chain:
+
+| Schema chain | `getLayerCount()` | Kinds (outer → inner) |
+|---|---|---|
+| `optional double x` | 0 | — |
+| `optional struct { ... int x }` | 1 | STRUCT |
+| `list<int>` | 1 | REPEATED |
+| `map<string, int>` | 1 | REPEATED |
+| `list<list<int>>` | 2 | REPEATED, REPEATED |
+| `optional struct { list<int> }` | 2 | STRUCT, REPEATED |
+| `list<optional struct { ... }>` | 2 | REPEATED, STRUCT |
+| `optional struct { map<string, int> }` | 2 | STRUCT, REPEATED |
+
+Maps report as `REPEATED` — the layer enum does not distinguish map-shape from list-shape; consult
+`getColumnSchema()` if you need that distinction.
+
+## Counts at each layer
+
+Every per-layer buffer is sized to `count(k)`, defined recursively:
+
+- `count(0) == getRecordCount()`
+- For `k > 0`: `count(k)` equals `count(k-1)` if layer `k-1` is `STRUCT`, or
+  `getLayerOffsets(k-1)[count(k-1)]` (the trailing sentinel) if layer `k-1` is `REPEATED`.
+
+The leaf array itself follows the same rule one step past the innermost layer, so
+`getValueCount()` matches `count(layerCount)`. Deeper nestings extend the same chain: at depth N you
+walk `getLayerOffsets(0)` through `getLayerOffsets(N - 1)`, checking `getLayerValidity(k)` (and, for
+`REPEATED` layers, the zero-length offsets diff that flags an empty container) at each step before
+descending.

--- a/docs/content/concepts/timestamps.md
+++ b/docs/content/concepts/timestamps.md
@@ -1,0 +1,54 @@
+<!--
+
+     SPDX-License-Identifier: CC-BY-SA-4.0
+
+     Copyright The original authors
+
+     Licensed under the Creative Commons Attribution-ShareAlike 4.0 International License;
+     you may not use this file except in compliance with the License.
+     You may obtain a copy of the License at https://creativecommons.org/licenses/by-sa/4.0/
+
+-->
+# Timestamp Semantics
+
+The Parquet TIMESTAMP logical type carries an `isAdjustedToUTC` flag that picks between two
+genuinely different kinds of value. Hardwood splits its accessor surface along the same line — a
+`getTimestamp` that returns `Instant` and a `getLocalTimestamp` that returns `LocalDateTime` —
+rather than papering over the difference with a single accessor.
+
+## Two kinds of timestamp
+
+- **`isAdjustedToUTC = true`** is an absolute point on the global timeline. The stored value counts
+  time units since the Unix epoch in UTC, and it identifies the same moment everywhere. Java's
+  `Instant` models exactly this: a count from the epoch with no attached zone, comparable across
+  systems.
+- **`isAdjustedToUTC = false`** is a wall-clock reading — a calendar date and time-of-day with no
+  zone information. "2026-06-04 09:00" means whatever local clock recorded it; it does *not* pin a
+  moment until a zone is supplied externally. Java's `LocalDateTime` models exactly this.
+
+The two are not interconvertible without a time zone, and silently treating one as the other shifts
+values by the local UTC offset — the classic source of off-by-hours bugs. A single accessor
+returning one Java type would force that lossy coercion on half of all timestamp columns, so the
+API keeps them distinct.
+
+## The split accessor pair
+
+Because the column's flag already records which kind it is, each accessor enforces the matching
+flag rather than guessing: `getTimestamp` is the `Instant` accessor and `getLocalTimestamp` the
+`LocalDateTime` one, and calling the wrong one for a column is a programming error that throws — the
+column's semantics, not the caller's expectation, win. The exact runtime contract (which flag each
+requires, the exception thrown) lives in [Typed Accessors](../reference/accessors.md). When a
+column's kind isn't known statically, branching on the flag — or the generic `getValue` accessor,
+which returns `Instant` or `LocalDateTime` per the flag — recovers the right type without a guess.
+
+## TIME's informational flag
+
+The TIME logical type carries the same `isAdjustedToUTC` flag, but the situation is different:
+`LocalTime` has no zone of its own, so there is no second Java type to split toward. `getTime`
+returns `LocalTime` either way and the flag is purely informational.
+
+## Legacy INT96
+
+Timestamps written by older Spark and Hive in the deprecated INT96 physical type carry no
+`isAdjustedToUTC` field at all. By the Spark / Hive convention they denote instants, so Hardwood
+reads them as `Instant` through `getTimestamp`.

--- a/docs/content/how-to/column-reader.md
+++ b/docs/content/how-to/column-reader.md
@@ -126,49 +126,15 @@ All three navigation methods return `null` when the group isn't of the expected 
 
 #### Reading nested data: the layer model
 
-`ColumnReader` exposes a column's schema chain as a sequence of **layers**. Each non-leaf node along the chain contributes zero or one layer:
+`ColumnReader` exposes a nested column's schema chain as a sequence of **layers**, numbered
+`0..getLayerCount() - 1` outermost-to-innermost, with the leaf queried separately. Each layer has a
+[Validity](/api/latest/dev/hardwood/reader/Validity.html) via `getLayerValidity(k)`; `REPEATED`
+layers (lists and maps) additionally have `getLayerOffsets(k)`; and the leaf has its own
+`getLeafValidity()`.
 
-| Schema node | Contributes layer? | Layer kind |
-|---|---|---|
-| `REQUIRED` group | no | — |
-| `OPTIONAL` group (struct) | yes | `STRUCT` |
-| `LIST` / `MAP`-annotated group | yes — exactly one | `REPEATED` |
-
-Layers are numbered `0..getLayerCount() - 1` outermost-to-innermost, and the leaf is queried separately. A flat column reports `getLayerCount() == 0`.
-
-For each layer, two buffers describe the items at that layer:
-
-- `getLayerValidity(k)` — a [Validity](/api/latest/dev/hardwood/reader/Validity.html) indexed by item position; `isNull(i)` / `isNotNull(i)` answer the per-item question, `hasNulls()` is the O(1) fast-path gate. Returns the shared `Validity.NO_NULLS` singleton when no item at layer `k` is null in this batch.
-- `getLayerOffsets(k)` — sentinel-suffixed offsets of length `count(k) + 1` into the next inner layer's items (or, for the innermost layer, into the leaf-value array). Only valid when `getLayerKind(k) == REPEATED`; throws on a `STRUCT` layer.
-
-The leaf has its own `getLeafValidity()` (also a `Validity`), and the four states of a `LIST`/`MAP` container fall out cleanly from offsets and validity:
-
-| Logical value | `getLayerValidity` | `offsets[r+1] - offsets[r]` |
-|---|---|---|
-| `null`           | `isNull(r)`    | `0` |
-| `[]`             | `isNotNull(r)` | `0` |
-| `[null]`         | `isNotNull(r)` | `1`, leaf validity says null |
-| `[v]`            | `isNotNull(r)` | `1`, leaf validity says not null |
-
-Empty-vs-null is the offsets diff; the validity bit picks out null. No empty-marker bitmap is needed.
-
-A quick reference for what `getLayerCount()` / `getLayerKind(k)` report for common chains:
-
-| Schema chain | `getLayerCount()` | Kinds (outer → inner) |
-|---|---|---|
-| `optional double x` | 0 | — |
-| `optional struct { ... int x }` | 1 | STRUCT |
-| `list<int>` | 1 | REPEATED |
-| `map<string, int>` | 1 | REPEATED |
-| `list<list<int>>` | 2 | REPEATED, REPEATED |
-| `optional struct { list<int> }` | 2 | STRUCT, REPEATED |
-| `list<optional struct { ... }>` | 2 | REPEATED, STRUCT |
-| `optional struct { map<string, int> }` | 2 | STRUCT, REPEATED |
-
-Two rules generate this table:
-
-1. **STRUCT keeps cardinality.** Items at layer `k+1` equal items at layer `k`. STRUCT layers carry validity, no offsets.
-2. **REPEATED expands cardinality.** Items at layer `k+1` equal `getLayerOffsets(k)[count(k)]`. REPEATED layers carry both validity and offsets.
+For the full model — how `STRUCT` and `REPEATED` nodes map to layers, the four container states,
+the offset/validity encoding, and the per-layer count recursion — see
+[The Layer Model](../concepts/nested-columns.md). The examples below walk the common shapes.
 
 #### Picking a null-check loop shape
 
@@ -418,19 +384,3 @@ Validity metaValidity  = reader.getLayerValidity(0);   // STRUCT layer for `meta
 Validity mapValidity   = reader.getLayerValidity(1);   // REPEATED layer for the map
 int[]    entryOffsets  = reader.getLayerOffsets(1);
 ```
-
-#### Real items only
-
-The leaf array and `getLayerOffsets` carry **real items only** — phantom slots from null/empty parents at any `REPEATED` layer are excluded. `getValueCount()` returns the real leaf count. `STRUCT` layers do not expand or contract the item stream — they carry a validity bitmap of the same length as their parent. Only `REPEATED` layers add cardinality, via their offsets.
-
-#### Counts at each layer
-
-Every per-layer buffer is sized to `count(k)`, defined recursively:
-
-- `count(0) == getRecordCount()`
-- For `k > 0`: `count(k)` equals `count(k-1)` if layer `k-1` is `STRUCT`, or `getLayerOffsets(k-1)[count(k-1)]` (the trailing sentinel) if layer `k-1` is `REPEATED`.
-
-The leaf array itself follows the same rule one step past the innermost layer, so `getValueCount()` matches `count(layerCount)`.
-
-Deeper nestings extend the same chain: at depth N you walk `getLayerOffsets(0)` through `getLayerOffsets(N - 1)`, checking `getLayerValidity(k)` (and, for `REPEATED` layers, the zero-length offsets diff that flags an empty container) at each step before descending.
-

--- a/docs/content/how-to/query-controls.md
+++ b/docs/content/how-to/query-controls.md
@@ -51,16 +51,7 @@ try (ParquetFileReader fileReader = ParquetFileReader.open(InputFile.of(path));
 }
 ```
 
-| Category | Supported |
-|---|---|
-| Comparison operators | `eq`, `notEq`, `lt`, `ltEq`, `gt`, `gtEq` |
-| Set operators | `in` (int, long), `inStrings` |
-| Null operators | `isNull`, `isNotNull` (any type) |
-| Physical types (comparison) | `int`, `long`, `float`, `double`, `boolean`, `String` |
-| Logical types (comparison) | `LocalDate`, `Instant`, `LocalTime`, `BigDecimal`, `UUID` |
-| Combinators | `and`, `or`, `not` (`and` / `or` accept varargs for three or more conditions) |
-
-All predicates, including those wrapped in `not`, are pushed down to the statistics level for row-group and page skipping.
+For the full matrix of supported operators, comparable physical and logical types, and combinators, see [Query Controls](../reference/query-controls.md#supported-filter-predicates). All predicates, including those wrapped in `not`, are pushed down to the statistics level for row-group and page skipping.
 
 ### Null Handling
 
@@ -181,14 +172,7 @@ try (ParquetFileReader fileReader = ParquetFileReader.open(InputFile.of(path));
 }
 ```
 
-**Projection options:**
-
-| Form | Description |
-|------|-------------|
-| `ColumnProjection.all()` | Read all columns (default) |
-| `ColumnProjection.columns("id", "name")` | Read specific columns by name |
-| `ColumnProjection.columns("address")` | Select an entire struct and all its children |
-| `ColumnProjection.columns("address.city")` | Select a specific nested field (dot notation) |
+`ColumnProjection.all()` reads every column (the default); `ColumnProjection.columns(...)` selects by name, including a whole struct and its children or a dot-notation nested field. See [Query Controls](../reference/query-controls.md#column-projection-forms) for the full list of forms.
 
 ### Combining Projection and Filters
 

--- a/docs/content/how-to/row-reader.md
+++ b/docs/content/how-to/row-reader.md
@@ -134,41 +134,36 @@ All accessor methods are available in two forms:
 - **Name-based** (e.g., `getInt("column_name")`) — convenient for ad-hoc access
 - **Index-based** (e.g., `getInt(columnIndex)`) — faster for performance-critical loops
 
-| Method | Physical Type | Logical Type | Java Type |
-|--------|--------------|-------------|-----------|
-| `getBoolean` | BOOLEAN | | `boolean` |
-| `getInt` | INT32 | | `int` |
-| `getLong` | INT64 | | `long` |
-| `getFloat` | FLOAT, or FIXED_LEN_BYTE_ARRAY(2) | FLOAT16 (optional) | `float` |
-| `getDouble` | DOUBLE | | `double` |
-| `getBinary` | BYTE_ARRAY | BSON (optional) | `byte[]` |
-| `getString` | BYTE_ARRAY | STRING or JSON | `String` |
-| `getDate` | INT32 | DATE | `LocalDate` |
-| `getTime` | INT32 or INT64 | TIME | `LocalTime` |
-| `getTimestamp` | INT64, or legacy INT96 | TIMESTAMP (`isAdjustedToUTC = true`) | `Instant` |
-| `getLocalTimestamp` | INT64 | TIMESTAMP (`isAdjustedToUTC = false`) | `LocalDateTime` |
-| `getDecimal` | INT32, INT64, or FIXED_LEN_BYTE_ARRAY | DECIMAL | `BigDecimal` |
-| `getUuid` | FIXED_LEN_BYTE_ARRAY | UUID | `UUID` |
-| `getInterval` | FIXED_LEN_BYTE_ARRAY(12) | INTERVAL | `PqInterval` |
-| `getStruct` | | | `PqStruct` |
-| `getList` | | LIST | `PqList` |
-| `getMap` | | MAP | `PqMap` |
-| `getVariant` | BYTE_ARRAY pair | VARIANT | `PqVariant` |
-| `isNull` | Any | Any | `boolean` |
+The common scalar and nested types:
 
-All methods are available as both `method(name)` and `method(index)`.
+| Method | Java Type |
+|--------|-----------|
+| `getBoolean` | `boolean` |
+| `getInt` | `int` |
+| `getLong` | `long` |
+| `getFloat` | `float` |
+| `getDouble` | `double` |
+| `getString` | `String` |
+| `getDate` | `LocalDate` |
+| `getTime` | `LocalTime` |
+| `getTimestamp` | `Instant` |
+| `getLocalTimestamp` | `LocalDateTime` |
+| `getDecimal` | `BigDecimal` |
+| `getUuid` | `UUID` |
+| `getStruct` / `getList` / `getMap` | `PqStruct` / `PqList` / `PqMap` |
 
-#### Null handling
+For the complete correspondence — physical and logical types, the `getBinary` / `getInterval` /
+`getVariant` accessors, FLOAT16, BSON, INT96, and the legacy `converted_type` columns — plus the
+null- and type-mismatch contracts, see [Typed Accessors](../reference/accessors.md).
 
-Primitive accessors (`getInt`, `getLong`, `getFloat`, `getDouble`, `getBoolean`) throw `NullPointerException` if the field is null — always check with `isNull()` first. Object accessors (`getString`, `getDate`, `getTimestamp`, `getLocalTimestamp`, `getDecimal`, `getUuid`, `getInterval`, `getStruct`, `getList`, `getMap`) return `null` for null fields.
+#### Null and type-mismatch handling
 
-#### Type mismatches
-
-Requesting the wrong type for a column (e.g. `getInt` on a `LONG` column, `getDate` on a `STRING` column) is a programming error; the call fails at runtime with an unchecked exception. The specific exception type is unspecified and may change between releases — do not catch it as part of normal control flow. If the column type isn't known statically, check it up front via `reader.getFileSchema().getColumn(name)` and inspect the returned `ColumnSchema`'s `type()` / `logicalType()` — see [Inspect File Metadata](metadata.md).
-
-The TIMESTAMP logical type carries an `isAdjustedToUTC` flag that picks between two distinct semantic kinds — a UTC-adjusted instant or a wall-clock local timestamp — and the accessor pair is split along the same line. `getTimestamp` requires `isAdjustedToUTC = true` and returns `Instant`; `getLocalTimestamp` requires `isAdjustedToUTC = false` and returns `LocalDateTime`. Calling the wrong one for a column throws `IllegalStateException` naming the column and the actual flag value. If the kind isn't known statically, branch on `((LogicalType.TimestampType) column.logicalType()).isAdjustedToUTC()` before the accessor call, or use the generic `getValue` accessor which returns `Instant` or `LocalDateTime` per the column's flag. Legacy INT96 columns have no `isAdjustedToUTC` field and are read as `Instant` via `getTimestamp` (Spark / Hive convention).
-
-The TIME logical type also carries an `isAdjustedToUTC` flag, but `LocalTime` has no zone of its own, so `getTime` returns `LocalTime` either way and the flag is informational — inspect `((LogicalType.TimeType) column.logicalType()).isAdjustedToUTC()` if the distinction matters to your application.
+Primitive accessors (`getInt`, `getLong`, `getFloat`, `getDouble`, `getBoolean`) throw
+`NullPointerException` on a null field — always check `isNull()` first; object accessors return
+`null`. Requesting the wrong type for a column fails at runtime with an unchecked exception. The
+full rules — including the split `getTimestamp` / `getLocalTimestamp` pair — are in
+[Typed Accessors](../reference/accessors.md); the reasoning behind the timestamp split is in
+[Timestamp Semantics](../concepts/timestamps.md).
 
 #### Index-based access
 
@@ -190,34 +185,7 @@ while (rowReader.hasNext()) {
 
 #### INTERVAL columns
 
-`PqInterval` is a plain record with three `long` properties — `months()`, `days()`, and `milliseconds()`. Each holds an unsigned 32-bit value in the range `[0, 4_294_967_295]`, so no additional conversion is needed. The components are independent and not normalized. `INTERVAL` is one of the legacy `converted_type` annotations handled transparently — see [Legacy converted-type annotations](#legacy-converted-type-annotations) below.
-
-#### FLOAT16 columns
-
-`getFloat` accepts FLOAT16 columns (`FIXED_LEN_BYTE_ARRAY(2)` annotated with the `FLOAT16` logical type) and decodes the 2-byte IEEE 754 half-precision payload to a single-precision `float`. The widening is lossless — half-precision NaN, ±Infinity, and signed zero round-trip cleanly, and the original NaN bit pattern is preserved (the Parquet spec does not canonicalize NaNs on write). Use `Float.isNaN(value)` for NaN checks rather than equality. As with all primitive accessors, `isNull()` must be checked before `getFloat()` since FLOAT16 columns can be optional.
-
-#### Legacy INT96 timestamps
-
-Parquet files written by older versions of Apache Spark and Hive store timestamps in the deprecated INT96 physical type without a TIMESTAMP logical type annotation. `getTimestamp` detects INT96 automatically and decodes it to an `Instant`; no caller-side handling is required.
-
-#### Legacy converted-type annotations
-
-Writers predating the modern logical-type union (older parquet-mr / Hive / Impala / Spark) annotate primitive columns with only a legacy `converted_type` and no `logicalType`. Hardwood promotes each one to its logical type, so the column decodes through the normal typed accessor with no caller-side opt-in:
-
-| `converted_type` | Accessor | Java type |
-|------------------|----------|-----------|
-| `UTF8` | `getString` | `String` |
-| `JSON` | `getString` | `String` |
-| `ENUM`, `BSON` | `getBinary` | `byte[]` |
-| `DATE` | `getDate` | `LocalDate` |
-| `DECIMAL` | `getDecimal` | `BigDecimal` |
-| `TIME_MILLIS`, `TIME_MICROS` | `getTime` | `LocalTime` |
-| `TIMESTAMP_MILLIS`, `TIMESTAMP_MICROS` | `getTimestamp` | `Instant` |
-| `INT_8`, `INT_16`, `INT_32`, `INT_64` | `getValue` | `Byte` / `Short` / `Integer` / `Long` |
-| `UINT_8`, `UINT_16`, `UINT_32`, `UINT_64` | `getValue` | `Integer` / `Long` (raw two's-complement bit pattern) |
-| `INTERVAL` | `getInterval` | `PqInterval` |
-
-`TIME_*` columns decode to a UTC-normalized `LocalTime` time-of-day and `TIMESTAMP_*` columns to a UTC-normalized `Instant`, matching the parquet-format backward-compatibility rule for these annotations. Unsigned columns preserve the stored bit pattern — reinterpret with `Integer.toUnsignedLong` / `Long.toUnsignedString` for the unsigned magnitude. When a file carries both a `converted_type` and a modern `logicalType`, the `logicalType` takes precedence.
+`PqInterval` is a plain record with three `long` properties — `months()`, `days()`, and `milliseconds()`. Each holds an unsigned 32-bit value in the range `[0, 4_294_967_295]`, so no additional conversion is needed. The components are independent and not normalized. `INTERVAL` is one of the legacy `converted_type` annotations handled transparently — see [Legacy converted-type annotations](../reference/accessors.md#legacy-converted-type-annotations).
 
 #### NULL columns
 

--- a/docs/content/how-to/s3.md
+++ b/docs/content/how-to/s3.md
@@ -129,6 +129,10 @@ When a custom endpoint is set, region can be omitted. Use `.pathStyle(true)` for
 
 ## Configuration
 
+The builder exposes timeouts, retries, and transport configuration. The consolidated option /
+default table is in the [S3 Reference](../reference/s3.md#s3source-builder-options); the worked
+examples below cover the common cases.
+
 ### Timeouts
 
 The builder provides connect and request timeouts with sensible defaults:
@@ -141,9 +145,6 @@ S3Source source = S3Source.builder()
         .requestTimeout(Duration.ofSeconds(60))   // default: 30s
         .build();
 ```
-
-- **Connect timeout** — maximum time to establish a TCP connection (default 10 seconds).
-- **Request timeout** — maximum time for an individual HTTP request to complete (default 30 seconds).
 
 ### Retries
 
@@ -207,12 +208,8 @@ try (S3InputFile in = source.inputFile("s3://my-bucket/data/trips.parquet");
 }
 ```
 
-- `networkRequestCount()` — HTTP GET requests issued since `open()`: the footer tail fetch plus every column-chunk range fetch. Tail-cache hits are not counted.
-- `networkBytesFetched()` — total bytes fetched across those requests, counted the same way.
-
-Read the counters before the try-with-resources block exits, while the `S3InputFile` is still open.
+Read the counters before the try-with-resources block exits, while the `S3InputFile` is still open. For the exact counting semantics of `networkRequestCount()` and `networkBytesFetched()`, see the [S3 Reference](../reference/s3.md#fetch-cost-counters).
 
 ### Not currently supported
 
-- **Anonymous (unsigned) requests** — `S3Credentials` requires an access key + secret key pair; there is no built-in mode for public buckets without credentials.
-- **Requester-pays buckets** — Hardwood does not send the `x-amz-request-payer` header. Reads against requester-pays buckets will fail with `403 AccessDenied` even with valid credentials.
+Anonymous (unsigned) requests and requester-pays buckets are not supported — see the [S3 Reference](../reference/s3.md#not-currently-supported) for details.

--- a/docs/content/reference/accessors.md
+++ b/docs/content/reference/accessors.md
@@ -1,0 +1,118 @@
+<!--
+
+     SPDX-License-Identifier: CC-BY-SA-4.0
+
+     Copyright The original authors
+
+     Licensed under the Creative Commons Attribution-ShareAlike 4.0 International License;
+     you may not use this file except in compliance with the License.
+     You may obtain a copy of the License at https://creativecommons.org/licenses/by-sa/4.0/
+
+-->
+# Typed Accessors
+
+`RowReader` — and the nested `PqStruct` / `PqList` / `PqMap` flyweights — decode each column to its
+logical-type Java representation through typed accessor methods. This page is the full
+correspondence between accessor, Parquet type, and Java type, together with the null- and
+type-mismatch contracts every accessor obeys. For the task-oriented walkthrough, see
+[Read Row by Row](../how-to/row-reader.md).
+
+## Accessor type mapping
+
+All accessors are available in two forms — name-based (`getInt("column_name")`) and index-based
+(`getInt(columnIndex)`); see [Index-based access](../how-to/row-reader.md#index-based-access).
+
+| Method | Physical Type | Logical Type | Java Type |
+|--------|--------------|-------------|-----------|
+| `getBoolean` | BOOLEAN | | `boolean` |
+| `getInt` | INT32 | | `int` |
+| `getLong` | INT64 | | `long` |
+| `getFloat` | FLOAT, or FIXED_LEN_BYTE_ARRAY(2) | FLOAT16 (optional) | `float` |
+| `getDouble` | DOUBLE | | `double` |
+| `getBinary` | BYTE_ARRAY | BSON (optional) | `byte[]` |
+| `getString` | BYTE_ARRAY | STRING or JSON | `String` |
+| `getDate` | INT32 | DATE | `LocalDate` |
+| `getTime` | INT32 or INT64 | TIME | `LocalTime` |
+| `getTimestamp` | INT64, or legacy INT96 | TIMESTAMP (`isAdjustedToUTC = true`) | `Instant` |
+| `getLocalTimestamp` | INT64 | TIMESTAMP (`isAdjustedToUTC = false`) | `LocalDateTime` |
+| `getDecimal` | INT32, INT64, or FIXED_LEN_BYTE_ARRAY | DECIMAL | `BigDecimal` |
+| `getUuid` | FIXED_LEN_BYTE_ARRAY | UUID | `UUID` |
+| `getInterval` | FIXED_LEN_BYTE_ARRAY(12) | INTERVAL | `PqInterval` |
+| `getStruct` | | | `PqStruct` |
+| `getList` | | LIST | `PqList` |
+| `getMap` | | MAP | `PqMap` |
+| `getVariant` | BYTE_ARRAY pair | VARIANT | `PqVariant` |
+| `isNull` | Any | Any | `boolean` |
+
+All methods are available as both `method(name)` and `method(index)`.
+
+## Null handling
+
+Primitive accessors (`getInt`, `getLong`, `getFloat`, `getDouble`, `getBoolean`) throw
+`NullPointerException` if the field is null — always check `isNull()` first. Object accessors
+(`getString`, `getDate`, `getTimestamp`, `getLocalTimestamp`, `getDecimal`, `getUuid`,
+`getInterval`, `getStruct`, `getList`, `getMap`) return `null` for null fields.
+
+## Type mismatches
+
+Requesting the wrong type for a column (e.g. `getInt` on a `LONG` column, `getDate` on a `STRING`
+column) is a programming error; the call fails at runtime with an unchecked exception. The
+specific exception type is unspecified and may change between releases — do not catch it as part of
+normal control flow. If the column type isn't known statically, check it up front via
+`reader.getFileSchema().getColumn(name)` and inspect the returned `ColumnSchema`'s `type()` /
+`logicalType()` — see [Inspect File Metadata](../how-to/metadata.md).
+
+The `getTimestamp` / `getLocalTimestamp` pair is split along the column's `isAdjustedToUTC` flag:
+`getTimestamp` requires `isAdjustedToUTC = true` and returns `Instant`; `getLocalTimestamp`
+requires `isAdjustedToUTC = false` and returns `LocalDateTime`. Calling the wrong one for a column
+throws `IllegalStateException` naming the column and the actual flag value. If the kind isn't known
+statically, branch on `((LogicalType.TimestampType) column.logicalType()).isAdjustedToUTC()` before
+the accessor call, or use the generic `getValue` accessor, which returns `Instant` or
+`LocalDateTime` per the column's flag. For why the pair is split, see
+[Timestamp Semantics](../concepts/timestamps.md).
+
+The TIME logical type also carries an `isAdjustedToUTC` flag, but `LocalTime` has no zone of its
+own, so `getTime` returns `LocalTime` either way and the flag is informational — inspect
+`((LogicalType.TimeType) column.logicalType()).isAdjustedToUTC()` if the distinction matters to
+your application.
+
+## FLOAT16 columns
+
+`getFloat` accepts FLOAT16 columns (`FIXED_LEN_BYTE_ARRAY(2)` annotated with the `FLOAT16` logical
+type) and decodes the 2-byte IEEE 754 half-precision payload to a single-precision `float`. The
+widening is lossless — half-precision NaN, ±Infinity, and signed zero round-trip cleanly, and the
+original NaN bit pattern is preserved (the Parquet spec does not canonicalize NaNs on write). Use
+`Float.isNaN(value)` for NaN checks rather than equality. As with all primitive accessors,
+`isNull()` must be checked before `getFloat()` since FLOAT16 columns can be optional.
+
+## Legacy INT96 timestamps
+
+Parquet files written by older versions of Apache Spark and Hive store timestamps in the deprecated
+INT96 physical type without a TIMESTAMP logical type annotation. `getTimestamp` detects INT96
+automatically and decodes it to an `Instant`; no caller-side handling is required.
+
+## Legacy converted-type annotations
+
+Writers predating the modern logical-type union (older parquet-mr / Hive / Impala / Spark) annotate
+primitive columns with only a legacy `converted_type` and no `logicalType`. Hardwood promotes each
+one to its logical type, so the column decodes through the normal typed accessor with no
+caller-side opt-in:
+
+| `converted_type` | Accessor | Java type |
+|------------------|----------|-----------|
+| `UTF8` | `getString` | `String` |
+| `JSON` | `getString` | `String` |
+| `ENUM`, `BSON` | `getBinary` | `byte[]` |
+| `DATE` | `getDate` | `LocalDate` |
+| `DECIMAL` | `getDecimal` | `BigDecimal` |
+| `TIME_MILLIS`, `TIME_MICROS` | `getTime` | `LocalTime` |
+| `TIMESTAMP_MILLIS`, `TIMESTAMP_MICROS` | `getTimestamp` | `Instant` |
+| `INT_8`, `INT_16`, `INT_32`, `INT_64` | `getValue` | `Byte` / `Short` / `Integer` / `Long` |
+| `UINT_8`, `UINT_16`, `UINT_32`, `UINT_64` | `getValue` | `Integer` / `Long` (raw two's-complement bit pattern) |
+| `INTERVAL` | `getInterval` | `PqInterval` |
+
+`TIME_*` columns decode to a UTC-normalized `LocalTime` time-of-day and `TIMESTAMP_*` columns to a
+UTC-normalized `Instant`, matching the parquet-format backward-compatibility rule for these
+annotations. Unsigned columns preserve the stored bit pattern — reinterpret with
+`Integer.toUnsignedLong` / `Long.toUnsignedString` for the unsigned magnitude. When a file carries
+both a `converted_type` and a modern `logicalType`, the `logicalType` takes precedence.

--- a/docs/content/reference/query-controls.md
+++ b/docs/content/reference/query-controls.md
@@ -1,0 +1,47 @@
+<!--
+
+     SPDX-License-Identifier: CC-BY-SA-4.0
+
+     Copyright The original authors
+
+     Licensed under the Creative Commons Attribution-ShareAlike 4.0 International License;
+     you may not use this file except in compliance with the License.
+     You may obtain a copy of the License at https://creativecommons.org/licenses/by-sa/4.0/
+
+-->
+# Query Controls
+
+Look-it-up reference for the predicate and projection controls. For worked examples and the I/O
+behavior of each control — predicate pushdown, projection, row limits, splits, and skip — see
+[Predicate Pushdown, Projection, Limits, and Splits](../how-to/query-controls.md).
+
+## Supported filter predicates
+
+| Category | Supported |
+|---|---|
+| Comparison operators | `eq`, `notEq`, `lt`, `ltEq`, `gt`, `gtEq` |
+| Set operators | `in` (int, long), `inStrings` |
+| Null operators | `isNull`, `isNotNull` (any type) |
+| Physical types (comparison) | `int`, `long`, `float`, `double`, `boolean`, `String` |
+| Logical types (comparison) | `LocalDate`, `Instant`, `LocalTime`, `BigDecimal`, `UUID` |
+| Combinators | `and`, `or`, `not` (`and` / `or` accept varargs for three or more conditions) |
+
+All predicates, including those wrapped in `not`, are pushed down to the statistics level for
+row-group and page skipping.
+
+The logical-type factories validate the column's logical type at reader creation: `BigDecimal`
+predicates require a `DECIMAL` column and `UUID` predicates require a `UUID` column. Applying them
+to a plain `FIXED_LEN_BYTE_ARRAY` column without the corresponding logical-type annotation throws
+`IllegalArgumentException`. Raw physical-type predicates (`int`, `long`, etc.) remain available for
+columns without logical types or for filtering on the underlying physical value directly. Filters
+work with all reader types — `RowReader`, `ColumnReader`, `AvroRowReader`, and across multi-file
+readers.
+
+## Column projection forms
+
+| Form | Description |
+|------|-------------|
+| `ColumnProjection.all()` | Read all columns (default) |
+| `ColumnProjection.columns("id", "name")` | Read specific columns by name |
+| `ColumnProjection.columns("address")` | Select an entire struct and all its children |
+| `ColumnProjection.columns("address.city")` | Select a specific nested field (dot notation) |

--- a/docs/content/reference/s3.md
+++ b/docs/content/reference/s3.md
@@ -1,0 +1,49 @@
+<!--
+
+     SPDX-License-Identifier: CC-BY-SA-4.0
+
+     Copyright The original authors
+
+     Licensed under the Creative Commons Attribution-ShareAlike 4.0 International License;
+     you may not use this file except in compliance with the License.
+     You may obtain a copy of the License at https://creativecommons.org/licenses/by-sa/4.0/
+
+-->
+# S3 Reference
+
+Look-it-up reference for the `hardwood-s3` module. For worked examples — credentials, S3-compatible
+endpoints, and multi-file reads — see [Reading from S3](../how-to/s3.md).
+
+## `S3Source` builder options
+
+| Option | Default | Effect |
+|--------|---------|--------|
+| `region(String)` | — | AWS region. Required unless `endpoint` is set. |
+| `endpoint(String)` | — | Custom endpoint for S3-compatible services (R2, GCS HMAC, MinIO). Region may be omitted when set. |
+| `pathStyle(boolean)` | `false` | Path-style addressing, for services that require it (MinIO, SeaweedFS). |
+| `credentials(...)` | — | Static `S3Credentials`, an `S3CredentialsProvider`, or the AWS chain via `hardwood-aws-auth`. Required. |
+| `connectTimeout(Duration)` | 10s | Maximum time to establish a TCP connection. Ignored when a custom `httpClient` is supplied. |
+| `requestTimeout(Duration)` | 30s | Maximum time for an individual HTTP request to complete. |
+| `maxRetries(int)` | 3 | GET retries on transient failures (HTTP 500, 503, network errors) with exponential backoff and jitter. `0` disables retries. |
+| `httpClient(HttpClient)` | internal | Caller-supplied client for full transport control. The caller is responsible for closing it — `S3Source.close()` will not. |
+
+When the retry budget is exhausted, the last failure is re-thrown as an `IOException`. For HTTP
+errors the message has the form `GET s3://<bucket>/<key> failed: HTTP <status>`; for network errors
+the original `IOException` message is preserved.
+
+## Fetch-cost counters
+
+Each `S3InputFile` tracks the network I/O it has performed since `open()`:
+
+- `networkRequestCount()` — HTTP GET requests issued: the footer tail fetch plus every
+  column-chunk range fetch. Tail-cache hits are not counted.
+- `networkBytesFetched()` — total bytes fetched across those requests, counted the same way.
+
+Read the counters before the try-with-resources block exits, while the `S3InputFile` is still open.
+
+## Not currently supported
+
+- **Anonymous (unsigned) requests** — `S3Credentials` requires an access key + secret key pair;
+  there is no built-in mode for public buckets without credentials.
+- **Requester-pays buckets** — Hardwood does not send the `x-amz-request-payer` header. Reads
+  against requester-pays buckets will fail with `403 AccessDenied` even with valid credentials.

--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -36,10 +36,15 @@ nav:
     - How a Parquet File Is Laid Out: concepts/parquet-layout.md
     - The Concurrency Model: concepts/concurrency-model.md
     - RowReader vs. ColumnReader: concepts/reader-models.md
+    - The Layer Model: concepts/nested-columns.md
     - Row Selection: concepts/row-selection.md
+    - Timestamp Semantics: concepts/timestamps.md
     - Compatibility Philosophy: concepts/compatibility-philosophy.md
   - Reference:
     - Configuration: reference/configuration.md
+    - Typed Accessors: reference/accessors.md
+    - Query Controls: reference/query-controls.md
+    - S3: reference/s3.md
     - Error Handling: reference/error-handling.md
     - CLI: reference/cli.md
     - Package Structure: reference/packages.md


### PR DESCRIPTION
Closes #585.

The how-to guides had accumulated capability matrices and type-mapping tables — look-it-up facts and model definitions that the Diátaxis structure assigns to **reference** (facts) and **concepts** (the model behind the API), not goal-oriented guides. This concentrates each fact in one canonical home, keeping the guides on a single worked path and matching the precedent already set by `reference/configuration.md`.

### Moves

- **RowReader accessor tables → `reference/accessors.md`.** Full accessor → physical/logical/Java-type table, the null- and type-mismatch contracts, and the FLOAT16 / INT96 / legacy `converted_type` facts. The `isAdjustedToUTC` *rationale* (why the `getTimestamp` / `getLocalTimestamp` pair is split) → `concepts/timestamps.md`.
- **Query-control capability tables → `reference/query-controls.md`.** The supported-predicate matrix and the `ColumnProjection` forms table.
- **ColumnReader layer model → `concepts/nested-columns.md`.** The defining tables (schema-node → layer-kind, the four LIST/MAP container states, `getLayerCount()` by chain, the per-layer count recursion) plus the narrative that explains them.
- **S3 builder configuration → `reference/s3.md`.** A consolidated `S3Source` option/default/effect table, the fetch-cost counter semantics, and the "not currently supported" list.

Each guide keeps its examples and links out. One deliberate duplication remains: a trimmed common-scalar accessor table stays in the RowReader guide as an ergonomic aid, with the exhaustive table in reference.

### Out of scope

Brief in-context "Limitations" notes tied to a single guide (variant, geospatial, filter limitations) stay where they are — a short caveat list is acceptable in a how-to.

This single commit addresses all four checkboxes on the umbrella issue, so #585 closes on merge.

Validated with `mkdocs build --strict`.