### PR TITLE
#608 Treat ColumnIndex field 7 as definition_level_histograms, not geospatial stats

### DIFF
--- a/FORMAT_COVERAGE.md
+++ b/FORMAT_COVERAGE.md
@@ -95,7 +95,7 @@ All fields (column_idx, descending, nulls_first) ❌ — struct not read.
 | 14 | bloom_filter_offset | 🟡 | shown in dive; no bloom-filter decode (#105) |
 | 15 | bloom_filter_length | 🟡 | #105 |
 | 16 | size_statistics | ❌ | #607 |
-| 17 | geospatial_statistics | ✅ | row-group / page filter evaluators |
+| 17 | geospatial_statistics | ✅ | row-group filter evaluator (no per-page geospatial stats exist) |
 
 ### PageEncodingStats
 All fields (page_type, encoding, count) ❌ — struct not read.
@@ -176,7 +176,7 @@ Empty struct; not read (see `PageHeader.index_page_header`).
 | 4 | boundary_order | ✅ | |
 | 5 | null_counts | ✅ | |
 | 6 | repetition_level_histograms | ❌ | #607 |
-| 7 | definition_level_histograms | ❌ | #607; currently mis-read as geospatial (#608) |
+| 7 | definition_level_histograms | ❌ | skipped; surfacing tracked by #607 |
 | 8 | nan_counts | ❌ | #607 |
 
 ### OffsetIndex
@@ -220,7 +220,7 @@ The ❌ rows cluster into a handful of capabilities, cross-referenced to ROADMAP
 
 - **Modular encryption** — entire feature stubbed to fail-fast. #128 (ROADMAP has no phase yet).
 - **Bloom-filter pushdown** — ROADMAP 9.3 / 9.4; #105.
-- **Size statistics & level histograms** — ROADMAP 9.x; #607, #608.
+- **Size statistics & level histograms** — ROADMAP 9.x; #607.
 - **Statistics completeness** — distinct_count, exactness flags, nan_count; #483, #607.
 - **Declared sort order** — `sorting_columns`, `is_sorted`; ROADMAP 4.2.
 - **Column orders** — float total-order vs type-defined; #483.

--- a/_designs/GEOSPATIAL_SUPPORT.md
+++ b/_designs/GEOSPATIAL_SUPPORT.md
@@ -13,7 +13,7 @@ their logical type, so both must be implemented together.
 parquet-java 1.16.0 added the metadata layer (logical types + statistics read/write)
 but does not provide spatial filter pushdown — engines like Sedona and DuckDB implement
 their own pushdown on top of the Parquet metadata. Hardwood's `Filter.intersects()`
-with row group and page-level evaluation would go beyond what parquet-java offers.
+with row-group evaluation would go beyond what parquet-java offers.
 
 ## Logical Types
 
@@ -77,12 +77,13 @@ Per-column-chunk statistics for spatial filter pushdown.
 For GEOGRAPHY columns, x is longitude ([-180, 180]) and y is latitude ([-90, 90]).
 `xmin > xmax` is legal and indicates antimeridian wrapping.
 
-The same `GeospatialStatistics` struct also appears in `ColumnIndex` (field 7) for
-page-level spatial filtering.
+Parquet defines geospatial statistics only per column chunk. `ColumnIndex` has no
+geospatial field — its field 7 is `definition_level_histograms` — so spatial filter
+pushdown is possible at row-group granularity only, not per page.
 
 ## Implementation
 
-Steps 1–4 build on each other and should land in order. Step 1 (logical types) is a
+Steps 1–3 build on each other and should land in order. Step 1 (logical types) is a
 prerequisite for step 2 — the statistics are not useful to consumers until the reader
 can identify geospatial columns.
 
@@ -118,13 +119,7 @@ No changes needed in `SchemaElementReader` — it already delegates field 10 to
 `GeospatialStatisticsReader` and `BoundingBoxReader` in the Thrift package, and a
 `geospatialStatistics` field on `ColumnMetaData`.
 
-### Step 3 — Page-level geospatial statistics on ColumnIndex
-
-Add `List<GeospatialStatistics> geospatialStatistics` (one per page) to the `ColumnIndex`
-record, parsed from field 7 of the Thrift `ColumnIndex` struct. This enables page-level
-spatial filter pushdown analogous to the existing min/max page index.
-
-### Step 4 — Spatial bounding box predicate
+### Step 3 — Spatial bounding box predicate
 
 Add a `IntersectsPredicate` to the `FilterPredicate` sealed interface:
 
@@ -189,15 +184,11 @@ evaluator throws `IllegalArgumentException`.
 
 #### Page-level evaluation
 
-In `PageFilterEvaluator`, add a case for `IntersectsPredicate`. For each page, read
-the per-page `GeospatialStatistics` from the `ColumnIndex` (step 3) and apply the same
-intersection test. Pages whose bounding box does not intersect the query box are excluded
-from the `RowRanges` result.
+Not applicable. Parquet has no per-page geospatial statistics, so `PageFilterEvaluator`
+returns `RowRanges.all()` for `IntersectsPredicate`; spatial pruning happens only at
+row-group granularity.
 
-If the column index does not contain geospatial statistics, fall back to
-`RowRanges.all()` (no page-level filtering), consistent with existing behavior.
-
-### Step 5 — End-to-end test with JTS
+### Step 4 — End-to-end test with JTS
 
 Add JTS (`org.locationtech.jts:jts-core`) as a test dependency in the core module.
 Write an end-to-end test that exercises the full chain a real user would follow:
@@ -253,14 +244,14 @@ Note that individual rows within a surviving row group may fall outside the quer
 box — pushdown is coarse-grained. The test asserts that *some* row groups were
 skipped, not that every row matches.
 
-### Step 6 — Documentation
+### Step 5 — Documentation
 
 - Update `docs/content/usage.md` with examples showing:
     - how to identify geospatial columns via their logical type
     - how to access bounding box metadata
     - how to use `intersects` for filter pushdown
 - Add test Parquet files (via `simple-datagen.py`) that contain GEOMETRY/GEOGRAPHY
-  logical types with geospatial statistics at both column chunk and page level.
+  logical types with column-chunk geospatial statistics.
 - Unit tests for the spatial predicate evaluator:
     - basic intersection / non-intersection
     - antimeridian wrapping
@@ -279,11 +270,9 @@ skipped, not that every row matches.
 | `core/.../thrift/BoundingBoxReader.java` | Create |
 | `core/.../thrift/ColumnMetaDataReader.java` | Add field 17 |
 | `core/.../metadata/ColumnMetaData.java` | Add `geospatialStatistics` field |
-| `core/.../metadata/ColumnIndex.java` | Add `geospatialStatistics` field |
-| `core/.../thrift/ColumnIndexReader.java` | Add field 7 |
 | `core/.../reader/FilterPredicate.java` | Add `IntersectsPredicate` record and factory |
 | `core/.../internal/reader/RowGroupFilterEvaluator.java` | Add spatial bbox evaluation |
-| `core/.../internal/reader/PageFilterEvaluator.java` | Add spatial bbox evaluation |
+| `core/.../internal/reader/PageFilterEvaluator.java` | Return `RowRanges.all()` for spatial predicates |
 | `core/pom.xml` | Add JTS test dependency |
 | `core/.../GeospatialEndToEndTest.java` | End-to-end test with JTS |
 | `docs/content/usage.md` | Update with geospatial examples |

--- a/core/src/main/java/dev/hardwood/internal/predicate/PageFilterEvaluator.java
+++ b/core/src/main/java/dev/hardwood/internal/predicate/PageFilterEvaluator.java
@@ -17,10 +17,7 @@ import dev.hardwood.internal.reader.RowRanges;
 import dev.hardwood.internal.thrift.ColumnIndexReader;
 import dev.hardwood.internal.thrift.OffsetIndexReader;
 import dev.hardwood.internal.thrift.ThriftCompactReader;
-import dev.hardwood.internal.util.Geospatial;
-import dev.hardwood.metadata.BoundingBox;
 import dev.hardwood.metadata.ColumnIndex;
-import dev.hardwood.metadata.GeospatialStatistics;
 import dev.hardwood.metadata.OffsetIndex;
 import dev.hardwood.metadata.PageLocation;
 import dev.hardwood.metadata.RowGroup;
@@ -76,7 +73,9 @@ public class PageFilterEvaluator {
             }
             case ResolvedPredicate.IsNullPredicate p -> evaluateNullPages(p.columnIndex(), true, rowGroup, indexBuffers, rowCount);
             case ResolvedPredicate.IsNotNullPredicate p -> evaluateNullPages(p.columnIndex(), false, rowGroup, indexBuffers, rowCount);
-            case ResolvedPredicate.GeospatialPredicate p -> evaluateSpatialIntersectionPages(p, rowGroup, indexBuffers, rowCount);
+            // Parquet has no per-page geospatial statistics (GeospatialStatistics lives only on
+            // ColumnMetaData, applied during row-group filtering), so no page-level pruning is possible.
+            case ResolvedPredicate.GeospatialPredicate ignored -> RowRanges.all(rowCount);
             default -> evaluateLeafPages(predicate, rowGroup, indexBuffers, rowCount);
         };
     }
@@ -214,60 +213,6 @@ public class PageFilterEvaluator {
             keep[i] = !canDropTest.canDrop(columnIdx, i);
         }
 
-        return RowRanges.fromPages(pages, keep, rowCount);
-    }
-
-    /// Evaluates a GeospatialPredicate against per-page bounding box statistics from the
-    /// Column Index. Pages whose bbox is disjoint from the query bbox are dropped; pages
-    /// without geospatial stats are kept.
-    ///
-    /// @param predicate    the spatial predicate to evaluate
-    /// @param rowGroup     the row group being evaluated
-    /// @param indexBuffers pre-fetched index buffers for the row group
-    /// @param rowCount     total rows in the row group
-    /// @return row ranges that might contain matching rows
-    private static RowRanges evaluateSpatialIntersectionPages(ResolvedPredicate.GeospatialPredicate predicate,
-            RowGroup rowGroup, RowGroupIndexBuffers indexBuffers, long rowCount) {
-        int columnIndex = predicate.columnIndex();
-        if (columnIndex < 0 || columnIndex >= rowGroup.columns().size()) {
-            return RowRanges.all(rowCount);
-        }
-
-        ColumnIndexBuffers colBuffers = indexBuffers.forColumn(columnIndex);
-        if (colBuffers == null || colBuffers.columnIndex() == null || colBuffers.offsetIndex() == null) {
-            return RowRanges.all(rowCount);
-        }
-
-        IndexPair indexPair;
-        try {
-            indexPair = readIndexPair(colBuffers);
-        }
-        catch (IOException e) {
-            throw new UncheckedIOException("Failed to parse Column/Offset Index for column index " + columnIndex, e);
-        }
-        return evaluateSpatialPages(indexPair.columnIndex, indexPair.offsetIndex, predicate, rowCount);
-    }
-
-    /// Computes the row ranges within a row group that intersect the query bbox, given the
-    /// per-page geospatial stats already parsed out of the Column Index. Pages without bbox
-    /// stats are kept conservatively.
-    static RowRanges evaluateSpatialPages(ColumnIndex columnIdx, OffsetIndex offsetIdx,
-            ResolvedPredicate.GeospatialPredicate predicate, long rowCount) {
-        List<PageLocation> pages = offsetIdx.pageLocations();
-        int pageCount = pages.size();
-        boolean[] keep = new boolean[pageCount];
-        List<GeospatialStatistics> pageStats = columnIdx.geospatialStatistics();
-        for (int i = 0; i < pageCount; i++) {
-            GeospatialStatistics stats = pageStats == null ? null : pageStats.get(i);
-            BoundingBox bbox = stats == null ? null : stats.bbox();
-            if (bbox == null) {
-                keep[i] = true; // no per-page bbox: keep conservatively
-                continue;
-            }
-            keep[i] = Geospatial.xAxisOverlaps(bbox.xmin(), bbox.xmax(), predicate.xmin(), predicate.xmax())
-                    && bbox.ymax() >= predicate.ymin()
-                    && bbox.ymin() <= predicate.ymax();
-        }
         return RowRanges.fromPages(pages, keep, rowCount);
     }
 

--- a/core/src/main/java/dev/hardwood/internal/thrift/ColumnIndexReader.java
+++ b/core/src/main/java/dev/hardwood/internal/thrift/ColumnIndexReader.java
@@ -12,7 +12,6 @@ import java.util.ArrayList;
 import java.util.List;
 
 import dev.hardwood.metadata.ColumnIndex;
-import dev.hardwood.metadata.GeospatialStatistics;
 
 /// Reader for ColumnIndex from Thrift Compact Protocol.
 ///
@@ -23,7 +22,11 @@ import dev.hardwood.metadata.GeospatialStatistics;
 /// - 3: max_values (list<binary>)
 /// - 4: boundary_order (enum BoundaryOrder)
 /// - 5: null_counts (list<i64>, optional)
-/// - 7: geospatial_stats (list<GeospatialStatistics>, optional)
+/// - 6: repetition_level_histograms (list<i64>, optional)
+/// - 7: definition_level_histograms (list<i64>, optional)
+/// - 8: nan_counts (list<i64>, optional)
+///
+/// Fields 6–8 are not yet surfaced and are skipped.
 public class ColumnIndexReader {
 
     public static ColumnIndex read(ThriftCompactReader reader) throws IOException {
@@ -42,7 +45,6 @@ public class ColumnIndexReader {
         List<byte[]> maxValues = new ArrayList<>();
         ColumnIndex.BoundaryOrder boundaryOrder = ColumnIndex.BoundaryOrder.UNORDERED;
         List<Long> nullCounts = null;
-        List<GeospatialStatistics> geospatialStatistics = null;
 
         while (true) {
             ThriftCompactReader.FieldHeader header = reader.readFieldHeader();
@@ -109,31 +111,14 @@ public class ColumnIndexReader {
                         reader.skipField(header.type());
                     }
                     break;
-                case 7: // geospatial_stats (list<GeospatialStatistics>, optional)
-                    if (header.type() == 0x09) { // LIST
-                        ThriftCompactReader.CollectionHeader listHeader = reader.readListHeader();
-                        if (listHeader.elementType() == 0x0C) { // STRUCT
-                            geospatialStatistics = new ArrayList<>(listHeader.size());
-                            for (int i = 0; i < listHeader.size(); i++) {
-                                geospatialStatistics.add(GeospatialStatisticsReader.read(reader));
-                            }
-                        }
-                        else {
-                            for (int i = 0; i < listHeader.size(); i++) {
-                                reader.skipField(listHeader.elementType());
-                            }
-                        }
-                    }
-                    else {
-                        reader.skipField(header.type());
-                    }
-                    break;
                 default:
+                    // Fields 6 (repetition_level_histograms), 7 (definition_level_histograms)
+                    // and 8 (nan_counts) are not yet surfaced and fall through to be skipped.
                     reader.skipField(header.type());
                     break;
             }
         }
 
-        return new ColumnIndex(nullPages, minValues, maxValues, boundaryOrder, nullCounts, geospatialStatistics);
+        return new ColumnIndex(nullPages, minValues, maxValues, boundaryOrder, nullCounts);
     }
 }

--- a/core/src/main/java/dev/hardwood/metadata/ColumnIndex.java
+++ b/core/src/main/java/dev/hardwood/metadata/ColumnIndex.java
@@ -16,7 +16,6 @@ import java.util.List;
 /// @param maxValues per-page maximum values in the column's physical sort order
 /// @param boundaryOrder ordering of min/max values: UNORDERED, ASCENDING, or DESCENDING
 /// @param nullCounts per-page null counts, or `null` if not available
-/// @param geospatialStatistics per-page geospatial stats, or `null` if not available
 /// @see <a href="https://parquet.apache.org/docs/file-format/pageindex/">File Format – Page Index</a>
 /// @see <a href="https://github.com/apache/parquet-format/blob/master/src/main/thrift/parquet.thrift">parquet.thrift</a>
 public record ColumnIndex(
@@ -24,8 +23,7 @@ public record ColumnIndex(
         List<byte[]> minValues,
         List<byte[]> maxValues,
         BoundaryOrder boundaryOrder,
-        List<Long> nullCounts,
-        List<GeospatialStatistics> geospatialStatistics) {
+        List<Long> nullCounts) {
 
     /// Ordering of min/max values across pages.
     public enum BoundaryOrder {

--- a/core/src/test/java/dev/hardwood/internal/predicate/PageFilterEvaluatorTest.java
+++ b/core/src/test/java/dev/hardwood/internal/predicate/PageFilterEvaluatorTest.java
@@ -25,10 +25,8 @@ import dev.hardwood.InputFile;
 import dev.hardwood.internal.reader.ParquetMetadataReader;
 import dev.hardwood.internal.reader.RowGroupIndexBuffers;
 import dev.hardwood.internal.reader.RowRanges;
-import dev.hardwood.metadata.BoundingBox;
 import dev.hardwood.metadata.ColumnIndex;
 import dev.hardwood.metadata.FileMetaData;
-import dev.hardwood.metadata.GeospatialStatistics;
 import dev.hardwood.metadata.OffsetIndex;
 import dev.hardwood.metadata.PageLocation;
 import dev.hardwood.metadata.RowGroup;
@@ -134,7 +132,7 @@ class PageFilterEvaluatorTest {
                 List.of(intBytes(1), intBytes(0), intBytes(21)),
                 List.of(intBytes(10), intBytes(0), intBytes(30)),
                 ColumnIndex.BoundaryOrder.UNORDERED,
-                null, null);
+                null);
 
         RowRanges ranges = PageFilterEvaluator.evaluatePages(nullPageColumnIndex, THREE_PAGE_OFFSET_INDEX, THREE_PAGE_ROW_COUNT,
                 (columnIndex, pageIndex) -> {
@@ -478,7 +476,7 @@ class PageFilterEvaluatorTest {
             nullPages.add(false);
         }
         return new ColumnIndex(nullPages, minValues, maxValues,
-                ColumnIndex.BoundaryOrder.UNORDERED, null, null);
+                ColumnIndex.BoundaryOrder.UNORDERED, null);
     }
 
     private static ColumnIndex longColumnIndex(long[] mins, long[] maxs) {
@@ -491,7 +489,7 @@ class PageFilterEvaluatorTest {
             nullPages.add(false);
         }
         return new ColumnIndex(nullPages, minValues, maxValues,
-                ColumnIndex.BoundaryOrder.UNORDERED, null, null);
+                ColumnIndex.BoundaryOrder.UNORDERED, null);
     }
 
     @Test
@@ -565,7 +563,7 @@ class PageFilterEvaluatorTest {
             nullPages.add(false);
         }
         return new ColumnIndex(nullPages, minValues, maxValues,
-                ColumnIndex.BoundaryOrder.UNORDERED, null, null);
+                ColumnIndex.BoundaryOrder.UNORDERED, null);
     }
 
     private static ColumnIndex doubleColumnIndex(double[] mins, double[] maxs) {
@@ -578,7 +576,7 @@ class PageFilterEvaluatorTest {
             nullPages.add(false);
         }
         return new ColumnIndex(nullPages, minValues, maxValues,
-                ColumnIndex.BoundaryOrder.UNORDERED, null, null);
+                ColumnIndex.BoundaryOrder.UNORDERED, null);
     }
 
     private static ColumnIndex booleanColumnIndex(boolean[] mins, boolean[] maxs) {
@@ -591,7 +589,7 @@ class PageFilterEvaluatorTest {
             nullPages.add(false);
         }
         return new ColumnIndex(nullPages, minValues, maxValues,
-                ColumnIndex.BoundaryOrder.UNORDERED, null, null);
+                ColumnIndex.BoundaryOrder.UNORDERED, null);
     }
 
     private static ColumnIndex binaryColumnIndex(List<byte[]> mins, List<byte[]> maxs) {
@@ -600,105 +598,7 @@ class PageFilterEvaluatorTest {
             nullPages.add(false);
         }
         return new ColumnIndex(nullPages, mins, maxs,
-                ColumnIndex.BoundaryOrder.UNORDERED, null, null);
-    }
-
-    // Geospatial Filtering Tests
-
-    @Test
-    void testSpatialPagesDropsDisjointPagesAndKeepsIntersecting() {
-        // 3 pages, each with a distinct bbox (Europe, Asia, Americas)
-        ColumnIndex columnIdx = geospatialColumnIndex(
-                bbox(-25.0, 45.0, 35.0, 72.0),     // Europe
-                bbox(60.0, 150.0, -10.0, 50.0),    // Asia
-                bbox(-130.0, -60.0, 25.0, 50.0));  // Americas
-        OffsetIndex offsetIdx = offsetIndex(30, 30, 30);
-
-        // Query box matching Europe
-        ResolvedPredicate.GeospatialPredicate europe = new ResolvedPredicate.GeospatialPredicate(
-                0, -10.0, 40.0, 30.0, 60.0);
-        RowRanges ranges = PageFilterEvaluator.evaluateSpatialPages(columnIdx, offsetIdx, europe, 90);
-
-        assertTrue(ranges.overlapsPage(0, 30));
-        assertFalse(ranges.overlapsPage(30, 60));
-        assertFalse(ranges.overlapsPage(60, 90));
-    }
-
-    @Test
-    void testSpatialPagesKeepsAllWhenNoGeospatialStats() {
-        // ColumnIndex with no geospatial stats — everything must be kept.
-        ColumnIndex columnIdx = new ColumnIndex(
-                List.of(false, false, false),
-                List.of(intBytes(0), intBytes(0), intBytes(0)),
-                List.of(intBytes(0), intBytes(0), intBytes(0)),
-                ColumnIndex.BoundaryOrder.UNORDERED, null, null);
-        OffsetIndex offsetIdx = offsetIndex(30, 30, 30);
-        ResolvedPredicate.GeospatialPredicate predicate = new ResolvedPredicate.GeospatialPredicate(
-                0, -10.0, 40.0, 30.0, 60.0);
-
-        RowRanges ranges = PageFilterEvaluator.evaluateSpatialPages(columnIdx, offsetIdx, predicate, 90);
-
-        assertTrue(ranges.overlapsPage(0, 30));
-        assertTrue(ranges.overlapsPage(30, 60));
-        assertTrue(ranges.overlapsPage(60, 90));
-    }
-
-    @Test
-    void testSpatialPagesKeepsPageWithMissingPerPageBbox() {
-        // Middle page's stats slot is null; should be kept.
-        List<GeospatialStatistics> stats = new ArrayList<>();
-        stats.add(new GeospatialStatistics(bbox(-25.0, 45.0, 35.0, 72.0), List.of()));
-        stats.add(null);
-        stats.add(new GeospatialStatistics(bbox(-130.0, -60.0, 25.0, 50.0), List.of()));
-        ColumnIndex columnIdx = geospatialColumnIndexFromStats(stats);
-        OffsetIndex offsetIdx = offsetIndex(30, 30, 30);
-        ResolvedPredicate.GeospatialPredicate europe = new ResolvedPredicate.GeospatialPredicate(
-                0, -10.0, 40.0, 30.0, 60.0);
-
-        RowRanges ranges = PageFilterEvaluator.evaluateSpatialPages(columnIdx, offsetIdx, europe, 90);
-
-        assertTrue(ranges.overlapsPage(0, 30));
-        assertTrue(ranges.overlapsPage(30, 60));   // unknown stats: keep
-        assertFalse(ranges.overlapsPage(60, 90));  // disjoint: drop
-    }
-
-    @Test
-    void testSpatialPagesAntimeridianWrappingPageIsKept() {
-        // Wrapping chunk bbox (xmin > xmax) overlapping a non-wrapping query bbox.
-        ColumnIndex columnIdx = geospatialColumnIndex(bbox(170.0, -170.0, -10.0, 10.0));
-        OffsetIndex offsetIdx = offsetIndex(50);
-        ResolvedPredicate.GeospatialPredicate touchingDateLine = new ResolvedPredicate.GeospatialPredicate(
-                0, 160.0, -5.0, 180.0, 5.0);
-
-        RowRanges ranges = PageFilterEvaluator.evaluateSpatialPages(
-                columnIdx, offsetIdx, touchingDateLine, 50);
-
-        assertTrue(ranges.overlapsPage(0, 50));
-    }
-
-    private static BoundingBox bbox(double xmin, double xmax, double ymin, double ymax) {
-        return new BoundingBox(xmin, xmax, ymin, ymax, null, null, null, null);
-    }
-
-    private static ColumnIndex geospatialColumnIndex(BoundingBox... pageBboxes) {
-        List<GeospatialStatistics> stats = new ArrayList<>();
-        for (BoundingBox bbox : pageBboxes) {
-            stats.add(new GeospatialStatistics(bbox, List.of()));
-        }
-        return geospatialColumnIndexFromStats(stats);
-    }
-
-    private static ColumnIndex geospatialColumnIndexFromStats(List<GeospatialStatistics> stats) {
-        List<Boolean> nullPages = new ArrayList<>();
-        List<byte[]> minValues = new ArrayList<>();
-        List<byte[]> maxValues = new ArrayList<>();
-        for (int i = 0; i < stats.size(); i++) {
-            nullPages.add(false);
-            minValues.add(new byte[0]);
-            maxValues.add(new byte[0]);
-        }
-        return new ColumnIndex(nullPages, minValues, maxValues,
-                ColumnIndex.BoundaryOrder.UNORDERED, null, stats);
+                ColumnIndex.BoundaryOrder.UNORDERED, null);
     }
 
     /// Creates an OffsetIndex with the given number of rows per page.

--- a/core/src/test/java/dev/hardwood/internal/thrift/ColumnIndexReaderTest.java
+++ b/core/src/test/java/dev/hardwood/internal/thrift/ColumnIndexReaderTest.java
@@ -1,0 +1,181 @@
+/*
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Copyright The original authors
+ *
+ *  Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package dev.hardwood.internal.thrift;
+
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
+
+import org.junit.jupiter.api.Test;
+
+import dev.hardwood.metadata.ColumnIndex;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class ColumnIndexReaderTest {
+
+    private static final byte TYPE_I32 = 0x05;
+    private static final byte TYPE_LIST = 0x09;
+
+    // Thrift Compact Protocol list element type codes.
+    private static final byte ELEM_BOOL = 0x01;
+    private static final byte ELEM_I64 = 0x06;
+    private static final byte ELEM_BINARY = 0x08;
+    private static final byte ELEM_STRUCT = 0x0C;
+
+    @Test
+    void readsCoreFieldsAndSkipsHistogramAndNanCountFields() throws IOException {
+        // Fields 6 (repetition_level_histograms), 7 (definition_level_histograms) and
+        // 8 (nan_counts) are all list<i64> and must be skipped without affecting fields 1-5.
+        byte[] thrift = struct()
+                .field(1, TYPE_LIST).boolList(false, true, false)
+                .field(2, TYPE_LIST).binaryList(bytes(1), bytes(0), bytes(21))
+                .field(3, TYPE_LIST).binaryList(bytes(10), bytes(0), bytes(30))
+                .field(4, TYPE_I32).i32(1) // ASCENDING
+                .field(5, TYPE_LIST).i64List(0, 3, 0)
+                .field(6, TYPE_LIST).i64List(1, 2, 3, 4)
+                .field(7, TYPE_LIST).i64List(5, 6, 7, 8)
+                .field(8, TYPE_LIST).i64List(0, 0, 0)
+                .stop().build();
+
+        ColumnIndex index = ColumnIndexReader.read(new ThriftCompactReader(ByteBuffer.wrap(thrift)));
+
+        assertThat(index.nullPages()).containsExactly(false, true, false);
+        assertThat(index.minValues()).hasSize(3);
+        assertThat(index.minValues().get(0)).isEqualTo(bytes(1));
+        assertThat(index.maxValues().get(2)).isEqualTo(bytes(30));
+        assertThat(index.boundaryOrder()).isEqualTo(ColumnIndex.BoundaryOrder.ASCENDING);
+        assertThat(index.nullCounts()).containsExactly(0L, 3L, 0L);
+        assertThat(index.getPageCount()).isEqualTo(3);
+    }
+
+    @Test
+    void skipsStructTypedFieldSevenWithoutCorruptingLaterFields() throws IOException {
+        // A malformed/adversarial file places STRUCT-typed elements at field 7. The reader must
+        // skip them cleanly (no geospatial decode) and still parse the surrounding fields.
+        byte[] thrift = struct()
+                .field(1, TYPE_LIST).boolList(false, false)
+                .field(2, TYPE_LIST).binaryList(bytes(1), bytes(2))
+                .field(3, TYPE_LIST).binaryList(bytes(9), bytes(9))
+                .field(4, TYPE_I32).i32(0)
+                .field(5, TYPE_LIST).i64List(2, 5)
+                .field(7, TYPE_LIST).emptyStructList(2)
+                .field(8, TYPE_LIST).i64List(0, 0)
+                .stop().build();
+
+        ColumnIndex index = ColumnIndexReader.read(new ThriftCompactReader(ByteBuffer.wrap(thrift)));
+
+        assertThat(index.nullPages()).containsExactly(false, false);
+        assertThat(index.nullCounts()).containsExactly(2L, 5L);
+        assertThat(index.getPageCount()).isEqualTo(2);
+    }
+
+    private static ThriftBuilder struct() {
+        return new ThriftBuilder();
+    }
+
+    private static byte[] bytes(int... values) {
+        byte[] out = new byte[values.length];
+        for (int i = 0; i < values.length; i++) {
+            out[i] = (byte) values[i];
+        }
+        return out;
+    }
+
+    /// Hand-rolled Thrift Compact Protocol struct builder for tests.
+    private static final class ThriftBuilder {
+        private final ByteBuffer buffer = ByteBuffer.allocate(512).order(ByteOrder.LITTLE_ENDIAN);
+        private short lastFieldId;
+
+        ThriftBuilder field(int id, byte type) {
+            short delta = (short) (id - lastFieldId);
+            if (delta > 0 && delta <= 15) {
+                buffer.put((byte) ((delta << 4) | (type & 0x0F)));
+            }
+            else {
+                buffer.put(type);
+                writeZigzag(id);
+            }
+            lastFieldId = (short) id;
+            return this;
+        }
+
+        ThriftBuilder boolList(boolean... values) {
+            listHeader(values.length, ELEM_BOOL);
+            for (boolean value : values) {
+                buffer.put((byte) (value ? 0x01 : 0x02));
+            }
+            return this;
+        }
+
+        ThriftBuilder binaryList(byte[]... values) {
+            listHeader(values.length, ELEM_BINARY);
+            for (byte[] value : values) {
+                writeVarint(value.length);
+                buffer.put(value);
+            }
+            return this;
+        }
+
+        ThriftBuilder i64List(long... values) {
+            listHeader(values.length, ELEM_I64);
+            for (long value : values) {
+                writeZigzag(value);
+            }
+            return this;
+        }
+
+        ThriftBuilder emptyStructList(int count) {
+            listHeader(count, ELEM_STRUCT);
+            for (int i = 0; i < count; i++) {
+                buffer.put((byte) 0); // empty struct: immediate STOP
+            }
+            return this;
+        }
+
+        ThriftBuilder i32(int value) {
+            writeZigzag(value);
+            return this;
+        }
+
+        ThriftBuilder stop() {
+            buffer.put((byte) 0);
+            return this;
+        }
+
+        byte[] build() {
+            byte[] out = new byte[buffer.position()];
+            buffer.flip();
+            buffer.get(out);
+            return out;
+        }
+
+        private void listHeader(int size, byte elementType) {
+            if (size < 15) {
+                buffer.put((byte) ((size << 4) | (elementType & 0x0F)));
+            }
+            else {
+                buffer.put((byte) (0xF0 | (elementType & 0x0F)));
+                writeVarint(size);
+            }
+        }
+
+        private void writeVarint(long value) {
+            long v = value;
+            while ((v & ~0x7FL) != 0) {
+                buffer.put((byte) ((v & 0x7F) | 0x80));
+                v >>>= 7;
+            }
+            buffer.put((byte) (v & 0x7F));
+        }
+
+        private void writeZigzag(long value) {
+            writeVarint((value << 1) ^ (value >> 63));
+        }
+    }
+}

--- a/docs/content/how-to/geospatial.md
+++ b/docs/content/how-to/geospatial.md
@@ -11,7 +11,7 @@
 -->
 # Geospatial Support
 
-Hardwood reads the [Parquet geospatial metadata layer](https://parquet.apache.org/docs/file-format/types/geospatial/) — GEOMETRY / GEOGRAPHY logical types and per-chunk / per-page `GeospatialStatistics` — and offers a bounding-box filter predicate that pushes spatial selectivity down to the row group and page level. Hardwood does not decode WKB payloads itself — geometry decoding is left to the caller, so the reader has no runtime geometry-library dependency. The de-facto standard Java library for this is the [JTS Topology Suite](https://locationtech.github.io/jts/); the snippets below assume JTS, but any WKB decoder works.
+Hardwood reads the [Parquet geospatial metadata layer](https://parquet.apache.org/docs/file-format/types/geospatial/) — GEOMETRY / GEOGRAPHY logical types and per-chunk `GeospatialStatistics` — and offers a bounding-box filter predicate that pushes spatial selectivity down to the row group level. Hardwood does not decode WKB payloads itself — geometry decoding is left to the caller, so the reader has no runtime geometry-library dependency. The de-facto standard Java library for this is the [JTS Topology Suite](https://locationtech.github.io/jts/); the snippets below assume JTS, but any WKB decoder works.
 
 To use JTS in the examples below, add the `jts-core` dependency:
 
@@ -50,7 +50,7 @@ try (ParquetFileReader reader = ParquetFileReader.open(InputFile.of(path))) {
 
 ### Bounding-Box Statistics
 
-Per-chunk geospatial statistics are exposed on `ColumnMetaData.geospatialStatistics()`. The `BoundingBox` carries `xmin/xmax/ymin/ymax` (always present) plus optional `zmin/zmax/mmin/mmax`. For GEOGRAPHY columns, `xmin > xmax` is legal and indicates a chunk that wraps the antimeridian. The same struct also appears per-page on `ColumnIndex.geospatialStatistics()` when the file was written with a Page Index.
+Per-chunk geospatial statistics are exposed on `ColumnMetaData.geospatialStatistics()`. The `BoundingBox` carries `xmin/xmax/ymin/ymax` (always present) plus optional `zmin/zmax/mmin/mmax`. For GEOGRAPHY columns, `xmin > xmax` is legal and indicates a chunk that wraps the antimeridian.
 
 ```java
 import dev.hardwood.metadata.BoundingBox;
@@ -110,7 +110,7 @@ FilterPredicate.and(
 
 ### Limitations
 
-`intersects` is **coarse-grained**: Hardwood drops row groups and pages whose bounding box is disjoint from the query box, but every row in a surviving page is returned. Rows whose individual geometry falls outside the query box are emitted along with truly intersecting ones. Apply your own per-row check on the WKB payload (e.g. via JTS) when you need exact geometric filtering — the bounding-box pushdown still saves the I/O for non-overlapping chunks.
+`intersects` is **coarse-grained**: Hardwood drops row groups whose bounding box is disjoint from the query box, but every row in a surviving row group is returned. Rows whose individual geometry falls outside the query box are emitted along with truly intersecting ones. Apply your own per-row check on the WKB payload (e.g. via JTS) when you need exact geometric filtering — the bounding-box pushdown still saves the I/O for non-overlapping chunks.
 
 Negation of `intersects` is **not supported**: `FilterPredicate.not(FilterPredicate.intersects(...))` throws `UnsupportedOperationException` at resolve time. The chunk-level criterion for "no row intersects" requires bbox containment rather than overlap, and the per-row dual would require decoding every WKB payload inside the reader — which would pull a geometry library into the runtime. If you need "geometries outside this box", read without a spatial filter and apply the negation yourself against `getBinary("location")`.
 


### PR DESCRIPTION
Fixes #608.

`ColumnIndexReader` mapped `ColumnIndex` Thrift field **7** to `list<GeospatialStatistics>`, but in `parquet.thrift` field 7 is `definition_level_histograms` (`list<i64>`). `ColumnIndex` has **no** geospatial field at all — `GeospatialStatistics` is referenced solely by `ColumnMetaData` (field 17).

The mis-numbered field had grown a whole dead, public layer: a `ColumnIndex.geospatialStatistics` record component and a `PageFilterEvaluator` page-level spatial-pruning path. Because a real `list<i64>` carries compact element type `0x06` (never the struct `0x0C` the branch needed), that component was always `null` from any real file and the page path pruned nothing in production — it only ever "worked" in in-memory unit tests.

## Changes
- **`ColumnIndexReader`** — removed the field-7 geospatial branch; fields 6/7/8 (`repetition_level_histograms`, `definition_level_histograms`, `nan_counts`) now skip cleanly. Corrected the class Javadoc to the real spec field names. (Parsing the histograms is left to #607.)
- **`ColumnIndex`** — removed the unreachable public `geospatialStatistics` component.
- **`PageFilterEvaluator`** — `GeospatialPredicate` now returns `RowRanges.all` (Parquet has no per-page geospatial stats to prune on); deleted `evaluateSpatialIntersectionPages` / `evaluateSpatialPages`.
- **Tests** — added `ColumnIndexReaderTest` (the reader had none): pins that fields 6/7/8 are skipped without disturbing 1–5, plus the adversarial struct-typed-field-7 case. Removed the in-memory-only page-geospatial tests from `PageFilterEvaluatorTest`.
- **Docs** — `how-to/geospatial.md` no longer claims page-level geospatial pushdown or a per-page `ColumnIndex.geospatialStatistics()`.

**Row-group** geospatial filtering (via `ColumnMetaData.geospatialStatistics()`, field 17) is unaffected and still works.

## Note on test-first
As the issue states, this defect is not exploitable — the old struct-decode and a clean skip consume identical bytes, and the buggy output was funneled into the now-removed `geospatialStatistics` field, so there is no observable red→green. The new reader test instead pins the corrected contract and exercises the path that replaced the dead branch.