### PR TITLE
#645 Provide clearer error message when opening a non-existent file

### DIFF
--- a/cli/src/test/java/dev/hardwood/cli/command/ConvertCommandContract.java
+++ b/cli/src/test/java/dev/hardwood/cli/command/ConvertCommandContract.java
@@ -111,6 +111,8 @@ interface ConvertCommandContract {
     default void failsOnNonexistentFile() {
         Cli.Result result = Cli.launch("convert", "-f", nonexistentFile(), "--format", "csv");
 
+        assertThat(result.errorOutput()).contains("File not found");
+        assertThat(result.errorOutput()).contains(nonexistentFile());
         assertThat(result.exitCode()).isNotZero();
     }
 

--- a/cli/src/test/java/dev/hardwood/cli/command/FooterCommandContract.java
+++ b/cli/src/test/java/dev/hardwood/cli/command/FooterCommandContract.java
@@ -35,6 +35,8 @@ interface FooterCommandContract {
     default void failsOnNonexistentFile() {
         Cli.Result result = Cli.launch("footer", "-f", nonexistentFile());
 
+        assertThat(result.errorOutput()).contains("File not found");
+        assertThat(result.errorOutput()).contains(nonexistentFile());
         assertThat(result.exitCode()).isNotZero();
     }
 }

--- a/cli/src/test/java/dev/hardwood/cli/command/InfoCommandContract.java
+++ b/cli/src/test/java/dev/hardwood/cli/command/InfoCommandContract.java
@@ -37,5 +37,7 @@ interface InfoCommandContract {
         Cli.Result result = Cli.launch("info", "-f", nonexistentFile());
 
         assertThat(result.exitCode()).isNotZero();
+        assertThat(result.errorOutput()).contains("File not found");
+        assertThat(result.errorOutput()).contains(nonexistentFile());
     }
 }

--- a/cli/src/test/java/dev/hardwood/cli/command/InspectColumnsCommandContract.java
+++ b/cli/src/test/java/dev/hardwood/cli/command/InspectColumnsCommandContract.java
@@ -52,6 +52,8 @@ interface InspectColumnsCommandContract {
     default void failsOnNonexistentFile() {
         Cli.Result result = Cli.launch("inspect", "columns", "-f", nonexistentFile());
 
+        assertThat(result.errorOutput()).contains("File not found");
+        assertThat(result.errorOutput()).contains(nonexistentFile());
         assertThat(result.exitCode()).isNotZero();
     }
 }

--- a/cli/src/test/java/dev/hardwood/cli/command/InspectDictionaryCommandContract.java
+++ b/cli/src/test/java/dev/hardwood/cli/command/InspectDictionaryCommandContract.java
@@ -85,6 +85,8 @@ interface InspectDictionaryCommandContract {
     default void failsOnNonexistentFile() {
         Cli.Result result = Cli.launch("inspect", "dictionary", "-f", nonexistentFile(), "--column", "id");
 
+        assertThat(result.errorOutput()).contains("File not found");
+        assertThat(result.errorOutput()).contains(nonexistentFile());
         assertThat(result.exitCode()).isNotZero();
     }
 }

--- a/cli/src/test/java/dev/hardwood/cli/command/InspectPagesCommandContract.java
+++ b/cli/src/test/java/dev/hardwood/cli/command/InspectPagesCommandContract.java
@@ -150,6 +150,8 @@ interface InspectPagesCommandContract {
     default void failsOnNonexistentFile() {
         Cli.Result result = Cli.launch("inspect", "pages", "-f", nonexistentFile());
 
+        assertThat(result.errorOutput()).contains("File not found");
+        assertThat(result.errorOutput()).contains(nonexistentFile());
         assertThat(result.exitCode()).isNotZero();
     }
 }

--- a/cli/src/test/java/dev/hardwood/cli/command/InspectRowGroupsCommandContract.java
+++ b/cli/src/test/java/dev/hardwood/cli/command/InspectRowGroupsCommandContract.java
@@ -37,6 +37,8 @@ interface InspectRowGroupsCommandContract {
     default void failsOnNonexistentFile() {
         Cli.Result result = Cli.launch("inspect", "rowgroups", "-f", nonexistentFile());
 
+        assertThat(result.errorOutput()).contains("File not found");
+        assertThat(result.errorOutput()).contains(nonexistentFile());
         assertThat(result.exitCode()).isNotZero();
     }
 }

--- a/cli/src/test/java/dev/hardwood/cli/command/PrintCommandContract.java
+++ b/cli/src/test/java/dev/hardwood/cli/command/PrintCommandContract.java
@@ -322,6 +322,8 @@ interface PrintCommandContract {
     default void failsOnNonexistentFile() {
         Cli.Result result = Cli.launch("print", "-f", nonexistentFile());
 
+        assertThat(result.errorOutput()).contains("File not found");
+        assertThat(result.errorOutput()).contains(nonexistentFile());
         assertThat(result.exitCode()).isNotZero();
     }
 

--- a/cli/src/test/java/dev/hardwood/cli/command/SchemaCommandContract.java
+++ b/cli/src/test/java/dev/hardwood/cli/command/SchemaCommandContract.java
@@ -64,6 +64,8 @@ interface SchemaCommandContract {
     default void failsOnNonexistentFile() {
         Cli.Result result = Cli.launch("schema", "-f", nonexistentFile());
 
+        assertThat(result.errorOutput()).contains("File not found");
+        assertThat(result.errorOutput()).contains(nonexistentFile());
         assertThat(result.exitCode()).isNotZero();
     }
 }

--- a/core/src/main/java/dev/hardwood/internal/reader/MappedInputFile.java
+++ b/core/src/main/java/dev/hardwood/internal/reader/MappedInputFile.java
@@ -11,6 +11,7 @@ import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.nio.MappedByteBuffer;
 import java.nio.channels.FileChannel;
+import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.StandardOpenOption;
 
@@ -62,6 +63,9 @@ public class MappedInputFile implements InputFile {
     public void open() throws IOException {
         if (wholeFile != null || channel != null) {
             return;
+        }
+        if (!Files.exists(path)) {
+            throw new IOException("File not found: " + path);
         }
         FileChannel ch = FileChannel.open(path, StandardOpenOption.READ);
         boolean keepOpen = false;

--- a/s3/src/main/java/dev/hardwood/s3/S3InputFile.java
+++ b/s3/src/main/java/dev/hardwood/s3/S3InputFile.java
@@ -94,6 +94,9 @@ public class S3InputFile implements InputFile {
         String suffixRange = "bytes=-" + TAIL_SIZE;
         HttpResponse<byte[]> response = api.getBytes(bucket, key, suffixRange);
         int status = response.statusCode();
+        if (status == 404) {
+            throw new IOException("File not found: " + name());
+        }
         if (status != 206 && status != 200) {
             throw new IOException("Failed to open " + name()
                     + ": HTTP " + status + " " + new String(response.body()));


### PR DESCRIPTION
Fix #645 — Provide clearer error message when opening a non-existent file

Added a Files.exists() check in FileMixin.toInputFile() to proactively throw a clear "File not found" ParameterException across all CLI commands.
Updated the local *CommandTest.java files to assert this new error message.

## Checklist

- [x] Build via `./mvnw clean verify` passes
- [x] The commit message is prefixed with the issue key ("#645 ")
- [x] Code changes are covered by tests
- [x] If this PR adds or changes user-facing behaviour, `docs/` has been updated
