### PR TITLE
#625 Clarify ColumnReader batch-size semantics and the Arrow lineage note

### DIFF
--- a/core/src/main/java/dev/hardwood/reader/ColumnReader.java
+++ b/core/src/main/java/dev/hardwood/reader/ColumnReader.java
@@ -225,7 +225,9 @@ public class ColumnReader implements AutoCloseable {
 
     /// Total number of leaf values in the current batch — sized to real items
     /// only (phantom slots from null/empty parents are excluded). For flat
-    /// columns this equals [#getRecordCount()].
+    /// columns this equals [#getRecordCount()]. For a repeated column it is not
+    /// bounded by the configured batch size — the batch size caps records, not
+    /// leaf values — so a batch may carry more leaf values than records.
     public int getValueCount() {
         checkBatchAvailable();
         if (!nested) {

--- a/core/src/main/java/dev/hardwood/reader/Validity.java
+++ b/core/src/main/java/dev/hardwood/reader/Validity.java
@@ -24,9 +24,8 @@ import dev.hardwood.internal.reader.NoNullsValidity;
 ///   `w` covers items `[w*64, w*64+64)`, low bit = lowest item.
 ///
 /// Consumer-side predicates (`isNull(i)` / `isNotNull(i)` / `hasNulls()`)
-/// describe nullability; the storage uses set-bit = present internally
-/// to match Arrow's layout. [#hasNulls()] makes the no-nulls fast path
-/// explicit:
+/// describe nullability; the storage uses set-bit = present internally.
+/// [#hasNulls()] makes the no-nulls fast path explicit:
 /// ```java
 /// if (!validity.hasNulls()) {
 ///     // tight loop, skip per-item check

--- a/docs/content/concepts/nested-columns.md
+++ b/docs/content/concepts/nested-columns.md
@@ -18,6 +18,12 @@ model** is how `ColumnReader` expresses that structure without boxing or per-row
 explains the model; for worked code against it, see
 [Column-Oriented Reading](../how-to/column-reader.md).
 
+> **A note on lineage.** The layer model — flat value arrays, offset buffers, and set-bit-present
+> validity bitmaps — takes inspiration from [Apache Arrow](https://arrow.apache.org/)'s columnar
+> representation, so the shapes feel familiar if you come from an Arrow-based engine. The
+> resemblance is conceptual only: Hardwood implements no part of the Arrow specification, and the
+> buffers are plain Java arrays rather than an Arrow-bit-compatible layout.
+
 ## Layers
 
 `ColumnReader` exposes a column's schema chain as a sequence of **layers**. Each non-leaf node

--- a/docs/content/how-to/column-reader.md
+++ b/docs/content/how-to/column-reader.md
@@ -93,6 +93,8 @@ try (ColumnReaders columns = parquet.buildColumnReaders(
 }
 ```
 
+The batch size caps the number of **records** per batch, never the number of leaf values. A batch boundary always falls between records: a record — and, for a repeated column, all of the leaf values belonging to it — is never split across two batches. A consequence for repeated columns is that `getValueCount()` can exceed the configured batch size, since one record may carry many leaf values; size any per-value buffers off `getValueCount()`, not the batch size.
+
 `ColumnReaders.nextBatch()` advances every underlying reader once and returns `false` when any reader is exhausted — partial advancement isn't possible because all readers consume from a shared `RowGroupIterator`. The aligned record count is exposed via `ColumnReaders.getRecordCount()`. As a defensive guard, mismatched per-reader record counts throw `IllegalStateException`. Single-column consumers, or callers that need fine-grained per-reader cadence, can still call `ColumnReader.nextBatch()` directly on the readers returned by `getColumnReader(...)`.
 
 ### Retaining and Handing Off Batch Arrays


### PR DESCRIPTION
Closes #625.

Docs/JavaDoc only — no behavioral change.

## What

- **Batch-size semantics made explicit.** `how-to/column-reader.md` and `ColumnReader#getValueCount()` now state that the batch size caps **records**, never leaf values; that a batch boundary always falls between records (so a record — and, for a repeated column, all of its leaf values — is never split across two batches); and that `getValueCount()` can therefore exceed the configured batch size for repeated columns. Per-value buffers should be sized off `getValueCount()`.
- **Arrow reference reframed.** `Validity`'s JavaDoc no longer says its bitmap polarity was chosen "to match Arrow's layout" (which read as a conformance claim); it now states the `set-bit = present` polarity as a plain fact. A reader-facing *note on lineage* in `concepts/nested-columns.md` frames the layer model as taking inspiration from Apache Arrow while implementing none of its specification (plain Java arrays, not an Arrow-bit-compatible layout).

## Why

The record-vs-value distinction and the no-split guarantee were implementation facts, not documented contracts; a consumer sizing buffers off the batch size would get repeated columns wrong. The "match Arrow" phrasing risked implying official Arrow semantics/compatibility.

Follow-up #626 (milestone 1.1) tracks actually supporting nested lists beyond the 32-bit offset range.