### PR TITLE
#628 Add commit SHA and project version to all JAR manifests

### DIFF
--- a/_designs/JAR_MANIFEST_BUILD_METADATA.md
+++ b/_designs/JAR_MANIFEST_BUILD_METADATA.md
@@ -1,0 +1,62 @@
+# JAR manifest build metadata
+
+Status: Completed
+
+Every published JAR carries its project version and the short Git commit SHA it
+was built from, in the JAR manifest (`META-INF/MANIFEST.MF`). This lets a JAR
+recovered from a classpath, a bug report, or a dependency tree be traced back to
+an exact source revision.
+
+## Manifest entries
+
+For each module that produces a JAR, the manifest includes:
+
+- `Implementation-Title` — the module's `${project.name}`.
+- `Implementation-Version` — the module's `${project.version}`.
+- `Implementation-Build` — the short (7-character) Git commit SHA of `HEAD`.
+
+`Implementation-Title` and `Implementation-Version` are produced by Maven
+Archiver's `addDefaultImplementationEntries`. `Implementation-Build` is an
+explicit manifest entry resolved from the `${revision}` property.
+
+## Capturing the revision
+
+A single `maven-antrun-plugin` execution (`capture-git-info`), bound to the
+`initialize` phase in the parent POM, runs `git rev-parse --short=7 HEAD` and
+`git status --porcelain` against the repository root and exports two Ant
+properties:
+
+- `revision` — the short SHA, or `unknown` when Git is unavailable or the build
+  runs outside a checkout (e.g. an unpacked source tarball).
+- `revisionDirty` — `true` when the working tree has uncommitted changes,
+  otherwise `false`.
+
+Because the execution lives in the parent POM's `<build><plugins>`, every
+module inherits it; the JAR-manifest configuration lives in the parent's
+`<pluginManagement>` for `maven-jar-plugin` and therefore applies to every JAR
+module (`core`, `avro`, `aws-auth`, `s3`, `cli`, …) without per-module setup.
+
+The `hardwood-cli` module additionally consumes `revision` and `revisionDirty`
+through resource filtering in `application.properties`, surfacing them in
+`hardwood --version`.
+
+## Reproducibility
+
+The project's reproducibility guarantee is enforced by
+`project.build.outputTimestamp` together with
+`maven-artifact-plugin:check-buildplan`. The manifest metadata is compatible
+with it:
+
+- `Implementation-*` version and vendor entries derive from the POM and are
+  fully deterministic.
+- The commit SHA is a deterministic function of the commit being built, so a
+  rebuild from the same revision yields byte-identical output. No build
+  timestamp, host name, or JDK identifier is added.
+- The working-tree dirty flag is `false` for any clean checkout of a released
+  tag, so released artifacts are unaffected by it.
+
+One inherent limitation: a byte-for-byte rebuild from a `.git`-less source
+archive resolves `revision` to `unknown`, which would not match a JAR released
+from a real checkout. This project verifies reproducibility from a Git checkout
+of the tag (where `git rev-parse` succeeds), not from a detached source
+tarball, so this does not affect the guarantee as exercised.

--- a/cli/pom.xml
+++ b/cli/pom.xml
@@ -670,65 +670,6 @@
           </execution>
         </executions>
       </plugin>
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-antrun-plugin</artifactId>
-        <executions>
-          <execution>
-            <!-- Capture the short commit SHA and a working-tree dirty flag for
-                 use in `application.properties` and the JAR manifest. Both git
-                 invocations are best-effort: when git is missing or the build
-                 runs from a non-checkout (e.g. a source tarball), `revision`
-                 falls back to `unknown` and `revisionDirty` to `false`. -->
-            <id>capture-git-info</id>
-            <phase>initialize</phase>
-            <goals>
-              <goal>run</goal>
-            </goals>
-            <configuration>
-              <exportAntProperties>true</exportAntProperties>
-              <target>
-                <exec executable="git" outputproperty="gitRevision" errorproperty="gitRevisionErr" resultproperty="gitRevisionExit" failifexecutionfails="false" failonerror="false" dir="${maven.multiModuleProjectDirectory}">
-                  <arg value="rev-parse" />
-                  <arg value="--short=7" />
-                  <arg value="HEAD" />
-                </exec>
-                <exec executable="git" outputproperty="gitStatus" errorproperty="gitStatusErr" resultproperty="gitStatusExit" failifexecutionfails="false" failonerror="false" dir="${maven.multiModuleProjectDirectory}">
-                  <arg value="status" />
-                  <arg value="--porcelain" />
-                </exec>
-                <condition property="revision" value="${gitRevision}">
-                  <and>
-                    <equals arg1="${gitRevisionExit}" arg2="0" />
-                    <not><equals arg1="${gitRevision}" arg2="" trim="true" /></not>
-                  </and>
-                </condition>
-                <property name="revision" value="unknown" />
-                <condition property="revisionDirty" value="true">
-                  <and>
-                    <equals arg1="${gitStatusExit}" arg2="0" />
-                    <not><equals arg1="${gitStatus}" arg2="" trim="true" /></not>
-                  </and>
-                </condition>
-                <property name="revisionDirty" value="false" />
-              </target>
-            </configuration>
-          </execution>
-        </executions>
-      </plugin>
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-jar-plugin</artifactId>
-        <configuration>
-          <archive>
-            <manifestEntries>
-              <Implementation-Title>${project.name}</Implementation-Title>
-              <Implementation-Version>${project.version}</Implementation-Version>
-              <Implementation-Build>${revision}</Implementation-Build>
-            </manifestEntries>
-          </archive>
-        </configuration>
-      </plugin>
     </plugins>
   </build>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -181,6 +181,16 @@
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-jar-plugin</artifactId>
           <version>3.5.0</version>
+          <configuration>
+            <archive>
+              <manifest>
+                <addDefaultImplementationEntries>true</addDefaultImplementationEntries>
+              </manifest>
+              <manifestEntries>
+                <Implementation-Build>${revision}</Implementation-Build>
+              </manifestEntries>
+            </archive>
+          </configuration>
         </plugin>
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
@@ -249,6 +259,52 @@
       </plugins>
     </pluginManagement>
     <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-antrun-plugin</artifactId>
+        <executions>
+          <execution>
+            <!-- Capture the short commit SHA and a working-tree dirty flag for
+                 use in every JAR manifest (and, in the CLI, `application.properties`).
+                 Both git invocations are best-effort: when git is missing or the
+                 build runs from a non-checkout (e.g. a source tarball), `revision`
+                 falls back to `unknown` and `revisionDirty` to `false`. -->
+            <id>capture-git-info</id>
+            <phase>initialize</phase>
+            <goals>
+              <goal>run</goal>
+            </goals>
+            <configuration>
+              <exportAntProperties>true</exportAntProperties>
+              <target>
+                <exec executable="git" outputproperty="gitRevision" errorproperty="gitRevisionErr" resultproperty="gitRevisionExit" failifexecutionfails="false" failonerror="false" dir="${maven.multiModuleProjectDirectory}">
+                  <arg value="rev-parse" />
+                  <arg value="--short=7" />
+                  <arg value="HEAD" />
+                </exec>
+                <exec executable="git" outputproperty="gitStatus" errorproperty="gitStatusErr" resultproperty="gitStatusExit" failifexecutionfails="false" failonerror="false" dir="${maven.multiModuleProjectDirectory}">
+                  <arg value="status" />
+                  <arg value="--porcelain" />
+                </exec>
+                <condition property="revision" value="${gitRevision}">
+                  <and>
+                    <equals arg1="${gitRevisionExit}" arg2="0" />
+                    <not><equals arg1="${gitRevision}" arg2="" trim="true" /></not>
+                  </and>
+                </condition>
+                <property name="revision" value="unknown" />
+                <condition property="revisionDirty" value="true">
+                  <and>
+                    <equals arg1="${gitStatusExit}" arg2="0" />
+                    <not><equals arg1="${gitStatus}" arg2="" trim="true" /></not>
+                  </and>
+                </condition>
+                <property name="revisionDirty" value="false" />
+              </target>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
       <plugin>
         <groupId>org.codehaus.mojo</groupId>
         <artifactId>flatten-maven-plugin</artifactId>


### PR DESCRIPTION
Closes #628.

Every published JAR now records its project version and the short Git commit SHA it was built from in `META-INF/MANIFEST.MF`, so a JAR recovered from a classpath, a bug report, or a dependency tree can be traced back to an exact source revision.

## Changes

- **`pom.xml`** — the `capture-git-info` antrun execution (previously CLI-only) moves to the parent `<build><plugins>`, so every module captures `revision`/`revisionDirty`. `maven-jar-plugin` in `<pluginManagement>` gains `addDefaultImplementationEntries` plus an explicit `Implementation-Build=${revision}` entry, so all JAR modules inherit it.
- **`cli/pom.xml`** — removes the now-redundant local antrun + jar-manifest blocks; the CLI inherits the shared config, and its `application.properties` filtering still resolves `${revision}`.
- **`_designs/JAR_MANIFEST_BUILD_METADATA.md`** — design doc, including the reproducibility analysis.

## Resulting manifest (e.g. `hardwood-core`)

```
Implementation-Title: Hardwood Core
Implementation-Version: 1.0.0-SNAPSHOT
Implementation-Build: 3a3378f
```

`core` keeps its existing `Multi-Release` / `Automatic-Module-Name` entries (merged, not replaced); modules with no jar config (`s3`, `avro`, `aws-auth`) inherit the new entries from the parent.

## Reproducibility

Only deterministic values are embedded (version + commit SHA) — no build timestamp, host, or JDK identifier. Verified with `-Pqa` active so `maven-artifact-plugin:check-buildplan` runs; the build is green.

One inherent limitation, unchanged from the prior CLI behavior: a rebuild from a `.git`-less source tarball resolves the revision to `unknown`. The project verifies reproducibility from a Git checkout of the tag, where `git rev-parse` succeeds, so this does not affect the guarantee as exercised.