### PR TITLE
#618 Publish API change reports alongside the JavaDoc

### DIFF
--- a/_designs/API_CHANGE_REPORT_PUBLISHING.md
+++ b/_designs/API_CHANGE_REPORT_PUBLISHING.md
@@ -1,0 +1,112 @@
+# Publishing API Change Reports
+
+**Status: Implemented**
+
+## Overview
+
+The japicmp-based API change report produced by `tools/api-report.sh` is published on the
+website alongside the JavaDoc, under `/api-changes/<version>/`. Each report compares the public
+API of two builds of the four published modules (`hardwood-core`, `hardwood-avro`,
+`hardwood-s3`, `hardwood-aws-auth`):
+
+- A **tagged release** is compared against the immediately preceding tagged release
+  (e.g. `1.0.0.CR1` against `1.0.0.Beta2`).
+- The **dev** build (`/api-changes/dev/`) is compared against the latest tagged release.
+
+`/api-changes/latest/` aliases the most recent release report, mirroring `/api/latest/` for
+JavaDoc. Reports for all releases from the first comparable pair (`1.0.0.Alpha1` → `1.0.0.Beta1`)
+onward are published; the very first release has no predecessor and therefore no report.
+
+---
+
+## Repositories
+
+| Repo | Role |
+|---|---|
+| `hardwood-hq/hardwood` | Owns the report generator (`tools/`) and the mkdocs nav link |
+| `hardwood-hq/hardwood-hq.github.io` | Generates and deploys the reports to `gh-pages` — never committed to manually |
+
+The publishing flow reuses the existing `publish-docs` `repository_dispatch`: when the site repo
+builds the docs and JavaDoc for a version, it also generates and copies the change report. No new
+dispatch event or trigger is introduced. The dev report therefore refreshes automatically after
+every successful Main Build (via `docs-trigger.yml`), and versioned reports publish when
+`docs-publish.yml` is run for a release — exactly as JavaDoc does.
+
+---
+
+## Version resolution
+
+The comparison endpoints are derived from the source repo's git tags. Release tags follow the
+`v<maven-version>` convention (`v1.0.0.Beta2`); `-docs` re-tags and the rolling
+`1.0-early-access` tag are not releases and are excluded. Release branches are tagged as
+siblings rather than ancestors of one another, so the predecessor cannot come from git
+ancestry — it is the version-order predecessor, independent of when each tag was created. A
+bugfix release therefore compares against its own line's prior release regardless of newer
+pre-releases tagged in between (e.g. `1.0.1.Final` against `1.0.0.Final`, not a `1.1.0.Beta1`
+tagged earlier).
+
+The release list is sorted with `sort -V`. That is a lexical sort, not a Maven version
+comparator; it produces the correct order only because release qualifiers are restricted to
+`Alpha<N>`/`Beta<N>`/`CR<N>`/`Final<N>`, which already sort alphabetically into Maven's
+precedence. The generator enforces this invariant: a tag whose qualifier falls outside that set
+(e.g. `RC`, which Maven orders before `Final` but which sorts after it lexically) aborts the run
+rather than risk a silently wrong predecessor.
+
+- For `dev`: the new side is the local `HEAD` snapshot; the old side is the highest release.
+- For release `V`: the new side is `V`, the old side is the release immediately preceding `V` in
+  version order. If `V` has no predecessor, no report is produced.
+
+---
+
+## Generator: `tools/publish-api-report.sh`
+
+A thin wrapper over `tools/api-report.sh` that resolves the comparison endpoints and lays the
+result out for publishing:
+
+```
+tools/publish-api-report.sh <version> <outputDir>
+  <version>    Maven release version (e.g. 1.0.0.CR1) or "dev"
+  <outputDir>  directory to receive index.html + the per-module reports
+```
+
+It resolves old/new as described above, invokes `api-report.sh`, then copies `target/japicmp/`
+into `<outputDir>` and exposes the unified `api-report.html` as `index.html` so
+`/api-changes/<version>/` serves cleanly. When the version has no predecessor it prints a notice
+and exits 0 without writing output.
+
+For a release version both compared sides are the published JARs (the release and its
+predecessor), so the report is correct from any checkout — the workflows never need to check out
+or build old code. `api-report.sh` still installs the local modules first regardless of the
+compared versions: japicmp resolves with `ONE_COMMON_CLASSPATH`, which puts the current project's
+own artifact on the shared classpath, and the goal fails to resolve that artifact if it is not
+installed. The installed snapshot only backs the classpath; the diff is computed strictly between
+the two requested versions.
+
+---
+
+## Site repo: `publish.yml` additions
+
+The source checkout fetches full history (`fetch-depth: 0`) so the generator can enumerate
+release tags. After the JavaDoc build, a step runs the generator into a workspace-level staging
+directory. The existing `gh-pages` deploy step copies the staged report into `api-changes/$VERSION/`
+(and, when `update_latest` is set for a non-dev version, into `api-changes/latest/`), then folds it
+into the same amended commit that publishes the docs and JavaDoc.
+
+## Site repo: `backfill-api-reports.yml`
+
+A `workflow_dispatch` one-shot that generates the historical reports (`1.0.0.Beta1`,
+`1.0.0.Beta2`, `1.0.0.CR1` by default; overridable via input) and commits them under
+`api-changes/<version>/` on `gh-pages`, also seeding `api-changes/latest` from the highest
+version. It checks out `hardwood` at `main` (which carries the report tooling that the historical
+tags lack) with full history, resolves each version's predecessor from tags, and runs the
+generator per version. Because release-to-release comparisons use the published JARs, no
+per-version source checkout is needed.
+
+---
+
+## mkdocs nav
+
+`docs/mkdocs.yml` gains a Reference entry linking to `/api-changes/latest/`, beside the existing
+`API (JavaDoc): /api/latest/`. The site `publish.yml` rewrites `/api-changes/latest/` to
+`/api-changes/$VERSION/` for versioned builds using the same mechanism already applied to
+`/api/latest/`.

--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -49,6 +49,7 @@ nav:
     - CLI: reference/cli.md
     - Package Structure: reference/packages.md
     - API (JavaDoc): /api/latest/
+    - API Changes: /api-changes/latest/
   - Contributing: contributing.md
   - Release Notes: release-notes.md
 

--- a/tools/api-report.sh
+++ b/tools/api-report.sh
@@ -14,9 +14,10 @@
 #   e.g. tools/api-report.sh 1.0.0.CR1               # HEAD (snapshot) vs 1.0.0.CR1
 #        tools/api-report.sh 1.0.0.Beta2 1.0.0.CR1   # compare two published versions
 #
-# When <newVersion> is omitted, the local snapshot is installed and used as the
-# new side. When it is supplied, both sides are resolved from the Maven
-# repository and no build is needed.
+# When <newVersion> is omitted, the local snapshot is the new side. When it is
+# supplied, both sides are resolved from the Maven repository. Either way the
+# local modules are installed first — japicmp's shared classpath needs the
+# project's own artifact present (see below).
 #
 # Outputs:
 #   target/japicmp/api-report.diff           — concatenated per-module diffs
@@ -46,18 +47,24 @@ if [ -z "$NEW" ]; then
   # Honor CI's ${GITHUB_SHA} when set, otherwise resolve it from the local repo.
   HEAD_SHA="$(git rev-parse --short "${GITHUB_SHA:-HEAD}")"
   CAPTION="HEAD ($HEAD_SHA) vs $OLD"
-  # error-prone-checks is wired as an annotationProcessorPath, not a project
-  # dependency, so it stays invisible to the reactor and must be installed into
-  # the local repo first. The four modules are then installed (not just
-  # packaged) so japicmp can resolve their snapshot dependencies
-  # cross-invocation.
-  echo "Installing error-prone-checks and module JARs..."
-  ./mvnw -ntp -pl :hardwood-error-prone-checks -DskipTests install -q
-  ./mvnw -ntp -pl "$MODULES" -am -DskipTests install -q
 else
   CAPTION="$NEW vs $OLD"
-  echo "Comparing published $NEW against $OLD — skipping local build."
 fi
+
+# The local modules are always installed, even when both compared versions are
+# published. japicmp resolves with ONE_COMMON_CLASSPATH, which pulls the current
+# project's own artifact (the local snapshot) onto the shared classpath; without
+# it the goal fails to resolve that snapshot regardless of the compared
+# coordinates. The installed snapshot only backs the classpath — the diff is
+# still computed strictly between $OLD and the new side.
+#
+# error-prone-checks is wired as an annotationProcessorPath, not a project
+# dependency, so it stays invisible to the reactor and must be installed into
+# the local repo first. The four modules are then installed (not just packaged)
+# so japicmp can resolve their snapshot dependencies cross-invocation.
+echo "Installing error-prone-checks and module JARs..."
+./mvnw -ntp -pl :hardwood-error-prone-checks -DskipTests install -q
+./mvnw -ntp -pl "$MODULES" -am -DskipTests install -q
 
 echo "Running japicmp..."
 if [ -z "$NEW" ]; then

--- a/tools/publish-api-report.sh
+++ b/tools/publish-api-report.sh
@@ -1,0 +1,98 @@
+#!/usr/bin/env bash
+#
+#  SPDX-License-Identifier: Apache-2.0
+#
+#  Copyright The original authors
+#
+#  Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+#
+
+# Generate an API change report laid out for publishing under /api-changes/<version>/.
+#
+# Resolves the comparison endpoints from the repo's git tags and delegates to
+# tools/api-report.sh, then stages the unified report in <outputDir> with the
+# combined HTML exposed as index.html so the published URL serves cleanly.
+#
+# Usage: tools/publish-api-report.sh <version> <outputDir>
+#   <version>    Maven release version (e.g. 1.0.0.CR1) or "dev"
+#   <outputDir>  directory to receive index.html + the per-module reports
+#
+# For "dev", the local HEAD snapshot is the new side and the latest tagged
+# release is the old side. For a release version, both sides are the published
+# JARs — the release and its immediate predecessor — so the report is correct
+# regardless of which ref the repository is checked out at. A version with no
+# predecessor (the very first release) produces no report; the script prints a
+# notice and exits 0.
+
+set -euo pipefail
+
+if [ $# -ne 2 ]; then
+  echo "Usage: $0 <version> <outputDir>" >&2
+  echo "Examples:" >&2
+  echo "  $0 dev /tmp/api-changes-dev" >&2
+  echo "  $0 1.0.0.CR1 /tmp/api-changes-cr1" >&2
+  exit 2
+fi
+
+VERSION="$1"
+OUT="$2"
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+cd "$ROOT"
+
+# Released versions, oldest first. Release tags are `v<maven-version>`; the
+# `-docs` re-tags and the rolling `1.0-early-access` tag are not releases. The
+# release branches are tagged as siblings (not ancestors of one another), so the
+# predecessor cannot be derived from git ancestry — only from version order.
+RELEASES="$(git tag --list 'v[0-9]*' \
+  | grep -vE -- '-(docs|early-access)$' \
+  | sed 's/^v//' \
+  | sort -V)"
+
+# `sort -V` is a lexical sort, not a Maven version comparator. It yields the
+# correct order *only* because the project restricts release qualifiers to
+# Alpha<N>/Beta<N>/CR<N>/Final<N>, which already sort alphabetically into Maven's
+# precedence. Fail loudly if a tag ever uses a qualifier outside that set (e.g.
+# RC, which Maven orders before Final but which sorts after it lexically): its
+# position would no longer match Maven's ordering and the predecessor could be
+# silently wrong. Extend this list and re-check the ordering before releasing
+# any other qualifier.
+BAD="$(printf '%s\n' "$RELEASES" \
+  | grep -vE '^[0-9]+\.[0-9]+\.[0-9]+\.(Alpha|Beta|CR|Final)[0-9]*$' || true)"
+if [ -n "$BAD" ]; then
+  echo "Release tag(s) with an unrecognized version qualifier:" >&2
+  printf '  %s\n' $BAD >&2
+  echo "Only Alpha/Beta/CR/Final sort lexically into Maven order — extend" >&2
+  echo "tools/publish-api-report.sh before releasing other qualifiers." >&2
+  exit 1
+fi
+
+if [ "$VERSION" = "dev" ]; then
+  OLD="$(printf '%s\n' "$RELEASES" | tail -1)"
+  if [ -z "$OLD" ]; then
+    echo "No tagged release to compare 'dev' against — skipping report." >&2
+    exit 0
+  fi
+  echo "Generating dev report: HEAD vs $OLD"
+  tools/api-report.sh "$OLD"
+else
+  OLD="$(printf '%s\n' "$RELEASES" \
+    | awk -v v="$VERSION" '$0 == v { print prev } { prev = $0 }')"
+  if [ -z "$OLD" ]; then
+    echo "No predecessor release for $VERSION — skipping report." >&2
+    exit 0
+  fi
+  echo "Generating release report: $VERSION vs $OLD"
+  tools/api-report.sh "$OLD" "$VERSION"
+fi
+
+REPORT_DIR="$ROOT/target/japicmp"
+if [ ! -f "$REPORT_DIR/api-report.html" ]; then
+  echo "Expected $REPORT_DIR/api-report.html was not produced." >&2
+  exit 1
+fi
+
+mkdir -p "$OUT"
+cp -r "$REPORT_DIR/." "$OUT/"
+cp "$OUT/api-report.html" "$OUT/index.html"
+
+echo "Staged report for /api-changes/$VERSION/ in $OUT"


### PR DESCRIPTION
Closes #618.

Publishes the japicmp API change report on the website under `/api-changes/<version>/`, mirroring how the JavaDoc is published at `/api/<version>/`. Until now the report only survived as a throwaway CI artifact.

This is the **main-repo** half; the site-repo workflow changes are in a companion PR against `hardwood-hq/hardwood-hq.github.io`.

## What's here
- **`tools/publish-api-report.sh`** (new) — resolves the comparison endpoints from the release tags and stages the unified report with `index.html` for clean URLs. `dev` compares HEAD against the latest release; a tagged release compares against its version-order predecessor.
- **`tools/api-report.sh`** — now installs the local modules even when both compared versions are published. japicmp resolves with `ONE_COMMON_CLASSPATH`, which needs the project's own artifact on the classpath; without it the two-version form failed outright (it was effectively unusable). The installed snapshot only backs the classpath — the diff stays strictly between the two requested versions.
- **`docs/mkdocs.yml`** — adds the `API Changes: /api-changes/latest/` nav entry (rewritten to the concrete version at deploy time by the site workflow, like the JavaDoc link).
- **`_designs/API_CHANGE_REPORT_PUBLISHING.md`** — design doc.

## Version resolution
The predecessor is the **version-order** predecessor, not the chronologically previous tag and not git ancestry (release branches are tagged as siblings, so ancestry is meaningless). A bugfix release therefore compares against its own line's prior release regardless of newer pre-releases tagged in between (`1.0.1.Final` → `1.0.0.Final`, not a `1.1.0.Beta1` tagged earlier).

Ordering uses `sort -V`, which only matches Maven precedence because qualifiers are restricted to `Alpha`/`Beta`/`CR`/`Final`. The generator enforces that invariant — a tag with any other qualifier (e.g. `RC`, which Maven orders before `Final` but sorts after it lexically) aborts the run rather than risk a silently wrong baseline.

## Verified
- End-to-end generation for `1.0.0.CR1` (two-version, published JARs) and `dev` (one-version, HEAD) — both produce a unified report with the correct caption and an `index.html`.
- The backfill comparison (`1.0.0.Beta1` vs `1.0.0.Beta2` from a `main` checkout) works build-free after install.
- Predecessor resolution and the qualifier guard checked against the real tags and against `RC`/`M`/bare-numeric inputs.