### PR TITLE
#595 Surface ColumnOrder and apply it to float/double ±0 pruning

### DIFF
--- a/FORMAT_COVERAGE.md
+++ b/FORMAT_COVERAGE.md
@@ -34,7 +34,7 @@ is read and displayed yet feeds no filtering). The read-vs-skipped axis matches 
 | 4 | row_groups | ✅ | |
 | 5 | key_value_metadata | ✅ | exposed on `FileMetaData` |
 | 6 | created_by | ✅ | displayed in CLI / dive |
-| 7 | column_orders | ❌ | stats sort order assumed type-defined; #483 |
+| 7 | column_orders | ✅ | decoded onto `FileMetaData.columnOrders`; #595 |
 | 8 | encryption_algorithm | ❌ | encrypted footers fail fast (#600); full support #128 |
 | 9 | footer_signing_key_metadata | ❌ | #128 |
 
@@ -43,7 +43,10 @@ All fields ❌ — Parquet Modular Encryption is unsupported; encrypted files fa
 fast. Tracked by **#128** (support), #600 (graceful failure).
 
 ### ColumnOrder (TypeDefinedOrder, IEEE754TotalOrder)
-❌ — tied to `FileMetaData.column_orders`; #483.
+✅ — decoded onto `FileMetaData.columnOrders` as `ColumnOrder`; an unrecognized union member maps to
+`ColumnOrder.UNKNOWN`. The order drives float/double statistics pruning: type-defined (and absent)
+orders widen `±0` bounds for correct signed-zero handling, while `IEEE754TotalOrder` prunes exactly;
+#595.
 
 ---
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -166,7 +166,7 @@ For field-level `parquet.thrift` metadata coverage (which spec fields are read/p
   - [x] Row groups
   - [x] Key-value metadata
   - [x] Created by string
-  - [ ] Column orders (field skipped — stats sort order assumed type-defined; #483)
+  - [x] Column orders (decoded onto `FileMetaData.columnOrders`; #595)
 - [ ] FileMetaData serialization
 - [x] FileMetaData deserialization
 

--- a/_designs/COLUMN_ORDER_HANDLING.md
+++ b/_designs/COLUMN_ORDER_HANDLING.md
@@ -1,0 +1,88 @@
+# Plan: Surface `ColumnOrder` and apply it to float/double pruning (#595)
+
+**Status: Implemented**
+
+## Context
+
+The Parquet footer carries an optional `FileMetaData.column_orders` field (Thrift field 7): a
+`list<ColumnOrder>` with one entry per leaf column, in schema order. `ColumnOrder` is a union with
+two members:
+
+| Union field | Member | Meaning |
+|---|---|---|
+| 1 | `TypeDefinedOrder` (`TYPE_ORDER`) | Order defined by the physical/logical type. For `FLOAT`/`DOUBLE` this is *signed comparison of the represented value* with documented NaN / ±0 compatibility rules. |
+| 2 | `IEEE754TotalOrder` (`IEEE_754_TOTAL_ORDER`) | The IEEE 754 total order. |
+
+Hardwood prunes `FLOAT`/`DOUBLE` row groups and pages with `Float.compare` / `Double.compare`, which
+implement the IEEE 754 *total order*.
+
+### What is and isn't a problem
+
+For `FLOAT`/`DOUBLE`, `TYPE_ORDER` and total order diverge only at **NaN** and **±0.0**. Everywhere
+else they are identical, so the choice of order is irrelevant for pruning every finite, non-zero value.
+
+- **NaN** bounds are already neutralised: `StatisticsFilterSupport.canDropFloat` / `canDropDouble`
+  return `false` whenever a bound is NaN and never prune.
+- **±0.0**: a spec-compliant `TYPE_ORDER` writer normalises zero bounds to `-0.0` for min and `+0.0`
+  for max. PyArrow 24.0.0 does exactly this: a float column whose minimum is zero is written with min
+  `-0.0` (raw `0x00000080`) and a column whose maximum is zero with max `+0.0` (raw `0x00000000`).
+  With these normalised bounds, total-order pruning is already correct. For writers that do not
+  normalise, the spec instead gives readers a compatibility rule — a `+0` min may also cover `-0`, a
+  `-0` max may also cover `+0` — which the [order-aware widening](#order-aware-0-pruning) below applies.
+
+PyArrow and parquet-mr emit `TYPE_ORDER` for every column, floats included. For these the widening is
+a no-op (their bounds are already normalised); it exists to honour the spec's reader rule for the
+type-defined order, keeping non-normalising and older files correct.
+
+## Design
+
+### Surface the field
+
+- New public enum `dev.hardwood.metadata.ColumnOrder` with `TYPE_DEFINED_ORDER`,
+  `IEEE754_TOTAL_ORDER`, and `UNKNOWN`.
+- `FileMetaData` gains a `List<ColumnOrder> columnOrders` component. When `column_orders` is absent
+  the list is empty (the implicit, type-defined ordering applies to all columns).
+- `ColumnOrderReader` decodes one `ColumnOrder` union from the Thrift Compact stream;
+  `FileMetaDataReader` decodes field 7 into the list.
+
+A union member Hardwood does not recognise (a future ordering with a field id other than 1 or 2)
+decodes to `ColumnOrder.UNKNOWN`. This follows the reader's existing convention for non-fatal unknown
+union/enum members — `LogicalType` skips and yields `null`, `Encoding` maps to `Encoding.UNKNOWN` —
+rather than failing the file open. The decoded value is surfaced on `FileMetaData.columnOrders` so a
+caller can inspect it; pruning is unaffected because a column with an unrecognised order simply falls
+back to the same total-order comparison used for the recognised orders.
+
+### Order-aware ±0 pruning
+
+The decoded order is threaded to the pruning site so each float/double leaf prunes by its own
+ordering. `FilterPredicateResolver` looks up the leaf's `ColumnOrder` and records a single
+`ieee754TotalOrder` boolean on the resolved `FloatPredicate` / `Float16Predicate` / `DoublePredicate`
+(`true` only for `IEEE754_TOTAL_ORDER`). `StatisticsFilterSupport.canDropFloat` / `canDropDouble` then:
+
+- **Type-defined / absent / unrecognized order** (`ieee754TotalOrder == false`) — the spec leaves
+  `±0` ambiguous (a `+0` min may hide `-0`, a `-0` max may hide `+0`), so a zero bound is widened to
+  its total-order extreme (`min` ⇒ `-0.0`, `max` ⇒ `+0.0`) before the `Float.compare` checks. Widening
+  only enlarges the candidate range, so it can never cause an incorrect drop.
+- **IEEE 754 total order** (`ieee754TotalOrder == true`) — `-0 < +0` is unambiguous and the stored
+  bounds are exact, so no widening is applied and `±0` prunes precisely.
+
+This matches the spec, which states the `±0` compatibility rule only for the type-defined order. Real
+writers (PyArrow, parquet-mr) emit the type-defined order, so they take the widening path.
+
+The order is resolved once per reader from the first file's `column_orders` and applies to the whole
+read. `column_orders` is not part of schema-compatibility validation, so in principle a sibling file
+of a multi-file read could declare a different order; in practice a writer emits a uniform order
+across a dataset. The only divergence that could mis-prune — a reference file declaring
+`IEEE754_TOTAL_ORDER` (skip widening) while a sibling is type-defined (needs widening) — requires the
+IEEE 754 total order, which no writer currently emits.
+
+## Testing
+
+- `ColumnOrderReaderTest` decodes the `TYPE_ORDER`, `IEEE_754_TOTAL_ORDER`, unrecognised, and empty
+  union forms from raw Thrift bytes.
+- `ColumnOrdersTest` asserts `column_orders` is surfaced as `TYPE_DEFINED_ORDER` for a real PyArrow
+  fixture.
+- `FilterPredicateResolverTest` asserts the `ieee754TotalOrder` flag is set from a leaf's
+  `ColumnOrder` (type-defined / IEEE754 / absent).
+- `NaNStatisticsFilterTest` asserts a type-defined `±0` bound is not dropped by a `== ∓0` predicate,
+  an IEEE754 `±0` bound prunes precisely, and non-zero predicates still prune under both orders.

--- a/core/src/main/java/dev/hardwood/internal/predicate/FilterPredicateResolver.java
+++ b/core/src/main/java/dev/hardwood/internal/predicate/FilterPredicateResolver.java
@@ -11,7 +11,9 @@ import java.math.BigDecimal;
 import java.math.BigInteger;
 import java.time.Instant;
 import java.time.LocalTime;
+import java.util.List;
 
+import dev.hardwood.metadata.ColumnOrder;
 import dev.hardwood.metadata.LogicalType;
 import dev.hardwood.metadata.PhysicalType;
 import dev.hardwood.reader.FilterPredicate;
@@ -46,12 +48,26 @@ import dev.hardwood.schema.FileSchema;
 /// need to repeat column lookups or type checks.
 public class FilterPredicateResolver {
 
-    /// Resolves a [FilterPredicate] tree into a [ResolvedPredicate] tree.
+    /// Resolves a [FilterPredicate] tree without column-order information. Float/double leaves are
+    /// treated as type-defined, so statistics pruning widens `±0` bounds (the conservative default).
     ///
     /// @param predicate the user-facing predicate tree
     /// @param schema the file schema for column resolution and type validation
     /// @return a fully resolved predicate tree ready for evaluation
     public static ResolvedPredicate resolve(FilterPredicate predicate, FileSchema schema) {
+        return resolve(predicate, schema, List.of());
+    }
+
+    /// Resolves a [FilterPredicate] tree into a [ResolvedPredicate] tree.
+    ///
+    /// @param predicate the user-facing predicate tree
+    /// @param schema the file schema for column resolution and type validation
+    /// @param columnOrders the file's decoded `column_orders` (empty if absent), used to mark
+    ///        float/double leaves that use the IEEE 754 total order so statistics pruning can skip
+    ///        the `±0` widening for them
+    /// @return a fully resolved predicate tree ready for evaluation
+    public static ResolvedPredicate resolve(FilterPredicate predicate, FileSchema schema,
+            List<ColumnOrder> columnOrders) {
         return switch (predicate) {
             case DateColumnPredicate p -> {
                 ColumnSchema cs = resolveColumn(p.column(), schema);
@@ -120,16 +136,19 @@ public class FilterPredicateResolver {
                 rejectRepeated(p.column(), cs);
                 if (cs.type() == PhysicalType.FIXED_LEN_BYTE_ARRAY
                         && cs.logicalType() instanceof LogicalType.Float16Type) {
-                    yield new ResolvedPredicate.Float16Predicate(cs.columnIndex(), p.op(), p.value());
+                    yield new ResolvedPredicate.Float16Predicate(cs.columnIndex(), p.op(), p.value(),
+                            isIeee754TotalOrder(cs.columnIndex(), columnOrders));
                 }
                 validateType(p.column(), PhysicalType.FLOAT, cs);
-                yield new ResolvedPredicate.FloatPredicate(cs.columnIndex(), p.op(), p.value());
+                yield new ResolvedPredicate.FloatPredicate(cs.columnIndex(), p.op(), p.value(),
+                        isIeee754TotalOrder(cs.columnIndex(), columnOrders));
             }
             case DoubleColumnPredicate p -> {
                 ColumnSchema cs = resolveColumn(p.column(), schema);
                 rejectRepeated(p.column(), cs);
                 validateType(p.column(), PhysicalType.DOUBLE, cs);
-                yield new ResolvedPredicate.DoublePredicate(cs.columnIndex(), p.op(), p.value());
+                yield new ResolvedPredicate.DoublePredicate(cs.columnIndex(), p.op(), p.value(),
+                        isIeee754TotalOrder(cs.columnIndex(), columnOrders));
             }
             case BooleanColumnPredicate p -> {
                 ColumnSchema cs = resolveColumn(p.column(), schema);
@@ -186,13 +205,13 @@ public class FilterPredicateResolver {
                 yield new ResolvedPredicate.IsNotNullPredicate(cs.columnIndex());
             }
             case And a -> new ResolvedPredicate.And(a.filters().stream()
-                    .map(f -> resolve(f, schema))
+                    .map(f -> resolve(f, schema, columnOrders))
                     .toList());
             case Or o -> new ResolvedPredicate.Or(o.filters().stream()
-                    .map(f -> resolve(f, schema))
+                    .map(f -> resolve(f, schema, columnOrders))
                     .toList());
             case Not n -> {
-                ResolvedPredicate resolvedDelegate = resolve(n.delegate(), schema);
+                ResolvedPredicate resolvedDelegate = resolve(n.delegate(), schema, columnOrders);
                 yield ResolvedPredicate.negate(resolvedDelegate);
             }
             case IntersectsPredicate p -> {
@@ -206,6 +225,14 @@ public class FilterPredicateResolver {
                         p.xmin(), p.ymin(), p.xmax(), p.ymax());
             }
         };
+    }
+
+    /// `true` when the leaf at `columnIndex` declares the IEEE 754 total order, whose signed-zero
+    /// statistics are exact. Any other case — type-defined order, an absent (empty) `column_orders`,
+    /// an out-of-range index, or an unrecognized order — yields `false`, so pruning widens `±0`.
+    private static boolean isIeee754TotalOrder(int columnIndex, List<ColumnOrder> columnOrders) {
+        return columnIndex < columnOrders.size()
+                && columnOrders.get(columnIndex) == ColumnOrder.IEEE754_TOTAL_ORDER;
     }
 
     // ==================== Column resolution ====================

--- a/core/src/main/java/dev/hardwood/internal/predicate/ResolvedPredicate.java
+++ b/core/src/main/java/dev/hardwood/internal/predicate/ResolvedPredicate.java
@@ -23,15 +23,37 @@ public sealed interface ResolvedPredicate {
 
     record IntPredicate(int columnIndex, FilterPredicate.Operator op, int value) implements ResolvedPredicate {}
     record LongPredicate(int columnIndex, FilterPredicate.Operator op, long value) implements ResolvedPredicate {}
-    record FloatPredicate(int columnIndex, FilterPredicate.Operator op, float value) implements ResolvedPredicate {}
+
+    /// `ieee754TotalOrder` carries the column's decoded [dev.hardwood.metadata.ColumnOrder]: `true`
+    /// only when it is the IEEE 754 total order, which orders `-0` below `+0` unambiguously, so
+    /// statistics min/max are exact. Under any other ordering (type-defined / absent / unrecognized)
+    /// the Parquet spec leaves `±0` ambiguous — a `+0` min may hide `-0` — so statistics pruning
+    /// widens `±0` bounds. The 3-arg convenience constructor defaults it to `false` (the conservative,
+    /// widening case) for callers that do not consult statistics (record/batch matching).
+    record FloatPredicate(int columnIndex, FilterPredicate.Operator op, float value,
+            boolean ieee754TotalOrder) implements ResolvedPredicate {
+        FloatPredicate(int columnIndex, FilterPredicate.Operator op, float value) {
+            this(columnIndex, op, value, false);
+        }
+    }
 
     /// User-facing `FloatColumnPredicate` against a column whose physical type is
     /// `FIXED_LEN_BYTE_ARRAY(2)` annotated `Float16Type`. Carried as a separate
     /// resolved type so evaluators can dispatch to the 2-byte decode path for
     /// both record values and stats min/max.
-    record Float16Predicate(int columnIndex, FilterPredicate.Operator op, float value) implements ResolvedPredicate {}
+    record Float16Predicate(int columnIndex, FilterPredicate.Operator op, float value,
+            boolean ieee754TotalOrder) implements ResolvedPredicate {
+        Float16Predicate(int columnIndex, FilterPredicate.Operator op, float value) {
+            this(columnIndex, op, value, false);
+        }
+    }
 
-    record DoublePredicate(int columnIndex, FilterPredicate.Operator op, double value) implements ResolvedPredicate {}
+    record DoublePredicate(int columnIndex, FilterPredicate.Operator op, double value,
+            boolean ieee754TotalOrder) implements ResolvedPredicate {
+        DoublePredicate(int columnIndex, FilterPredicate.Operator op, double value) {
+            this(columnIndex, op, value, false);
+        }
+    }
     record BooleanPredicate(int columnIndex, FilterPredicate.Operator op, boolean value) implements ResolvedPredicate {}
 
     /// Binary predicate with optional signed comparison for FIXED_LEN_BYTE_ARRAY decimals.
@@ -102,9 +124,12 @@ public sealed interface ResolvedPredicate {
         return switch (predicate) {
             case IntPredicate p -> new IntPredicate(p.columnIndex(), p.op().invert(), p.value());
             case LongPredicate p -> new LongPredicate(p.columnIndex(), p.op().invert(), p.value());
-            case FloatPredicate p -> new FloatPredicate(p.columnIndex(), p.op().invert(), p.value());
-            case Float16Predicate p -> new Float16Predicate(p.columnIndex(), p.op().invert(), p.value());
-            case DoublePredicate p -> new DoublePredicate(p.columnIndex(), p.op().invert(), p.value());
+            case FloatPredicate p -> new FloatPredicate(p.columnIndex(), p.op().invert(), p.value(),
+                    p.ieee754TotalOrder());
+            case Float16Predicate p -> new Float16Predicate(p.columnIndex(), p.op().invert(), p.value(),
+                    p.ieee754TotalOrder());
+            case DoublePredicate p -> new DoublePredicate(p.columnIndex(), p.op().invert(), p.value(),
+                    p.ieee754TotalOrder());
             case BooleanPredicate p -> new BooleanPredicate(p.columnIndex(), p.op().invert(), p.value());
             case BinaryPredicate p -> new BinaryPredicate(p.columnIndex(), p.op().invert(), p.value(), p.signed());
             case IsNullPredicate p -> new IsNotNullPredicate(p.columnIndex());

--- a/core/src/main/java/dev/hardwood/internal/predicate/StatisticsFilterSupport.java
+++ b/core/src/main/java/dev/hardwood/internal/predicate/StatisticsFilterSupport.java
@@ -37,13 +37,13 @@ final class StatisticsFilterSupport {
                     StatisticsDecoder.decodeLong(stats.maxValue()));
             case ResolvedPredicate.FloatPredicate p -> canDropFloat(p.op(), p.value(),
                     StatisticsDecoder.decodeFloat(stats.minValue()),
-                    StatisticsDecoder.decodeFloat(stats.maxValue()));
+                    StatisticsDecoder.decodeFloat(stats.maxValue()), p.ieee754TotalOrder());
             case ResolvedPredicate.Float16Predicate p -> canDropFloat(p.op(), p.value(),
                     StatisticsDecoder.decodeFloat16(stats.minValue()),
-                    StatisticsDecoder.decodeFloat16(stats.maxValue()));
+                    StatisticsDecoder.decodeFloat16(stats.maxValue()), p.ieee754TotalOrder());
             case ResolvedPredicate.DoublePredicate p -> canDropDouble(p.op(), p.value(),
                     StatisticsDecoder.decodeDouble(stats.minValue()),
-                    StatisticsDecoder.decodeDouble(stats.maxValue()));
+                    StatisticsDecoder.decodeDouble(stats.maxValue()), p.ieee754TotalOrder());
             case ResolvedPredicate.BooleanPredicate p -> canDrop(p.op(), p.value() ? 1 : 0,
                     StatisticsDecoder.decodeBoolean(stats.minValue()) ? 1 : 0,
                     StatisticsDecoder.decodeBoolean(stats.maxValue()) ? 1 : 0);
@@ -92,13 +92,22 @@ final class StatisticsFilterSupport {
         };
     }
 
-    static boolean canDropFloat(FilterPredicate.Operator op, float value, float min, float max) {
+    static boolean canDropFloat(FilterPredicate.Operator op, float value, float min, float max,
+            boolean ieee754TotalOrder) {
         // The Parquet spec forbids writing NaN to statistics min/max, but older / buggy writers
         // have produced such bounds. NaN sorts above every finite value in Float.compare's total
         // order, so applying the range checks below would silently prune row groups / pages that
         // hold matching finite rows. Treat NaN bounds as no-bound and never prune.
         if (Float.isNaN(min) || Float.isNaN(max)) {
             return false;
+        }
+        // Under the type-defined ordering the spec leaves +0/-0 ambiguous: a +0 min may hide -0, a
+        // -0 max may hide +0. Float.compare's total order separates them (-0 < +0), which could
+        // wrongly drop the opposite zero, so widen each zero bound to its total-order extreme. The
+        // IEEE 754 total order is unambiguous, so its bounds are already exact and left as-is.
+        if (!ieee754TotalOrder) {
+            min = (min == 0.0f) ? -0.0f : min;
+            max = (max == 0.0f) ? 0.0f : max;
         }
         return switch (op) {
             case EQ -> Float.compare(value, min) < 0 || Float.compare(value, max) > 0;
@@ -110,9 +119,16 @@ final class StatisticsFilterSupport {
         };
     }
 
-    static boolean canDropDouble(FilterPredicate.Operator op, double value, double min, double max) {
+    static boolean canDropDouble(FilterPredicate.Operator op, double value, double min, double max,
+            boolean ieee754TotalOrder) {
         if (Double.isNaN(min) || Double.isNaN(max)) {
             return false;
+        }
+        // See canDropFloat: widen ±0 bounds under the type-defined ordering, leave them exact for
+        // the unambiguous IEEE 754 total order.
+        if (!ieee754TotalOrder) {
+            min = (min == 0.0) ? -0.0 : min;
+            max = (max == 0.0) ? 0.0 : max;
         }
         return switch (op) {
             case EQ -> Double.compare(value, min) < 0 || Double.compare(value, max) > 0;

--- a/core/src/main/java/dev/hardwood/internal/thrift/ColumnOrderReader.java
+++ b/core/src/main/java/dev/hardwood/internal/thrift/ColumnOrderReader.java
@@ -1,0 +1,45 @@
+/*
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Copyright The original authors
+ *
+ *  Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package dev.hardwood.internal.thrift;
+
+import java.io.IOException;
+
+import dev.hardwood.metadata.ColumnOrder;
+
+/// Reader for the `ColumnOrder` union from Thrift Compact Protocol.
+///
+/// `ColumnOrder` is a union, so exactly one member field is set per entry. The set field id
+/// identifies the ordering; its value is an empty marker struct that carries no further data.
+public class ColumnOrderReader {
+
+    /// Thrift union field id of the `TYPE_ORDER` (`TypeDefinedOrder`) member.
+    private static final short TYPE_ORDER = 1;
+    /// Thrift union field id of the `IEEE_754_TOTAL_ORDER` (`IEEE754TotalOrder`) member.
+    private static final short IEEE_754_TOTAL_ORDER = 2;
+
+    public static ColumnOrder read(ThriftCompactReader reader) throws IOException {
+        short saved = reader.pushFieldIdContext();
+        try {
+            ColumnOrder order = ColumnOrder.UNKNOWN;
+            ThriftCompactReader.FieldHeader header = reader.readFieldHeader();
+            while (header != null) {
+                order = switch (header.fieldId()) {
+                    case TYPE_ORDER -> ColumnOrder.TYPE_DEFINED_ORDER;
+                    case IEEE_754_TOTAL_ORDER -> ColumnOrder.IEEE754_TOTAL_ORDER;
+                    default -> ColumnOrder.UNKNOWN;
+                };
+                reader.skipField(header.type());
+                header = reader.readFieldHeader();
+            }
+            return order;
+        }
+        finally {
+            reader.popFieldIdContext(saved);
+        }
+    }
+}

--- a/core/src/main/java/dev/hardwood/internal/thrift/FileMetaDataReader.java
+++ b/core/src/main/java/dev/hardwood/internal/thrift/FileMetaDataReader.java
@@ -14,6 +14,7 @@ import java.util.List;
 import java.util.Map;
 
 import dev.hardwood.internal.EncryptedParquetException;
+import dev.hardwood.metadata.ColumnOrder;
 import dev.hardwood.metadata.FileMetaData;
 import dev.hardwood.metadata.RowGroup;
 import dev.hardwood.metadata.SchemaElement;
@@ -30,6 +31,7 @@ public class FileMetaDataReader {
         List<RowGroup> rowGroups = new ArrayList<>();
         Map<String, String> keyValueMetadata = Collections.emptyMap();
         String createdBy = null;
+        List<ColumnOrder> columnOrders = Collections.emptyList();
 
         while (true) {
             ThriftCompactReader.FieldHeader header = reader.readFieldHeader();
@@ -92,6 +94,18 @@ public class FileMetaDataReader {
                         reader.skipField(header.type());
                     }
                     break;
+                case 7: // column_orders (optional list<ColumnOrder>)
+                    if (header.type() == 0x09) { // LIST
+                        ThriftCompactReader.CollectionHeader listHeader = reader.readListHeader();
+                        columnOrders = new ArrayList<>(listHeader.size());
+                        for (int i = 0; i < listHeader.size(); i++) {
+                            columnOrders.add(ColumnOrderReader.read(reader));
+                        }
+                    }
+                    else {
+                        reader.skipField(header.type());
+                    }
+                    break;
                 case 8: // encryption_algorithm (present only with a plaintext footer)
                     // The footer parses, but the column data is encrypted and
                     // Hardwood cannot decrypt it. Fail fast rather than letting a
@@ -103,6 +117,7 @@ public class FileMetaDataReader {
             }
         }
 
-        return new FileMetaData(version, schema, numRows, rowGroups, keyValueMetadata, createdBy);
+        return new FileMetaData(version, schema, numRows, rowGroups, keyValueMetadata, createdBy,
+                columnOrders);
     }
 }

--- a/core/src/main/java/dev/hardwood/metadata/ColumnOrder.java
+++ b/core/src/main/java/dev/hardwood/metadata/ColumnOrder.java
@@ -1,0 +1,27 @@
+/*
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Copyright The original authors
+ *
+ *  Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package dev.hardwood.metadata;
+
+/// The ordering used for a leaf column's `min`/`max` statistics, decoded from the
+/// `FileMetaData.column_orders` union.
+///
+/// When a file omits `column_orders`, the type-defined ordering applies implicitly to every
+/// column and [FileMetaData#columnOrders] is empty.
+///
+/// @see <a href="https://github.com/apache/parquet-format/blob/master/src/main/thrift/parquet.thrift">parquet.thrift</a>
+public enum ColumnOrder {
+    /// Ordering defined by the column's physical or logical type (the `TYPE_ORDER` union member).
+    /// For `FLOAT` and `DOUBLE` this is a signed comparison of the represented value, with the
+    /// documented NaN and ±0 compatibility rules applied when reading statistics.
+    TYPE_DEFINED_ORDER,
+    /// The IEEE 754 total order (the `IEEE_754_TOTAL_ORDER` union member).
+    IEEE754_TOTAL_ORDER,
+    /// A `ColumnOrder` union member that this version of Hardwood does not recognize, e.g. an
+    /// ordering added to the Parquet format after this release.
+    UNKNOWN
+}

--- a/core/src/main/java/dev/hardwood/metadata/FileMetaData.java
+++ b/core/src/main/java/dev/hardwood/metadata/FileMetaData.java
@@ -18,6 +18,8 @@ import java.util.Map;
 /// @param rowGroups metadata for each row group in the file
 /// @param keyValueMetadata application-defined key-value metadata, or an empty map if absent
 /// @param createdBy identifier of the library that wrote the file, or `null` if absent
+/// @param columnOrders the statistics ordering for each leaf column, in schema order, or an empty
+///        list if the file omits `column_orders` (in which case the type-defined ordering applies)
 /// @see <a href="https://parquet.apache.org/docs/file-format/metadata/#file-metadata">File Format – File Metadata</a>
 /// @see <a href="https://github.com/apache/parquet-format/blob/master/src/main/thrift/parquet.thrift">parquet.thrift</a>
 public record FileMetaData(
@@ -26,5 +28,6 @@ public record FileMetaData(
         long numRows,
         List<RowGroup> rowGroups,
         Map<String, String> keyValueMetadata,
-        String createdBy) {
+        String createdBy,
+        List<ColumnOrder> columnOrders) {
 }

--- a/core/src/main/java/dev/hardwood/reader/ParquetFileReader.java
+++ b/core/src/main/java/dev/hardwood/reader/ParquetFileReader.java
@@ -384,7 +384,7 @@ public class ParquetFileReader implements AutoCloseable {
                                      long maxRows, List<RowGroup> firstFileRowGroups,
                                      long tailSkip) {
         ResolvedPredicate resolved = filter != null
-                ? FilterPredicateResolver.resolve(filter, schema) : null;
+                ? FilterPredicateResolver.resolve(filter, schema, firstFileMetaData.columnOrders()) : null;
 
         ProjectedSchema projectedSchema = ProjectedSchema.create(schema, projection);
 
@@ -467,7 +467,7 @@ public class ParquetFileReader implements AutoCloseable {
             RowGroupPredicate rowGroupFilter,
             int batchSize) {
         ResolvedPredicate resolved = filter != null
-                ? FilterPredicateResolver.resolve(filter, schema) : null;
+                ? FilterPredicateResolver.resolve(filter, schema, firstFileMetaData.columnOrders()) : null;
         List<RowGroup> rowGroups = filterRowGroups(resolved, rowGroupFilter);
 
         if (resolved == null) {

--- a/core/src/test/java/dev/hardwood/ColumnOrdersTest.java
+++ b/core/src/test/java/dev/hardwood/ColumnOrdersTest.java
@@ -1,0 +1,38 @@
+/*
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Copyright The original authors
+ *
+ *  Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package dev.hardwood;
+
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+
+import dev.hardwood.metadata.ColumnOrder;
+import dev.hardwood.reader.ParquetFileReader;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/// Tests that `FileMetaData.column_orders` is decoded and surfaced.
+///
+/// `primitive_types_test.parquet` (written by PyArrow) carries one `ColumnOrder` per leaf; PyArrow
+/// emits the type-defined ordering for every column, floats and doubles included.
+class ColumnOrdersTest {
+
+    private static final Path FILE = Paths.get("src/test/resources/primitive_types_test.parquet");
+
+    @Test
+    void columnOrdersSurfaceTypeDefinedOrderForEveryColumn() throws Exception {
+        try (ParquetFileReader reader = ParquetFileReader.open(InputFile.of(FILE))) {
+            List<ColumnOrder> orders = reader.getFileMetaData().columnOrders();
+            // int, long, float, double, bool, string, binary
+            assertThat(orders).hasSize(7);
+            assertThat(orders).containsOnly(ColumnOrder.TYPE_DEFINED_ORDER);
+        }
+    }
+}

--- a/core/src/test/java/dev/hardwood/internal/predicate/FilterPredicateResolverTest.java
+++ b/core/src/test/java/dev/hardwood/internal/predicate/FilterPredicateResolverTest.java
@@ -16,6 +16,7 @@ import java.util.UUID;
 
 import org.junit.jupiter.api.Test;
 
+import dev.hardwood.metadata.ColumnOrder;
 import dev.hardwood.metadata.LogicalType;
 import dev.hardwood.metadata.PhysicalType;
 import dev.hardwood.metadata.RepetitionType;
@@ -415,6 +416,51 @@ class FilterPredicateResolverTest {
                 FilterPredicate.not(FilterPredicate.intersects("loc", 0.0, 0.0, 1.0, 1.0)), schema))
                 .isInstanceOf(UnsupportedOperationException.class)
                 .hasMessageContaining("Negation");
+    }
+
+    // ==================== Column order propagation (#595) ====================
+
+    @Test
+    void floatTypeDefinedOrderMarksPredicateForWidening() {
+        FileSchema schema = schemaWithLogicalType("f", PhysicalType.FLOAT, null);
+        ResolvedPredicate resolved = FilterPredicateResolver.resolve(
+                FilterPredicate.eq("f", 1.0f), schema, List.of(ColumnOrder.TYPE_DEFINED_ORDER));
+        assertThat(((ResolvedPredicate.FloatPredicate) resolved).ieee754TotalOrder()).isFalse();
+    }
+
+    @Test
+    void floatIeee754OrderMarksPredicateExact() {
+        FileSchema schema = schemaWithLogicalType("f", PhysicalType.FLOAT, null);
+        ResolvedPredicate resolved = FilterPredicateResolver.resolve(
+                FilterPredicate.eq("f", 1.0f), schema, List.of(ColumnOrder.IEEE754_TOTAL_ORDER));
+        assertThat(((ResolvedPredicate.FloatPredicate) resolved).ieee754TotalOrder()).isTrue();
+    }
+
+    @Test
+    void doubleAbsentColumnOrdersDefaultsToTypeDefined() {
+        FileSchema schema = schemaWithLogicalType("d", PhysicalType.DOUBLE, null);
+        ResolvedPredicate resolved = FilterPredicateResolver.resolve(
+                FilterPredicate.eq("d", 1.0), schema, List.of());
+        assertThat(((ResolvedPredicate.DoublePredicate) resolved).ieee754TotalOrder()).isFalse();
+    }
+
+    @Test
+    void float16TypeDefinedOrderMarksPredicateForWidening() {
+        FileSchema schema = schemaWithLogicalType("h", PhysicalType.FIXED_LEN_BYTE_ARRAY, 2,
+                new LogicalType.Float16Type());
+        ResolvedPredicate resolved = FilterPredicateResolver.resolve(
+                FilterPredicate.eq("h", 1.0f), schema, List.of(ColumnOrder.TYPE_DEFINED_ORDER));
+        assertThat(resolved).isInstanceOf(ResolvedPredicate.Float16Predicate.class);
+        assertThat(((ResolvedPredicate.Float16Predicate) resolved).ieee754TotalOrder()).isFalse();
+    }
+
+    @Test
+    void float16Ieee754OrderMarksPredicateExact() {
+        FileSchema schema = schemaWithLogicalType("h", PhysicalType.FIXED_LEN_BYTE_ARRAY, 2,
+                new LogicalType.Float16Type());
+        ResolvedPredicate resolved = FilterPredicateResolver.resolve(
+                FilterPredicate.eq("h", 1.0f), schema, List.of(ColumnOrder.IEEE754_TOTAL_ORDER));
+        assertThat(((ResolvedPredicate.Float16Predicate) resolved).ieee754TotalOrder()).isTrue();
     }
 
     // ==================== Helpers ====================

--- a/core/src/test/java/dev/hardwood/internal/predicate/NaNStatisticsFilterTest.java
+++ b/core/src/test/java/dev/hardwood/internal/predicate/NaNStatisticsFilterTest.java
@@ -9,6 +9,7 @@ package dev.hardwood.internal.predicate;
 
 import java.util.stream.Stream;
 
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.EnumSource;
@@ -29,7 +30,7 @@ class NaNStatisticsFilterTest {
     @ParameterizedTest(name = "double {0} with NaN min")
     @EnumSource(Operator.class)
     void doubleNaNMinNeverDrops(Operator op) {
-        assertThat(StatisticsFilterSupport.canDropDouble(op, 1.0, Double.NaN, 10.0))
+        assertThat(StatisticsFilterSupport.canDropDouble(op, 1.0, Double.NaN, 10.0, false))
                 .as("NaN min must be treated as no-bound and never prune")
                 .isFalse();
     }
@@ -37,7 +38,7 @@ class NaNStatisticsFilterTest {
     @ParameterizedTest(name = "double {0} with NaN max")
     @EnumSource(Operator.class)
     void doubleNaNMaxNeverDrops(Operator op) {
-        assertThat(StatisticsFilterSupport.canDropDouble(op, 1.0, -10.0, Double.NaN))
+        assertThat(StatisticsFilterSupport.canDropDouble(op, 1.0, -10.0, Double.NaN, false))
                 .as("NaN max must be treated as no-bound and never prune")
                 .isFalse();
     }
@@ -45,14 +46,14 @@ class NaNStatisticsFilterTest {
     @ParameterizedTest(name = "double {0} with NaN min and max")
     @EnumSource(Operator.class)
     void doubleNaNBothNeverDrops(Operator op) {
-        assertThat(StatisticsFilterSupport.canDropDouble(op, 1.0, Double.NaN, Double.NaN))
+        assertThat(StatisticsFilterSupport.canDropDouble(op, 1.0, Double.NaN, Double.NaN, false))
                 .isFalse();
     }
 
     @ParameterizedTest(name = "float {0} with NaN min")
     @EnumSource(Operator.class)
     void floatNaNMinNeverDrops(Operator op) {
-        assertThat(StatisticsFilterSupport.canDropFloat(op, 1.0f, Float.NaN, 10.0f))
+        assertThat(StatisticsFilterSupport.canDropFloat(op, 1.0f, Float.NaN, 10.0f, false))
                 .as("NaN min must be treated as no-bound and never prune")
                 .isFalse();
     }
@@ -60,7 +61,7 @@ class NaNStatisticsFilterTest {
     @ParameterizedTest(name = "float {0} with NaN max")
     @EnumSource(Operator.class)
     void floatNaNMaxNeverDrops(Operator op) {
-        assertThat(StatisticsFilterSupport.canDropFloat(op, 1.0f, -10.0f, Float.NaN))
+        assertThat(StatisticsFilterSupport.canDropFloat(op, 1.0f, -10.0f, Float.NaN, false))
                 .as("NaN max must be treated as no-bound and never prune")
                 .isFalse();
     }
@@ -68,7 +69,7 @@ class NaNStatisticsFilterTest {
     @ParameterizedTest(name = "float {0} with NaN min and max")
     @EnumSource(Operator.class)
     void floatNaNBothNeverDrops(Operator op) {
-        assertThat(StatisticsFilterSupport.canDropFloat(op, 1.0f, Float.NaN, Float.NaN))
+        assertThat(StatisticsFilterSupport.canDropFloat(op, 1.0f, Float.NaN, Float.NaN, false))
                 .isFalse();
     }
 
@@ -77,7 +78,7 @@ class NaNStatisticsFilterTest {
     @ParameterizedTest(name = "double {0}({1}) on [{2},{3}] expectDrop={4}")
     @MethodSource
     void doubleFiniteStillPrunes(Operator op, double value, double min, double max, boolean expectDrop) {
-        assertThat(StatisticsFilterSupport.canDropDouble(op, value, min, max)).isEqualTo(expectDrop);
+        assertThat(StatisticsFilterSupport.canDropDouble(op, value, min, max, false)).isEqualTo(expectDrop);
     }
 
     static Stream<Arguments> doubleFiniteStillPrunes() {
@@ -87,5 +88,34 @@ class NaNStatisticsFilterTest {
                 Arguments.of(Operator.GT,   20.0, 1.0, 10.0, true),  // all values <= 10 → drop
                 Arguments.of(Operator.EQ,  100.0, 1.0, 10.0, true),  // 100 out of [1,10] → drop
                 Arguments.of(Operator.EQ,    5.0, 1.0, 10.0, false));
+    }
+
+    /// Order-aware ±0 pruning (#595). Under the type-defined ordering (`ieee754TotalOrder == false`)
+    /// the spec leaves `+0`/`-0` ambiguous, so a zero bound is widened and the opposite zero is not
+    /// dropped. Under the IEEE 754 total order the bounds are exact, so `-0 < +0` prunes precisely.
+    @Test
+    void typeDefinedZeroBoundDoesNotDropOppositeZero() {
+        // min = +0, max = +0 may also hold -0 → == -0 must not drop.
+        assertThat(StatisticsFilterSupport.canDropFloat(Operator.EQ, -0.0f, 0.0f, 0.0f, false)).isFalse();
+        assertThat(StatisticsFilterSupport.canDropDouble(Operator.EQ, -0.0, 0.0, 0.0, false)).isFalse();
+        // max = -0, min = -0 may also hold +0 → == +0 must not drop.
+        assertThat(StatisticsFilterSupport.canDropFloat(Operator.EQ, 0.0f, -0.0f, -0.0f, false)).isFalse();
+        assertThat(StatisticsFilterSupport.canDropDouble(Operator.EQ, 0.0, -0.0, -0.0, false)).isFalse();
+    }
+
+    @Test
+    void ieee754ZeroBoundPrunesExactly() {
+        // Total order is unambiguous: min = +0 genuinely excludes -0 → == -0 prunes.
+        assertThat(StatisticsFilterSupport.canDropFloat(Operator.EQ, -0.0f, 0.0f, 0.0f, true)).isTrue();
+        assertThat(StatisticsFilterSupport.canDropDouble(Operator.EQ, -0.0, 0.0, 0.0, true)).isTrue();
+        // max = -0 genuinely excludes +0 → == +0 prunes.
+        assertThat(StatisticsFilterSupport.canDropFloat(Operator.EQ, 0.0f, -0.0f, -0.0f, true)).isTrue();
+        assertThat(StatisticsFilterSupport.canDropDouble(Operator.EQ, 0.0, -0.0, -0.0, true)).isTrue();
+    }
+
+    @Test
+    void zeroBoundsStillPruneNonZeroValuesUnderBothOrders() {
+        assertThat(StatisticsFilterSupport.canDropFloat(Operator.EQ, 5.0f, -0.0f, 0.0f, false)).isTrue();
+        assertThat(StatisticsFilterSupport.canDropFloat(Operator.EQ, 5.0f, -0.0f, 0.0f, true)).isTrue();
     }
 }

--- a/core/src/test/java/dev/hardwood/internal/predicate/PageFilterEvaluatorTest.java
+++ b/core/src/test/java/dev/hardwood/internal/predicate/PageFilterEvaluatorTest.java
@@ -200,7 +200,7 @@ class PageFilterEvaluatorTest {
                 (columnIndex, pageIndex) -> {
                     float min = StatisticsDecoder.decodeFloat(columnIndex.minValues().get(pageIndex));
                     float max = StatisticsDecoder.decodeFloat(columnIndex.maxValues().get(pageIndex));
-                    return StatisticsFilterSupport.canDropFloat(op, value, min, max);
+                    return StatisticsFilterSupport.canDropFloat(op, value, min, max, false);
                 });
 
         assertEquals(page0Kept, ranges.overlapsPage(0, 50),  "page 0 (rows 0-50)");
@@ -238,7 +238,7 @@ class PageFilterEvaluatorTest {
                 (columnIndex, pageIndex) -> {
                     double min = StatisticsDecoder.decodeDouble(columnIndex.minValues().get(pageIndex));
                     double max = StatisticsDecoder.decodeDouble(columnIndex.maxValues().get(pageIndex));
-                    return StatisticsFilterSupport.canDropDouble(op, value, min, max);
+                    return StatisticsFilterSupport.canDropDouble(op, value, min, max, false);
                 });
 
         assertEquals(page0Kept, ranges.overlapsPage(0, 50),  "page 0 (rows 0-50)");

--- a/core/src/test/java/dev/hardwood/internal/thrift/ColumnOrderReaderTest.java
+++ b/core/src/test/java/dev/hardwood/internal/thrift/ColumnOrderReaderTest.java
@@ -1,0 +1,55 @@
+/*
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Copyright The original authors
+ *
+ *  Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package dev.hardwood.internal.thrift;
+
+import java.nio.ByteBuffer;
+
+import org.junit.jupiter.api.Test;
+
+import dev.hardwood.metadata.ColumnOrder;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/// Unit tests for [ColumnOrderReader], decoding the `ColumnOrder` Thrift union.
+///
+/// Each union entry is a struct holding one member field (an empty marker struct) followed by a
+/// STOP byte. The field header byte packs the field-id delta in the high nibble and the Thrift
+/// type (0x0C = STRUCT) in the low nibble.
+class ColumnOrderReaderTest {
+
+    private static ColumnOrder decode(byte... bytes) throws Exception {
+        return ColumnOrderReader.read(new ThriftCompactReader(ByteBuffer.wrap(bytes)));
+    }
+
+    @Test
+    void decodesTypeDefinedOrder() throws Exception {
+        // field id 1 (TYPE_ORDER), STRUCT type → header 0x1C; empty marker struct STOP; union STOP
+        assertThat(decode((byte) 0x1C, (byte) 0x00, (byte) 0x00))
+                .isEqualTo(ColumnOrder.TYPE_DEFINED_ORDER);
+    }
+
+    @Test
+    void decodesIeee754TotalOrder() throws Exception {
+        // field id 2 (IEEE_754_TOTAL_ORDER) → header 0x2C
+        assertThat(decode((byte) 0x2C, (byte) 0x00, (byte) 0x00))
+                .isEqualTo(ColumnOrder.IEEE754_TOTAL_ORDER);
+    }
+
+    @Test
+    void decodesUnknownUnionMemberAsUnknown() throws Exception {
+        // field id 3 — a future union member Hardwood does not recognize → header 0x3C
+        assertThat(decode((byte) 0x3C, (byte) 0x00, (byte) 0x00))
+                .isEqualTo(ColumnOrder.UNKNOWN);
+    }
+
+    @Test
+    void decodesEmptyUnionAsUnknown() throws Exception {
+        // An empty union (immediate STOP) carries no member; treat leniently as UNKNOWN.
+        assertThat(decode((byte) 0x00)).isEqualTo(ColumnOrder.UNKNOWN);
+    }
+}

--- a/docs/content/how-to/metadata.md
+++ b/docs/content/how-to/metadata.md
@@ -15,13 +15,14 @@ Inspecting metadata before reading is useful for understanding file structure, c
 
 A Parquet file is organized as follows:
 
-- **FileMetaData** — top-level: row count, schema, key-value metadata (e.g. Spark schema, pandas metadata), and the writer that produced the file (`createdBy`)
+- **FileMetaData** — top-level: row count, schema, key-value metadata (e.g. Spark schema, pandas metadata), the writer that produced the file (`createdBy`), and the per-column statistics ordering (`columnOrders`)
 - **RowGroup** — a horizontal partition of the data; each row group contains all columns for a subset of rows
 - **ColumnChunk** — one column within a row group; holds compression codec, byte sizes, and optional statistics (min/max values, null count) used for predicate pushdown. Per-chunk byte ranges for the column index and offset index (when present in the file) are exposed via `columnIndexOffset`/`columnIndexLength` and `offsetIndexOffset`/`offsetIndexLength` on `ColumnChunk`. The bloom-filter byte range (`bloomFilterOffset`/`bloomFilterLength`) is exposed on `ColumnMetaData`, matching its position in the Parquet Thrift schema.
 
 ```java
 import dev.hardwood.metadata.ColumnChunk;
 import dev.hardwood.metadata.ColumnMetaData;
+import dev.hardwood.metadata.ColumnOrder;
 import dev.hardwood.metadata.FileMetaData;
 import dev.hardwood.metadata.RowGroup;
 import dev.hardwood.metadata.Statistics;
@@ -29,6 +30,7 @@ import dev.hardwood.reader.ParquetFileReader;
 import dev.hardwood.schema.ColumnSchema;
 import dev.hardwood.schema.FileSchema;
 
+import java.util.List;
 import java.util.Map;
 
 try (ParquetFileReader reader = ParquetFileReader.open(InputFile.of(path))) {
@@ -43,6 +45,11 @@ try (ParquetFileReader reader = ParquetFileReader.open(InputFile.of(path))) {
     for (Map.Entry<String, String> entry : kvMetadata.entrySet()) {
         System.out.println("  " + entry.getKey() + " = " + entry.getValue());
     }
+
+    // The statistics ordering for each leaf column, in schema order. Empty when the file omits
+    // column_orders, in which case the type-defined ordering applies to every column. The value is
+    // one of ColumnOrder.TYPE_DEFINED_ORDER, IEEE754_TOTAL_ORDER, or UNKNOWN.
+    List<ColumnOrder> columnOrders = metadata.columnOrders();
 
     // Schema inspection
     FileSchema schema = reader.getFileSchema();


### PR DESCRIPTION
Hey, I've been looking into #595, checking pyarrow, it's still not following the recommendation to use `IEEE_754_TOTAL_ORDER`, it writes `TYPE_ORDER`, yet it does follow [the spec](https://github.com/apache/parquet-format/blob/325b9f4a70663c88485d4d59fdc1a121d7497943/src/main/thrift/parquet.thrift#L1126-L1169) correctly, writing `+0.0` for a zero max and `-0.0` for a zero min, hence why it was working as expected

On the other side, for writers who don't normalise those bounds, the spec identifies it as a compatibility rule to apply under the type-defined order:

> If the min is +0, the row group may contain -0 values as well.
> If the max is -0, the row group may contain +0 values as well.

Since it's being mentioned as a compatibility rule, I'd rather honor it than drop accuracy with a warning, so in this PR, I chose to widen the bounds to `[-0.0, +0.0]` for the type-defined order before pruning float/double statistics. columns with `IEEE_754_TOTAL_ORDER` order prune exactly with no widening


No strong opinion, though, happy to revert to the warning approach if you feel strongly about it, but since the spec frames it as a reader compatibility rule, following it keeps old/non-compliant files correct rather than just flagging them.

I'm not sure, but if we agree on shipping it in this way, perhaps it should land on 1.0 instead of 1.1? 

## Checklist

- [x] Build via `./mvnw clean verify` passes
- [x] The commit message is prefixed with the issue key ("#123 Adding support for...")
- [x] Code changes are covered by tests
- [x] If this PR adds or changes user-facing behaviour, `docs/` has been updated
