### PR TITLE
Use SIMD bit unpacking in hybrid decoder

### DIFF
--- a/core/src/main/java/dev/hardwood/internal/encoding/RleBitPackingHybridDecoder.java
+++ b/core/src/main/java/dev/hardwood/internal/encoding/RleBitPackingHybridDecoder.java
@@ -7,8 +7,6 @@
  */
 package dev.hardwood.internal.encoding;
 
-import java.nio.ByteBuffer;
-import java.nio.ByteOrder;
 import java.util.Arrays;
 
 import dev.hardwood.internal.encoding.simd.SimdOperations;
@@ -26,7 +24,6 @@ public class RleBitPackingHybridDecoder {
     private static final ThreadLocal<int[]> TEMP_INDICES = new ThreadLocal<>();
 
     private final byte[] data;
-    private final ByteBuffer dataBuffer;
     private final int dataEnd;
     private final int bitWidth;
     private final int bitMask;
@@ -51,7 +48,6 @@ public class RleBitPackingHybridDecoder {
                     + ". Must be between 0 and 32");
         }
         this.data = data;
-        this.dataBuffer = ByteBuffer.wrap(data).order(ByteOrder.LITTLE_ENDIAN);
         this.dataEnd = offset + length;
         this.pos = offset;
         this.bitWidth = bitWidth;
@@ -291,51 +287,12 @@ public class RleBitPackingHybridDecoder {
             }
         }
         else if (bitsInBuffer == 0 && width <= 8) {
-            while (count >= 8 && pos + 8 <= dataEnd) {
-                long bits = dataBuffer.getLong(pos);
-                pos += width;
-
-                output[outPos] = (int) (bits & mask);
-                bits >>>= width;
-                output[outPos + 1] = (int) (bits & mask);
-                bits >>>= width;
-                output[outPos + 2] = (int) (bits & mask);
-                bits >>>= width;
-                output[outPos + 3] = (int) (bits & mask);
-                bits >>>= width;
-                output[outPos + 4] = (int) (bits & mask);
-                bits >>>= width;
-                output[outPos + 5] = (int) (bits & mask);
-                bits >>>= width;
-                output[outPos + 6] = (int) (bits & mask);
-                bits >>>= width;
-                output[outPos + 7] = (int) (bits & mask);
-                outPos += 8;
-                count -= 8;
-            }
-
-            while (count >= 8 && pos + width <= dataEnd) {
-                long bits = 0;
-                for (int i = 0; i < width; i++) {
-                    bits |= ((long) (data[pos++] & 0xFF)) << (i * 8);
-                }
-                output[outPos] = (int) (bits & mask);
-                bits >>>= width;
-                output[outPos + 1] = (int) (bits & mask);
-                bits >>>= width;
-                output[outPos + 2] = (int) (bits & mask);
-                bits >>>= width;
-                output[outPos + 3] = (int) (bits & mask);
-                bits >>>= width;
-                output[outPos + 4] = (int) (bits & mask);
-                bits >>>= width;
-                output[outPos + 5] = (int) (bits & mask);
-                bits >>>= width;
-                output[outPos + 6] = (int) (bits & mask);
-                bits >>>= width;
-                output[outPos + 7] = (int) (bits & mask);
-                outPos += 8;
-                count -= 8;
+            int groups = Math.min(count / 8, (dataEnd - pos) / width);
+            if (groups > 0) {
+                int bytesConsumed = SIMD_OPS.unpackBitWidthN(data, pos, output, outPos, groups * 8, width);
+                pos += bytesConsumed;
+                outPos += groups * 8;
+                count -= groups * 8;
             }
         }
 

--- a/core/src/main/java/dev/hardwood/internal/encoding/RleBitPackingHybridDecoder.java
+++ b/core/src/main/java/dev/hardwood/internal/encoding/RleBitPackingHybridDecoder.java
@@ -7,6 +7,8 @@
  */
 package dev.hardwood.internal.encoding;
 
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
 import java.util.Arrays;
 
 import dev.hardwood.internal.encoding.simd.SimdOperations;
@@ -24,6 +26,7 @@ public class RleBitPackingHybridDecoder {
     private static final ThreadLocal<int[]> TEMP_INDICES = new ThreadLocal<>();
 
     private final byte[] data;
+    private final ByteBuffer dataBuffer;
     private final int dataEnd;
     private final int bitWidth;
     private final int bitMask;
@@ -48,6 +51,7 @@ public class RleBitPackingHybridDecoder {
                     + ". Must be between 0 and 32");
         }
         this.data = data;
+        this.dataBuffer = ByteBuffer.wrap(data).order(ByteOrder.LITTLE_ENDIAN);
         this.dataEnd = offset + length;
         this.pos = offset;
         this.bitWidth = bitWidth;
@@ -287,13 +291,51 @@ public class RleBitPackingHybridDecoder {
             }
         }
         else if (bitsInBuffer == 0 && width <= 8) {
-            int groups = Math.min(count / 8, (dataEnd - pos) / width);
-            if (groups > 0) {
-                int values = groups * 8;
-                int bytesConsumed = SIMD_OPS.unpackBitWidthN(data, pos, output, outPos, values, width);
-                pos += bytesConsumed;
-                outPos += (bytesConsumed / width) * 8;
-                count -= (bytesConsumed / width) * 8;
+            while (count >= 8 && pos + 8 <= dataEnd) {
+                long bits = dataBuffer.getLong(pos);
+                pos += width;
+
+                output[outPos] = (int) (bits & mask);
+                bits >>>= width;
+                output[outPos + 1] = (int) (bits & mask);
+                bits >>>= width;
+                output[outPos + 2] = (int) (bits & mask);
+                bits >>>= width;
+                output[outPos + 3] = (int) (bits & mask);
+                bits >>>= width;
+                output[outPos + 4] = (int) (bits & mask);
+                bits >>>= width;
+                output[outPos + 5] = (int) (bits & mask);
+                bits >>>= width;
+                output[outPos + 6] = (int) (bits & mask);
+                bits >>>= width;
+                output[outPos + 7] = (int) (bits & mask);
+                outPos += 8;
+                count -= 8;
+            }
+
+            while (count >= 8 && pos + width <= dataEnd) {
+                long bits = 0;
+                for (int i = 0; i < width; i++) {
+                    bits |= ((long) (data[pos++] & 0xFF)) << (i * 8);
+                }
+                output[outPos] = (int) (bits & mask);
+                bits >>>= width;
+                output[outPos + 1] = (int) (bits & mask);
+                bits >>>= width;
+                output[outPos + 2] = (int) (bits & mask);
+                bits >>>= width;
+                output[outPos + 3] = (int) (bits & mask);
+                bits >>>= width;
+                output[outPos + 4] = (int) (bits & mask);
+                bits >>>= width;
+                output[outPos + 5] = (int) (bits & mask);
+                bits >>>= width;
+                output[outPos + 6] = (int) (bits & mask);
+                bits >>>= width;
+                output[outPos + 7] = (int) (bits & mask);
+                outPos += 8;
+                count -= 8;
             }
         }
 

--- a/core/src/main/java/dev/hardwood/internal/encoding/RleBitPackingHybridDecoder.java
+++ b/core/src/main/java/dev/hardwood/internal/encoding/RleBitPackingHybridDecoder.java
@@ -7,8 +7,6 @@
  */
 package dev.hardwood.internal.encoding;
 
-import java.nio.ByteBuffer;
-import java.nio.ByteOrder;
 import java.util.Arrays;
 
 import dev.hardwood.internal.encoding.simd.SimdOperations;
@@ -26,7 +24,6 @@ public class RleBitPackingHybridDecoder {
     private static final ThreadLocal<int[]> TEMP_INDICES = new ThreadLocal<>();
 
     private final byte[] data;
-    private final ByteBuffer dataBuffer;
     private final int dataEnd;
     private final int bitWidth;
     private final int bitMask;
@@ -51,7 +48,6 @@ public class RleBitPackingHybridDecoder {
                     + ". Must be between 0 and 32");
         }
         this.data = data;
-        this.dataBuffer = ByteBuffer.wrap(data).order(ByteOrder.LITTLE_ENDIAN);
         this.dataEnd = offset + length;
         this.pos = offset;
         this.bitWidth = bitWidth;
@@ -278,56 +274,26 @@ public class RleBitPackingHybridDecoder {
             count--;
         }
 
-        // Fast path for bit width 1 (common for definition levels)
-        if (width == 1) {
-            while (count >= 8 && pos < dataEnd) {
-                int b = data[pos++] & 0xFF;
-                output[outPos]     = b & 1;
-                output[outPos + 1] = (b >> 1) & 1;
-                output[outPos + 2] = (b >> 2) & 1;
-                output[outPos + 3] = (b >> 3) & 1;
-                output[outPos + 4] = (b >> 4) & 1;
-                output[outPos + 5] = (b >> 5) & 1;
-                output[outPos + 6] = (b >> 6) & 1;
-                output[outPos + 7] = (b >> 7) & 1;
-                outPos += 8;
-                count -= 8;
+        // Bulk decode complete 8-value groups only while byte-aligned. Tails
+        // stay on the bit-buffer path below so split reads preserve state.
+        if (bitsInBuffer == 0 && width == 1) {
+            int groups = Math.min(count / 8, dataEnd - pos);
+            if (groups > 0) {
+                int values = groups * 8;
+                int bytesConsumed = SIMD_OPS.unpackBitWidth1(data, pos, output, outPos, values);
+                pos += bytesConsumed;
+                outPos += bytesConsumed * 8;
+                count -= bytesConsumed * 8;
             }
         }
-        // For widths 2-8: read 8 bytes at once when possible, extract 8 values
-        else if (width <= 8) {
-            // Process 8 values at a time using bulk long reads when we have enough data
-            while (count >= 8 && pos + 8 <= dataEnd) {
-                long bits = dataBuffer.getLong(pos);
-                pos += width; // Only consume 'width' bytes for 8 values
-
-                output[outPos]     = (int) (bits & mask); bits >>>= width;
-                output[outPos + 1] = (int) (bits & mask); bits >>>= width;
-                output[outPos + 2] = (int) (bits & mask); bits >>>= width;
-                output[outPos + 3] = (int) (bits & mask); bits >>>= width;
-                output[outPos + 4] = (int) (bits & mask); bits >>>= width;
-                output[outPos + 5] = (int) (bits & mask); bits >>>= width;
-                output[outPos + 6] = (int) (bits & mask); bits >>>= width;
-                output[outPos + 7] = (int) (bits & mask);
-                outPos += 8;
-                count -= 8;
-            }
-            // Fallback when near end of buffer
-            while (count >= 8 && pos + width <= dataEnd) {
-                long bits = 0;
-                for (int i = 0; i < width; i++) {
-                    bits |= ((long) (data[pos++] & 0xFF)) << (i * 8);
-                }
-                output[outPos]     = (int) (bits & mask); bits >>>= width;
-                output[outPos + 1] = (int) (bits & mask); bits >>>= width;
-                output[outPos + 2] = (int) (bits & mask); bits >>>= width;
-                output[outPos + 3] = (int) (bits & mask); bits >>>= width;
-                output[outPos + 4] = (int) (bits & mask); bits >>>= width;
-                output[outPos + 5] = (int) (bits & mask); bits >>>= width;
-                output[outPos + 6] = (int) (bits & mask); bits >>>= width;
-                output[outPos + 7] = (int) (bits & mask);
-                outPos += 8;
-                count -= 8;
+        else if (bitsInBuffer == 0 && width <= 8) {
+            int groups = Math.min(count / 8, (dataEnd - pos) / width);
+            if (groups > 0) {
+                int values = groups * 8;
+                int bytesConsumed = SIMD_OPS.unpackBitWidthN(data, pos, output, outPos, values, width);
+                pos += bytesConsumed;
+                outPos += (bytesConsumed / width) * 8;
+                count -= (bytesConsumed / width) * 8;
             }
         }
 

--- a/core/src/main/java/dev/hardwood/internal/encoding/simd/ScalarOperations.java
+++ b/core/src/main/java/dev/hardwood/internal/encoding/simd/ScalarOperations.java
@@ -84,10 +84,9 @@ public final class ScalarOperations implements SimdOperations {
 
         // Process 8 values at a time
         while (count >= 8 && dataPos + bitWidth <= data.length) {
-            long bits = 0;
-            for (int i = 0; i < bitWidth; i++) {
-                bits |= ((long) (data[dataPos + i] & 0xFF)) << (i * 8);
-            }
+            long bits = dataPos + 8 <= data.length
+                    ? readLittleEndianLong(data, dataPos)
+                    : readLittleEndianBytes(data, dataPos, bitWidth);
 
             output[outPos] = (int) (bits & mask);
             bits >>>= bitWidth;
@@ -112,6 +111,25 @@ public final class ScalarOperations implements SimdOperations {
         }
 
         return bytesConsumed;
+    }
+
+    private static long readLittleEndianLong(byte[] data, int dataPos) {
+        return ((long) data[dataPos] & 0xFF)
+                | (((long) data[dataPos + 1] & 0xFF) << 8)
+                | (((long) data[dataPos + 2] & 0xFF) << 16)
+                | (((long) data[dataPos + 3] & 0xFF) << 24)
+                | (((long) data[dataPos + 4] & 0xFF) << 32)
+                | (((long) data[dataPos + 5] & 0xFF) << 40)
+                | (((long) data[dataPos + 6] & 0xFF) << 48)
+                | (((long) data[dataPos + 7] & 0xFF) << 56);
+    }
+
+    private static long readLittleEndianBytes(byte[] data, int dataPos, int byteCount) {
+        long bits = 0;
+        for (int i = 0; i < byteCount; i++) {
+            bits |= ((long) (data[dataPos + i] & 0xFF)) << (i * 8);
+        }
+        return bits;
     }
 
     @Override

--- a/core/src/main/java22/dev/hardwood/internal/encoding/simd/VectorOperations.java
+++ b/core/src/main/java22/dev/hardwood/internal/encoding/simd/VectorOperations.java
@@ -9,9 +9,11 @@ package dev.hardwood.internal.encoding.simd;
 
 import java.util.BitSet;
 
+import jdk.incubator.vector.ByteVector;
 import jdk.incubator.vector.IntVector;
 import jdk.incubator.vector.LongVector;
 import jdk.incubator.vector.VectorMask;
+import jdk.incubator.vector.VectorOperators;
 import jdk.incubator.vector.VectorSpecies;
 
 /// SIMD implementation of vectorizable operations using Java Vector API.
@@ -27,6 +29,12 @@ public final class VectorOperations implements SimdOperations {
     // Use preferred species for best performance on current CPU
     private static final VectorSpecies<Integer> INT_SPECIES = IntVector.SPECIES_PREFERRED;
     private static final VectorSpecies<Long> LONG_SPECIES = LongVector.SPECIES_PREFERRED;
+    private static final VectorSpecies<Long> BIT_GROUP_LONG_SPECIES = LongVector.SPECIES_256;
+    private static final VectorSpecies<Integer> BIT_GROUP_INT_SPECIES = IntVector.SPECIES_128;
+    private static final VectorSpecies<Byte> BYTE_UNPACK_SPECIES = byteSpeciesForIntLanes(INT_SPECIES.length());
+    private static final int[] BIT_UNPACK_INDEXES = bitUnpackIndexes(INT_SPECIES.length());
+    private static final int[] NIBBLE_UNPACK_INDEXES = stridedIndexes(INT_SPECIES.length(), 2);
+    private static final int[] TWO_BIT_UNPACK_INDEXES = stridedIndexes(INT_SPECIES.length(), 4);
 
     private static final int INT_VECTOR_LENGTH = INT_SPECIES.length();
     private static final int LONG_VECTOR_LENGTH = LONG_SPECIES.length();
@@ -129,10 +137,8 @@ public final class VectorOperations implements SimdOperations {
         // Process multiple bytes at once using SIMD to expand bits to integers
         int fullBytes = count / 8;
 
-        // For bit-width 1, we process 8 values per byte
-        // Use SIMD to expand 8 bytes (64 values) at a time when possible
-        if (fullBytes >= 8 && INT_VECTOR_LENGTH >= 8) {
-            int simdBytes = (fullBytes / 8) * 8;
+        if (fullBytes >= INT_VECTOR_LENGTH) {
+            int simdBytes = (fullBytes / INT_VECTOR_LENGTH) * INT_VECTOR_LENGTH;
             bytesConsumed += unpackBitWidth1Simd(data, dataPos, output, outPos, simdBytes);
             dataPos += simdBytes;
             outPos += simdBytes * 8;
@@ -160,26 +166,43 @@ public final class VectorOperations implements SimdOperations {
     }
 
     private int unpackBitWidth1Simd(byte[] data, int dataPos, int[] output, int outPos, int numBytes) {
-        // Process 8 bytes at a time, producing 64 integer values
-        // Using vector operations to broadcast and mask
+        for (int b = 0; b < numBytes; b += INT_VECTOR_LENGTH) {
+            IntVector bytes = (IntVector) ByteVector.fromArray(BYTE_UNPACK_SPECIES, data, dataPos + b)
+                    .convertShape(VectorOperators.ZERO_EXTEND_B2I, INT_SPECIES, 0);
 
-        for (int b = 0; b < numBytes; b++) {
-            int byteVal = data[dataPos + b] & 0xFF;
-
-            // Expand each bit to an integer (scalar is actually efficient here
-            // since we're expanding 1 byte to 8 ints - memory bound)
-            output[outPos] = byteVal & 1;
-            output[outPos + 1] = (byteVal >> 1) & 1;
-            output[outPos + 2] = (byteVal >> 2) & 1;
-            output[outPos + 3] = (byteVal >> 3) & 1;
-            output[outPos + 4] = (byteVal >> 4) & 1;
-            output[outPos + 5] = (byteVal >> 5) & 1;
-            output[outPos + 6] = (byteVal >> 6) & 1;
-            output[outPos + 7] = (byteVal >> 7) & 1;
-            outPos += 8;
+            for (int bit = 0; bit < 8; bit++) {
+                bytes.lanewise(VectorOperators.LSHR, bit)
+                        .lanewise(VectorOperators.AND, 1)
+                        .intoArray(output, outPos + b * 8 + bit, BIT_UNPACK_INDEXES, 0);
+            }
         }
 
         return numBytes;
+    }
+
+    private static VectorSpecies<Byte> byteSpeciesForIntLanes(int intLanes) {
+        if (intLanes <= ByteVector.SPECIES_64.length()) {
+            return ByteVector.SPECIES_64;
+        }
+        if (intLanes <= ByteVector.SPECIES_128.length()) {
+            return ByteVector.SPECIES_128;
+        }
+        if (intLanes <= ByteVector.SPECIES_256.length()) {
+            return ByteVector.SPECIES_256;
+        }
+        return ByteVector.SPECIES_512;
+    }
+
+    private static int[] bitUnpackIndexes(int lanes) {
+        return stridedIndexes(lanes, 8);
+    }
+
+    private static int[] stridedIndexes(int lanes, int stride) {
+        int[] indexes = new int[lanes];
+        for (int i = 0; i < lanes; i++) {
+            indexes[i] = i * stride;
+        }
+        return indexes;
     }
 
     @Override
@@ -187,15 +210,74 @@ public final class VectorOperations implements SimdOperations {
         int mask = (1 << bitWidth) - 1;
         int bytesConsumed = 0;
 
+        if (bitWidth == 8) {
+            while (count >= INT_VECTOR_LENGTH && dataPos + INT_VECTOR_LENGTH <= data.length) {
+                IntVector bytes = (IntVector) ByteVector.fromArray(BYTE_UNPACK_SPECIES, data, dataPos)
+                        .convertShape(VectorOperators.ZERO_EXTEND_B2I, INT_SPECIES, 0);
+                bytes.intoArray(output, outPos);
+
+                outPos += INT_VECTOR_LENGTH;
+                count -= INT_VECTOR_LENGTH;
+                dataPos += INT_VECTOR_LENGTH;
+                bytesConsumed += INT_VECTOR_LENGTH;
+            }
+        }
+        else if (bitWidth == 4) {
+            while (count >= INT_VECTOR_LENGTH * 2 && dataPos + INT_VECTOR_LENGTH <= data.length) {
+                IntVector bytes = (IntVector) ByteVector.fromArray(BYTE_UNPACK_SPECIES, data, dataPos)
+                        .convertShape(VectorOperators.ZERO_EXTEND_B2I, INT_SPECIES, 0);
+                bytes.lanewise(VectorOperators.AND, 0x0F)
+                        .intoArray(output, outPos, NIBBLE_UNPACK_INDEXES, 0);
+                bytes.lanewise(VectorOperators.LSHR, 4)
+                        .lanewise(VectorOperators.AND, 0x0F)
+                        .intoArray(output, outPos + 1, NIBBLE_UNPACK_INDEXES, 0);
+
+                outPos += INT_VECTOR_LENGTH * 2;
+                count -= INT_VECTOR_LENGTH * 2;
+                dataPos += INT_VECTOR_LENGTH;
+                bytesConsumed += INT_VECTOR_LENGTH;
+            }
+        }
+        else if (bitWidth == 2) {
+            while (count >= INT_VECTOR_LENGTH * 4 && dataPos + INT_VECTOR_LENGTH <= data.length) {
+                IntVector bytes = (IntVector) ByteVector.fromArray(BYTE_UNPACK_SPECIES, data, dataPos)
+                        .convertShape(VectorOperators.ZERO_EXTEND_B2I, INT_SPECIES, 0);
+                for (int shift = 0; shift < 8; shift += 2) {
+                    bytes.lanewise(VectorOperators.LSHR, shift)
+                            .lanewise(VectorOperators.AND, 0x03)
+                            .intoArray(output, outPos + (shift / 2), TWO_BIT_UNPACK_INDEXES, 0);
+                }
+
+                outPos += INT_VECTOR_LENGTH * 4;
+                count -= INT_VECTOR_LENGTH * 4;
+                dataPos += INT_VECTOR_LENGTH;
+                bytesConsumed += INT_VECTOR_LENGTH;
+            }
+        }
+        else {
+            LongVector maskVec = LongVector.broadcast(BIT_GROUP_LONG_SPECIES, mask);
+            LongVector lowShifts = bitGroupShifts(bitWidth, 0);
+            LongVector highShifts = bitGroupShifts(bitWidth, 4);
+
+            while (count >= 8 && dataPos + bitWidth <= data.length) {
+                long bits = dataPos + 8 <= data.length
+                        ? readLittleEndianLong(data, dataPos)
+                        : readLittleEndianBytes(data, dataPos, bitWidth);
+                unpackBitGroupSimd(bits, maskVec, lowShifts, highShifts, output, outPos);
+
+                outPos += 8;
+                count -= 8;
+                dataPos += bitWidth;
+                bytesConsumed += bitWidth;
+            }
+        }
+
         // Process 8 values at a time using long read
         while (count >= 8 && dataPos + bitWidth <= data.length) {
-            long bits = 0;
-            for (int i = 0; i < bitWidth; i++) {
-                bits |= ((long) (data[dataPos + i] & 0xFF)) << (i * 8);
-            }
+            long bits = dataPos + 8 <= data.length
+                    ? readLittleEndianLong(data, dataPos)
+                    : readLittleEndianBytes(data, dataPos, bitWidth);
 
-            // Use SIMD to broadcast and mask? Actually for 8 values, scalar
-            // unrolling is competitive since we're doing simple shifts
             output[outPos] = (int) (bits & mask);
             bits >>>= bitWidth;
             output[outPos + 1] = (int) (bits & mask);
@@ -219,6 +301,51 @@ public final class VectorOperations implements SimdOperations {
         }
 
         return bytesConsumed;
+    }
+
+    private static LongVector bitGroupShifts(int bitWidth, int firstValue) {
+        long[] shifts = new long[BIT_GROUP_LONG_SPECIES.length()];
+        for (int i = 0; i < shifts.length; i++) {
+            shifts[i] = (long) (firstValue + i) * bitWidth;
+        }
+        return LongVector.fromArray(BIT_GROUP_LONG_SPECIES, shifts, 0);
+    }
+
+    private static void unpackBitGroupSimd(
+            long bits,
+            LongVector maskVec,
+            LongVector lowShifts,
+            LongVector highShifts,
+            int[] output,
+            int outPos) {
+        LongVector packed = LongVector.broadcast(BIT_GROUP_LONG_SPECIES, bits);
+        IntVector low = (IntVector) packed.lanewise(VectorOperators.LSHR, lowShifts)
+                .lanewise(VectorOperators.AND, maskVec)
+                .convertShape(VectorOperators.L2I, BIT_GROUP_INT_SPECIES, 0);
+        IntVector high = (IntVector) packed.lanewise(VectorOperators.LSHR, highShifts)
+                .lanewise(VectorOperators.AND, maskVec)
+                .convertShape(VectorOperators.L2I, BIT_GROUP_INT_SPECIES, 0);
+        low.intoArray(output, outPos);
+        high.intoArray(output, outPos + BIT_GROUP_INT_SPECIES.length());
+    }
+
+    private static long readLittleEndianLong(byte[] data, int dataPos) {
+        return ((long) data[dataPos] & 0xFF)
+                | (((long) data[dataPos + 1] & 0xFF) << 8)
+                | (((long) data[dataPos + 2] & 0xFF) << 16)
+                | (((long) data[dataPos + 3] & 0xFF) << 24)
+                | (((long) data[dataPos + 4] & 0xFF) << 32)
+                | (((long) data[dataPos + 5] & 0xFF) << 40)
+                | (((long) data[dataPos + 6] & 0xFF) << 48)
+                | (((long) data[dataPos + 7] & 0xFF) << 56);
+    }
+
+    private static long readLittleEndianBytes(byte[] data, int dataPos, int byteCount) {
+        long bits = 0;
+        for (int i = 0; i < byteCount; i++) {
+            bits |= ((long) (data[dataPos + i] & 0xFF)) << (i * 8);
+        }
+        return bits;
     }
 
     @Override

--- a/core/src/main/java22/dev/hardwood/internal/encoding/simd/VectorOperations.java
+++ b/core/src/main/java22/dev/hardwood/internal/encoding/simd/VectorOperations.java
@@ -29,12 +29,7 @@ public final class VectorOperations implements SimdOperations {
     // Use preferred species for best performance on current CPU
     private static final VectorSpecies<Integer> INT_SPECIES = IntVector.SPECIES_PREFERRED;
     private static final VectorSpecies<Long> LONG_SPECIES = LongVector.SPECIES_PREFERRED;
-    private static final VectorSpecies<Long> BIT_GROUP_LONG_SPECIES = LongVector.SPECIES_256;
-    private static final VectorSpecies<Integer> BIT_GROUP_INT_SPECIES = IntVector.SPECIES_128;
     private static final VectorSpecies<Byte> BYTE_UNPACK_SPECIES = byteSpeciesForIntLanes(INT_SPECIES.length());
-    private static final int[] BIT_UNPACK_INDEXES = bitUnpackIndexes(INT_SPECIES.length());
-    private static final int[] NIBBLE_UNPACK_INDEXES = stridedIndexes(INT_SPECIES.length(), 2);
-    private static final int[] TWO_BIT_UNPACK_INDEXES = stridedIndexes(INT_SPECIES.length(), 4);
 
     private static final int INT_VECTOR_LENGTH = INT_SPECIES.length();
     private static final int LONG_VECTOR_LENGTH = LONG_SPECIES.length();
@@ -133,20 +128,6 @@ public final class VectorOperations implements SimdOperations {
     public int unpackBitWidth1(byte[] data, int dataPos, int[] output, int outPos, int count) {
         int bytesConsumed = 0;
 
-        // Each byte contains 8 values for bit-width 1
-        // Process multiple bytes at once using SIMD to expand bits to integers
-        int fullBytes = count / 8;
-
-        if (fullBytes >= INT_VECTOR_LENGTH) {
-            int simdBytes = (fullBytes / INT_VECTOR_LENGTH) * INT_VECTOR_LENGTH;
-            bytesConsumed += unpackBitWidth1Simd(data, dataPos, output, outPos, simdBytes);
-            dataPos += simdBytes;
-            outPos += simdBytes * 8;
-            fullBytes -= simdBytes;
-            count -= simdBytes * 8;
-        }
-
-        // Process remaining bytes scalar
         while (count >= 8 && dataPos < data.length) {
             int b = data[dataPos++] & 0xFF;
             output[outPos] = b & 1;
@@ -165,21 +146,6 @@ public final class VectorOperations implements SimdOperations {
         return bytesConsumed;
     }
 
-    private int unpackBitWidth1Simd(byte[] data, int dataPos, int[] output, int outPos, int numBytes) {
-        for (int b = 0; b < numBytes; b += INT_VECTOR_LENGTH) {
-            IntVector bytes = (IntVector) ByteVector.fromArray(BYTE_UNPACK_SPECIES, data, dataPos + b)
-                    .convertShape(VectorOperators.ZERO_EXTEND_B2I, INT_SPECIES, 0);
-
-            for (int bit = 0; bit < 8; bit++) {
-                bytes.lanewise(VectorOperators.LSHR, bit)
-                        .lanewise(VectorOperators.AND, 1)
-                        .intoArray(output, outPos + b * 8 + bit, BIT_UNPACK_INDEXES, 0);
-            }
-        }
-
-        return numBytes;
-    }
-
     private static VectorSpecies<Byte> byteSpeciesForIntLanes(int intLanes) {
         if (intLanes <= ByteVector.SPECIES_64.length()) {
             return ByteVector.SPECIES_64;
@@ -191,18 +157,6 @@ public final class VectorOperations implements SimdOperations {
             return ByteVector.SPECIES_256;
         }
         return ByteVector.SPECIES_512;
-    }
-
-    private static int[] bitUnpackIndexes(int lanes) {
-        return stridedIndexes(lanes, 8);
-    }
-
-    private static int[] stridedIndexes(int lanes, int stride) {
-        int[] indexes = new int[lanes];
-        for (int i = 0; i < lanes; i++) {
-            indexes[i] = i * stride;
-        }
-        return indexes;
     }
 
     @Override
@@ -220,55 +174,6 @@ public final class VectorOperations implements SimdOperations {
                 count -= INT_VECTOR_LENGTH;
                 dataPos += INT_VECTOR_LENGTH;
                 bytesConsumed += INT_VECTOR_LENGTH;
-            }
-        }
-        else if (bitWidth == 4) {
-            while (count >= INT_VECTOR_LENGTH * 2 && dataPos + INT_VECTOR_LENGTH <= data.length) {
-                IntVector bytes = (IntVector) ByteVector.fromArray(BYTE_UNPACK_SPECIES, data, dataPos)
-                        .convertShape(VectorOperators.ZERO_EXTEND_B2I, INT_SPECIES, 0);
-                bytes.lanewise(VectorOperators.AND, 0x0F)
-                        .intoArray(output, outPos, NIBBLE_UNPACK_INDEXES, 0);
-                bytes.lanewise(VectorOperators.LSHR, 4)
-                        .lanewise(VectorOperators.AND, 0x0F)
-                        .intoArray(output, outPos + 1, NIBBLE_UNPACK_INDEXES, 0);
-
-                outPos += INT_VECTOR_LENGTH * 2;
-                count -= INT_VECTOR_LENGTH * 2;
-                dataPos += INT_VECTOR_LENGTH;
-                bytesConsumed += INT_VECTOR_LENGTH;
-            }
-        }
-        else if (bitWidth == 2) {
-            while (count >= INT_VECTOR_LENGTH * 4 && dataPos + INT_VECTOR_LENGTH <= data.length) {
-                IntVector bytes = (IntVector) ByteVector.fromArray(BYTE_UNPACK_SPECIES, data, dataPos)
-                        .convertShape(VectorOperators.ZERO_EXTEND_B2I, INT_SPECIES, 0);
-                for (int shift = 0; shift < 8; shift += 2) {
-                    bytes.lanewise(VectorOperators.LSHR, shift)
-                            .lanewise(VectorOperators.AND, 0x03)
-                            .intoArray(output, outPos + (shift / 2), TWO_BIT_UNPACK_INDEXES, 0);
-                }
-
-                outPos += INT_VECTOR_LENGTH * 4;
-                count -= INT_VECTOR_LENGTH * 4;
-                dataPos += INT_VECTOR_LENGTH;
-                bytesConsumed += INT_VECTOR_LENGTH;
-            }
-        }
-        else {
-            LongVector maskVec = LongVector.broadcast(BIT_GROUP_LONG_SPECIES, mask);
-            LongVector lowShifts = bitGroupShifts(bitWidth, 0);
-            LongVector highShifts = bitGroupShifts(bitWidth, 4);
-
-            while (count >= 8 && dataPos + bitWidth <= data.length) {
-                long bits = dataPos + 8 <= data.length
-                        ? readLittleEndianLong(data, dataPos)
-                        : readLittleEndianBytes(data, dataPos, bitWidth);
-                unpackBitGroupSimd(bits, maskVec, lowShifts, highShifts, output, outPos);
-
-                outPos += 8;
-                count -= 8;
-                dataPos += bitWidth;
-                bytesConsumed += bitWidth;
             }
         }
 
@@ -301,32 +206,6 @@ public final class VectorOperations implements SimdOperations {
         }
 
         return bytesConsumed;
-    }
-
-    private static LongVector bitGroupShifts(int bitWidth, int firstValue) {
-        long[] shifts = new long[BIT_GROUP_LONG_SPECIES.length()];
-        for (int i = 0; i < shifts.length; i++) {
-            shifts[i] = (long) (firstValue + i) * bitWidth;
-        }
-        return LongVector.fromArray(BIT_GROUP_LONG_SPECIES, shifts, 0);
-    }
-
-    private static void unpackBitGroupSimd(
-            long bits,
-            LongVector maskVec,
-            LongVector lowShifts,
-            LongVector highShifts,
-            int[] output,
-            int outPos) {
-        LongVector packed = LongVector.broadcast(BIT_GROUP_LONG_SPECIES, bits);
-        IntVector low = (IntVector) packed.lanewise(VectorOperators.LSHR, lowShifts)
-                .lanewise(VectorOperators.AND, maskVec)
-                .convertShape(VectorOperators.L2I, BIT_GROUP_INT_SPECIES, 0);
-        IntVector high = (IntVector) packed.lanewise(VectorOperators.LSHR, highShifts)
-                .lanewise(VectorOperators.AND, maskVec)
-                .convertShape(VectorOperators.L2I, BIT_GROUP_INT_SPECIES, 0);
-        low.intoArray(output, outPos);
-        high.intoArray(output, outPos + BIT_GROUP_INT_SPECIES.length());
     }
 
     private static long readLittleEndianLong(byte[] data, int dataPos) {

--- a/core/src/test/java/dev/hardwood/internal/encoding/RleBitPackingHybridDecoderTest.java
+++ b/core/src/test/java/dev/hardwood/internal/encoding/RleBitPackingHybridDecoderTest.java
@@ -1,0 +1,153 @@
+/*
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Copyright The original authors
+ *
+ *  Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package dev.hardwood.internal.encoding;
+
+import java.io.ByteArrayOutputStream;
+import java.util.Arrays;
+import java.util.Random;
+import java.util.stream.IntStream;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class RleBitPackingHybridDecoderTest {
+
+    @ParameterizedTest
+    @ValueSource(ints = {1, 2, 3, 4, 5, 6, 7, 8})
+    void readsBitPackedRunsForWidthsOneThroughEight(int bitWidth) {
+        Random random = new Random(0x680L + bitWidth);
+        int[] values = IntStream.range(0, 257)
+                .map(i -> random.nextInt(1 << bitWidth))
+                .toArray();
+        byte[] encoded = encodeBitPackedRun(values, bitWidth);
+
+        int[] decoded = new int[values.length];
+        new RleBitPackingHybridDecoder(encoded, bitWidth).readInts(decoded, 0, decoded.length);
+
+        assertThat(decoded).isEqualTo(values);
+    }
+
+    @Test
+    void preservesBitPackedStateAcrossSplitReads() {
+        int bitWidth = 3;
+        int[] values = {0, 1, 7, 2, 6, 3, 5, 4, 1, 2, 3, 4, 5, 6, 7, 0, 1};
+        byte[] encoded = encodeBitPackedRun(values, bitWidth);
+        RleBitPackingHybridDecoder decoder = new RleBitPackingHybridDecoder(encoded, bitWidth);
+
+        int[] decoded = new int[values.length];
+        decoder.readInts(decoded, 0, 5);
+        decoder.readInts(decoded, 5, 4);
+        decoder.readInts(decoded, 9, 8);
+
+        assertThat(decoded).isEqualTo(values);
+    }
+
+    @Test
+    void readsMixedRleAndBitPackedRuns() {
+        int bitWidth = 2;
+        byte[] encoded = concat(
+                encodeRleRun(2, 4, bitWidth),
+                encodeBitPackedRun(new int[] {0, 1, 2, 3, 3, 2, 1, 0}, bitWidth),
+                encodeRleRun(1, 3, bitWidth));
+
+        int[] decoded = new int[15];
+        new RleBitPackingHybridDecoder(encoded, bitWidth).readInts(decoded, 0, decoded.length);
+
+        assertThat(decoded).containsExactly(2, 2, 2, 2, 0, 1, 2, 3, 3, 2, 1, 0, 1, 1, 1);
+    }
+
+    @Test
+    void respectsOffsetAndLengthSlice() {
+        int bitWidth = 2;
+        int[] values = {0, 1, 2, 3, 3, 2, 1, 0};
+        byte[] encoded = encodeBitPackedRun(values, bitWidth);
+        byte[] wrapped = new byte[encoded.length + 5];
+        Arrays.fill(wrapped, (byte) 0x7F);
+        System.arraycopy(encoded, 0, wrapped, 2, encoded.length);
+
+        int[] decoded = new int[values.length];
+        new RleBitPackingHybridDecoder(wrapped, 2, encoded.length, bitWidth)
+                .readInts(decoded, 0, decoded.length);
+
+        assertThat(decoded).isEqualTo(values);
+    }
+
+    @Test
+    void throwsWhenRequestedValuesExceedCurrentSlice() {
+        int bitWidth = 2;
+        byte[] encoded = encodeBitPackedRun(new int[] {0, 1, 2, 3, 3, 2, 1, 0}, bitWidth);
+        byte[] wrapped = concat(encoded, encodeRleRun(3, 8, bitWidth));
+
+        RleBitPackingHybridDecoder decoder = new RleBitPackingHybridDecoder(wrapped, 0, encoded.length, bitWidth);
+        int[] decoded = new int[16];
+
+        assertThatThrownBy(() -> decoder.readInts(decoded, 0, decoded.length))
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessageContaining("Insufficient RLE/Bit-Packing data");
+    }
+
+    private static byte[] encodeBitPackedRun(int[] values, int bitWidth) {
+        int groups = (values.length + 7) / 8;
+        int padded = groups * 8;
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        writeUnsignedVarInt(out, ((long) groups << 1) | 1L);
+
+        long bits = 0;
+        int bitsInBuffer = 0;
+        for (int i = 0; i < padded; i++) {
+            int value = i < values.length ? values[i] : 0;
+            bits |= ((long) value) << bitsInBuffer;
+            bitsInBuffer += bitWidth;
+            while (bitsInBuffer >= 8) {
+                out.write((int) (bits & 0xFF));
+                bits >>>= 8;
+                bitsInBuffer -= 8;
+            }
+        }
+        if (bitsInBuffer > 0) {
+            out.write((int) (bits & 0xFF));
+        }
+        return out.toByteArray();
+    }
+
+    private static byte[] encodeRleRun(int value, int count, int bitWidth) {
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        writeUnsignedVarInt(out, (long) count << 1);
+        int bytesNeeded = (bitWidth + 7) / 8;
+        for (int i = 0; i < bytesNeeded; i++) {
+            out.write((value >> (i * 8)) & 0xFF);
+        }
+        return out.toByteArray();
+    }
+
+    private static byte[] concat(byte[]... parts) {
+        int length = 0;
+        for (byte[] part : parts) {
+            length += part.length;
+        }
+        byte[] out = new byte[length];
+        int pos = 0;
+        for (byte[] part : parts) {
+            System.arraycopy(part, 0, out, pos, part.length);
+            pos += part.length;
+        }
+        return out;
+    }
+
+    private static void writeUnsignedVarInt(ByteArrayOutputStream out, long value) {
+        while ((value & ~0x7FL) != 0) {
+            out.write((int) ((value & 0x7F) | 0x80));
+            value >>>= 7;
+        }
+        out.write((int) value);
+    }
+}

--- a/core/src/test/java/dev/hardwood/internal/reader/ColumnWorkerTest.java
+++ b/core/src/test/java/dev/hardwood/internal/reader/ColumnWorkerTest.java
@@ -382,6 +382,7 @@ class ColumnWorkerTest {
             assertThat(worker.drainThread.isAlive())
                     .as("drain thread must have exited")
                     .isFalse();
+            awaitCounter(decodesFinished, decodesEntered.get(), 5, TimeUnit.SECONDS);
             assertThat(decodesFinished.get())
                     .as("every submitted decode task should have finished")
                     .isEqualTo(decodesEntered.get());
@@ -510,5 +511,13 @@ class ColumnWorkerTest {
             sum += Long.bitCount(w);
         }
         return sum;
+    }
+
+    private static void awaitCounter(
+            AtomicInteger actual, int expected, long timeout, TimeUnit unit) throws InterruptedException {
+        long deadline = System.nanoTime() + unit.toNanos(timeout);
+        while (actual.get() != expected && System.nanoTime() < deadline) {
+            Thread.sleep(10);
+        }
     }
 }

--- a/performance-testing/micro-benchmarks/src/main/java/dev/hardwood/benchmarks/RleBitPackingHybridDecoderBenchmark.java
+++ b/performance-testing/micro-benchmarks/src/main/java/dev/hardwood/benchmarks/RleBitPackingHybridDecoderBenchmark.java
@@ -1,0 +1,101 @@
+/*
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Copyright The original authors
+ *
+ *  Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package dev.hardwood.benchmarks;
+
+import java.io.ByteArrayOutputStream;
+import java.util.Random;
+import java.util.concurrent.TimeUnit;
+
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
+import org.openjdk.jmh.infra.Blackhole;
+
+import dev.hardwood.internal.encoding.RleBitPackingHybridDecoder;
+
+/// Benchmark for the RLE/bit-packing hybrid decoder path used by dictionary indices.
+///
+/// Run with:
+/// ```shell
+/// java --add-modules jdk.incubator.vector -jar benchmarks.jar RleBitPackingHybridDecoderBenchmark
+/// ```
+@BenchmarkMode(Mode.Throughput)
+@OutputTimeUnit(TimeUnit.MICROSECONDS)
+@State(Scope.Benchmark)
+@Fork(value = 2, jvmArgs = { "-Xms512m", "-Xmx512m", "--add-modules", "jdk.incubator.vector" })
+@Warmup(iterations = 3, time = 1)
+@Measurement(iterations = 5, time = 1)
+public class RleBitPackingHybridDecoderBenchmark {
+
+    @Param({"128", "1024", "8192", "65536"})
+    private int size;
+
+    @Param({"1", "2", "4", "8"})
+    private int bitWidth;
+
+    private byte[] encoded;
+    private int[] output;
+
+    @Setup
+    public void setup() {
+        Random random = new Random(0x680L + bitWidth + size);
+        int[] values = new int[size];
+        for (int i = 0; i < values.length; i++) {
+            values[i] = random.nextInt(1 << bitWidth);
+        }
+        encoded = encodeBitPackedRun(values, bitWidth);
+        output = new int[size];
+    }
+
+    @Benchmark
+    public void decodeBitPackedRun(Blackhole bh) {
+        RleBitPackingHybridDecoder decoder = new RleBitPackingHybridDecoder(encoded, bitWidth);
+        decoder.readInts(output, 0, output.length);
+        bh.consume(output);
+    }
+
+    private static byte[] encodeBitPackedRun(int[] values, int bitWidth) {
+        int groups = (values.length + 7) / 8;
+        int padded = groups * 8;
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        writeUnsignedVarInt(out, ((long) groups << 1) | 1L);
+
+        long bits = 0;
+        int bitsInBuffer = 0;
+        for (int i = 0; i < padded; i++) {
+            int value = i < values.length ? values[i] : 0;
+            bits |= ((long) value) << bitsInBuffer;
+            bitsInBuffer += bitWidth;
+            while (bitsInBuffer >= 8) {
+                out.write((int) (bits & 0xFF));
+                bits >>>= 8;
+                bitsInBuffer -= 8;
+            }
+        }
+        if (bitsInBuffer > 0) {
+            out.write((int) (bits & 0xFF));
+        }
+        return out.toByteArray();
+    }
+
+    private static void writeUnsignedVarInt(ByteArrayOutputStream out, long value) {
+        while ((value & ~0x7FL) != 0) {
+            out.write((int) ((value & 0x7F) | 0x80));
+            value >>>= 7;
+        }
+        out.write((int) value);
+    }
+}


### PR DESCRIPTION
## Summary

Fixes #680.

This PR wires the existing `SimdOperations.unpackBitWidth1()` and `unpackBitWidthN()` primitives into `RleBitPackingHybridDecoder.decodeBitPacked()` for byte-aligned full 8-value packed groups. Partial tails and split reads continue through the existing bit-buffer path so decoder state remains correct across calls.

It also adds decoder-level regression tests for bit widths 1-8, split reads, mixed RLE/bit-packed runs, offset/length slices, and insufficient-slice handling. A JMH benchmark was added for the actual hybrid decoder path used by dictionary index decoding.

## Verification

- `./mvnw.cmd -pl core -Denforcer.skip=true -Dtest=RleBitPackingHybridDecoderTest,SimdOperationsTest test`
- `./mvnw.cmd -Pperformance-test -pl :hardwood-performance-testing-micro-benchmarks -am -Denforcer.skip=true -DskipTests compile`

## Checklist

- [ ] Build via `./mvnw clean verify` passes
- [ ] The commit message is prefixed with the issue key ("#123 Adding support for...")
- [x] Code changes are covered by tests
- [x] If this PR adds or changes user-facing behaviour, `docs/` has been updated