### PR TITLE
#640 Fail fast when dive has no interactive terminal

### DIFF
--- a/cli/src/main/java/dev/hardwood/cli/command/DiveCommand.java
+++ b/cli/src/main/java/dev/hardwood/cli/command/DiveCommand.java
@@ -73,6 +73,15 @@ public class DiveCommand implements Callable<Integer> {
 
     @Override
     public Integer call() {
+        // Without a TTY the JLine TUI can't run; checked before any file I/O.
+        // Smoke-render never enters raw mode, so it is exempt.
+        if (!smokeRender && interactiveTerminalUnavailable()) {
+            spec.commandLine().getErr().println(
+                    "Error: 'dive' requires an interactive terminal. "
+                            + "Re-run attached to a TTY (with Docker: docker run -it ...).");
+            return CommandLine.ExitCode.USAGE;
+        }
+
         // Dive re-reads the same byte ranges constantly (page-up/page-down
         // navigation, jump-to-end-then-back, the `t` toggle, etc.). Opt
         // into the sparse-tempfile range cache so those repeats hit a
@@ -107,6 +116,13 @@ public class DiveCommand implements Callable<Integer> {
                 logHandler.close();
             }
         }
+    }
+
+    /// Reports whether stdin or stdout is not attached to a terminal.
+    /// `System.console()` is `null` when either is redirected, including in
+    /// the native image.
+    private static boolean interactiveTerminalUnavailable() {
+        return System.console() == null;
     }
 
     /// Configures JUL logging for an interactive dive session.

--- a/cli/src/test/java/dev/hardwood/cli/command/DiveCommandTest.java
+++ b/cli/src/test/java/dev/hardwood/cli/command/DiveCommandTest.java
@@ -36,4 +36,17 @@ class DiveCommandTest {
         assertThat(result.exitCode()).isNotZero();
         assertThat(result.errorOutput()).containsIgnoringCase("file");
     }
+
+    /// The Surefire fork has no console (stdout/stdin are piped), so the
+    /// fail-fast guard fires for real — the same path a `docker run` without
+    /// `-it` hits.
+    @Test
+    void failsFastWithoutTty() {
+        Path fixture = Path.of(getClass().getResource("/compat_plain_int64.parquet").getPath());
+
+        Cli.Result result = Cli.launch("dive", "-f", fixture.toString());
+
+        assertThat(result.exitCode()).isNotZero();
+        assertThat(result.errorOutput()).containsIgnoringCase("interactive terminal");
+    }
 }

--- a/docs/content/reference/cli.md
+++ b/docs/content/reference/cli.md
@@ -81,6 +81,8 @@ hardwood convert -n -50 --format csv -f data.parquet
 hardwood dive -f data.parquet
 ```
 
+`dive` requires an interactive terminal. When stdin or stdout is not a TTY (e.g., a `docker run` without `-it`, or output piped to a file), it exits with an error instead of launching the UI.
+
 <script src="https://asciinema.org/a/992284.js" id="asciicast-992284" async="true"></script>
 
 ### What you can do with it


### PR DESCRIPTION
## Description

This PR will close #640 by addressing a bit of low-hanging fruit for the TUI. `hardwood dive` launched the JLine TUI even without an interactive terminal. When stdin or stdout is not a TTY — most easily a `docker run` without `-it` — JLine's startup queries leak to the other end of the pipe and nothing renders. These changes introduce a guard for the command and exits early with the following actionable message:

> Error: 'dive' requires an interactive terminal. Re-run attached to a TTY (with Docker: docker run -it ...).

## Key Changes
  - Guard `DiveCommand` on `System.console() != null`, before any file I/O so a non-interactive run never pays a (possibly remote) open. `System.console()` is `null` whenever either stream is redirected.
  - `--smoke-render` is exempt (it never enters raw mode), so the native-image smoke test is unaffected.
  - Documented the requirement in `docs/content/reference/cli.md`.

## Verification and Testing
  - `DiveCommandTest.failsFastWithoutTty` launches `dive -f <fixture>` without `--smoke-render`. The Surefire fork has no console, so the guard fires for real — the same path a `docker run` without `-it` hits — rather than being mocked. The existing smoke-render test doubles as proof the guard is correctly bypassed.
  - `cli`: full module suite green, 379 tests.

  ## Checklist

  - [x] Build via `./mvnw clean verify` passes
  - [x] The commit message is prefixed with the issue key
  - [x] Code changes are covered by tests
  - [x] User-facing behavior change documented (`docs/content/reference/cli.md`)