### PR TITLE
#609 Stamp the HEAD commit SHA into the snapshot API report caption

### DIFF
--- a/tools/api-report.sh
+++ b/tools/api-report.sh
@@ -42,7 +42,10 @@ MODULES=":hardwood-core,:hardwood-avro,:hardwood-s3,:hardwood-aws-auth"
 ARTIFACTS=(hardwood-core hardwood-avro hardwood-s3 hardwood-aws-auth)
 
 if [ -z "$NEW" ]; then
-  CAPTION="HEAD vs $OLD"
+  # Record which commit HEAD was so a downloaded report names its exact source.
+  # Honor CI's ${GITHUB_SHA} when set, otherwise resolve it from the local repo.
+  HEAD_SHA="$(git rev-parse --short "${GITHUB_SHA:-HEAD}")"
+  CAPTION="HEAD ($HEAD_SHA) vs $OLD"
   # error-prone-checks is wired as an annotationProcessorPath, not a project
   # dependency, so it stays invisible to the reactor and must be installed into
   # the local repo first. The four modules are then installed (not just


### PR DESCRIPTION
Closes #609.

The snapshot path of `tools/api-report.sh` named its new side only as the literal `HEAD`, so a japicmp artifact downloaded from a main build carried no record of which commit it described.

This resolves the short SHA (preferring CI's `${GITHUB_SHA}`, falling back to `git rev-parse --short HEAD` locally) and folds it into `CAPTION`, e.g. `HEAD (a1b2c3d) vs 1.0.0.CR1`. Since `CAPTION` already flows into both the unified `.diff` header and the HTML `<title>`/heading, both pick it up automatically. The two-published-versions path is untouched — it already names both sides.