### PR TITLE
#599 Reject shredded Variant objects repeating a field across typed_value and value

### DIFF
--- a/core/src/main/java/dev/hardwood/internal/reader/VariantShredReassembler.java
+++ b/core/src/main/java/dev/hardwood/internal/reader/VariantShredReassembler.java
@@ -269,16 +269,20 @@ public final class VariantShredReassembler {
 
     /// Decode the partial-unshredded object bytes in `raw`, appending each
     /// (name, valueBytes) pair into `names` / `values` starting at `count`.
-    /// Spec guarantees these names are disjoint from the shredded set, so we
-    /// can simply append — no deduplication needed. Field ids index into the
-    /// top-level metadata dictionary (same for all nesting depths within a
+    /// The spec requires these names to be disjoint from the shredded set
+    /// (`names[0..count)`); a collision is a malformed file that would yield a
+    /// Variant object with duplicate field ids, so we reject it via
+    /// [#rejectFieldCollision] rather than append blindly. Field ids index into
+    /// the top-level metadata dictionary (same for all nesting depths within a
     /// variant), resolved via `currentMetadata`. Returns the new count.
     private int mergeUnshreddedObject(byte[] raw, String[] names, byte[][] values, int count) {
+        int shreddedCount = count;
         ObjectLayout layout = VariantValueDecoder.parseObject(raw, 0);
         int n = layout.numElements();
         for (int i = 0; i < n; i++) {
             int fieldId = VariantValueDecoder.objectFieldId(raw, layout, i);
             String fieldName = currentMetadata.getField(fieldId);
+            rejectFieldCollision(fieldName, names, shreddedCount);
             int valueStart = VariantValueDecoder.objectValueOffset(raw, layout, i);
             // The object's offset array has `numElements + 1` entries, so
             // offset[i+1] is always valid and points at the byte past element i.
@@ -290,6 +294,23 @@ public final class VariantShredReassembler {
             count++;
         }
         return count;
+    }
+
+    /// Enforce the shredding invariant that a partially-shredded object's
+    /// `typed_value` struct and unshredded `value` object carry disjoint field
+    /// names. `shreddedNames[0..shreddedCount)` holds the names already emitted
+    /// from the shredded struct; an unshredded field that repeats one of them
+    /// is a malformed file (the reassembled object would have duplicate field
+    /// ids), so fail early rather than produce a corrupt Variant. Objects are
+    /// typically tiny, so a linear scan is cheaper than allocating a set.
+    private static void rejectFieldCollision(String fieldName, String[] shreddedNames, int shreddedCount) {
+        for (int i = 0; i < shreddedCount; i++) {
+            if (fieldName.equals(shreddedNames[i])) {
+                throw new IllegalStateException(
+                        "Malformed shredded Variant: field '" + fieldName + "' appears in both the "
+                        + "shredded typed_value and the unshredded value object");
+            }
+        }
     }
 
     /// Emit the object framing with fields sorted alphabetically (spec

--- a/core/src/test/java/dev/hardwood/internal/reader/VariantShredReassemblerTest.java
+++ b/core/src/test/java/dev/hardwood/internal/reader/VariantShredReassemblerTest.java
@@ -1,0 +1,94 @@
+/*
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Copyright The original authors
+ *
+ *  Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package dev.hardwood.internal.reader;
+
+import java.util.Arrays;
+
+import org.junit.jupiter.api.Test;
+
+import dev.hardwood.internal.variant.ShredLevel;
+import dev.hardwood.internal.variant.ShredLevel.Typed;
+import dev.hardwood.internal.variant.VariantMetadata;
+import dev.hardwood.internal.variant.VariantValueEncoder;
+import dev.hardwood.metadata.PhysicalType;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/// White-box tests for [VariantShredReassembler]'s handling of malformed
+/// shredded input that violates the per-level shredding invariants.
+class VariantShredReassemblerTest {
+
+    /// Variant metadata dictionary holding a single field `dup` (header 0x01,
+    /// dictionary_size 1, offsets [0, 3], strings "dup").
+    private static final byte[] METADATA_DUP = { 0x01, 0x01, 0x00, 0x03, 'd', 'u', 'p' };
+
+    /// A shredded OBJECT may carry both a `typed_value` struct and a `value`
+    /// blob (partial shredding), but only when their field-name sets are
+    /// disjoint. A file where the same field appears on both sides is malformed
+    /// and must be rejected rather than silently reassembled into a Variant
+    /// object with duplicate field ids.
+    @Test
+    void shreddedObjectFieldAlsoPresentInUnshreddedValueIsRejected() {
+        // Column layout (projected indices):
+        //   col 0 = top-level `value`        (BYTE_ARRAY)
+        //   col 1 = field "dup" typed_value  (INT64)
+        ShredLevel fieldDup = new ShredLevel(-1, 0,
+                new Typed.Primitive(1, 1, PhysicalType.INT64, null));
+        ShredLevel root = new ShredLevel(0, 1,
+                new Typed.Object(1, new String[] { "dup" }, new ShredLevel[] { fieldDup }));
+
+        // The unshredded `value` is an object that ALSO carries field "dup" —
+        // colliding with the shredded struct.
+        byte[] innerValue = encode(buf -> VariantValueEncoder.writeInt8(buf, 0, 5));
+        byte[] unshreddedObject = encode(buf ->
+                VariantValueEncoder.writeObject(buf, 0, new int[] { 0 }, new byte[][] { innerValue }, 0));
+
+        NestedBatchIndex batch = singleRowObjectBatch(unshreddedObject, 42L);
+
+        VariantShredReassembler reassembler = new VariantShredReassembler();
+        reassembler.setCurrentMetadata(new VariantMetadata(METADATA_DUP));
+
+        assertThatThrownBy(() -> reassembler.reassemble(root, batch, 0))
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessageContaining("dup");
+    }
+
+    // ==================== Helpers ====================
+
+    @FunctionalInterface
+    private interface VariantWriter {
+        int write(byte[] buf);
+    }
+
+    private static byte[] encode(VariantWriter writer) {
+        byte[] buf = new byte[64];
+        return Arrays.copyOf(buf, writer.write(buf));
+    }
+
+    /// Build a single-row, two-column batch matching the column layout above:
+    /// col 0 is a top-level `value` BYTE_ARRAY holding `valueObject`; col 1 is
+    /// the shredded field's INT64 `typed_value`. Both are non-null at def level
+    /// 1. Repetition/record offsets are left null (non-repeated columns).
+    private static NestedBatchIndex singleRowObjectBatch(byte[] valueObject, long typedFieldValue) {
+        NestedBatch valueCol = new NestedBatch();
+        valueCol.values = new BinaryBatchValues(valueObject, new int[] { 0, valueObject.length });
+        valueCol.valueCount = 1;
+        valueCol.recordCount = 1;
+        valueCol.definitionLevels = new int[] { 1 };
+
+        NestedBatch typedCol = new NestedBatch();
+        typedCol.values = new long[] { typedFieldValue };
+        typedCol.valueCount = 1;
+        typedCol.recordCount = 1;
+        typedCol.definitionLevels = new int[] { 1 };
+
+        return NestedBatchIndex.buildFromBatches(
+                new NestedBatch[] { valueCol, typedCol },
+                null, null, null, null);
+    }
+}


### PR DESCRIPTION
Closes #599.

## Problem

The Variant shredding spec lets an object be *partially shredded* — `typed_value` carries the known fields and `value` carries the rest — but only when the two sides name **disjoint** fields. `VariantShredReassembler.mergeUnshreddedObject` trusted that invariant and appended the unshredded fields without checking. A malformed file naming the same field on both sides was therefore silently reassembled into a Variant object with **duplicate field ids** — corrupt output, no error. That is precisely the silent-wrong-result the project's fail-early stance forbids.

This is the object path that #315 explicitly left open ("their path already handles the both-present case via `mergeUnshreddedObject`"); #315 covers the distinct non-object case.

## Change

- Detect the collision during the merge and throw `IllegalStateException` naming the offending field, rather than emit a corrupt Variant. The check lives in `mergeUnshreddedObject`, so it covers both reassembly entry points — `writeObjectLevel` (row) and `writeElementObject` (array-of-objects).
- Objects are typically tiny, so the check is a linear scan over the already-emitted shredded names — no set allocation on the read path.

## Tests

- New `VariantShredReassemblerTest` constructs a malformed shredded object (same field on both sides) and asserts reassembly throws. Written test-first; confirmed it failed (silent corruption) before the fix.
- Valid partial-shredding is unaffected: the end-to-end shredding tests (`VariantLogicalTypeTest`, `VariantInRepeatedAccessorsTest`, which read real fixtures) still pass.
- Full `core` suite: 1290 tests, 0 failures, 0 errors.

## Acceptance criteria (from #599)

- [x] A shredded-object row whose unshredded `value` repeats a shredded field name throws with a message identifying the field.
- [x] Valid partial-shredding (disjoint field sets) continues to reassemble unchanged.