### PR TITLE
#646 Publish only the unified API change report HTML, link versions to commits

### DIFF
--- a/_designs/API_CHANGE_REPORT_PUBLISHING.md
+++ b/_designs/API_CHANGE_REPORT_PUBLISHING.md
@@ -17,6 +17,12 @@ API of two builds of the four published modules (`hardwood-core`, `hardwood-avro
 JavaDoc. Reports for all releases from the first comparable pair (`1.0.0.Alpha1` → `1.0.0.Beta1`)
 onward are published; the very first release has no predecessor and therefore no report.
 
+The report caption names the two compared sides (e.g. `HEAD (abc1234) vs 1.0.0.CR1` for the dev
+build, or `1.0.0.CR2 vs 1.0.0.CR1` for a release). In the HTML report each side links to its
+GitHub commit (`.../commit/<sha>`) — the snapshot side to the source commit being published,
+each release side to the commit its tag resolves to. A side whose commit cannot be resolved
+renders as plain text. The plaintext text diff caption is left unlinked.
+
 ---
 
 ## Repositories
@@ -66,13 +72,16 @@ result out for publishing:
 ```
 tools/publish-api-report.sh <version> <outputDir>
   <version>    Maven release version (e.g. 1.0.0.CR1) or "dev"
-  <outputDir>  directory to receive index.html + the per-module reports
+  <outputDir>  directory to receive index.html (the unified HTML report)
 ```
 
-It resolves old/new as described above, invokes `api-report.sh`, then copies `target/japicmp/`
-into `<outputDir>` and exposes the unified `api-report.html` as `index.html` so
-`/api-changes/<version>/` serves cleanly. When the version has no predecessor it prints a notice
-and exits 0 without writing output.
+It resolves old/new as described above, invokes `api-report.sh`, then stages only the unified
+`api-report.html` as `<outputDir>/index.html` so `/api-changes/<version>/` serves cleanly. The
+combined HTML splices every module's body inline, so it is self-contained; the per-module reports
+and the unified text diff that `api-report.sh` also writes under `target/japicmp/` are deliberately
+left unpublished — nothing on the site links to them, and shipping them re-published unchanged
+files on every build. When the version has no predecessor it prints a notice and exits 0 without
+writing output.
 
 For a release version both compared sides are the published JARs (the release and its
 predecessor), so the report is correct from any checkout — the workflows never need to check out

--- a/tools/api-report.sh
+++ b/tools/api-report.sh
@@ -42,17 +42,45 @@ cd "$ROOT"
 MODULES=":hardwood-core,:hardwood-avro,:hardwood-s3,:hardwood-aws-auth"
 ARTIFACTS=(hardwood-core hardwood-avro hardwood-s3 hardwood-aws-auth)
 
+REPO_URL="https://github.com/hardwood-hq/hardwood"
+
+# Resolve a git ref to a full commit SHA, or empty if it cannot be resolved
+# (e.g. the tag was not fetched). Non-fatal: a missing SHA just drops the link.
+commit_sha() { git rev-parse --verify --quiet "$1^{commit}" 2>/dev/null || true; }
+
+# Wrap a caption term in a link to its GitHub commit when the SHA is known,
+# otherwise emit it as plain text.
+link_commit() { # <label> <sha>
+  if [ -n "$2" ]; then
+    printf '<a href="%s/commit/%s" target="_blank" rel="noopener">%s</a>' \
+      "$REPO_URL" "$2" "$1"
+  else
+    printf '%s' "$1"
+  fi
+}
+
+# Each side of the comparison is named by a label (for the plaintext caption) and
+# resolved to a commit SHA (for the HTML caption's links). The old side is always
+# a release tag; the new side is either a release tag or, for the snapshot run,
+# the source commit being published.
+OLD_SHA="$(commit_sha "v$OLD")"
 if [ -z "$NEW" ]; then
   # Name the new side by its source commit. The site publish workflow runs this
   # from a hardwood checkout but under its own ${GITHUB_SHA} (the *site* repo's
   # commit), so prefer ${SOURCE_REF} — the hardwood commit being published, set
   # by that workflow, just as the docs footer does. Fall back to ${GITHUB_SHA}
   # for the main-repo CI runs, then the local HEAD.
-  HEAD_SHA="$(git rev-parse --short "${SOURCE_REF:-${GITHUB_SHA:-HEAD}}")"
-  CAPTION="HEAD ($HEAD_SHA) vs $OLD"
+  NEW_REF="${SOURCE_REF:-${GITHUB_SHA:-HEAD}}"
+  HEAD_SHA="$(git rev-parse --short "$NEW_REF")"
+  NEW_LABEL="HEAD ($HEAD_SHA)"
+  NEW_SHA="$(commit_sha "$NEW_REF")"
 else
-  CAPTION="$NEW vs $OLD"
+  NEW_LABEL="$NEW"
+  NEW_SHA="$(commit_sha "v$NEW")"
 fi
+CAPTION="$NEW_LABEL vs $OLD"
+# HTML variant of the caption, with each version linked to its GitHub commit.
+CAPTION_HTML="$(link_commit "$NEW_LABEL" "$NEW_SHA") vs $(link_commit "$OLD" "$OLD_SHA")"
 
 # The local modules are always installed, even when both compared versions are
 # published. japicmp resolves with ONE_COMMON_CLASSPATH, which pulls the current
@@ -119,7 +147,7 @@ if [ -n "$template" ] && [ -f "$template" ]; then
       | sed "s|<title>.*</title>|<title>Hardwood API report — $CAPTION</title>|"
     echo "<body>"
     echo "<h1>Hardwood API report</h1>"
-    echo "<p>$CAPTION &mdash; generated $GENERATED</p>"
+    echo "<p>$CAPTION_HTML &mdash; generated $GENERATED</p>"
     echo "<ul>"
     for artifact in "${ARTIFACTS[@]}"; do
       echo "  <li><a href=\"#$artifact\">$artifact</a></li>"

--- a/tools/publish-api-report.sh
+++ b/tools/publish-api-report.sh
@@ -10,12 +10,15 @@
 # Generate an API change report laid out for publishing under /api-changes/<version>/.
 #
 # Resolves the comparison endpoints from the repo's git tags and delegates to
-# tools/api-report.sh, then stages the unified report in <outputDir> with the
-# combined HTML exposed as index.html so the published URL serves cleanly.
+# tools/api-report.sh, then stages only the unified combined HTML in <outputDir>
+# as index.html so the published URL serves cleanly. The per-module reports and
+# the unified text diff that api-report.sh also writes under target/japicmp/ are
+# left unpublished — the combined HTML splices every module's body inline, so it
+# is self-contained, and nothing on the site links to the other files.
 #
 # Usage: tools/publish-api-report.sh <version> <outputDir>
 #   <version>    Maven release version (e.g. 1.0.0.CR1) or "dev"
-#   <outputDir>  directory to receive index.html + the per-module reports
+#   <outputDir>  directory to receive index.html (the unified HTML report)
 #
 # For "dev", the local HEAD snapshot is the new side and the latest tagged
 # release is the old side. For a release version, both sides are the published
@@ -92,7 +95,6 @@ if [ ! -f "$REPORT_DIR/api-report.html" ]; then
 fi
 
 mkdir -p "$OUT"
-cp -r "$REPORT_DIR/." "$OUT/"
-cp "$OUT/api-report.html" "$OUT/index.html"
+cp "$REPORT_DIR/api-report.html" "$OUT/index.html"
 
 echo "Staged report for /api-changes/$VERSION/ in $OUT"


### PR DESCRIPTION
Closes #646.

Two cleanups to the API change report tooling, orthogonal to the broader gh-pages diff-noise work (deferred).

### Publish only the unified HTML

`tools/publish-api-report.sh` copied the whole `target/japicmp/` tree onto gh-pages, so each build shipped four per-module subtrees, a duplicate `api-report.html`, and the unified text diff alongside `index.html`. None of it is linked from the site — the nav serves only the unified HTML, which splices every module's body inline and is self-contained — so it was dead weight that re-published every build. Now only the unified HTML is staged as `index.html`.

### Link versions to their commits

The report caption was plain text. Each compared side now links to its GitHub commit (`.../commit/<sha>`): the snapshot side to the source commit being published, each release side to the commit its tag resolves to. Links live in the HTML report only — the `<title>` and the plaintext text diff keep the unlinked caption. A side whose commit can't be resolved degrades to plain text.

### Verification

Ran `tools/publish-api-report.sh dev /tmp/api-changes-dev` locally: staged output is only `index.html`, and the caption links `HEAD (<sha>)` to the source commit and `1.0.0.CR2` to its release commit, with the `<title>` left plaintext.