### PR TITLE
#618 Stamp the dev API report with the hardwood commit, not the site commit

### DIFF
--- a/tools/api-report.sh
+++ b/tools/api-report.sh
@@ -43,9 +43,12 @@ MODULES=":hardwood-core,:hardwood-avro,:hardwood-s3,:hardwood-aws-auth"
 ARTIFACTS=(hardwood-core hardwood-avro hardwood-s3 hardwood-aws-auth)
 
 if [ -z "$NEW" ]; then
-  # Record which commit HEAD was so a downloaded report names its exact source.
-  # Honor CI's ${GITHUB_SHA} when set, otherwise resolve it from the local repo.
-  HEAD_SHA="$(git rev-parse --short "${GITHUB_SHA:-HEAD}")"
+  # Name the new side by its source commit. The site publish workflow runs this
+  # from a hardwood checkout but under its own ${GITHUB_SHA} (the *site* repo's
+  # commit), so prefer ${SOURCE_REF} — the hardwood commit being published, set
+  # by that workflow, just as the docs footer does. Fall back to ${GITHUB_SHA}
+  # for the main-repo CI runs, then the local HEAD.
+  HEAD_SHA="$(git rev-parse --short "${SOURCE_REF:-${GITHUB_SHA:-HEAD}}")"
   CAPTION="HEAD ($HEAD_SHA) vs $OLD"
 else
   CAPTION="$NEW vs $OLD"


### PR DESCRIPTION
Follow-up bug fix to #618.

The `dev` API change report's caption (`HEAD (<sha>) vs <old>`) showed the **site** repo's commit instead of the **hardwood** source commit. The report is generated by the site publish workflow from a hardwood checkout, but under that workflow's `${GITHUB_SHA}` — which is the site repo's triggering commit. `api-report.sh` preferred `${GITHUB_SHA}`, so it stamped the wrong repo.

Same class of bug as the earlier site-footer fix, and the same remedy: prefer `${SOURCE_REF}` (the hardwood commit the workflow is publishing, set in `publish.yml`'s job env), exactly as `docs/hooks/git_commit.py` does. `${GITHUB_SHA}` stays as the fallback so the main-repo CI runs (`main-build.yml`, `release.sh`) are unchanged, then local `HEAD`.

```
                          GITHUB_SHA   SOURCE_REF   -> stamped
site publish (dev)        site         hardwood     -> hardwood  ✓ (was: site)
main-repo CI              main         (unset)      -> main      ✓
local run                 (unset)      (unset)      -> HEAD       ✓
```

Only the one-version (`dev`) path carries this caption; the two-version release reports caption as `<new> vs <old>` and are unaffected.