### PR TITLE
#690 Use conventional single-character short option names in `print`

### DIFF
--- a/cli/src/main/java/dev/hardwood/cli/command/PrintCommand.java
+++ b/cli/src/main/java/dev/hardwood/cli/command/PrintCommand.java
@@ -45,22 +45,22 @@ public class PrintCommand implements Callable<Integer> {
     @Spec
     CommandSpec spec;
 
-    @CommandLine.Option(names = {"-ss", "--sample-size"}, defaultValue = "10", description = "Max number of lines used to auto-adjust the column width.")
+    @CommandLine.Option(names = {"-s", "--sample-size"}, defaultValue = "10", description = "Max number of lines used to auto-adjust the column width.")
     int sampleSize;
 
-    @CommandLine.Option(names = {"-mw", "--max-width"}, defaultValue = "50", description = "Max width in characters of a column.")
+    @CommandLine.Option(names = {"-w", "--max-width"}, defaultValue = "50", description = "Max width in characters of a column.")
     int maxWidth;
 
     @CommandLine.Option(names = {"-t", "--truncate"}, negatable = true, fallbackValue = "true", defaultValue = "true", description = "Should rows be truncated instead of wrapping on next line when too long.")
     boolean truncate;
 
-    @CommandLine.Option(names = {"-tp", "--transpose"}, defaultValue = "false", description = "When true, the rows are printed with two columns, the headers and values.")
+    @CommandLine.Option(names = {"--transpose"}, defaultValue = "false", description = "When true, the rows are printed with two columns, the headers and values.")
     boolean transpose;
 
-    @CommandLine.Option(names = {"-ri", "--row-index"}, defaultValue = "false", description = "When true, a virtual column is added containing the row index.")
+    @CommandLine.Option(names = {"-i", "--row-index"}, defaultValue = "false", description = "When true, a virtual column is added containing the row index.")
     boolean addRowIndex;
 
-    @CommandLine.Option(names = {"-rd", "--row-delimiter"}, description = "Should a line separate rows, it is lighter without but less readable when it overlaps a single terminal line.")
+    @CommandLine.Option(names = {"-d", "--row-delimiter"}, description = "Should a line separate rows, it is lighter without but less readable when it overlaps a single terminal line.")
     boolean rowDelimiter;
 
     @CommandLine.Option(names = {"-n", "--rows"}, defaultValue = RowLimits.ALL, description = "Number of rows to display. Positive values show the first N rows (head), negative values show the last N rows (tail), 'ALL' shows every row.")

--- a/cli/src/test/java/dev/hardwood/cli/command/PrintCommandContract.java
+++ b/cli/src/test/java/dev/hardwood/cli/command/PrintCommandContract.java
@@ -109,7 +109,7 @@ interface PrintCommandContract {
 
     @Test
     default void showsRowIndexWhenEnabled() {
-        Cli.Result result = Cli.launch("print", "-f", plainFile(), "-ri");
+        Cli.Result result = Cli.launch("print", "-f", plainFile(), "-i");
 
         assertThat(result.exitCode()).isZero();
         assertThat(result.output()).isEqualTo("""
@@ -139,7 +139,7 @@ interface PrintCommandContract {
 
     @Test
     default void columnsFilterWithNestedStruct() {
-        Cli.Result result = Cli.launch("print", "-f", deepNestedFile(), "--columns", "name,account", "-mw", "150");
+        Cli.Result result = Cli.launch("print", "-f", deepNestedFile(), "--columns", "name,account", "-w", "150");
 
         assertThat(result.exitCode()).isZero();
         assertThat(result.output()).isEqualTo("""
@@ -209,7 +209,7 @@ interface PrintCommandContract {
 
     @Test
     default void transposesRows() {
-        Cli.Result result = Cli.launch("print", "-f", byteArrayFile(), "-tp", "-n", "3");
+        Cli.Result result = Cli.launch("print", "-f", byteArrayFile(), "--transpose", "-n", "3");
 
         assertThat(result.exitCode()).isZero();
         assertThat(result.output()).isEqualTo("""
@@ -258,7 +258,7 @@ interface PrintCommandContract {
 
     @Test
     default void displaysNestedStructFields() {
-        Cli.Result result = Cli.launch("print", "-f", deepNestedFile(), "-mw", "150");
+        Cli.Result result = Cli.launch("print", "-f", deepNestedFile(), "-w", "150");
 
         assertThat(result.exitCode()).isZero();
         assertThat(result.output()).isEqualTo("""
@@ -274,7 +274,7 @@ interface PrintCommandContract {
 
     @Test
     default void wrapsWhenTruncationDisabled() {
-        Cli.Result result = Cli.launch("print", "-f", byteArrayFile(), "--no-truncate", "-mw", "5");
+        Cli.Result result = Cli.launch("print", "-f", byteArrayFile(), "--no-truncate", "-w", "5");
 
         assertThat(result.exitCode()).isZero();
         assertThat(result.output()).isEqualTo("""

--- a/cli/src/test/java/dev/hardwood/cli/command/PrintCommandTest.java
+++ b/cli/src/test/java/dev/hardwood/cli/command/PrintCommandTest.java
@@ -96,7 +96,7 @@ class PrintCommandTest implements PrintCommandContract {
 
     @Test
     void rendersVariantObjectAsJsonLikeText() {
-        Cli.Result result = Cli.launch("print", "-f", VARIANT_ATTRIBUTES_FILE, "-mw", "120");
+        Cli.Result result = Cli.launch("print", "-f", VARIANT_ATTRIBUTES_FILE, "-w", "120");
 
         assertThat(result.exitCode()).isZero();
         assertThat(result.output()).isEqualTo("""

--- a/docs/content/release-notes.md
+++ b/docs/content/release-notes.md
@@ -27,6 +27,7 @@ Highlights of this release:
 - `ColumnReader` and `RowReader` `close()` methods are now idempotent, fixing a close-time performance regression introduced in Beta2
 - Logical types render as Parquet-style annotation tokens (e.g. `STRING`) instead of a misleading record `toString()`
 - `hardwood dive` fails fast with a clear message when stdout is not an interactive terminal
+- `hardwood print` short option names follow the conventional single-dash, single-character form (`-s`, `-w`, `-i`, `-d`); `--transpose` is long-only
 - Documentation and tooling polish: corrected Docker image tags in the published docs, a single unified API change report linking each version to its commit, and stable JavaDoc diagrams
 
 See the [1.0.0.Final milestone](https://github.com/hardwood-hq/hardwood/milestone/7?closed=1) on GitHub for the full list of resolved issues.


### PR DESCRIPTION
Fixes #690.

The `print` command was the only command exposing single-dash, multi-character option names. Under the GNU/Picocli grammar a single dash introduces single-character short options that may cluster (`-ab` == `-a -b`), so `-ss` and friends are neither valid short options nor standard long options. This settles the grammar before 1.0.0.Final, where it would become a breaking change.

| Option | Before | After |
|--------|--------|-------|
| `--sample-size` | `-ss` | `-s` |
| `--max-width` | `-mw` | `-w` |
| `--row-index` | `-ri` | `-i` |
| `--row-delimiter` | `-rd` | `-d` |
| `--transpose` | `-tp` | (long-only) |

`--transpose` keeps only its long form: its mnemonic letter `-t` is already `--truncate`, and a case-distinguished `-t`/`-T` pair on the same command would silently flip a different boolean on a single mistype. A short name can be added later without breaking anyone; taking one back cannot.

`-s`, `-w`, `-i`, `-d` are all free across the entire CLI. An audit confirmed `print` was the only affected command; every other command already uses single-character shorts.

No `docs/content/` change: these per-option short names are not documented (only general `-n`/`-f` usage is).

### Testing
`PrintCommandTest` + `PrintCommandContract` updated to the new flags — 23 tests pass.