### PR TITLE
#622 Persist the Maven local repository across dev-container sessions

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -50,6 +50,7 @@ services:
     volumes:
       - .:/workspace
       - claude-config:/claude-config
+      - maven-repo:/root/.m2
     environment:
       - GH_TOKEN
       - COLORTERM=truecolor
@@ -65,6 +66,7 @@ services:
 
 volumes:
   claude-config:
+  maven-repo:
 
 networks:
   claude-net:


### PR DESCRIPTION
Closes #622.

The dev container mounted only `/workspace` and the `claude-config` named volume, leaving the Maven local repository (`/root/.m2`) on the container's ephemeral writable layer. Every fresh session therefore had to re-install the reactor-local modules (`error-prone-checks`, `test-support`) and re-download all third-party dependencies.

This backs `/root/.m2` with a `maven-repo` named volume, mirroring the existing `claude-config` pattern, so the cache survives container recreations.

A named volume is used rather than a host bind-mount of `~/.m2` to keep the cache isolated from the macOS host's own Maven repo and avoid ownership friction through the `fakeowner` layer.

**Rollout:** takes effect on the next container recreate; the first session on the new volume still populates the cache (full download + `install`), every session after reuses it.