### PR TITLE
#651 Adding examples links and little improvements

### DIFF
--- a/docs/content/concepts/concurrency-model.md
+++ b/docs/content/concepts/concurrency-model.md
@@ -94,3 +94,6 @@ shared pool matters, since all the files draw on the same workers. See
   decode itself.
 - [Read Multiple Files as One Dataset](../how-to/multi-file.md) — the cross-file API and pool
   sharing in practice.
+- [Concurrent Column Consumer](https://github.com/hardwood-hq/hardwood-examples/tree/main/concurrent-column-consumer)
+  — a runnable example that fans each batch's per-value work across a thread pool, with a
+  single-threaded baseline to show the gains.

--- a/docs/content/concepts/nested-columns.md
+++ b/docs/content/concepts/nested-columns.md
@@ -18,6 +18,13 @@ model** is how `ColumnReader` expresses that structure without boxing or per-row
 explains the model; for worked code against it, see
 [Column-Oriented Reading](../how-to/column-reader.md).
 
+!!! example "Try it yourself"
+    Want to run it or explore the capabilities yourself?
+    [**Layer Model**](https://github.com/hardwood-hq/hardwood-examples/tree/main/layer-model) counts list
+    and map items from offsets without materializing rows, and
+    [**Nested Data**](https://github.com/hardwood-hq/hardwood-examples/tree/main/nested-data) reads the
+    same shapes through the Row API.
+
 > **A note on lineage.** The layer model — flat value arrays, offset buffers, and set-bit-present
 > validity bitmaps — takes inspiration from [Apache Arrow](https://arrow.apache.org/)'s columnar
 > representation, so the shapes feel familiar if you come from an Arrow-based engine. The

--- a/docs/content/getting-started.md
+++ b/docs/content/getting-started.md
@@ -150,4 +150,4 @@ If you attempt to read a file using a compression codec whose library is not on 
 
 With the core dependency in place, you're ready to read. The [Read Your First Parquet File](tutorial/first-read.md) tutorial walks through it end-to-end against a real dataset — printing the schema, reading rows with typed accessors, narrowing the read with a projection and a filter, and summing a column the columnar way.
 
-For the full API — column projection, predicate pushdown, column-oriented reading, and more — see the [How-to Guides](how-to/index.md).
+For the full API — column projection, predicate pushdown, column-oriented reading, and more — see the [How-to Guides](how-to/index.md). For example projects you can clone and run, see the [hardwood-examples](https://github.com/hardwood-hq/hardwood-examples) repository.

--- a/docs/content/how-to/column-reader.md
+++ b/docs/content/how-to/column-reader.md
@@ -16,6 +16,9 @@ The `ColumnReader` provides batch-oriented columnar access with typed primitive 
 !!! warning "Experimental API"
     The `ColumnReader` is under active development; the shape of the batch accessors and layer representation may change in future releases without prior deprecation.
 
+!!! example "Try it yourself"
+    Want to run it or explore the capabilities yourself? [**Column Analytics**](https://github.com/hardwood-hq/hardwood-examples/tree/main/column-analytics) aggregates a column batch by batch, [**Layer Model**](https://github.com/hardwood-hq/hardwood-examples/tree/main/layer-model) reads nested columns from offsets, and [**Concurrent Column Consumer**](https://github.com/hardwood-hq/hardwood-examples/tree/main/concurrent-column-consumer) fans batch arrays across a thread pool.
+
 ### Reading a Single Column
 
 ```java
@@ -384,7 +387,7 @@ Two orthogonal offset axes show up here, as in `list<string>`: `entryOffsets` wa
 If the map sits under an `OPTIONAL` group — e.g. `optional group meta { map<string, int> tags }` — the chain gains a `STRUCT` layer on top. The same key/value lockstep walk applies, with `getLayerValidity(0)` for `meta`, `getLayerValidity(1)` plus `getLayerOffsets(1)` for the map, and `getLeafValidity()` for the value:
 
 ```java
-Validity metaValidity  = reader.getLayerValidity(0);   // STRUCT layer for `meta`
-Validity mapValidity   = reader.getLayerValidity(1);   // REPEATED layer for the map
-int[]    entryOffsets  = reader.getLayerOffsets(1);
+Validity metaValidity  = values.getLayerValidity(0);   // STRUCT layer for `meta`
+Validity mapValidity   = values.getLayerValidity(1);   // REPEATED layer for the map
+int[]    entryOffsets  = values.getLayerOffsets(1);
 ```

--- a/docs/content/how-to/geospatial.md
+++ b/docs/content/how-to/geospatial.md
@@ -13,6 +13,9 @@
 
 Hardwood reads the [Parquet geospatial metadata layer](https://parquet.apache.org/docs/file-format/types/geospatial/) — GEOMETRY / GEOGRAPHY logical types and per-chunk `GeospatialStatistics` — and offers a bounding-box filter predicate that pushes spatial selectivity down to the row group level. Hardwood does not decode WKB payloads itself — geometry decoding is left to the caller, so the reader has no runtime geometry-library dependency. The de-facto standard Java library for this is the [JTS Topology Suite](https://locationtech.github.io/jts/); the snippets below assume JTS, but any WKB decoder works.
 
+!!! example "Try it yourself"
+    Want to run it or explore the capabilities yourself? The [**Geospatial**](https://github.com/hardwood-hq/hardwood-examples/tree/main/geospatial) example reads a GEOMETRY column, pushes a bounding-box filter down to the row-group level, and decodes WKB points with JTS.
+
 To use JTS in the examples below, add the `jts-core` dependency:
 
 ```xml
@@ -88,7 +91,7 @@ import org.locationtech.jts.io.WKBReader;
 
 FilterPredicate filter = FilterPredicate.intersects("location", -25.0, 35.0, 45.0, 72.0);
 try (ParquetFileReader fileReader = ParquetFileReader.open(InputFile.of(path));
-        RowReader rowReader = fileReader.createRowReader(filter)) {
+        RowReader rowReader = fileReader.buildRowReader().filter(filter).build()) {
     WKBReader wkbReader = new WKBReader();
     while (rowReader.hasNext()) {
         rowReader.next();

--- a/docs/content/how-to/index.md
+++ b/docs/content/how-to/index.md
@@ -24,6 +24,12 @@ Read Parquet files with Hardwood — pick the guide that matches what you need:
 - [**Read Geospatial Columns**](geospatial.md) — GEOMETRY / GEOGRAPHY columns, bounding-box filter pushdown.
 - [**Inspect File Metadata**](metadata.md) — file metadata, row groups, column chunks, schema introspection.
 
+!!! example "Runnable examples"
+    Each guide below links to a matching standalone example in the
+    [hardwood-examples](https://github.com/hardwood-hq/hardwood-examples) repository — every example is a
+    complete project you can clone and run with a single command. New to Hardwood? Start with
+    [Hello Hardwood](https://github.com/hardwood-hq/hardwood-examples/tree/main/hello-hardwood).
+
 For detailed class-level documentation, see the [JavaDoc](/api/latest/).
 
 ## Choosing a Reader

--- a/docs/content/how-to/metadata.md
+++ b/docs/content/how-to/metadata.md
@@ -13,6 +13,9 @@
 
 Inspecting metadata before reading is useful for understanding file structure, choosing which columns to project, validating files in a pipeline, or building tooling. Hardwood exposes the full Parquet metadata hierarchy without reading any row data.
 
+!!! example "Try it yourself"
+    Want to run it or explore the capabilities yourself? The [**Metadata Explorer**](https://github.com/hardwood-hq/hardwood-examples/tree/main/metadata-explorer) example describes a Parquet file from its footer alone — version, schema, and per-row-group column statistics.
+
 A Parquet file is organized as follows:
 
 - **FileMetaData** — top-level: row count, schema, key-value metadata (e.g. Spark schema, pandas metadata), the writer that produced the file (`createdBy`), and the per-column statistics ordering (`columnOrders`)

--- a/docs/content/how-to/multi-file.md
+++ b/docs/content/how-to/multi-file.md
@@ -14,6 +14,9 @@
 When processing multiple Parquet files, use the `Hardwood` class to share a thread pool across readers.
 `Hardwood.openAll(List<InputFile>)` returns a `ParquetFileReader` over many files. The same `RowReader`, `ColumnReader`, and `ColumnReaders` APIs apply.
 
+!!! example "Try it yourself"
+    Want to run it or explore the capabilities yourself? [**Multi-File**](https://github.com/hardwood-hq/hardwood-examples/tree/main/multi-file) reads three months of data as one dataset, and [**Byte Buffer Source**](https://github.com/hardwood-hq/hardwood-examples/tree/main/byte-buffer-source) reads several in-memory `ByteBuffer`s as one dataset.
+
 ```java
 import dev.hardwood.Hardwood;
 import dev.hardwood.InputFile;

--- a/docs/content/how-to/query-controls.md
+++ b/docs/content/how-to/query-controls.md
@@ -11,6 +11,9 @@
 -->
 # Predicate Pushdown, Projection, Limits, and Splits
 
+!!! example "Try it yourself"
+    Want to run it or explore the capabilities yourself? The [**Query Controls**](https://github.com/hardwood-hq/hardwood-examples/tree/main/query-controls) example filters, projects, limits, paginates, and splits a read by byte range.
+
 ## Predicate Pushdown (Filter)
 
 Filter predicates apply at three levels, in this order:

--- a/docs/content/how-to/row-reader.md
+++ b/docs/content/how-to/row-reader.md
@@ -13,6 +13,9 @@
 
 The `RowReader` provides a convenient row-oriented interface for reading Parquet files with typed accessor methods for type-safe field access.
 
+!!! example "Try it yourself"
+    Want to run it or explore the capabilities yourself? [**Nested Data**](https://github.com/hardwood-hq/hardwood-examples/tree/main/nested-data) walks structs, lists, and maps with the Row API, and [**Hello Hardwood**](https://github.com/hardwood-hq/hardwood-examples/tree/main/hello-hardwood) covers the basics.
+
 ```java
 import dev.hardwood.InputFile;
 import dev.hardwood.reader.ParquetFileReader;

--- a/docs/content/how-to/s3.md
+++ b/docs/content/how-to/s3.md
@@ -13,6 +13,9 @@
 
 Parquet files often live in cloud object storage rather than on local disk. The `hardwood-s3` module lets you read them directly from Amazon S3 and S3-compatible services (Cloudflare R2, GCP Cloud Storage via HMAC keys, MinIO) without downloading files first. Hardwood minimizes S3 requests by pre-fetching the file footer on open and coalescing column chunk reads within each row group. Column projection and page-level predicate pushdown further reduce the amount of data transferred.
 
+!!! example "Try it yourself"
+    Want to run it or explore the capabilities yourself? The [**Reading from S3**](https://github.com/hardwood-hq/hardwood-examples/tree/main/reading-from-s3) example streams a Parquet file straight from an S3-compatible endpoint against a throwaway Testcontainers S3 server (no AWS account needed), proves projection only fetches the byte ranges it needs via `networkBytesFetched()` / `networkRequestCount()`, and opens a whole bucket as one dataset with `Hardwood.openAll(...)`.
+
 ```xml
 <dependency>
     <groupId>dev.hardwood</groupId>

--- a/docs/content/how-to/s3.md
+++ b/docs/content/how-to/s3.md
@@ -14,7 +14,7 @@
 Parquet files often live in cloud object storage rather than on local disk. The `hardwood-s3` module lets you read them directly from Amazon S3 and S3-compatible services (Cloudflare R2, GCP Cloud Storage via HMAC keys, MinIO) without downloading files first. Hardwood minimizes S3 requests by pre-fetching the file footer on open and coalescing column chunk reads within each row group. Column projection and page-level predicate pushdown further reduce the amount of data transferred.
 
 !!! example "Try it yourself"
-    Want to run it or explore the capabilities yourself? The [**Reading from S3**](https://github.com/hardwood-hq/hardwood-examples/tree/main/reading-from-s3) example streams a Parquet file straight from an S3-compatible endpoint against a throwaway Testcontainers S3 server (no AWS account needed), proves projection only fetches the byte ranges it needs via `networkBytesFetched()` / `networkRequestCount()`, and opens a whole bucket as one dataset with `Hardwood.openAll(...)`.
+    Want to run it or explore the capabilities yourself? The [**Reading from S3**](https://github.com/hardwood-hq/hardwood-examples/tree/main/reading-from-s3) example streams a Parquet file straight from an S3-compatible endpoint, proves projection only fetches the byte ranges it needs via `networkBytesFetched()` / `networkRequestCount()`, and opens a whole bucket as one dataset with `Hardwood.openAll(...)`.
 
 ```xml
 <dependency>

--- a/docs/content/how-to/variant.md
+++ b/docs/content/how-to/variant.md
@@ -13,6 +13,9 @@
 
 A Parquet column annotated with the [`VARIANT`](https://parquet.apache.org/docs/file-format/types/variantencoding/) logical type carries semi-structured, JSON-like data in a self-describing binary encoding. Physically it is a group of two required `BYTE_ARRAY` children, `metadata` and `value`, whose bytes together define a Variant value with its own type tag (object, array, string, int, etc.). `getVariant` reads both children and surfaces them through the `PqVariant` API.
 
+!!! example "Try it yourself"
+    Want to run it or explore the capabilities yourself? The [**Variant Columns**](https://github.com/hardwood-hq/hardwood-examples/tree/main/variant-columns) example renders every Variant type through one recursive method, including nested objects and arrays.
+
 ```java
 try (RowReader rowReader = fileReader.rowReader()) {
     while (rowReader.hasNext()) {

--- a/docs/content/index.md
+++ b/docs/content/index.md
@@ -47,6 +47,8 @@ try (ParquetFileReader fileReader = ParquetFileReader.open(InputFile.of(path));
 
 Ready? [Install Hardwood](getting-started.md), then read [your first file end-to-end](tutorial/first-read.md).
 
+Prefer to learn by running code? The [hardwood-examples](https://github.com/hardwood-hq/hardwood-examples) repository collects small, self-contained examples — one per concept — that you can clone and run with a single command.
+
 ## Status and Limitations
 
 This is Beta quality software, under active development.

--- a/docs/content/reference/accessors.md
+++ b/docs/content/reference/accessors.md
@@ -17,6 +17,9 @@ correspondence between accessor, Parquet type, and Java type, together with the 
 type-mismatch contracts every accessor obeys. For the task-oriented walkthrough, see
 [Read Row by Row](../how-to/row-reader.md).
 
+!!! example "Try it yourself"
+    Want to run it or explore the capabilities yourself? The [**Typed Accessors**](https://github.com/hardwood-hq/hardwood-examples/tree/main/typed-accessors) example decodes dates, times, UTC and local timestamps, decimals, UUIDs, intervals, FLOAT16, and JSON/BSON to their natural Java types.
+
 ## Accessor type mapping
 
 All accessors are available in two forms — name-based (`getInt("column_name")`) and index-based

--- a/docs/content/tutorial/first-read.md
+++ b/docs/content/tutorial/first-read.md
@@ -21,6 +21,11 @@ options. When you're done, the [how-to guides](../how-to/index.md) cover the ful
 choices, and the [background pages](../concepts/parquet-layout.md) explain how Parquet files
 and the reader APIs work underneath.
 
+!!! example "Try it yourself"
+    Want to run this as a standalone example? The [Hello Hardwood](https://github.com/hardwood-hq/hardwood-examples/tree/main/hello-hardwood)
+    example mirrors these steps — opening a file, inspecting its schema and footer, reading a few
+    rows, and summing a column.
+
 ## Before you start
 
 - Java 21 or newer (`java -version` to check).
@@ -160,7 +165,7 @@ try (ParquetFileReader reader =
 
     double total = 0;
     while (fare.nextBatch()) {
-        int count = fare.getValueCount();
+        int count = fare.getRecordCount();
         double[] values = fare.getDoubles();
         Validity validity = fare.getLeafValidity();
         boolean hasNulls = validity.hasNulls();


### PR DESCRIPTION
Hello, this PR wires the examples repository to the docs, adding a similar info panel across the docs where we have examples for and an entry point to the repository as a whole in getting started and main pages 
<img width="900" height="167" alt="image" src="https://github.com/user-attachments/assets/1a1ae707-8994-4efc-8cee-c69d30d1fcf5" />


## Checklist

- [ ] Build via `./mvnw clean verify` passes
- [ ] The commit message is prefixed with the issue key ("#123 Adding support for...")
- [ ] Code changes are covered by tests
- [ ] If this PR adds or changes user-facing behaviour, `docs/` has been updated
