### PR TITLE
#648 Strip embedded PlantUML metadata from generated JavaDoc SVGs

### DIFF
--- a/_designs/API_CHANGE_REPORT_PUBLISHING.md
+++ b/_designs/API_CHANGE_REPORT_PUBLISHING.md
@@ -17,6 +17,12 @@ API of two builds of the four published modules (`hardwood-core`, `hardwood-avro
 JavaDoc. Reports for all releases from the first comparable pair (`1.0.0.Alpha1` → `1.0.0.Beta1`)
 onward are published; the very first release has no predecessor and therefore no report.
 
+The report caption names the two compared sides (e.g. `HEAD (abc1234) vs 1.0.0.CR1` for the dev
+build, or `1.0.0.CR2 vs 1.0.0.CR1` for a release). In the HTML report each side links to its
+GitHub commit (`.../commit/<sha>`) — the snapshot side to the source commit being published,
+each release side to the commit its tag resolves to. A side whose commit cannot be resolved
+renders as plain text. The plaintext text diff caption is left unlinked.
+
 ---
 
 ## Repositories
@@ -66,13 +72,16 @@ result out for publishing:
 ```
 tools/publish-api-report.sh <version> <outputDir>
   <version>    Maven release version (e.g. 1.0.0.CR1) or "dev"
-  <outputDir>  directory to receive index.html + the per-module reports
+  <outputDir>  directory to receive index.html (the unified HTML report)
 ```
 
-It resolves old/new as described above, invokes `api-report.sh`, then copies `target/japicmp/`
-into `<outputDir>` and exposes the unified `api-report.html` as `index.html` so
-`/api-changes/<version>/` serves cleanly. When the version has no predecessor it prints a notice
-and exits 0 without writing output.
+It resolves old/new as described above, invokes `api-report.sh`, then stages only the unified
+`api-report.html` as `<outputDir>/index.html` so `/api-changes/<version>/` serves cleanly. The
+combined HTML splices every module's body inline, so it is self-contained; the per-module reports
+and the unified text diff that `api-report.sh` also writes under `target/japicmp/` are deliberately
+left unpublished — nothing on the site links to them, and shipping them re-published unchanged
+files on every build. When the version has no predecessor it prints a notice and exits 0 without
+writing output.
 
 For a release version both compared sides are the published JARs (the release and its
 predecessor), so the report is correct from any checkout — the workflows never need to check out

--- a/tools/api-report.sh
+++ b/tools/api-report.sh
@@ -42,17 +42,45 @@ cd "$ROOT"
 MODULES=":hardwood-core,:hardwood-avro,:hardwood-s3,:hardwood-aws-auth"
 ARTIFACTS=(hardwood-core hardwood-avro hardwood-s3 hardwood-aws-auth)
 
+REPO_URL="https://github.com/hardwood-hq/hardwood"
+
+# Resolve a git ref to a full commit SHA, or empty if it cannot be resolved
+# (e.g. the tag was not fetched). Non-fatal: a missing SHA just drops the link.
+commit_sha() { git rev-parse --verify --quiet "$1^{commit}" 2>/dev/null || true; }
+
+# Wrap a caption term in a link to its GitHub commit when the SHA is known,
+# otherwise emit it as plain text.
+link_commit() { # <label> <sha>
+  if [ -n "$2" ]; then
+    printf '<a href="%s/commit/%s" target="_blank" rel="noopener">%s</a>' \
+      "$REPO_URL" "$2" "$1"
+  else
+    printf '%s' "$1"
+  fi
+}
+
+# Each side of the comparison is named by a label (for the plaintext caption) and
+# resolved to a commit SHA (for the HTML caption's links). The old side is always
+# a release tag; the new side is either a release tag or, for the snapshot run,
+# the source commit being published.
+OLD_SHA="$(commit_sha "v$OLD")"
 if [ -z "$NEW" ]; then
   # Name the new side by its source commit. The site publish workflow runs this
   # from a hardwood checkout but under its own ${GITHUB_SHA} (the *site* repo's
   # commit), so prefer ${SOURCE_REF} — the hardwood commit being published, set
   # by that workflow, just as the docs footer does. Fall back to ${GITHUB_SHA}
   # for the main-repo CI runs, then the local HEAD.
-  HEAD_SHA="$(git rev-parse --short "${SOURCE_REF:-${GITHUB_SHA:-HEAD}}")"
-  CAPTION="HEAD ($HEAD_SHA) vs $OLD"
+  NEW_REF="${SOURCE_REF:-${GITHUB_SHA:-HEAD}}"
+  HEAD_SHA="$(git rev-parse --short "$NEW_REF")"
+  NEW_LABEL="HEAD ($HEAD_SHA)"
+  NEW_SHA="$(commit_sha "$NEW_REF")"
 else
-  CAPTION="$NEW vs $OLD"
+  NEW_LABEL="$NEW"
+  NEW_SHA="$(commit_sha "v$NEW")"
 fi
+CAPTION="$NEW_LABEL vs $OLD"
+# HTML variant of the caption, with each version linked to its GitHub commit.
+CAPTION_HTML="$(link_commit "$NEW_LABEL" "$NEW_SHA") vs $(link_commit "$OLD" "$OLD_SHA")"
 
 # The local modules are always installed, even when both compared versions are
 # published. japicmp resolves with ONE_COMMON_CLASSPATH, which pulls the current
@@ -119,7 +147,7 @@ if [ -n "$template" ] && [ -f "$template" ]; then
       | sed "s|<title>.*</title>|<title>Hardwood API report — $CAPTION</title>|"
     echo "<body>"
     echo "<h1>Hardwood API report</h1>"
-    echo "<p>$CAPTION &mdash; generated $GENERATED</p>"
+    echo "<p>$CAPTION_HTML &mdash; generated $GENERATED</p>"
     echo "<ul>"
     for artifact in "${ARTIFACTS[@]}"; do
       echo "  <li><a href=\"#$artifact\">$artifact</a></li>"

--- a/tools/publish-api-report.sh
+++ b/tools/publish-api-report.sh
@@ -10,12 +10,15 @@
 # Generate an API change report laid out for publishing under /api-changes/<version>/.
 #
 # Resolves the comparison endpoints from the repo's git tags and delegates to
-# tools/api-report.sh, then stages the unified report in <outputDir> with the
-# combined HTML exposed as index.html so the published URL serves cleanly.
+# tools/api-report.sh, then stages only the unified combined HTML in <outputDir>
+# as index.html so the published URL serves cleanly. The per-module reports and
+# the unified text diff that api-report.sh also writes under target/japicmp/ are
+# left unpublished — the combined HTML splices every module's body inline, so it
+# is self-contained, and nothing on the site links to the other files.
 #
 # Usage: tools/publish-api-report.sh <version> <outputDir>
 #   <version>    Maven release version (e.g. 1.0.0.CR1) or "dev"
-#   <outputDir>  directory to receive index.html + the per-module reports
+#   <outputDir>  directory to receive index.html (the unified HTML report)
 #
 # For "dev", the local HEAD snapshot is the new side and the latest tagged
 # release is the old side. For a release version, both sides are the published
@@ -92,7 +95,6 @@ if [ ! -f "$REPORT_DIR/api-report.html" ]; then
 fi
 
 mkdir -p "$OUT"
-cp -r "$REPORT_DIR/." "$OUT/"
-cp "$OUT/api-report.html" "$OUT/index.html"
+cp "$REPORT_DIR/api-report.html" "$OUT/index.html"
 
 echo "Staged report for /api-changes/$VERSION/ in $OUT"

--- a/tools/strip-svg-metadata.sh
+++ b/tools/strip-svg-metadata.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+#
+#  SPDX-License-Identifier: Apache-2.0
+#
+#  Copyright The original authors
+#
+#  Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+#
+
+# Strip PlantUML metadata processing instructions from generated JavaDoc SVGs.
+#
+# UMLDoclet renders each class diagram with PlantUML, which embeds a copy of the
+# diagram source into the SVG as a `<?plantuml-src ...?>` processing instruction
+# (preceded by a `<?plantuml <version>?>` header). That embedded source carries a
+# wall-clock `' Generated <timestamp>` comment, so every diagram's bytes change on
+# every build even when the rendered graphic is byte-for-byte identical — churning
+# every class-diagram SVG on the published site on each republish. The embedded
+# source only matters for re-importing a diagram into PlantUML; the site never
+# uses it. Removing both PIs makes the SVGs reproducible (and smaller) while
+# leaving the rendered `<svg>` untouched.
+#
+# Usage: tools/strip-svg-metadata.sh <dir>
+#   <dir>  directory tree to scan for *.svg (e.g. target/reports/apidocs)
+
+set -euo pipefail
+
+if [ $# -ne 1 ]; then
+  echo "Usage: $0 <dir>" >&2
+  exit 2
+fi
+
+DIR="$1"
+if [ ! -d "$DIR" ]; then
+  echo "Not a directory: $DIR" >&2
+  exit 1
+fi
+
+count=0
+while IFS= read -r -d '' svg; do
+  # PlantUML writes single-line SVGs; the PIs sit inline. Drop the version header
+  # and the embedded-source blob, both of which match `<?plantuml...?>`.
+  perl -0pi -e 's{<\?plantuml(?:-src)?\b[^>]*\?>}{}g' "$svg"
+  count=$((count + 1))
+done < <(find "$DIR" -type f -name '*.svg' -print0)
+
+echo "Stripped PlantUML metadata from $count SVG(s) under $DIR"


### PR DESCRIPTION
Closes #648.

## Problem

Republishing the docs rewrites every JavaDoc class-diagram SVG under `api/<version>/` (~100 files) even when the rendered diagram is unchanged. UMLDoclet embeds a copy of each diagram's PlantUML source into the SVG as a `<?plantuml-src ...?>` processing instruction, and that source carries a wall-clock `' Generated <timestamp>` comment. The timestamp changes every build → the compressed blob changes → the file changes, while the actual vector graphic is byte-for-byte identical. (Decoding the blob from a real publish confirmed the only differing line is the timestamp.)

UMLDoclet exposes no `-nometadata` flag or property to suppress the embedded source, so it's stripped after the build instead.

## Change

`tools/strip-svg-metadata.sh <dir>` removes the `<?plantuml...?>` PIs from generated SVGs, leaving the rendered `<svg>` untouched (and the files smaller). The site `publish.yml` runs it between `javadoc:aggregate` and the copy into `api/<version>/` (companion change in the site repo).

## Verification

Against the before/after SVGs of an actual noisy publish: after stripping, the two builds are byte-identical, no PI remains, `</svg>` intact, and the strip is idempotent.

Note: already-published per-version trees keep their metadata until that version is next republished; the first publish after this merges shows a one-time cleanup diff, then stays quiet.