### PR TITLE
#702 Allow sizing the decoder thread pool via the Hardwood entry point

### DIFF
--- a/core/src/main/java/dev/hardwood/Hardwood.java
+++ b/core/src/main/java/dev/hardwood/Hardwood.java
@@ -24,18 +24,47 @@ import dev.hardwood.reader.ParquetFileReader;
 /// }
 /// ```
 ///
+/// To control the decode parallelism, or to reuse one context (and its thread
+/// pool) across many reads and standalone [ParquetFileReader]s, create the
+/// [HardwoodContext] yourself and pass it in:
+/// ```java
+/// try (HardwoodContext context = HardwoodContext.create(4)) {
+///     try (Hardwood hardwood = Hardwood.create(context)) {
+///         // ...
+///     }
+///     // context is still open here for further use
+/// }
+/// ```
+///
 /// For single-file usage, [ParquetFileReader#open(InputFile)] is simpler.
 public class Hardwood implements AutoCloseable {
 
     private final HardwoodContextImpl context;
+    private final boolean ownsContext;
 
-    private Hardwood(HardwoodContextImpl context) {
+    private Hardwood(HardwoodContextImpl context, boolean ownsContext) {
         this.context = context;
+        this.ownsContext = ownsContext;
     }
 
     /// Create a new Hardwood instance with a thread pool sized to available processors.
+    /// The context is owned by this instance and closed when it is closed.
     public static Hardwood create() {
-        return new Hardwood(HardwoodContextImpl.create());
+        return new Hardwood(HardwoodContextImpl.create(), true);
+    }
+
+    /// Create a new Hardwood instance backed by the given context, e.g. one
+    /// created via [HardwoodContext#create(int)] to size the decode thread pool.
+    ///
+    /// The caller retains ownership of the context: it is **not** closed when
+    /// this instance is closed, so the same context — and its thread pool — can
+    /// be reused for later reads and shared with standalone [ParquetFileReader]s
+    /// opened via [ParquetFileReader#open(InputFile, HardwoodContext)].
+    public static Hardwood create(HardwoodContext context) {
+        if (context == null) {
+            throw new IllegalArgumentException("context must not be null");
+        }
+        return new Hardwood((HardwoodContextImpl) context, false);
     }
 
     /// Open a single Parquet file. The file is opened immediately and
@@ -57,6 +86,8 @@ public class Hardwood implements AutoCloseable {
 
     @Override
     public void close() {
-        context.close();
+        if (ownsContext) {
+            context.close();
+        }
     }
 }

--- a/core/src/test/java/dev/hardwood/MultiFileRowReaderTest.java
+++ b/core/src/test/java/dev/hardwood/MultiFileRowReaderTest.java
@@ -49,6 +49,38 @@ class MultiFileRowReaderTest {
     }
 
     @Test
+    void testSuppliedContextSizesPoolAndIsNotClosed() throws Exception {
+        Path filePath = Paths.get("src/test/resources/plain_uncompressed.parquet");
+        List<Path> files = List.of(filePath, filePath);
+
+        try (HardwoodContext context = HardwoodContext.create(2)) {
+            List<Long> ids = new ArrayList<>();
+
+            try (Hardwood hardwood = Hardwood.create(context);
+                 ParquetFileReader parquet = hardwood.openAll(InputFile.ofPaths(files));
+                 RowReader reader = parquet.rowReader()) {
+
+                while (reader.hasNext()) {
+                    reader.next();
+                    ids.add(reader.getLong("id"));
+                }
+            }
+
+            assertThat(ids).containsExactly(1L, 2L, 3L, 1L, 2L, 3L);
+            // The caller owns the context, so closing the Hardwood instance must
+            // not shut its executor down — it is still usable for further reads.
+            assertThat(context.executor().isShutdown()).isFalse();
+        }
+    }
+
+    @Test
+    void testCreateRejectsNullContext() {
+        assertThatThrownBy(() -> Hardwood.create(null))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("context");
+    }
+
+    @Test
     void testReadMultipleIdenticalFiles() throws Exception {
         // Read the same file multiple times to test cross-file prefetching
         Path filePath = Paths.get("src/test/resources/plain_uncompressed.parquet");

--- a/docs/content/concepts/concurrency-model.md
+++ b/docs/content/concepts/concurrency-model.md
@@ -33,9 +33,12 @@ that context comes into being:
 
 - **Implicit.** `ParquetFileReader.open(InputFile)` creates and owns a context sized to the
   available processors. Closing the reader shuts it down.
-- **Explicit.** Create a `Hardwood` (via `Hardwood.create()`) or a `HardwoodContext` (via
-  `HardwoodContext.create(threadCount)`) yourself and pass it to the reader. The pool then
-  outlives any one reader and is shared across all readers opened against it.
+- **Explicit.** Create a `HardwoodContext` (via `HardwoodContext.create(threadCount)`) to size the
+  pool, then share it: pass it to `Hardwood.create(HardwoodContext)` for multi-file reads or to
+  `ParquetFileReader.open(InputFile, HardwoodContext)` for single-file reads. `Hardwood.create()`
+  with no context is the shorthand that builds and owns a default-sized one. An explicitly created
+  context outlives any one reader and is shared across all readers opened against it; the caller
+  closes it.
 
 Share one context across many reads. The pool is the expensive, reusable resource; readers are
 cheap and short-lived. This matters most when reading many files — see below.

--- a/docs/content/how-to/multi-file.md
+++ b/docs/content/how-to/multi-file.md
@@ -46,15 +46,18 @@ Cross-file prefetching is automatic: when pages from file N are running low, pag
 
 The schema of the first file is the reference schema. Each subsequent file is validated against it as it is opened: every projected column must exist with a matching physical type, logical type, and repetition type, otherwise a `SchemaIncompatibleException` is thrown. Non-projected columns are not checked, so files may carry additional columns. With no explicit projection, all columns of the first file are projected and therefore required in every subsequent file.
 
-By default, `Hardwood.create()` sizes the thread pool to the number of available processors. For custom thread pool sizing, use `HardwoodContext` directly:
+By default, `Hardwood.create()` sizes the thread pool to the number of available processors. To control the decode parallelism, create a `HardwoodContext` of the desired size and pass it to `Hardwood.create(HardwoodContext)`:
 
 ```java
 import dev.hardwood.HardwoodContext;
 
 try (HardwoodContext context = HardwoodContext.create(4);  // 4 threads
-     ParquetFileReader reader = ParquetFileReader.open(InputFile.of(path), context);
-     RowReader rowReader = reader.rowReader()) {
+     Hardwood hardwood = Hardwood.create(context);
+     ParquetFileReader parquet = hardwood.openAll(files);
+     RowReader reader = parquet.rowReader()) {
     // ...
 }
 ```
+
+The caller owns the supplied context: it is not closed when the `Hardwood` instance is closed, so the same context — and its thread pool — can be reused across later reads and shared with single-file reads via `ParquetFileReader.open(InputFile, HardwoodContext)`.
 


### PR DESCRIPTION
Fixes #702.

`Hardwood.create(int threads)` used to let callers size the page-decode thread pool when bootstrapping the multi-file reader, but it was dropped in #98 ("Introducing InputFile abstraction"), incidental to that commit. The sizing plumbing survived on the public `HardwoodContext.create(int)` and remained reachable for single-file reads via `ParquetFileReader.open(InputFile, HardwoodContext)`, but `Hardwood` exposed only a no-arg `create()` whose constructor took the internal `HardwoodContextImpl` — so the documented multi-file entry point had no way to control decode parallelism.

## Change

- Add `Hardwood.create(HardwoodContext)`, accepting a caller-built (and caller-sized) context.
- The supplied context stays **caller-owned**: it is not closed by `Hardwood.close()`, so one context — and its thread pool — can be reused across reads and shared with standalone `ParquetFileReader`s. This mirrors the existing ownership contract of `ParquetFileReader.openAll(files, context)`.
- Docs updated: `how-to/multi-file.md` and `concepts/concurrency-model.md`.

This goes a step beyond the old `create(int)`: rather than only sizing a private pool, it lets the context be shared across entry points.

## Tests

- A read over a supplied 2-thread context, asserting both correct output and that the context survives `Hardwood.close()` (ownership contract).
- A null-context rejection test.

All `MultiFileRowReaderTest` cases pass and the full reactor compiles.