### PR TITLE
#695 Force-include MAP key and VARIANT siblings in sub-field projections

### DIFF
--- a/core/src/main/java/dev/hardwood/internal/schema/ProjectedSchema.java
+++ b/core/src/main/java/dev/hardwood/internal/schema/ProjectedSchema.java
@@ -51,6 +51,24 @@ public final class ProjectedSchema {
     /// @return a projected schema containing only the selected columns
     /// @throws IllegalArgumentException if a projected column name is not found in the schema
     public static ProjectedSchema create(FileSchema schema, ColumnProjection projection) {
+        return create(schema, projection, false);
+    }
+
+    /// Resolves a [ColumnProjection] against `schema`.
+    ///
+    /// When `completeContainers` is true, special groups are expanded to the
+    /// leaves they cannot be materialized without: a MAP's `key` column and every
+    /// leaf of a VARIANT (read atomically). Row assembly requires this; the
+    /// columnar [ColumnReader] / [dev.hardwood.reader.ColumnReaders] paths read
+    /// individual leaves and pass false to keep the projection literal.
+    ///
+    /// @param schema the file schema
+    /// @param projection the requested columns
+    /// @param completeContainers whether to pull in required sibling leaves of
+    ///        projected MAP / VARIANT groups
+    /// @return the resolved projection
+    public static ProjectedSchema create(FileSchema schema, ColumnProjection projection,
+            boolean completeContainers) {
         if (projection.projectsAll()) {
             return createAllColumnsProjection(schema);
         }
@@ -77,12 +95,27 @@ public final class ProjectedSchema {
             }
         }
 
-        // Sort by original index to maintain column order
-        includedOriginalIndices.sort(Integer::compareTo);
-        includedFieldIndices.sort(Integer::compareTo);
+        // Enforce structural invariants on special groups: a MAP cannot be
+        // assembled without its key column, and a VARIANT is read atomically.
+        // Pull in the required sibling leaves whenever any part of such a group
+        // is projected, then rebuild the leaf list in column order.
+        boolean[] includedLeaf = new boolean[originalCount];
+        for (int idx : includedOriginalIndices) {
+            includedLeaf[idx] = true;
+        }
+        if (completeContainers) {
+            enforceGroupInvariants(schema.getRootNode(), includedLeaf);
+        }
 
-        // Remove duplicates from field indices
-        includedFieldIndices = new ArrayList<>(includedFieldIndices.stream().distinct().toList());
+        includedOriginalIndices = new ArrayList<>();
+        for (int i = 0; i < originalCount; i++) {
+            if (includedLeaf[i]) {
+                includedOriginalIndices.add(i);
+            }
+        }
+
+        // Sort and de-duplicate field indices
+        includedFieldIndices = new ArrayList<>(includedFieldIndices.stream().sorted().distinct().toList());
 
         // Build projected arrays
         int projectedCount = includedOriginalIndices.size();
@@ -126,14 +159,19 @@ public final class ProjectedSchema {
                                             List<Integer> includedOriginalIndices,
                                             List<Integer> includedFieldIndices,
                                             int[] originalToProjected) {
-        // First check if it's a direct column name (flat schema)
+        // First check if it's a direct column name. The match is on leaf name
+        // (`FieldPath.leafName()`), so this also picks up a nested leaf whose
+        // last path segment equals `name`. Register the leaf's top-level
+        // ancestor as a projected field so the projection is coherent at the
+        // row level — for a flat top-level leaf the ancestor is the leaf
+        // itself; for a nested match it's the containing top-level group.
         for (ColumnSchema col : schema.getColumns()) {
             if (col.name().equals(name) && originalToProjected[col.columnIndex()] < 0) {
                 includedOriginalIndices.add(col.columnIndex());
-                // Find the field index
+                String topLevel = col.fieldPath().topLevelName();
                 List<SchemaNode> children = schema.getRootNode().children();
                 for (int i = 0; i < children.size(); i++) {
-                    if (children.get(i).name().equals(name)) {
+                    if (children.get(i).name().equals(topLevel)) {
                         includedFieldIndices.add(i);
                         break;
                     }
@@ -219,6 +257,60 @@ public final class ProjectedSchema {
             case SchemaNode.GroupNode group -> {
                 for (SchemaNode child : group.children()) {
                     collectColumnsFromNode(child, includedOriginalIndices, originalToProjected);
+                }
+            }
+        }
+    }
+
+    /// Walks the schema tree and, for any special group that has at least one
+    /// projected leaf, pulls in the sibling leaves the group cannot be read
+    /// without: a MAP's `key` column, and every leaf of a VARIANT (which is
+    /// reassembled atomically). Without this, a sub-field projection such as
+    /// `people.key_value.value.age` or `var.typed_value` would leave the reader
+    /// unable to assemble the map or the variant.
+    private static void enforceGroupInvariants(SchemaNode node, boolean[] includedLeaf) {
+        if (!(node instanceof SchemaNode.GroupNode group)) {
+            return;
+        }
+        for (SchemaNode child : group.children()) {
+            enforceGroupInvariants(child, includedLeaf);
+        }
+        if (!hasIncludedLeaf(group, includedLeaf)) {
+            return;
+        }
+        if (group.isVariant()) {
+            addAllLeaves(group, includedLeaf);
+        }
+        else if (group.isMap()) {
+            SchemaNode key = group.getMapKey();
+            if (key != null) {
+                addAllLeaves(key, includedLeaf);
+            }
+        }
+    }
+
+    /// True if `node` is, or transitively contains, an already-included leaf.
+    private static boolean hasIncludedLeaf(SchemaNode node, boolean[] includedLeaf) {
+        return switch (node) {
+            case SchemaNode.PrimitiveNode prim -> includedLeaf[prim.columnIndex()];
+            case SchemaNode.GroupNode group -> {
+                for (SchemaNode child : group.children()) {
+                    if (hasIncludedLeaf(child, includedLeaf)) {
+                        yield true;
+                    }
+                }
+                yield false;
+            }
+        };
+    }
+
+    /// Marks every leaf under `node` as included.
+    private static void addAllLeaves(SchemaNode node, boolean[] includedLeaf) {
+        switch (node) {
+            case SchemaNode.PrimitiveNode prim -> includedLeaf[prim.columnIndex()] = true;
+            case SchemaNode.GroupNode group -> {
+                for (SchemaNode child : group.children()) {
+                    addAllLeaves(child, includedLeaf);
                 }
             }
         }

--- a/core/src/main/java/dev/hardwood/reader/ParquetFileReader.java
+++ b/core/src/main/java/dev/hardwood/reader/ParquetFileReader.java
@@ -352,7 +352,7 @@ public class ParquetFileReader implements AutoCloseable {
         // Probing through the iterator avoids the prior duplicate probe
         // where canFastSkipTail and computeFetchPlans both ran the same
         // page-format check per row group.
-        ProjectedSchema projectedSchema = ProjectedSchema.create(schema, projection);
+        ProjectedSchema projectedSchema = ProjectedSchema.create(schema, projection, true);
         RowGroupIterator iterator = new RowGroupIterator(inputFiles, context, 0L, 0L);
         iterator.setFirstFile(schema, subset);
         iterator.initialize(projectedSchema, null);
@@ -386,7 +386,7 @@ public class ParquetFileReader implements AutoCloseable {
         ResolvedPredicate resolved = filter != null
                 ? FilterPredicateResolver.resolve(filter, schema, firstFileMetaData.columnOrders()) : null;
 
-        ProjectedSchema projectedSchema = ProjectedSchema.create(schema, projection);
+        ProjectedSchema projectedSchema = ProjectedSchema.create(schema, projection, true);
 
         RowGroupIterator iterator = new RowGroupIterator(inputFiles, context, maxRows, tailSkip);
         iterator.setFirstFile(schema, firstFileRowGroups);

--- a/core/src/test/java/dev/hardwood/ColumnProjectionTest.java
+++ b/core/src/test/java/dev/hardwood/ColumnProjectionTest.java
@@ -365,6 +365,46 @@ public class ColumnProjectionTest {
     }
 
     @Test
+    void mapKeyOnlyProjectionDoesNotPullInValue() throws Exception {
+        // Same map_struct_value_test.parquet fixture. Projecting only the key
+        // sub-field people.key_value.value... is the mirror of the value-side
+        // case: the key is structurally mandatory, but the value is not, so
+        // container completion must force-include the key and nothing more — a
+        // key-only key_value group is a valid map (the value column stays
+        // unprojected and reads back as absent).
+        Path parquetFile = Paths.get("src/test/resources/map_struct_value_test.parquet");
+
+        try (ParquetFileReader reader = ParquetFileReader.open(InputFile.of(parquetFile))) {
+            FileSchema schema = reader.getFileSchema();
+
+            // Resolver-level: the value leaves must not be force-included.
+            ProjectedSchema projected = ProjectedSchema.create(
+                    schema, ColumnProjection.columns("people.key_value.key"), true);
+            assertThat(projected.getProjectedColumnCount()).isEqualTo(1);
+            assertThat(projected.getProjectedColumn(0).name()).isEqualTo("key");
+
+            // Row-level: the map still assembles and the keys read across all
+            // rows, including the empty-map row, with the value absent.
+            try (RowReader rows = reader.buildRowReader()
+                    .projection(ColumnProjection.columns("people.key_value.key")).build()) {
+
+                assertThat(rows.getFieldCount()).isEqualTo(1);
+                assertThat(rows.getFieldName(0)).isEqualTo("people");
+
+                List<String> keys = new ArrayList<>();
+                while (rows.hasNext()) {
+                    rows.next();
+                    PqMap people = rows.getMap("people");
+                    for (PqMap.Entry entry : people.getEntries()) {
+                        keys.add(entry.getStringKey());
+                    }
+                }
+                assertThat(keys).containsExactly("employee1", "employee2", "manager");
+            }
+        }
+    }
+
+    @Test
     void simpleNameMatchingNestedLeafShouldReadMap() throws Exception {
         // Same map_struct_value_test.parquet fixture, but projecting "age" by
         // simple name (no dot notation). The bare name matches the nested leaf

--- a/core/src/test/java/dev/hardwood/ColumnProjectionTest.java
+++ b/core/src/test/java/dev/hardwood/ColumnProjectionTest.java
@@ -9,13 +9,18 @@ package dev.hardwood;
 
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.List;
 
 import org.junit.jupiter.api.Test;
 
 import dev.hardwood.internal.schema.ProjectedSchema;
 import dev.hardwood.reader.ParquetFileReader;
 import dev.hardwood.reader.RowReader;
+import dev.hardwood.row.PqMap;
 import dev.hardwood.row.PqStruct;
+import dev.hardwood.row.PqVariant;
+import dev.hardwood.row.VariantType;
 import dev.hardwood.schema.ColumnProjection;
 import dev.hardwood.schema.FileSchema;
 
@@ -325,6 +330,157 @@ public class ColumnProjectionTest {
             rows.next();
             assertThat(rows.getInt("id")).isEqualTo(3);
             assertThat(rows.getStruct("address")).isNull();
+        }
+    }
+
+    @Test
+    void mapValueSubFieldProjectionShouldReadKeysAndValue() throws Exception {
+        // map_struct_value_test.parquet: id, people map<string, struct{name, age}>.
+        // Row 0: {employee1:{Alice,30}, employee2:{Bob,25}}.
+        // Row 1: {manager:{Charlie,45}}.
+        // Row 2: empty map.
+        //
+        // Projecting only the value sub-field people.key_value.value.age should
+        // read a well-formed map across all rows: a Parquet MAP's key column is
+        // mandatory, so the resolver must keep it (parquet-java does the same).
+        Path parquetFile = Paths.get("src/test/resources/map_struct_value_test.parquet");
+
+        try (ParquetFileReader reader = ParquetFileReader.open(InputFile.of(parquetFile));
+             RowReader rows = reader.buildRowReader()
+                     .projection(ColumnProjection.columns("people.key_value.value.age")).build()) {
+
+            List<String> keys = new ArrayList<>();
+            List<Integer> ages = new ArrayList<>();
+            while (rows.hasNext()) {
+                rows.next();
+                PqMap people = rows.getMap("people");
+                for (PqMap.Entry entry : people.getEntries()) {
+                    keys.add(entry.getStringKey());
+                    ages.add(entry.getStructValue().getInt("age"));
+                }
+            }
+            assertThat(keys).containsExactly("employee1", "employee2", "manager");
+            assertThat(ages).containsExactly(30, 25, 45);
+        }
+    }
+
+    @Test
+    void simpleNameMatchingNestedLeafShouldReadMap() throws Exception {
+        // Same map_struct_value_test.parquet fixture, but projecting "age" by
+        // simple name (no dot notation). The bare name matches the nested leaf
+        // people.key_value.value.age via its leaf name. The resolver must (a)
+        // register the leaf's top-level ancestor `people` so the field is
+        // addressable at the row level, and (b) force-include the map's key
+        // column so the map can be assembled.
+        Path parquetFile = Paths.get("src/test/resources/map_struct_value_test.parquet");
+
+        try (ParquetFileReader reader = ParquetFileReader.open(InputFile.of(parquetFile));
+             RowReader rows = reader.buildRowReader()
+                     .projection(ColumnProjection.columns("age")).build()) {
+
+            assertThat(rows.getFieldCount()).isEqualTo(1);
+            assertThat(rows.getFieldName(0)).isEqualTo("people");
+
+            List<String> keys = new ArrayList<>();
+            List<Integer> ages = new ArrayList<>();
+            while (rows.hasNext()) {
+                rows.next();
+                PqMap people = rows.getMap("people");
+                for (PqMap.Entry entry : people.getEntries()) {
+                    keys.add(entry.getStringKey());
+                    ages.add(entry.getStructValue().getInt("age"));
+                }
+            }
+            assertThat(keys).containsExactly("employee1", "employee2", "manager");
+            assertThat(ages).containsExactly(30, 25, 45);
+        }
+    }
+
+    @Test
+    void mapOfVariantSubFieldProjectionShouldReadBothSiblings() throws Exception {
+        // variant_in_repeated_test.parquet: var_map is map<string, variant{metadata,value}>.
+        // Row 0: {a -> BOOLEAN_TRUE, b -> INT32(7)}.
+        // Row 1: {c -> "hi"}.
+        //
+        // Project a single leaf of the variant inside the map
+        // (`var_map.key_value.value.value`). The resolver must pull in two
+        // structural siblings in one pass: the variant's `metadata` leaf (read
+        // atomically) and the MAP's `key` leaf. This exercises the post-order
+        // traversal in enforceGroupInvariants on a compound shape.
+        Path parquetFile = Paths.get("src/test/resources/variant_in_repeated_test.parquet");
+
+        try (ParquetFileReader reader = ParquetFileReader.open(InputFile.of(parquetFile));
+             RowReader rows = reader.buildRowReader()
+                     .projection(ColumnProjection.columns("var_map.key_value.value.value")).build()) {
+
+            rows.next();
+            PqMap row0 = rows.getMap("var_map");
+            List<PqMap.Entry> r0Entries = row0.getEntries();
+            assertThat(r0Entries).hasSize(2);
+            assertThat(r0Entries.get(0).getStringKey()).isEqualTo("a");
+            assertThat(r0Entries.get(0).getVariantValue().type()).isEqualTo(VariantType.BOOLEAN_TRUE);
+            assertThat(r0Entries.get(1).getStringKey()).isEqualTo("b");
+            assertThat(r0Entries.get(1).getVariantValue().asInt()).isEqualTo(7);
+
+            rows.next();
+            PqMap row1 = rows.getMap("var_map");
+            List<PqMap.Entry> r1Entries = row1.getEntries();
+            assertThat(r1Entries).hasSize(1);
+            assertThat(r1Entries.get(0).getStringKey()).isEqualTo("c");
+            assertThat(r1Entries.get(0).getVariantValue().asString()).isEqualTo("hi");
+
+            assertThat(rows.hasNext()).isFalse();
+        }
+    }
+
+    @Test
+    void variantSubFieldProjectionShouldReassemble() throws Exception {
+        // variant_shredded_test.parquet: var is a shredded Variant
+        // {metadata, value, typed_value:int64}. Four rows exercise the distinct
+        // reassembly outcomes:
+        //   Row 1: shredded INT64(42)        — typed_value set
+        //   Row 2: unshredded BOOLEAN_TRUE   — value carries the Variant bytes,
+        //                                      typed_value null (only readable
+        //                                      if `value` is also projected)
+        //   Row 3: Variant NULL              — both leaves null at non-null group
+        //   Row 4: shredded INT64(10^12)
+        //
+        // Projecting a single Variant leaf (var.typed_value) must still yield a
+        // correctly reassembled Variant across all rows — a Variant is read
+        // atomically, so the resolver must pull in metadata and value as well.
+        // Row 2 is the load-bearing case: if only typed_value were projected, the
+        // unshredded boolean would be lost.
+        Path parquetFile = Paths.get("src/test/resources/variant_shredded_test.parquet");
+
+        try (ParquetFileReader reader = ParquetFileReader.open(InputFile.of(parquetFile));
+             RowReader rows = reader.buildRowReader()
+                     .projection(ColumnProjection.columns("var.typed_value")).build()) {
+
+            rows.next();
+            PqVariant v1 = rows.getVariant("var");
+            assertThat(v1).isNotNull();
+            assertThat(v1.type()).isEqualTo(VariantType.INT64);
+            assertThat(v1.asLong()).isEqualTo(42L);
+
+            rows.next();
+            PqVariant v2 = rows.getVariant("var");
+            assertThat(v2).isNotNull();
+            assertThat(v2.type()).isEqualTo(VariantType.BOOLEAN_TRUE);
+            assertThat(v2.asBoolean()).isTrue();
+
+            rows.next();
+            PqVariant v3 = rows.getVariant("var");
+            assertThat(v3).isNotNull();
+            assertThat(v3.type()).isEqualTo(VariantType.NULL);
+            assertThat(v3.isNull()).isTrue();
+
+            rows.next();
+            PqVariant v4 = rows.getVariant("var");
+            assertThat(v4).isNotNull();
+            assertThat(v4.type()).isEqualTo(VariantType.INT64);
+            assertThat(v4.asLong()).isEqualTo(1_000_000_000_000L);
+
+            assertThat(rows.hasNext()).isFalse();
         }
     }
 

--- a/core/src/test/java/dev/hardwood/PredicatePushDownTest.java
+++ b/core/src/test/java/dev/hardwood/PredicatePushDownTest.java
@@ -524,6 +524,24 @@ class PredicatePushDownTest {
     }
 
     @Test
+    void testFilterOnMapSubFieldIsRejected() throws Exception {
+        // A MAP's key_value group is REPEATED, so any leaf below it inherits a
+        // rep level > 0 and is rejected by the same guard. This pins the safety
+        // net the SelectionEngine relies on: the literal-projection path it uses
+        // for predicate columns (no map-key force-include) is structurally
+        // unreachable because the predicate is rejected before resolution.
+        Path mapFile = Paths.get("src/test/resources/map_struct_value_test.parquet");
+        try (ParquetFileReader reader = ParquetFileReader.open(InputFile.of(mapFile))) {
+            FilterPredicate filter = FilterPredicate.eq("people.key_value.value.age", 30);
+
+            assertThatThrownBy(() -> reader.buildColumnReaders(ColumnProjection.columns("id"))
+                    .filter(filter).build())
+                    .isInstanceOf(IllegalArgumentException.class)
+                    .hasMessageContaining("repeated");
+        }
+    }
+
+    @Test
     void testFilterOnFlatColumnFiltersRepeatedColumn() throws Exception {
         // Filter on flat "id" column, read all columns including repeated "scores"
         // id > 6 -> skip RG0 (id 1-3) and RG1 (id 4-6), keep RG2 (id 7-9)

--- a/docs/content/how-to/variant.md
+++ b/docs/content/how-to/variant.md
@@ -53,5 +53,5 @@ The `PqVariantObject` view exposes the same primitive getters as a Parquet struc
 ## Current limitations
 
 - **No Variant-aware predicate pushdown.** Filter predicates against a Variant sub-path (e.g. `WHERE v.age > 30`) aren't yet understood by the pushdown pipeline. Filtering still works against the file's physical shredded columns if you know the layout — a `FilterPredicate.gt("v.typed_value.age", 30)` gets row-group and page skipping via ordinary column statistics — but that ties query code to the writer's shredding strategy and misses any rows where the payload sits in the opaque `value` blob instead. Tracked as [#309](https://github.com/hardwood-hq/hardwood/issues/309).
-- **No path projection optimization.** Reading only `v.age` from a Variant column still reassembles the whole Variant for each row rather than reading just the shredded `typed_value.age` column. Requires the same variant-aware planning as #309; no separate issue filed yet.
+- **No path projection optimization.** Reading only `v.age` from a Variant column still reassembles the whole Variant for each row rather than reading just the shredded `typed_value.age` column. Requires the same variant-aware planning as #309. Tracked as [#700](https://github.com/hardwood-hq/hardwood/issues/700).
 


### PR DESCRIPTION
Closes #695.

## Summary

`ColumnProjection` lists leaf paths, not a schema subset, so the resolver has no structural invariant to lean on the way parquet-java's requested `MessageType` does. As a result, projecting a sub-field of a `MAP` value or a `VARIANT` left the reader unable to assemble those columns:

- `columns("people.key_value.value.age")` dropped the MAP's mandatory `key` leaf → `ArrayIndexOutOfBoundsException` at `PqMapImpl.create` when reading the map.
- `columns("var.typed_value")` dropped `metadata` and `value` → `getVariant("var")` returned `null` (silent wrong data — also affects unshredded rows that carry their payload in `value`).

The resolver now walks the schema post-order and, for any `MAP`/`VARIANT` group with at least one projected descendant, pulls in the leaves it cannot be materialized without: a `MAP`'s `key` column, and every leaf of a `VARIANT` (read atomically). This is opt-in via a new `completeContainers` parameter — the row-reader paths in `ParquetFileReader` pass `true`; the columnar `ColumnReader` / `ColumnReaders` paths keep passing `false` and read leaves literally.

While in `ProjectedSchema`, also fixed a separate coherency bug in `resolveSimpleColumn`: a bare-name match landing on a nested leaf (e.g. `columns("age")` matching `people.key_value.value.age` by `leafName()`) now registers the leaf's top-level ancestor field via `fieldPath().topLevelName()`, so the projection is addressable at the row level instead of yielding `getFieldCount() == 0`.

## Test plan

Four new tests in `ColumnProjectionTest` and one in `PredicatePushDownTest`:

- [x] `mapValueSubFieldProjectionShouldReadKeysAndValue` — `columns("people.key_value.value.age")` reads keys + ages across all rows of `map_struct_value_test.parquet` (including the empty-map row).
- [x] `simpleNameMatchingNestedLeafShouldReadMap` — `columns("age")` (bare name, no dot) resolves to the same projection, with `getFieldCount() == 1` and field name `"people"`.
- [x] `variantSubFieldProjectionShouldReassemble` — `columns("var.typed_value")` reassembles correctly across all 4 rows of `variant_shredded_test.parquet`, including row 2 (unshredded `BOOLEAN_TRUE` carried in `value`) — the load-bearing case that fails if only `typed_value` is pulled in.
- [x] `mapOfVariantSubFieldProjectionShouldReadBothSiblings` — `columns("var_map.key_value.value.value")` against `variant_in_repeated_test.parquet` exercises the post-order traversal on a compound shape: variant siblings (`metadata`) and the outer MAP's `key` are both force-included in one pass.
- [x] `testFilterOnMapSubFieldIsRejected` — pins the safety net that the `SelectionEngine` filter path relies on: `FilterPredicate.eq("people.key_value.value.age", 30)` is rejected at resolution time because the column is repeated, so the literal-projection path used for predicate columns is structurally unreachable.
- [x] Full core test suite passes (`./mvnw -pl core test` → 1384 tests).