### PR TITLE
#653 Fix broken CLI link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 # Hardwood
 
 _A parser for the Apache Parquet file format, optimized for minimal dependencies and great performance.
-Available as a Java library and a [command-line tool](https://hardwood.dev/latest/cli/)._
+Available as a Java library and a [command-line tool](https://hardwood.dev/latest/reference/cli/)._
 
 Goals of the project are:
 


### PR DESCRIPTION
## Description
This pull request closes #653, which reported that the "command-line tool" link on the main README points to https://hardwood.dev/latest/cli/, a page that returns a 404. The CLI reference moved under `reference/` as part of the recent restructure (#517), and the README link was never updated to match.

## Key Changes
- Point the README's "command-line tool" link at https://hardwood.dev/latest/reference/cli/. 

## Checklist
  - [x] Build via `./mvnw clean verify` passes
  - [x] The commit message is prefixed with the issue key
  - [x] Code changes are covered by tests
  - [x] If this PR adds or changes user-facing behavior, `docs/` has been updated