### PR TITLE
#535 Bind the tutorial's flat ColumnReader loop on getValueCount()

### DIFF
--- a/docs/content/tutorial/first-read.md
+++ b/docs/content/tutorial/first-read.md
@@ -160,7 +160,7 @@ try (ParquetFileReader reader =
 
     double total = 0;
     while (fare.nextBatch()) {
-        int count = fare.getRecordCount();
+        int count = fare.getValueCount();
         double[] values = fare.getDoubles();
         Validity validity = fare.getLeafValidity();
         boolean hasNulls = validity.hasNulls();


### PR DESCRIPTION
Closes #535.

Trailing follow-up to the #535 doc pass. The tutorial's single-column accumulation example (`docs/content/tutorial/first-read.md`) still bound its loop on `getRecordCount()`, while it indexes the leaf value array and leaf validity — which live on the value axis. The sibling `how-to/column-reader.md` loops were already converted to `getValueCount()` under #535; this one example slipped through.

`getValueCount()` is the copy-safe bound here. The two counts are equal for flat columns, so the example wasn't producing wrong output — but it contradicted the convention the rest of the docs now follow.