### PR TITLE
#611 Add FORMAT_COVERAGE.md tracking parquet.thrift field coverage

### DIFF
--- a/FORMAT_COVERAGE.md
+++ b/FORMAT_COVERAGE.md
@@ -1,0 +1,227 @@
+# Parquet Format Coverage
+
+Field-level companion to [ROADMAP.md](ROADMAP.md). For every struct/union in the
+Parquet [`parquet.thrift`](https://github.com/apache/parquet-format/blob/master/src/main/thrift/parquet.thrift)
+metadata definition, this table records whether Hardwood reads the field and
+whether it acts on it.
+
+ROADMAP tracks *capabilities* (encodings, codecs, bloom filters, the writer);
+this table tracks *metadata fields*. It covers the footer/page metadata Hardwood
+parses, not the breadth of encoding/compression decoders (that lives in ROADMAP
+phases 2 and 8) or the value-conversion layer (phase 7.4).
+
+## Legend
+
+- ✅ **processed** — parsed and used by the reader/decoder/filter pipeline, or surfaced on the public API.
+- 🟡 **read-only** — parsed but with no functional consumer.
+- ❌ **skipped** — not read (the reader's `default` branch, or an explicit skip case).
+
+The 🟡-vs-✅ distinction is a maintained judgment (whether a parsed value is
+*meaningfully* consumed cannot be derived automatically — e.g. `bloom_filter_offset`
+is read and displayed yet feeds no filtering). The read-vs-skipped axis matches the
+`switch`-on-field-id in each `internal.thrift` reader.
+
+---
+
+## File metadata
+
+### FileMetaData
+| id | field | status | notes |
+|----|-------|--------|-------|
+| 1 | version | ✅ | surfaced in CLI / dive / `info` |
+| 2 | schema | ✅ | |
+| 3 | num_rows | ✅ | |
+| 4 | row_groups | ✅ | |
+| 5 | key_value_metadata | ✅ | exposed on `FileMetaData` |
+| 6 | created_by | ✅ | displayed in CLI / dive |
+| 7 | column_orders | ❌ | stats sort order assumed type-defined; #483 |
+| 8 | encryption_algorithm | ❌ | encrypted footers fail fast (#600); full support #128 |
+| 9 | footer_signing_key_metadata | ❌ | #128 |
+
+### FileCryptoMetaData · EncryptionAlgorithm (AesGcmV1, AesGcmCtrV1) · ColumnCryptoMetaData (EncryptionWithFooterKey, EncryptionWithColumnKey)
+All fields ❌ — Parquet Modular Encryption is unsupported; encrypted files fail
+fast. Tracked by **#128** (support), #600 (graceful failure).
+
+### ColumnOrder (TypeDefinedOrder, IEEE754TotalOrder)
+❌ — tied to `FileMetaData.column_orders`; #483.
+
+---
+
+## Row group & column
+
+### RowGroup
+| id | field | status | notes |
+|----|-------|--------|-------|
+| 1 | columns | ✅ | |
+| 2 | total_byte_size | ✅ | |
+| 3 | num_rows | ✅ | |
+| 4 | sorting_columns | ❌ | declared sort order not exploited |
+| 5 | file_offset | ❌ | |
+| 6 | total_compressed_size | ❌ | |
+| 7 | ordinal | ❌ | |
+
+### SortingColumn
+All fields (column_idx, descending, nulls_first) ❌ — struct not read.
+
+### ColumnChunk
+| id | field | status | notes |
+|----|-------|--------|-------|
+| 1 | file_path | ❌ | legacy split-file layout unsupported |
+| 2 | file_offset | ❌ | |
+| 3 | meta_data | ✅ | |
+| 4 | offset_index_offset | ✅ | `RowGroupIndexBuffers` |
+| 5 | offset_index_length | ✅ | |
+| 6 | column_index_offset | ✅ | |
+| 7 | column_index_length | ✅ | |
+| 8 | crypto_metadata | ❌ | #128 |
+| 9 | encrypted_column_metadata | ❌ | #128 |
+
+### ColumnMetaData
+| id | field | status | notes |
+|----|-------|--------|-------|
+| 1 | type | ✅ | |
+| 2 | encodings | ✅ | |
+| 3 | path_in_schema | ✅ | |
+| 4 | codec | ✅ | |
+| 5 | num_values | ✅ | |
+| 6 | total_uncompressed_size | ✅ | |
+| 7 | total_compressed_size | ✅ | fetch planning |
+| 8 | key_value_metadata | ✅ | |
+| 9 | data_page_offset | ✅ | |
+| 10 | index_page_offset | ❌ | explicit skip; index pages superseded by Column Index |
+| 11 | dictionary_page_offset | ✅ | |
+| 12 | statistics | ✅ | row-group filtering |
+| 13 | encoding_stats | ❌ | dictionary/plain page mix not read |
+| 14 | bloom_filter_offset | 🟡 | shown in dive; no bloom-filter decode (#105) |
+| 15 | bloom_filter_length | 🟡 | #105 |
+| 16 | size_statistics | ❌ | #607 |
+| 17 | geospatial_statistics | ✅ | row-group / page filter evaluators |
+
+### PageEncodingStats
+All fields (page_type, encoding, count) ❌ — struct not read.
+
+---
+
+## Statistics
+
+### Statistics
+| id | field | status | notes |
+|----|-------|--------|-------|
+| 1 | max (deprecated) | ✅ | fallback when 5/6 absent |
+| 2 | min (deprecated) | ✅ | fallback |
+| 3 | null_count | ✅ | validity + filtering |
+| 4 | distinct_count | 🟡 | on public record, no functional consumer (#483) |
+| 5 | max_value | ✅ | preferred |
+| 6 | min_value | ✅ | preferred |
+| 7 | is_max_value_exact | ❌ | truncated-bound flag ignored; #483 |
+| 8 | is_min_value_exact | ❌ | #483 |
+| 9 | nan_count | ❌ | #607 |
+
+### SizeStatistics
+All fields (unencoded_byte_array_data_bytes, repetition_level_histogram,
+definition_level_histogram) ❌ — struct not read. **#607**.
+
+### GeospatialStatistics
+| id | field | status | notes |
+|----|-------|--------|-------|
+| 1 | bbox | ✅ | |
+| 2 | geospatial_types | ✅ | |
+
+### BoundingBox
+All fields (xmin..mmax, ids 1–8) ✅.
+
+---
+
+## Page headers
+
+### PageHeader
+| id | field | status | notes |
+|----|-------|--------|-------|
+| 1 | type | ✅ | |
+| 2 | uncompressed_page_size | ✅ | |
+| 3 | compressed_page_size | ✅ | |
+| 4 | crc | ✅ | CRC32 validation |
+| 5 | data_page_header | ✅ | |
+| 6 | index_page_header | ❌ | INDEX_PAGE unused in practice |
+| 7 | dictionary_page_header | ✅ | |
+| 8 | data_page_header_v2 | ✅ | |
+
+### DataPageHeader
+All fields (ids 1–5: num_values, encoding, definition_level_encoding,
+repetition_level_encoding, statistics) ✅.
+
+### DataPageHeaderV2
+All fields (ids 1–8, incl. is_compressed) ✅.
+
+### DictionaryPageHeader
+| id | field | status | notes |
+|----|-------|--------|-------|
+| 1 | num_values | ✅ | |
+| 2 | encoding | ✅ | |
+| 3 | is_sorted | ❌ | sorted-dictionary hint not used |
+
+### IndexPageHeader
+Empty struct; not read (see `PageHeader.index_page_header`).
+
+---
+
+## Page index
+
+### ColumnIndex
+| id | field | status | notes |
+|----|-------|--------|-------|
+| 1 | null_pages | ✅ | |
+| 2 | min_values | ✅ | page skipping |
+| 3 | max_values | ✅ | |
+| 4 | boundary_order | ✅ | |
+| 5 | null_counts | ✅ | |
+| 6 | repetition_level_histograms | ❌ | #607 |
+| 7 | definition_level_histograms | ❌ | #607; currently mis-read as geospatial (#608) |
+| 8 | nan_counts | ❌ | #607 |
+
+### OffsetIndex
+| id | field | status | notes |
+|----|-------|--------|-------|
+| 1 | page_locations | ✅ | page scanning |
+| 2 | unencoded_byte_array_data_bytes | ❌ | #607 |
+
+### PageLocation
+All fields (offset, compressed_page_size, first_row_index) ✅.
+
+---
+
+## Logical types
+
+### LogicalType (union)
+All variants recognized ✅: STRING (1), MAP (2), LIST (3), ENUM (4), DECIMAL (5),
+DATE (6), TIME (7), TIMESTAMP (8), INTERVAL (9, also via `ConvertedType` 21),
+INTEGER (10), UNKNOWN/NULL (11), JSON (12), BSON (13), UUID (14), FLOAT16 (15),
+VARIANT (16), GEOMETRY (17), GEOGRAPHY (18).
+
+Parameterized sub-structs — all fields ✅: `DecimalType` (scale, precision),
+`TimeType` (isAdjustedToUTC, unit), `TimestampType` (isAdjustedToUTC, unit),
+`IntType` (bitWidth, isSigned), `VariantType` (specification_version),
+`GeometryType` (crs), `GeographyType` (crs, algorithm), `TimeUnit` union
+(MILLIS/MICROS/NANOS).
+
+---
+
+## Bloom filter
+
+### BloomFilterHeader · BloomFilterAlgorithm · BloomFilterHash · BloomFilterCompression
+All fields ❌ — no bloom-filter reader or decoder; the `ColumnMetaData` offset/length
+pointers (🟡 above) are read but unused. Tracked by **#105** (pushdown), #507 (dive).
+
+---
+
+## Capability gaps at a glance
+
+The ❌ rows cluster into a handful of capabilities, cross-referenced to ROADMAP:
+
+- **Modular encryption** — entire feature stubbed to fail-fast. #128 (ROADMAP has no phase yet).
+- **Bloom-filter pushdown** — ROADMAP 9.3 / 9.4; #105.
+- **Size statistics & level histograms** — ROADMAP 9.x; #607, #608.
+- **Statistics completeness** — distinct_count, exactness flags, nan_count; #483, #607.
+- **Declared sort order** — `sorting_columns`, `is_sorted`; ROADMAP 4.2.
+- **Column orders** — float total-order vs type-defined; #483.
+- **Deprecated / niche** — split-file `file_path`, index pages, encoding_stats, row-group ordinals: no planned support.

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -2,6 +2,8 @@
 
 A from-scratch implementation of Apache Parquet reader/writer in Java with no dependencies except compression libraries.
 
+For field-level `parquet.thrift` metadata coverage (which spec fields are read/processed/skipped), see [FORMAT_COVERAGE.md](FORMAT_COVERAGE.md).
+
 ## Phase 1: Foundation & Format Understanding
 
 ### 1.1 Core Data Structures
@@ -12,7 +14,7 @@ A from-scratch implementation of Apache Parquet reader/writer in Java with no de
   - [x] UINT_8, UINT_16, UINT_32, UINT_64 (unsigned integers)
   - [x] LIST (nested list support with arbitrary depth)
   - [x] MAP (map<key, value> with nested maps and struct values)
-  - [ ] INTERVAL (not implemented)
+  - [x] INTERVAL
 - [x] Define repetition types: `REQUIRED`, `OPTIONAL`, `REPEATED`
 
 ### 1.2 Schema Representation
@@ -164,7 +166,7 @@ A from-scratch implementation of Apache Parquet reader/writer in Java with no de
   - [x] Row groups
   - [x] Key-value metadata
   - [x] Created by string
-  - [x] Column orders
+  - [ ] Column orders (field skipped — stats sort order assumed type-defined; #483)
 - [ ] FileMetaData serialization
 - [x] FileMetaData deserialization
 
@@ -267,8 +269,7 @@ A from-scratch implementation of Apache Parquet reader/writer in Java with no de
   - [x] `PqVariant` / `PqVariantObject` / `PqVariantArray` row-API
   - [x] Shredded variant reassembly — primitive, object, array, nested (Phase 2, #286)
   - [x] Cross-impl byte-for-byte oracle against `parquet-testing/shredded_variant/*.variant.bin`
-- [ ] Not implemented (future)
-  - [ ] INTERVAL
+- [x] INTERVAL (FIXED_LEN_BYTE_ARRAY[12] → `PqInterval` via `LogicalTypeConverter`)
 
 ---
 


### PR DESCRIPTION
Adds `FORMAT_COVERAGE.md`, a maintainer-facing, field-level companion to `ROADMAP.md`: one table per `parquet.thrift` struct/union, each field classified ✅ processed / 🟡 read-only / ❌ skipped, with a notes column naming the consumer or a tracking issue. The ❌/🟡 rows double as the format-capability gap inventory, cross-referenced to #128 (encryption), #105 (bloom filters), #607 (SizeStatistics), #608 (ColumnIndex field 7), and #483 (expose remaining fields).

Building the table surfaced two stale ROADMAP entries, both corrected here:

- **`column_orders`** was marked done, but `FileMetaDataReader` has no case for field 7 — it falls through to `skipField`. Now `[ ]`, noting stats sort order is assumed type-defined (#483).
- **INTERVAL** was marked unimplemented, but it is both parsed (`LogicalTypeReader`) and converted (`LogicalTypeConverter` → `PqInterval`). Now `[x]` in both places it appeared.

ROADMAP's intro links to the new doc.

## Why hand-maintained, not enforced

An automated guard was considered and intentionally left out (see #611). The read-vs-skipped axis is mechanical, but processed-vs-read-but-ignored turns on whether a parsed value is *meaningfully* consumed — not derivable automatically (`bloom_filter_offset` is read, stored, and shown in `dive`, yet feeds no filtering). An enforced check could only cover completeness, not the classification that carries the value, so the table is kept ad-hoc for now.

Docs-only; no code or test changes.