### PR TITLE
#675 Clarify getListElement() behavior on legacy 2-level lists

### DIFF
--- a/core/src/main/java/dev/hardwood/schema/SchemaNode.java
+++ b/core/src/main/java/dev/hardwood/schema/SchemaNode.java
@@ -92,9 +92,9 @@ public sealed interface SchemaNode {
             return logicalType instanceof LogicalType.VariantType;
         }
 
-    /// For LIST groups, returns the element node (skipping the intermediate
-    /// `list`/`key_value` group in standard 3-level encoding). Returns `null`
-    /// if not a list or improperly structured.
+    /// For LIST groups, returns the list's element node — the logical element,
+    /// independent of whether the list uses 2-level or 3-level encoding. Returns
+    /// `null` if not a list or improperly structured.
     ///
     /// Applies the Parquet backward-compatibility rules for legacy 2-level
     /// encodings as defined in the format spec; see
@@ -107,7 +107,24 @@ public sealed interface SchemaNode {
     ///    single-field wrapper (legacy 2-level encoding of a list whose element is itself a list).
     /// 4. If the repeated field is a group with one field and is named either `array` or uses
     ///    the LIST-annotated group's name with `_tuple` appended, the repeated group is the element.
-    /// 5. Otherwise, the repeated field's single child is the element (standard 3-level encoding).
+    /// 5. Otherwise, the repeated field is a wrapper and its single child is the element — the
+    ///    standard `list`/`element` structure and any other single-field 3-level shape not matched
+    ///    by rules 1–4 (the child need not be named `element`).
+    ///
+    /// The returned node is an existing schema node, so its repetition is authentic: a 2-level
+    /// list's element is itself `REPEATED` (the repeated field is both the element and the list's
+    /// repetition carrier), while a 3-level list's element is the non-repeated child of the
+    /// intermediate `list` group. A list's nesting depth is the count of `repeated` nodes on the
+    /// path (the leaf's max repetition level), not the count of `LIST` annotations. Since the
+    /// element may itself be a list, walk to the leaf by recursing while it is a list — uniform
+    /// across both encodings:
+    ///
+    /// ```java
+    /// SchemaNode node = listGroup;
+    /// while (node instanceof GroupNode g && g.isList()) {
+    ///     node = g.getListElement();
+    /// }
+    /// ```
         public SchemaNode getListElement() {
             if (!isList() || children.isEmpty()) {
                 return null;
@@ -136,7 +153,8 @@ public sealed interface SchemaNode {
             if ("array".equals(innerName) || (name() + "_tuple").equals(innerName)) {
                 return innerGroup;
             }
-            // Rule 5: standard 3-level encoding — the repeated group's single child is the element.
+            // Rule 5: wrapper group (standard `list`/`element` or any other single-field 3-level
+            // shape) — descend to the repeated group's single child.
             return innerGroup.children().get(0);
         }
 

--- a/docs/content/concepts/nested-columns.md
+++ b/docs/content/concepts/nested-columns.md
@@ -133,6 +133,22 @@ same layer shape a `required` list would have, differing only in that validity. 
 `element` struct, which carries validity but no offsets, so `getLayerOffsets(1)` throws `Layer 1 is
 STRUCT, not REPEATED`.
 
+## Logical element versus physical encoding
+
+The same logical-over-physical split governs schema *navigation*, not just layers.
+`SchemaNode.GroupNode.getListElement()` returns a list's **logical** element — *what* the element
+is — independent of whether the list is physically 2-level or 3-level. For `list<list<int>>` the
+element is the inner `list<int>`; for `list<int>` it is the `int`. The encoding changes only *where*
+that element sits in the node tree, never what `getListElement()` resolves it to.
+
+The returned node keeps all its physical attributes. In a standard 3-level list the element is the
+non-repeated child below the synthetic `repeated group`; in a legacy 2-level list the repeated field
+*is* the element, so the returned node is itself `REPEATED`. Counted structurally, a list's nesting
+depth is the number of `repeated` nodes on the path (equivalently, the leaf's maximum repetition
+level), not the number of `LIST` annotations. To walk to the leaf logically, recurse
+`getListElement()` while the result `isList()` — uniform across both encodings. To inspect the raw
+physical tree instead, walk `children()`.
+
 ## Counts at each layer
 
 Every per-layer buffer is sized to `count(k)`, defined recursively:

--- a/docs/content/how-to/column-reader.md
+++ b/docs/content/how-to/column-reader.md
@@ -122,7 +122,7 @@ The reader stays a single-threaded cursor: only the loop thread calls `nextBatch
 Before opening a reader for a nested column, you usually need to walk the file's schema tree to find the leaf you want. `SchemaNode.GroupNode` exposes the structural primitives:
 
 - `isList()` / `isMap()` / `isStruct()` — disambiguate which kind of group a node is.
-- `getListElement()` — for LIST groups, returns the element node, applying Parquet's backward-compatibility rules for legacy 2-level encodings.
+- `getListElement()` — for LIST groups, returns the element node, applying Parquet's backward-compatibility rules for legacy 2-level encodings. For a legacy 2-level list the returned element is itself `REPEATED` and, in a nested list, itself a LIST; a list's nesting depth is the number of `repeated` nodes on the path, not the number of LIST annotations. Walk to the leaf uniformly by recursing while the result `isList()`.
 - `getMapKey()` / `getMapValue()` — for MAP groups, returns the key and value nodes from the standard `map.key_value.key` / `map.key_value.value` encoding.
 - `children()` — for plain struct groups, iterate to get each field.
 


### PR DESCRIPTION
Documentation-only follow-up to #675.

The element node returned by `getListElement()` for a legacy 2-level list is itself `REPEATED` and may itself be a `LIST`, which reads as a surprising extra nesting level when inspecting the schema by eye (the source of the confusion in #675).

This clarifies the `getListElement()` Javadoc and the column-reader how-to:

- the returned node is a real schema node carrying authentic repetition (2-level element is `REPEATED`; 3-level element is the non-repeated child of the intermediate `list` group);
- a list's nesting depth is the count of `repeated` nodes on the path (the leaf's max repetition level), not the count of `LIST` annotations;
- recursing while `isList()` walks to the leaf uniformly across 2-level and 3-level encodings.

Also fixes a stray `key_value` (the map wrapper) to `bag` in the existing list-wrapper note.

No behavior change.