### PR TITLE
#677 Install fonts in dev container for PlantUML diagram rendering

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,6 +20,8 @@ RUN microdnf install -y --nodocs \
       binutils \
       file \
       vim-common \
+      fontconfig \
+      dejavu-sans-fonts \
       python3 \
       python3-pip \
     && microdnf clean all


### PR DESCRIPTION
Fixes #677.

`./mvnw -pl core javadoc:javadoc` fails in the dev container with a `ClassNotFoundException: net.sourceforge.plantuml.fun.IconLoader`. That is a secondary symptom: umldoclet runs PlantUML to render the Javadoc class diagrams, PlantUML needs fonts for text layout, and the `fedora-minimal` base image ships none. The primary SVG render fails, PlantUML falls back to drawing a diagnostic image, and that path reaches a logo class that is absent from umldoclet's shaded jar — surfacing as the misleading missing-class error.

Adding `fontconfig` and `dejavu-sans-fonts` to the `microdnf` install list fixes it. Verified in-container: after installing these, `javadoc:javadoc` completes and renders 122 diagram SVGs.

See #677 for the full diagnosis.