### PR TITLE
#664 Render logical types as Parquet-style annotation tokens

### DIFF
--- a/core/src/main/java/dev/hardwood/metadata/LogicalType.java
+++ b/core/src/main/java/dev/hardwood/metadata/LogicalType.java
@@ -10,6 +10,10 @@ package dev.hardwood.metadata;
 /// Logical types that provide semantic meaning to physical types.
 /// Sealed interface allows for parameterized types (e.g., DECIMAL with scale/precision).
 ///
+/// Each implementation's `toString()` renders the Parquet-style annotation token shown in
+/// schema dumps and metadata views — `STRING`, `LIST`, `DECIMAL(10, 2)`, `TIMESTAMP(MICROS, UTC)`,
+/// and so on — not the default record representation.
+///
 /// @see <a href="https://parquet.apache.org/docs/file-format/types/logicaltypes/">File Format – Logical Types</a>
 /// @see <a href="https://github.com/apache/parquet-format/blob/master/src/main/thrift/parquet.thrift">parquet.thrift</a>
 public sealed
@@ -18,33 +22,78 @@ permits LogicalType.StringType,LogicalType.EnumType,LogicalType.UuidType,Logical
 {
 
     /// UTF-8 encoded string.
-    record StringType() implements LogicalType {}
+    record StringType() implements LogicalType {
+        @Override
+        public String toString() {
+            return "STRING";
+        }
+    }
 
     /// Column whose every value is null. Carries no parameters; the value of
     /// every row in such a column is SQL NULL.
-    record NullType() implements LogicalType {}
+    record NullType() implements LogicalType {
+        @Override
+        public String toString() {
+            return "NULL";
+        }
+    }
 
     /// Enum stored as a UTF-8 string.
-    record EnumType() implements LogicalType {}
+    record EnumType() implements LogicalType {
+        @Override
+        public String toString() {
+            return "ENUM";
+        }
+    }
 
     /// UUID stored as a 16-byte fixed-length byte array.
-    record UuidType() implements LogicalType {}
+    record UuidType() implements LogicalType {
+        @Override
+        public String toString() {
+            return "UUID";
+        }
+    }
 
     /// Calendar date (days since Unix epoch).
-    record DateType() implements LogicalType {}
+    record DateType() implements LogicalType {
+        @Override
+        public String toString() {
+            return "DATE";
+        }
+    }
 
     /// JSON document stored as a UTF-8 string.
-    record JsonType() implements LogicalType {}
+    record JsonType() implements LogicalType {
+        @Override
+        public String toString() {
+            return "JSON";
+        }
+    }
 
     /// BSON document stored as a byte array.
-    record BsonType() implements LogicalType {}
+    record BsonType() implements LogicalType {
+        @Override
+        public String toString() {
+            return "BSON";
+        }
+    }
 
     /// Interval stored as a 12-byte fixed-length byte array (months, days, millis).
-    record IntervalType() implements LogicalType {}
+    record IntervalType() implements LogicalType {
+        @Override
+        public String toString() {
+            return "INTERVAL";
+        }
+    }
 
     /// IEEE 754 half-precision (binary16) floating point, stored as a 2-byte
     /// `FIXED_LEN_BYTE_ARRAY` in little-endian byte order.
-    record Float16Type() implements LogicalType {}
+    record Float16Type() implements LogicalType {
+        @Override
+        public String toString() {
+            return "FLOAT16";
+        }
+    }
 
     /// Integer type with a specific bit width and signedness.
     ///
@@ -55,6 +104,11 @@ permits LogicalType.StringType,LogicalType.EnumType,LogicalType.UuidType,Logical
             if (bitWidth != 8 && bitWidth != 16 && bitWidth != 32 && bitWidth != 64) {
                 throw new IllegalArgumentException("Invalid bit width: " + bitWidth);
             }
+        }
+
+        @Override
+        public String toString() {
+            return (isSigned ? "INT" : "UINT") + "_" + bitWidth;
         }
     }
 
@@ -71,25 +125,50 @@ permits LogicalType.StringType,LogicalType.EnumType,LogicalType.UuidType,Logical
                 throw new IllegalArgumentException("Scale cannot be negative: " + scale);
             }
         }
+
+        @Override
+        public String toString() {
+            return "DECIMAL(" + precision + ", " + scale + ")";
+        }
     }
 
     /// Time of day with configurable precision and UTC adjustment.
     ///
     /// @param isAdjustedToUTC `true` if the value is normalized to UTC
     /// @param unit time resolution (millis, micros, or nanos)
-    record TimeType(boolean isAdjustedToUTC, TimeUnit unit) implements LogicalType {}
+    record TimeType(boolean isAdjustedToUTC, TimeUnit unit) implements LogicalType {
+        @Override
+        public String toString() {
+            return "TIME(" + unit + ", " + (isAdjustedToUTC ? "UTC" : "local") + ")";
+        }
+    }
 
     /// Timestamp with configurable precision and UTC adjustment.
     ///
     /// @param isAdjustedToUTC `true` if the value is normalized to UTC
     /// @param unit time resolution (millis, micros, or nanos)
-    record TimestampType(boolean isAdjustedToUTC, TimeUnit unit) implements LogicalType {}
+    record TimestampType(boolean isAdjustedToUTC, TimeUnit unit) implements LogicalType {
+        @Override
+        public String toString() {
+            return "TIMESTAMP(" + unit + ", " + (isAdjustedToUTC ? "UTC" : "local") + ")";
+        }
+    }
 
     /// List (repeated element) logical type.
-    record ListType() implements LogicalType {}
+    record ListType() implements LogicalType {
+        @Override
+        public String toString() {
+            return "LIST";
+        }
+    }
 
     /// Map (key-value pairs) logical type.
-    record MapType() implements LogicalType {}
+    record MapType() implements LogicalType {
+        @Override
+        public String toString() {
+            return "MAP";
+        }
+    }
 
     /// Variant (self-describing, semi-structured) logical type per the Parquet
     /// Variant spec. Annotates a group whose children are `metadata` (binary) and
@@ -112,13 +191,33 @@ permits LogicalType.StringType,LogicalType.EnumType,LogicalType.UuidType,Logical
     /// Geometry type with configurable CRS
     ///
     /// @param crs geospatial coordinate reference system, OGC:CRS84 if absent
-    record GeometryType(String crs) implements LogicalType {}
+    record GeometryType(String crs) implements LogicalType {
+        @Override
+        public String toString() {
+            return crs == null ? "GEOMETRY" : "GEOMETRY(" + crs + ")";
+        }
+    }
 
     /// Geography type with configurable CRS
     ///
     /// @param crs geospatial coordinate reference system, OGC:CRS84 if absent
     /// @param edgeInterpolation geodesic formulation
-    record GeographyType(String crs, EdgeInterpolationAlgorithm edgeInterpolation) implements LogicalType {}
+    record GeographyType(String crs, EdgeInterpolationAlgorithm edgeInterpolation) implements LogicalType {
+        @Override
+        public String toString() {
+            StringBuilder params = new StringBuilder();
+            if (crs != null) {
+                params.append(crs);
+            }
+            if (edgeInterpolation != null) {
+                if (params.length() > 0) {
+                    params.append(", ");
+                }
+                params.append(edgeInterpolation);
+            }
+            return params.length() == 0 ? "GEOGRAPHY" : "GEOGRAPHY(" + params + ")";
+        }
+    }
 
     /// Resolution of time and timestamp logical types.
     enum TimeUnit {

--- a/core/src/test/java/dev/hardwood/DebugParquetTest.java
+++ b/core/src/test/java/dev/hardwood/DebugParquetTest.java
@@ -11,7 +11,6 @@ import java.nio.file.Paths;
 import java.time.Instant;
 import java.time.LocalDateTime;
 import java.time.ZoneOffset;
-import java.util.Locale;
 
 import dev.hardwood.metadata.LogicalType;
 import dev.hardwood.reader.ParquetFileReader;
@@ -112,29 +111,7 @@ public class DebugParquetTest {
     }
 
     private static String formatLogicalType(LogicalType logicalType) {
-        if (logicalType == null) {
-            return "-";
-        }
-        // Extract the simple type name from the record class
-        String name = logicalType.getClass().getSimpleName();
-        // Remove "Type" suffix if present (e.g., "TimestampType" -> "TIMESTAMP")
-        if (name.endsWith("Type")) {
-            name = name.substring(0, name.length() - 4);
-        }
-        // Add parameters for parameterized types
-        if (logicalType instanceof LogicalType.TimestampType ts) {
-            return name.toUpperCase(Locale.ROOT) + "(" + ts.unit() + ")";
-        }
-        if (logicalType instanceof LogicalType.TimeType t) {
-            return name.toUpperCase(Locale.ROOT) + "(" + t.unit() + ")";
-        }
-        if (logicalType instanceof LogicalType.DecimalType d) {
-            return name.toUpperCase(Locale.ROOT) + "(" + d.precision() + "," + d.scale() + ")";
-        }
-        if (logicalType instanceof LogicalType.IntType i) {
-            return (i.isSigned() ? "INT" : "UINT") + "_" + i.bitWidth();
-        }
-        return name.toUpperCase(Locale.ROOT);
+        return logicalType == null ? "-" : logicalType.toString();
     }
 
     private static String padRight(String s, int width) {

--- a/core/src/test/java/dev/hardwood/SchemaCompatibilityTest.java
+++ b/core/src/test/java/dev/hardwood/SchemaCompatibilityTest.java
@@ -38,8 +38,8 @@ class SchemaCompatibilityTest {
                 }
             }).isInstanceOf(SchemaIncompatibleException.class)
                     .hasMessage("[compat_ts_millis.parquet] Column 'ts' has incompatible logical type:" +
-                            " expected TimestampType[isAdjustedToUTC=true, unit=MICROS]" +
-                            " but found TimestampType[isAdjustedToUTC=true, unit=MILLIS]");
+                            " expected TIMESTAMP(MICROS, UTC)" +
+                            " but found TIMESTAMP(MILLIS, UTC)");
         }
     }
 
@@ -58,8 +58,8 @@ class SchemaCompatibilityTest {
                 }
             }).isInstanceOf(SchemaIncompatibleException.class)
                     .hasMessage("[compat_decimal_10_4.parquet] Column 'amount' has incompatible logical type:" +
-                            " expected DecimalType[scale=2, precision=10]" +
-                            " but found DecimalType[scale=4, precision=10]");
+                            " expected DECIMAL(10, 2)" +
+                            " but found DECIMAL(10, 4)");
         }
     }
 
@@ -97,7 +97,7 @@ class SchemaCompatibilityTest {
                 }
             }).isInstanceOf(SchemaIncompatibleException.class)
                     .hasMessage("[compat_plain_int64.parquet] Column 'ts' has incompatible logical type:" +
-                            " expected TimestampType[isAdjustedToUTC=true, unit=MICROS] but found null");
+                            " expected TIMESTAMP(MICROS, UTC) but found null");
         }
     }
 

--- a/docs/content/concepts/nested-columns.md
+++ b/docs/content/concepts/nested-columns.md
@@ -108,11 +108,11 @@ group`, and that pair contributes one `REPEATED` layer rather than one layer per
 above resolve any schema unambiguously. Take a `contacts` column whose schema prints as:
 
 ```
-optional group contacts (ListType[]) {
+optional group contacts (LIST) {
   repeated group list {
     optional group element {
-      required byte_array name (StringType[]);
-      optional byte_array phoneNumber (StringType[]);
+      required byte_array name (STRING);
+      optional byte_array phoneNumber (STRING);
     }
   }
 }
@@ -121,10 +121,10 @@ optional group contacts (ListType[]) {
 Walking the chain for `contacts.list.element.name`, the two `LIST` nodes fuse into one layer:
 
 ```
-optional group contacts (ListType[])   ──┐
-  repeated group list                  ──┴─►  REPEATED  (layer 0)
-    optional group element             ────►  STRUCT    (layer 1)
-      required byte_array name          ───►  leaf
+optional group contacts (LIST)  ──┐
+  repeated group list           ──┴─►  REPEATED  (layer 0)
+    optional group element      ────►  STRUCT    (layer 1)
+      required byte_array name  ────►  leaf
 ```
 
 `getLayerCount()` is `2`, with kinds `[REPEATED, STRUCT]`. The list's own nullability is not a


### PR DESCRIPTION
Closes #664.

> **Stacked on #663** — base is `662-layer-model-docs`, because this PR updates the schema-dump example that #663 introduces. Merge #663 first, then this PR's base auto-retargets to `main` (or retarget manually).

## What

Parameterless logical types fell back to Java's default record `toString()`, printing `StringType[]`, `ListType[]`, etc. — the trailing `[]` reads as array syntax — while parameterized ones printed Java field syntax (`DecimalType[scale=2, precision=10]`) and only `VariantType` rendered a clean token. A single schema dump mixed three styles.

Each `LogicalType` now has a `toString()` that emits the conventional Parquet annotation token. Every printer that already delegates to `toString()` benefits with no call-site changes: the `FileSchema`/`ColumnSchema` schema printer, the CLI `schema` command, the three `dive` TUI screens, and schema-compatibility exception messages. This also aligns logical-type rendering stylistically with the uppercase `ConvertedType` fallback in the same printer.

## Rendering (per the decisions on the issue)

| Type | Renders as |
|---|---|
| `StringType` / `ListType` / `MapType` / `EnumType` / … | `STRING` / `LIST` / `MAP` / `ENUM` / … |
| `IntType(32, true)` / `IntType(64, false)` | `INT_32` / `UINT_64` |
| `DecimalType(scale=2, precision=10)` | `DECIMAL(10, 2)` |
| `TimestampType(true, MICROS)` | `TIMESTAMP(MICROS, UTC)` |
| `TimeType(false, MILLIS)` | `TIME(MILLIS, local)` |
| `VariantType(1)` | `VARIANT(1)` (unchanged) |
| `GeometryType(crs)` / `GeographyType(crs, edge)` | `GEOMETRY(crs)` / `GEOGRAPHY(crs, edge)` (bare name when absent) |

## Notes

- `INT_32`/`UINT_64` and the UTC/CRS inclusions are the maintainer's calls recorded on the issue.
- `DecimalType`'s record is `(scale, precision)` but the token is `DECIMAL(precision, scale)` — handled.
- `DebugParquetTest`'s hand-rolled formatter now defers to the production rendering.
- `SchemaCompatibilityTest` exception-message assertions updated (the messages get strictly more readable).
- `docs/content/concepts/nested-columns.md`: the #663 example dump now shows `(LIST)` / `(STRING)`; the layer diagram was re-aligned for the shorter tokens.
- `docs/content/reference/cli.md` already documented `VARIANT(1)` — still accurate.

## Verification

- `core`: full suite, 1361 passed.
- `cli`: `DiveRenderTest` (74) + `SchemaCommandTest` (9) passed.
- No checked-in Parquet fixtures pin these strings, so none needed regenerating.