### PR TITLE
#633 Byte-budget the ColumnReader default batch size

### DIFF
--- a/_designs/COLUMN_READER_ADAPTIVE_BATCH_SIZING.md
+++ b/_designs/COLUMN_READER_ADAPTIVE_BATCH_SIZING.md
@@ -1,0 +1,43 @@
+<!--
+
+     SPDX-License-Identifier: CC-BY-SA-4.0
+
+     Copyright The original authors
+
+     Licensed under the Creative Commons Attribution-ShareAlike 4.0 International License;
+     you may not use this file except in compliance with the License.
+     You may obtain a copy of the License at https://creativecommons.org/licenses/by-sa/4.0/
+
+-->
+# Adaptive default batch sizing for the ColumnReader API
+
+Status: **Completed**
+
+## Problem
+
+The reader has two batch-sizing regimes that must agree but did not:
+
+- The `RowReader` path (`FlatRowReader` / `NestedRowReader`) sizes each batch by a **byte budget**: `BatchSizing.computeOptimalBatchSize` targets ~6 MB across all projected columns and clamps the resulting row count to `[16 384, 524 288]`, so the per-batch column arrays stay within L2 cache regardless of column width or projection breadth.
+- The `ColumnReader` / `ColumnReaders` builders used a fixed **record count** default of `262 144` rows.
+
+Because the `ColumnReader` default was a fixed row count, the real per-batch footprint floated with the data: ~1 MB for a single `INT32`, ~2 MB for a single `INT64`/`DOUBLE`, tens of MB for a `BYTE_ARRAY` column once payload and `String` objects are counted, and ~210 MB for a 100-column `INT64` projection (each reader allocating its own `262 144`-row arrays). The batch arrays are freshly allocated per batch (no scratch reuse) and `BatchExchange` prefetch adds a queue-depth multiplier on top, so an oversized default translates directly into allocation and GC churn.
+
+## End state
+
+The default batch size for the column path is **byte-budgeted**, routed through the same `BatchSizing.computeOptimalBatchSize` the row path uses. The two regimes now produce identical batch sizes for the same projection.
+
+- `ColumnReaderBuilder.batchSize(int)` and `ColumnReadersBuilder.batchSize(int)` remain the explicit override and are honored verbatim. The positivity check is unchanged.
+- When the caller does not set `batchSize`, the builder leaves it unset and the size is resolved at `build()` time from the projection's column widths.
+- The width used is that of **every column the batch decodes**: the full projection on the plain path, and the predicate-augmented projection on the exact-filtering path (the predicate columns allocate arrays too, so they count toward the budget).
+- The public `ColumnReader.DEFAULT_BATCH_SIZE` constant is removed: there is no longer a single fixed default to name. `BatchSizing.MAX_BATCH` (`524 288`) remains the upper clamp.
+
+This is a no-op for callers that already pass an explicit `batchSize`. Callers relying on the default get smaller, width-aware batches and lower peak allocation, especially on wide and variable-width projections.
+
+## Mechanics
+
+`batchSize` carries a sentinel of `0` ("unset") from the builders down to the bridge methods on `ParquetFileReader`. `resolveBatchSize(requested, projectedSchema)` returns `requested` when positive and `BatchSizing.computeOptimalBatchSize(projectedSchema)` otherwise. Resolution happens at the single point where the full `ProjectedSchema` is known:
+
+- `ParquetFileReader.buildColumnReaders` — resolves against the plain projection (unfiltered) or the augmented projection (filtered) before constructing `ColumnReaders`.
+- `ColumnReader.create` — the single-column, unfiltered entry point builds its own one-column `ProjectedSchema` and resolves against it.
+
+All downstream consumers (`ColumnReaders`, `ColumnReader.createFromIterator`, the workers, `BatchExchange.allocateArray`) continue to receive a concrete, already-resolved positive batch size.

--- a/core/src/main/java/dev/hardwood/reader/ColumnReader.java
+++ b/core/src/main/java/dev/hardwood/reader/ColumnReader.java
@@ -16,6 +16,7 @@ import dev.hardwood.InputFile;
 import dev.hardwood.internal.ExceptionContext;
 import dev.hardwood.internal.predicate.ResolvedPredicate;
 import dev.hardwood.internal.reader.BatchExchange;
+import dev.hardwood.internal.reader.BatchSizing;
 import dev.hardwood.internal.reader.BinaryBatchValues;
 import dev.hardwood.internal.reader.FlatColumnWorker;
 import dev.hardwood.internal.reader.HardwoodContextImpl;
@@ -71,10 +72,6 @@ import dev.hardwood.schema.FileSchema;
 /// deprecation.
 @Experimental
 public class ColumnReader implements AutoCloseable {
-
-    /// The default maximum number of records returned per batch when no batch
-    /// size is configured via `batchSize(int)` on the reader builders.
-    public static final int DEFAULT_BATCH_SIZE = 262_144;
 
     private final ColumnSchema column;
     private final boolean nested;
@@ -885,12 +882,16 @@ public class ColumnReader implements AutoCloseable {
         ProjectedSchema projectedSchema = ProjectedSchema.create(schema,
                 ColumnProjection.columns(columnSchema.fieldPath().toString()));
 
+        int resolvedBatchSize = batchSize > 0
+                ? batchSize
+                : BatchSizing.computeOptimalBatchSize(projectedSchema);
+
         RowGroupIterator rowGroupIterator = new RowGroupIterator(
                 List.of(inputFile), context, 0);
         rowGroupIterator.setFirstFile(schema, rowGroups);
         rowGroupIterator.initialize(projectedSchema, filter);
 
-        return createFromIterator(columnSchema, schema, rowGroupIterator, context, 0, rowGroupIterator, batchSize);
+        return createFromIterator(columnSchema, schema, rowGroupIterator, context, 0, rowGroupIterator, resolvedBatchSize);
     }
 
     /// Creates a ColumnReader from a pre-configured RowGroupIterator.

--- a/core/src/main/java/dev/hardwood/reader/ParquetFileReader.java
+++ b/core/src/main/java/dev/hardwood/reader/ParquetFileReader.java
@@ -18,6 +18,7 @@ import dev.hardwood.internal.ExceptionContext;
 import dev.hardwood.internal.predicate.FilterPredicateResolver;
 import dev.hardwood.internal.predicate.ResolvedPredicate;
 import dev.hardwood.internal.predicate.RowGroupFilterEvaluator;
+import dev.hardwood.internal.reader.BatchSizing;
 import dev.hardwood.internal.reader.FlatRowReader;
 import dev.hardwood.internal.reader.HardwoodContextImpl;
 import dev.hardwood.internal.reader.NestedRowReader;
@@ -59,6 +60,13 @@ import dev.hardwood.schema.FileSchema;
 /// most 2 GB ([Integer#MAX_VALUE] bytes) of compressed data. The in-memory and
 /// object-store backends have a 2 GB limit on the whole file.
 public class ParquetFileReader implements AutoCloseable {
+
+    /// Sentinel used by the column-reader builders to mean "no explicit batch
+    /// size set": the size is then resolved from the projected column widths via
+    /// [BatchSizing#computeOptimalBatchSize(dev.hardwood.internal.schema.ProjectedSchema)]
+    /// at build time. Never reaches the workers — [#resolveBatchSize] turns it
+    /// into a concrete positive count.
+    private static final int AUTO_BATCH_SIZE = 0;
 
     private final List<InputFile> inputFiles;
     /// Metadata of the first file. For single-file readers this is the
@@ -415,7 +423,7 @@ public class ParquetFileReader implements AutoCloseable {
     }
 
     ColumnReader buildColumnReader(String columnName, FilterPredicate filter) {
-        return buildColumnReader(columnName, filter, null, ColumnReader.DEFAULT_BATCH_SIZE);
+        return buildColumnReader(columnName, filter, null, AUTO_BATCH_SIZE);
     }
 
     ColumnReader buildColumnReader(
@@ -433,7 +441,7 @@ public class ParquetFileReader implements AutoCloseable {
     }
 
     ColumnReader buildColumnReader(int columnIndex, FilterPredicate filter) {
-        return buildColumnReader(columnIndex, filter, null, ColumnReader.DEFAULT_BATCH_SIZE);
+        return buildColumnReader(columnIndex, filter, null, AUTO_BATCH_SIZE);
     }
 
     ColumnReader buildColumnReader(
@@ -450,7 +458,7 @@ public class ParquetFileReader implements AutoCloseable {
     }
 
     ColumnReaders buildColumnReaders(ColumnProjection projection, FilterPredicate filter) {
-        return buildColumnReaders(projection, filter, null, ColumnReader.DEFAULT_BATCH_SIZE);
+        return buildColumnReaders(projection, filter, null, AUTO_BATCH_SIZE);
     }
 
     ColumnReaders buildColumnReaders(
@@ -467,7 +475,8 @@ public class ParquetFileReader implements AutoCloseable {
             iterator.setFirstFile(schema, rowGroups);
             ProjectedSchema projected = iterator.initialize(projection, null);
             rowGroupIterators.add(iterator);
-            return new ColumnReaders(context, iterator, schema, projected, batchSize);
+            return new ColumnReaders(context, iterator, schema, projected,
+                    resolveBatchSize(batchSize, projected));
         }
 
         // Exact filtering (#624): decode the payload columns *and* the predicate
@@ -480,8 +489,20 @@ public class ParquetFileReader implements AutoCloseable {
         ProjectedSchema augProjected = iterator.initialize(augmented, resolved);
         ProjectedSchema payloadProjected = ProjectedSchema.create(schema, projection);
         rowGroupIterators.add(iterator);
+        // Size against the augmented projection — the predicate columns allocate
+        // per-batch arrays too, so they count toward the byte budget.
         return ColumnReaders.filtered(
-                context, iterator, schema, augProjected, payloadProjected, resolved, batchSize);
+                context, iterator, schema, augProjected, payloadProjected, resolved,
+                resolveBatchSize(batchSize, augProjected));
+    }
+
+    /// Resolves a requested batch size to a concrete record count. A positive
+    /// `requested` (set explicitly via the builders' `batchSize(int)`) is used
+    /// verbatim; the [#AUTO_BATCH_SIZE] sentinel is turned into a byte-budgeted
+    /// size derived from the projected column widths, the same logic the
+    /// `RowReader` path uses, so both regimes agree.
+    private static int resolveBatchSize(int requested, ProjectedSchema projected) {
+        return requested > 0 ? requested : BatchSizing.computeOptimalBatchSize(projected);
     }
 
     /// Builds the union of `projection` and the predicate's leaf columns so the
@@ -734,7 +755,7 @@ public class ParquetFileReader implements AutoCloseable {
         private final boolean byName;
         private FilterPredicate filter;
         private RowGroupPredicate rowGroupFilter;
-        private int batchSize = ColumnReader.DEFAULT_BATCH_SIZE;
+        private int batchSize = AUTO_BATCH_SIZE;
 
         private ColumnReaderBuilder(ParquetFileReader fileReader, String columnName) {
             this.fileReader = fileReader;
@@ -770,7 +791,11 @@ public class ParquetFileReader implements AutoCloseable {
         }
 
         /// Set the maximum number of records to return in each batch.
-        /// Default: [ColumnReader#DEFAULT_BATCH_SIZE].
+        ///
+        /// When unset, the batch size is chosen adaptively from the column's
+        /// physical width so the per-batch arrays stay within the CPU cache —
+        /// the same byte-budgeted sizing the [RowReader] path uses — rather
+        /// than a fixed record count. Set this explicitly to override.
         public ColumnReaderBuilder batchSize(int batchSize) {
             if (batchSize <= 0) {
                 throw new IllegalArgumentException("batchSize must be positive: " + batchSize);
@@ -808,7 +833,7 @@ public class ParquetFileReader implements AutoCloseable {
         private final ColumnProjection projection;
         private FilterPredicate filter;
         private RowGroupPredicate rowGroupFilter;
-        private int batchSize = ColumnReader.DEFAULT_BATCH_SIZE;
+        private int batchSize = AUTO_BATCH_SIZE;
 
         private ColumnReadersBuilder(ParquetFileReader fileReader, ColumnProjection projection) {
             if (projection == null) {
@@ -838,7 +863,11 @@ public class ParquetFileReader implements AutoCloseable {
         }
 
         /// Set the maximum number of records to return in each batch for all columns.
-        /// Default: [ColumnReader#DEFAULT_BATCH_SIZE].
+        ///
+        /// When unset, the batch size is chosen adaptively from the projected
+        /// columns' physical widths so the per-batch arrays stay within the CPU
+        /// cache — the same byte-budgeted sizing the [RowReader] path uses —
+        /// rather than a fixed record count. Set this explicitly to override.
         public ColumnReadersBuilder batchSize(int batchSize) {
             if (batchSize <= 0) {
                 throw new IllegalArgumentException("batchSize must be positive: " + batchSize);

--- a/core/src/test/java/dev/hardwood/internal/reader/BatchSizingTest.java
+++ b/core/src/test/java/dev/hardwood/internal/reader/BatchSizingTest.java
@@ -1,0 +1,74 @@
+/*
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Copyright The original authors
+ *
+ *  Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package dev.hardwood.internal.reader;
+
+import java.nio.file.Path;
+
+import org.junit.jupiter.api.Test;
+
+import dev.hardwood.InputFile;
+import dev.hardwood.internal.schema.ProjectedSchema;
+import dev.hardwood.reader.ParquetFileReader;
+import dev.hardwood.schema.ColumnProjection;
+import dev.hardwood.schema.FileSchema;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/// Verifies the byte-budgeted batch sizing the column- and row-reader paths
+/// share: the size depends on the projected columns' physical widths and is
+/// clamped to `[16 384, MAX_BATCH]`, rather than being a fixed record count.
+class BatchSizingTest {
+
+    /// `int_col` (INT32), `long_col` (INT64), `float_col` (FLOAT),
+    /// `double_col` (DOUBLE), `bool_col` (BOOLEAN), `string_col` (BYTE_ARRAY).
+    private static final Path PRIMITIVES = Path.of("src/test/resources/primitive_types_test.parquet");
+
+    private static final long TARGET_BYTES = 6L * 1024 * 1024;
+
+    @Test
+    void narrowProjectionClampsToMaxBatch() throws Exception {
+        try (ParquetFileReader reader = ParquetFileReader.open(InputFile.of(PRIMITIVES))) {
+            // A single 1-byte column would compute 6 Mi rows; the clamp caps it.
+            assertThat(sizeFor(reader, "bool_col")).isEqualTo(BatchSizing.MAX_BATCH);
+            // A single 8-byte column computes 786 432 rows, still above the clamp.
+            assertThat(sizeFor(reader, "long_col")).isEqualTo(BatchSizing.MAX_BATCH);
+        }
+    }
+
+    @Test
+    void batchSizeShrinksAsProjectionWidens() throws Exception {
+        try (ParquetFileReader reader = ParquetFileReader.open(InputFile.of(PRIMITIVES))) {
+            int single = sizeFor(reader, "long_col");
+            int wide = sizeFor(reader, "int_col", "long_col", "float_col",
+                    "double_col", "bool_col", "string_col");
+
+            // The wider projection must size smaller — the whole point of byte
+            // budgeting over a fixed record count.
+            assertThat(wide).isLessThan(single);
+
+            // Width sum: 4 + 8 + 4 + 8 + 1 + 16 = 41 bytes/row.
+            assertThat(wide).isEqualTo((int) (TARGET_BYTES / 41));
+        }
+    }
+
+    @Test
+    void sizeMatchesByteBudgetForAModeratelyWideProjection() throws Exception {
+        try (ParquetFileReader reader = ParquetFileReader.open(InputFile.of(PRIMITIVES))) {
+            // long_col (8) + double_col (8) + string_col (16) = 32 bytes/row.
+            int expected = (int) (TARGET_BYTES / 32);
+            assertThat(sizeFor(reader, "long_col", "double_col", "string_col")).isEqualTo(expected);
+            assertThat(expected).isBetween(16_384, BatchSizing.MAX_BATCH);
+        }
+    }
+
+    private static int sizeFor(ParquetFileReader reader, String... columns) {
+        FileSchema schema = reader.getFileSchema();
+        ProjectedSchema projected = ProjectedSchema.create(schema, ColumnProjection.columns(columns));
+        return BatchSizing.computeOptimalBatchSize(projected);
+    }
+}

--- a/docs/content/how-to/column-reader.md
+++ b/docs/content/how-to/column-reader.md
@@ -84,7 +84,7 @@ try (ParquetFileReader parquet = ParquetFileReader.open(InputFile.of(path));
 }
 ```
 
-To customize the batch size for all columns, use `.batchSize(int)` on the builder:
+By default the batch size is chosen adaptively from the projected columns' physical widths, so the per-batch arrays stay within the CPU cache regardless of how wide or how many columns you project — the same byte-budgeted sizing the `RowReader` path uses. To pin a specific record count instead, use `.batchSize(int)` on the builder:
 
 ```java
 try (ColumnReaders columns = parquet.buildColumnReaders(

--- a/docs/content/release-notes.md
+++ b/docs/content/release-notes.md
@@ -20,7 +20,7 @@ See [GitHub Releases](https://github.com/hardwood-hq/hardwood/releases) for down
 Highlights of this release:
 
 - **Breaking:** `RowReaderBuilder.firstRow()` renamed to `skip()`, which now composes with a filter as a logical `OFFSET` — rows are skipped after the filter is applied
-- Configurable read batch size for `ColumnReader` / `ColumnReaders`, with the default batch size now part of the public API
+- Configurable read batch size for `ColumnReader` / `ColumnReaders`, with the default now sized adaptively from the projected column widths (byte-budgeted to stay within CPU cache, matching the `RowReader` path) instead of a fixed record count
 - TIMESTAMP accessors honor `isAdjustedToUTC`, with dedicated accessors for local (non-UTC) timestamps
 - Graceful, explicit failure when opening encrypted Parquet files
 - Stricter metadata validation: negative sizes, counts, and offsets are rejected, as are shredded Variant objects repeating a field across `typed_value` and `value`

--- a/s3/src/test/java/dev/hardwood/s3/S3SelectiveReadJfrTest.java
+++ b/s3/src/test/java/dev/hardwood/s3/S3SelectiveReadJfrTest.java
@@ -529,9 +529,13 @@ public class S3SelectiveReadJfrTest extends AbstractJfrRecorderTest {
     void columnReaderPartialReadDoesNotScanAllRowGroups() throws Exception {
         // ColumnReader has the same lazy row-group fetching as RowReader.
         // Reading a single batch from one column should not scan all 20 row groups.
+        // Pin the batch to one row group's worth of rows so the assertion tracks
+        // lazy fetching rather than the (adaptive, width-derived) default batch
+        // size — a single INT64 column would otherwise byte-budget to 524K rows,
+        // i.e. ~11 of the 50K-row row groups, just to fill one batch.
         try (ParquetFileReader reader = ParquetFileReader.open(
                 source.inputFile("test-bucket", LAZY_ROWGROUP_FILE));
-             ColumnReader col = reader.columnReader("c0")) {
+             ColumnReader col = reader.buildColumnReader("c0").batchSize(LAZY_RG_ROWS).build()) {
             assertThat(col.nextBatch()).isTrue();
             // Consume one batch and close — don't read further
         }


### PR DESCRIPTION
Fixes #633.

## Problem

The `ColumnReader` / `ColumnReaders` builders defaulted to a fixed **record count** of `262_144`, while the `RowReader` path sizes batches by a **byte budget** (`BatchSizing.computeOptimalBatchSize` — ~6 MB across the projected columns, clamped to `[16_384, 524_288]` rows, to keep the per-batch arrays within L2 cache).

Because the column default was a fixed row count, the real footprint floated with the data:

| Per-column case | Old footprint |
|---|---|
| 1× INT32 | ~1 MB |
| 1× INT64 / DOUBLE | ~2 MB |
| 1× BYTE_ARRAY / string | tens of MB (refs + payload + `String` objects) |
| `buildColumnReaders`, 100× INT64 | ~210 MB per batch |

Batch arrays are freshly allocated per batch (no scratch reuse) and `BatchExchange` prefetch adds a queue-depth multiplier on top, so an oversized default turns straight into allocation and GC churn.

## Change

Route the column-path default through the same `BatchSizing.computeOptimalBatchSize` the row path uses, so both regimes agree.

- Removed the public `ColumnReader.DEFAULT_BATCH_SIZE` constant — there is no longer a single fixed default to name. The builders carry an `AUTO_BATCH_SIZE` sentinel for "unset"; `resolveBatchSize` keeps an explicit positive `batchSize(int)` verbatim and byte-budgets the sentinel.
- Resolution happens where the full `ProjectedSchema` is known: the plain projection (unfiltered) and the predicate-**augmented** projection (filtered — those columns allocate per-batch arrays too, so they count toward the budget).
- `batchSize(int)` is a no-op change for callers that set it explicitly; callers on the default get smaller, width-aware batches.

The constant was only exposed in the unreleased CR2 cycle, so nothing released ever had it (japicmp compares against CR1 and isn't bound to `verify`).

## Docs / design

- `docs/content/how-to/column-reader.md` and the CR2 release note updated to describe the adaptive default.
- `_designs/COLUMN_READER_ADAPTIVE_BATCH_SIZING.md` (marked Completed).

## Tests

New `BatchSizingTest` locks in width/count sensitivity and the clamps via real `ProjectedSchema`s. Observing the *resolved* default through the public API would need a multi-MB fixture (any batch smaller than the row count implies a file near the ~6 MB budget), so the shared sizing function is tested directly rather than checking in a large fixture; the existing column-reader correctness suite already exercises the adaptive default path end to end.

Full core suite (1338 tests) green; `verify` gates and a full-reactor compile pass.