### PR TITLE
Avoid column index fetches for unfiltered scans

### DIFF
--- a/core/src/main/java/dev/hardwood/internal/reader/RowGroupIndexBuffers.java
+++ b/core/src/main/java/dev/hardwood/internal/reader/RowGroupIndexBuffers.java
@@ -47,6 +47,20 @@ public class RowGroupIndexBuffers {
     /// @param rowGroup  the row group whose indexes to fetch
     public static RowGroupIndexBuffers fetch(InputFile inputFile,
             RowGroup rowGroup) throws IOException {
+        return fetch(inputFile, rowGroup, true);
+    }
+
+    /// Fetches offset indexes for a row group, and optionally column indexes.
+    ///
+    /// Unfiltered scans need OffsetIndex bytes to plan page reads, but do not
+    /// need ColumnIndex statistics. Filtered scans include both so page-level
+    /// predicate pushdown can evaluate min/max/null-count metadata.
+    ///
+    /// @param inputFile the file to read from
+    /// @param rowGroup the row group whose indexes to fetch
+    /// @param includeColumnIndexes whether ColumnIndex buffers should be fetched
+    public static RowGroupIndexBuffers fetch(InputFile inputFile,
+            RowGroup rowGroup, boolean includeColumnIndexes) throws IOException {
 
         List<ColumnChunk> allColumns = rowGroup.columns();
 
@@ -58,7 +72,7 @@ public class RowGroupIndexBuffers {
                 maxEnd = Math.max(maxEnd,
                         col.offsetIndexOffset() + col.offsetIndexLength());
             }
-            if (col.columnIndexOffset() != null) {
+            if (includeColumnIndexes && col.columnIndexOffset() != null) {
                 minOffset = Math.min(minOffset, col.columnIndexOffset());
                 maxEnd = Math.max(maxEnd,
                         col.columnIndexOffset() + col.columnIndexLength());
@@ -86,7 +100,7 @@ public class RowGroupIndexBuffers {
                 int relOffset = Math.toIntExact(col.offsetIndexOffset() - minOffset);
                 oi = indexRegion.slice(relOffset, col.offsetIndexLength());
             }
-            if (col.columnIndexOffset() != null) {
+            if (includeColumnIndexes && col.columnIndexOffset() != null) {
                 int relOffset = Math.toIntExact(col.columnIndexOffset() - minOffset);
                 ci = indexRegion.slice(relOffset, col.columnIndexLength());
             }

--- a/core/src/main/java/dev/hardwood/internal/reader/RowGroupIterator.java
+++ b/core/src/main/java/dev/hardwood/internal/reader/RowGroupIterator.java
@@ -279,7 +279,8 @@ public class RowGroupIterator {
             try (FetchReason.Scope ignored = FetchReason.set(
                     "rg=" + workItem.rowGroupIndex() + " indexes")) {
                 RowGroupIndexBuffers indexBuffers = RowGroupIndexBuffers.fetch(
-                        workItem.inputFile(), workItem.rowGroup());
+                        workItem.inputFile(), workItem.rowGroup(),
+                        filterPredicate != null);
 
                 RowRanges matchingRows = RowRanges.ALL;
                 if (filterPredicate != null) {

--- a/core/src/test/java/dev/hardwood/internal/reader/CountingInputFile.java
+++ b/core/src/test/java/dev/hardwood/internal/reader/CountingInputFile.java
@@ -10,6 +10,7 @@ package dev.hardwood.internal.reader;
 import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicLong;
 
 import dev.hardwood.InputFile;
 
@@ -20,6 +21,7 @@ class CountingInputFile implements InputFile {
 
     private final InputFile delegate;
     private final AtomicInteger readRangeCount = new AtomicInteger();
+    private final AtomicLong bytesRead = new AtomicLong();
 
     CountingInputFile(InputFile delegate) {
         this.delegate = delegate;
@@ -34,6 +36,10 @@ class CountingInputFile implements InputFile {
         return readRangeCount.get();
     }
 
+    long bytesRead() {
+        return bytesRead.get();
+    }
+
     @Override
     public void open() throws IOException {
         delegate.open();
@@ -42,6 +48,7 @@ class CountingInputFile implements InputFile {
     @Override
     public ByteBuffer readRange(long offset, int length) throws IOException {
         readRangeCount.incrementAndGet();
+        bytesRead.addAndGet(length);
         return delegate.readRange(offset, length);
     }
 

--- a/core/src/test/java/dev/hardwood/internal/reader/RowGroupIndexBuffersTest.java
+++ b/core/src/test/java/dev/hardwood/internal/reader/RowGroupIndexBuffersTest.java
@@ -48,6 +48,44 @@ class RowGroupIndexBuffersTest {
     }
 
     @Test
+    void skipsColumnIndexesWhenNotRequested() throws Exception {
+        CountingInputFile fullIndexFile = new CountingInputFile(InputFile.of(PAGE_INDEX_FILE));
+        fullIndexFile.open();
+        FileMetaData fullMeta = ParquetMetadataReader.readMetadata(fullIndexFile);
+        RowGroup fullRowGroup = fullMeta.rowGroups().get(0);
+
+        long fullBytesBefore = fullIndexFile.bytesRead();
+        RowGroupIndexBuffers fullBuffers = RowGroupIndexBuffers.fetch(
+                fullIndexFile, fullRowGroup, true);
+        long fullIndexBytes = fullIndexFile.bytesRead() - fullBytesBefore;
+
+        CountingInputFile offsetOnlyFile = new CountingInputFile(InputFile.of(PAGE_INDEX_FILE));
+        offsetOnlyFile.open();
+        FileMetaData offsetOnlyMeta = ParquetMetadataReader.readMetadata(offsetOnlyFile);
+        RowGroup offsetOnlyRowGroup = offsetOnlyMeta.rowGroups().get(0);
+
+        long offsetOnlyBytesBefore = offsetOnlyFile.bytesRead();
+        RowGroupIndexBuffers offsetOnlyBuffers = RowGroupIndexBuffers.fetch(
+                offsetOnlyFile, offsetOnlyRowGroup, false);
+        long offsetOnlyBytes = offsetOnlyFile.bytesRead() - offsetOnlyBytesBefore;
+
+        assertThat(offsetOnlyBytes)
+                .as("Offset-only index fetch should skip ColumnIndex bytes")
+                .isLessThan(fullIndexBytes);
+
+        for (int i = 0; i < offsetOnlyRowGroup.columns().size(); i++) {
+            ColumnIndexBuffers colBuffers = offsetOnlyBuffers.forColumn(i);
+            assertThat(colBuffers).as("Column %d", i).isNotNull();
+            assertThat(colBuffers.offsetIndex())
+                    .as("Column %d offset index", i).isNotNull();
+            assertThat(colBuffers.columnIndex())
+                    .as("Column %d column index", i).isNull();
+            assertThat(fullBuffers.forColumn(i).columnIndex())
+                    .as("Column %d full column index", i).isNotNull();
+        }
+    }
+
+    @Test
     void returnsNullForFileWithoutIndexes() throws Exception {
         CountingInputFile countingFile = new CountingInputFile(InputFile.of(PLAIN_FILE));
         countingFile.open();


### PR DESCRIPTION
## Summary

Fixes #683 by avoiding ColumnIndex metadata fetches during unfiltered scans.

Unfiltered reads still fetch OffsetIndex metadata so page locations can be planned efficiently, but they now skip ColumnIndex statistics bytes since those are only needed for page-level predicate pushdown. Filtered reads keep the existing behavior and fetch both index types.

## Changes

- Added an offset-only mode to `RowGroupIndexBuffers.fetch(...)`
- Updated `RowGroupIterator` to request ColumnIndex buffers only when a filter predicate is present
- Extended `CountingInputFile` test helper to track fetched bytes
- Added a test proving offset-only index fetches skip ColumnIndex buffers and read fewer index bytes

## Testing

- `git diff --check` passes
- `./mvnw clean verify` 

## Checklist

- [ ] Build via `./mvnw clean verify` passes
- [x] The commit message is prefixed with the issue key ("#123 Adding support for...")
- [x] Code changes are covered by tests
- [x] If this PR adds or changes user-facing behaviour, `docs/` has been updated