### PR TITLE
Make multi-file skip a global offset

### DIFF
--- a/core/src/main/java/dev/hardwood/internal/reader/RowGroupIterator.java
+++ b/core/src/main/java/dev/hardwood/internal/reader/RowGroupIterator.java
@@ -72,6 +72,7 @@ public class RowGroupIterator {
     private final List<InputFile> inputFiles;
     private final HardwoodContextImpl context;
     private final long maxRows;
+    private final long physicalSkip;
 
     /// Number of leading rows of the first row group to skip. Non-zero only on
     /// the tail-read fast path; consumed by [#computeFetchPlans] to synthesize
@@ -80,6 +81,7 @@ public class RowGroupIterator {
     /// be promoted from the construction-time value of `0` via
     /// [#setTailSkip(long)] once the gate decision is in.
     private long tailSkip;
+    private long firstRowGroupSkip;
 
     // Set after first file
     private FileSchema referenceSchema;
@@ -171,21 +173,46 @@ public class RowGroupIterator {
     ///        cross-column alignment.
     public RowGroupIterator(List<InputFile> inputFiles, HardwoodContextImpl context,
                             long maxRows, long tailSkip) {
+        this(inputFiles, context, maxRows, tailSkip, 0);
+    }
+
+    /// Creates a RowGroupIterator with tail-skip and physical-skip budgets.
+    ///
+    /// @param inputFiles one or more input files (must not be empty)
+    /// @param context the Hardwood context
+    /// @param maxRows maximum rows to read (0 = unlimited)
+    /// @param tailSkip leading rows of the first row group to skip via per-page
+    ///        masking (0 = unused)
+    /// @param physicalSkip leading physical rows to skip while building the
+    ///        work list (0 = unused). Whole row groups are dropped; the residue
+    ///        within the first kept row group is exposed via [#firstRowGroupSkip()].
+    public RowGroupIterator(List<InputFile> inputFiles, HardwoodContextImpl context,
+                            long maxRows, long tailSkip, long physicalSkip) {
         if (inputFiles.isEmpty()) {
             throw new IllegalArgumentException("At least one file must be provided");
         }
         if (tailSkip < 0) {
             throw new IllegalArgumentException("tailSkip must be non-negative, got " + tailSkip);
         }
+        if (physicalSkip < 0) {
+            throw new IllegalArgumentException("physicalSkip must be non-negative, got " + physicalSkip);
+        }
         this.inputFiles = new ArrayList<>(inputFiles);
         this.context = context;
         this.maxRows = maxRows;
         this.tailSkip = tailSkip;
+        this.physicalSkip = physicalSkip;
     }
 
     /// Returns the maximum rows limit (0 = unlimited).
     public long maxRows() {
         return maxRows;
+    }
+
+    /// Rows to discard from the first kept row group after whole row groups
+    /// before the physical skip target have been dropped from the work list.
+    public long firstRowGroupSkip() {
+        return firstRowGroupSkip;
     }
 
     /// Sets the reference schema and pre-prepared first file, skipping [#openFirst()].
@@ -821,7 +848,8 @@ public class RowGroupIterator {
         if (maxRows <= 0 || filterPredicate != null) {
             return 0;
         }
-        return Math.max(0, maxRows - workItem.rowsConsumedBefore());
+        long leadingSkip = workItem.workItemIndex() == 0 ? firstRowGroupSkip : 0;
+        return Math.max(0, maxRows - workItem.rowsConsumedBefore() + leadingSkip);
     }
 
     /// Returns the context.
@@ -858,6 +886,7 @@ public class RowGroupIterator {
     private void buildWorkList() {
         long rowBudget = maxRows > 0 ? maxRows : Long.MAX_VALUE;
         long rowsConsumed = 0;
+        long physicalSkipRemaining = physicalSkip;
         boolean hasFilter = filterPredicate != null;
 
         for (int fileIndex = 0; fileIndex < inputFiles.size() && rowBudget > 0; fileIndex++) {
@@ -866,6 +895,18 @@ public class RowGroupIterator {
 
             for (int rgIndex = 0; rgIndex < rowGroups.size() && rowBudget > 0; rgIndex++) {
                 RowGroup rg = rowGroups.get(rgIndex);
+                long rgRows = rg.numRows();
+                if (physicalSkipRemaining >= rgRows) {
+                    physicalSkipRemaining -= rgRows;
+                    continue;
+                }
+
+                long leadingSkip = physicalSkipRemaining;
+                physicalSkipRemaining = 0;
+                if (workItems.isEmpty()) {
+                    firstRowGroupSkip = leadingSkip;
+                }
+
                 workItems.add(new WorkItem(
                         prepared.inputFile,
                         rg,
@@ -879,9 +920,9 @@ public class RowGroupIterator {
                 // With a filter active, actual match count is unpredictable,
                 // so all row groups remain available.
                 if (!hasFilter) {
-                    rowBudget -= rg.numRows();
+                    rowBudget -= rgRows - leadingSkip;
                 }
-                rowsConsumed += rg.numRows();
+                rowsConsumed += rgRows - leadingSkip;
             }
 
             // Trigger prefetch of next file

--- a/core/src/main/java/dev/hardwood/internal/reader/RowGroupIterator.java
+++ b/core/src/main/java/dev/hardwood/internal/reader/RowGroupIterator.java
@@ -186,6 +186,9 @@ public class RowGroupIterator {
     /// @param physicalSkip leading physical rows to skip while building the
     ///        work list (0 = unused). Whole row groups are dropped; the residue
     ///        within the first kept row group is exposed via [#firstRowGroupSkip()].
+    ///        Mutually exclusive with `tailSkip` — one masks the first row group's
+    ///        leading rows, the other drops leading row groups, with no combined
+    ///        semantics.
     public RowGroupIterator(List<InputFile> inputFiles, HardwoodContextImpl context,
                             long maxRows, long tailSkip, long physicalSkip) {
         if (inputFiles.isEmpty()) {
@@ -196,6 +199,11 @@ public class RowGroupIterator {
         }
         if (physicalSkip < 0) {
             throw new IllegalArgumentException("physicalSkip must be non-negative, got " + physicalSkip);
+        }
+        if (tailSkip > 0 && physicalSkip > 0) {
+            throw new IllegalArgumentException(
+                    "tailSkip and physicalSkip are mutually exclusive, got tailSkip=" + tailSkip
+                            + ", physicalSkip=" + physicalSkip);
         }
         this.inputFiles = new ArrayList<>(inputFiles);
         this.context = context;

--- a/core/src/main/java/dev/hardwood/reader/ParquetFileReader.java
+++ b/core/src/main/java/dev/hardwood/reader/ParquetFileReader.java
@@ -269,40 +269,9 @@ public class ParquetFileReader implements AutoCloseable {
             return discardLeadingRows(reader, skip);
         }
 
-        // No filter: `skip` is a physical row offset. Locate the row group containing
-        // `skip` by walking cumulative RowGroup.numRows() over the filtered list, open
-        // from there, and discard the within-group residue — earlier row groups are
-        // never opened (O(1 row-group) seek). After the loop, `cumulative` equals the
-        // total row count of `filteredRowGroups` if no target was found.
-        long cumulative = 0L;
-        int targetRg = -1;
-        long withinRg = 0L;
-        for (int i = 0; i < filteredRowGroups.size(); i++) {
-            long rgRows = filteredRowGroups.get(i).numRows();
-            if (skip < cumulative + rgRows) {
-                targetRg = i;
-                withinRg = skip - cumulative;
-                break;
-            }
-            cumulative += rgRows;
-        }
-        if (targetRg < 0) {
-            // skip >= total rows — a SQL OFFSET past the end of the relation, so an
-            // empty reader (consistent with the filtered case overshooting the matches).
-            return buildRowReader(projection, filter, maxRows, List.<RowGroup>of());
-        }
-        List<RowGroup> rowGroups = targetRg == 0
-                ? filteredRowGroups
-                : filteredRowGroups.subList(targetRg, filteredRowGroups.size());
-        // The reader yields from the start of `targetRg`. We bump maxRows
-        // by the within-RG skip distance because head(N) bounds *yielded*
-        // rows; the residue rows we discard via next() count too.
-        long maxRowsAdjusted = maxRows == 0 ? 0 : maxRows + withinRg;
-        RowReader reader = buildRowReader(projection, filter, maxRowsAdjusted, rowGroups);
-        // Walk past the within-RG residue. These rows *are* decoded —
-        // page-level skip via OffsetIndex (#381) would let us drop the
-        // leading pages at the byte level instead.
-        return discardLeadingRows(reader, withinRg);
+        RowReader reader = buildRowReader(projection, filter, maxRows, filteredRowGroups, 0L, skip);
+        long firstRowGroupSkip = rowGroupIterators.get(rowGroupIterators.size() - 1).firstRowGroupSkip();
+        return discardLeadingRows(reader, firstRowGroupSkip);
     }
 
     /// Advances `reader` past its first `count` rows via `next()` and returns it,
@@ -380,17 +349,24 @@ public class ParquetFileReader implements AutoCloseable {
     private RowReader buildRowReader(ColumnProjection projection, FilterPredicate filter,
                                      long maxRows, List<RowGroup> firstFileRowGroups,
                                      long tailSkip) {
+        return buildRowReader(projection, filter, maxRows, firstFileRowGroups, tailSkip, 0L);
+    }
+
+    private RowReader buildRowReader(ColumnProjection projection, FilterPredicate filter,
+                                     long maxRows, List<RowGroup> firstFileRowGroups,
+                                     long tailSkip, long physicalSkip) {
         ResolvedPredicate resolved = filter != null
                 ? FilterPredicateResolver.resolve(filter, schema, firstFileMetaData.columnOrders()) : null;
 
         ProjectedSchema projectedSchema = ProjectedSchema.create(schema, projection, true);
 
-        RowGroupIterator iterator = new RowGroupIterator(inputFiles, context, maxRows, tailSkip);
+        RowGroupIterator iterator = new RowGroupIterator(inputFiles, context, maxRows, tailSkip, physicalSkip);
         iterator.setFirstFile(schema, firstFileRowGroups);
         iterator.initialize(projectedSchema, resolved);
         rowGroupIterators.add(iterator);
 
-        return createRowReader(iterator, schema, projectedSchema, context, resolved, maxRows);
+        long readerMaxRows = maxRows == 0 ? 0 : Math.addExact(maxRows, iterator.firstRowGroupSkip());
+        return createRowReader(iterator, schema, projectedSchema, context, resolved, readerMaxRows);
     }
 
     /// Creates a [RowReader] for the given pipeline components.
@@ -687,13 +663,12 @@ public class ParquetFileReader implements AutoCloseable {
         /// Skip leading rows before reading — SQL `OFFSET`. Its meaning depends on
         /// whether a [#filter(FilterPredicate)] is present:
         ///
-        /// - **Without a filter:** a physical absolute row index. Earlier row groups
-        ///   are not opened — an O(1 row-group) seek on remote backends (the leading
-        ///   residue within the target row group is still decoded). For a single-file
-        ///   reader, `skip >= totalRows` yields an empty reader. For a multi-file reader
-        ///   the offset resolves against the first file only and never carries across
-        ///   a file boundary. `skip` at or beyond the first file's row count drops
-        ///   it entirely and streams the remaining files in full.
+        /// - **Without a filter:** a physical absolute row index over the concatenated
+        ///   input relation. Earlier row groups are not opened — an O(1 row-group)
+        ///   seek on remote backends (the leading residue within the target row group
+        ///   is still decoded). For a multi-file reader, footers of skipped files are
+        ///   read until the target file is found, but skipped files' data pages are
+        ///   not fetched or decoded. `skip >= totalRows` yields an empty reader.
         /// - **With a filter:** a *logical* offset over the matched rows — discards the
         ///   first `n` rows matching the predicate, symmetric with [#head] as `LIMIT`.
         ///   The O(1) seek does not apply: the reader decodes earlier groups to count

--- a/core/src/main/java/dev/hardwood/reader/ParquetFileReader.java
+++ b/core/src/main/java/dev/hardwood/reader/ParquetFileReader.java
@@ -269,9 +269,11 @@ public class ParquetFileReader implements AutoCloseable {
             return discardLeadingRows(reader, skip);
         }
 
-        RowReader reader = buildRowReader(projection, filter, maxRows, filteredRowGroups, 0L, skip);
-        long firstRowGroupSkip = rowGroupIterators.get(rowGroupIterators.size() - 1).firstRowGroupSkip();
-        return discardLeadingRows(reader, firstRowGroupSkip);
+        // No filter: `skip` is a physical row offset over the concatenated relation.
+        // buildRowReader seeks to the row group the offset lands in (dropping earlier
+        // groups across files without fetching their data) and discards the within-group
+        // residue.
+        return buildRowReader(projection, filter, maxRows, filteredRowGroups, 0L, skip);
     }
 
     /// Advances `reader` past its first `count` rows via `next()` and returns it,
@@ -365,8 +367,15 @@ public class ParquetFileReader implements AutoCloseable {
         iterator.initialize(projectedSchema, resolved);
         rowGroupIterators.add(iterator);
 
-        long readerMaxRows = maxRows == 0 ? 0 : Math.addExact(maxRows, iterator.firstRowGroupSkip());
-        return createRowReader(iterator, schema, projectedSchema, context, resolved, readerMaxRows);
+        // Physical-skip residue: the iterator has seeked to the row group the offset
+        // lands in and exposes the leading rows of that group still to be dropped. The
+        // reader yields them (head(N) bounds *yielded* rows), so cap it at the
+        // residue-adjusted limit and then walk past the residue. Both are zero — and the
+        // discard a no-op — for non-skip reads and for the filtered (logical) skip path.
+        long firstRowGroupSkip = iterator.firstRowGroupSkip();
+        long readerMaxRows = maxRows == 0 ? 0 : Math.addExact(maxRows, firstRowGroupSkip);
+        RowReader reader = createRowReader(iterator, schema, projectedSchema, context, resolved, readerMaxRows);
+        return discardLeadingRows(reader, firstRowGroupSkip);
     }
 
     /// Creates a [RowReader] for the given pipeline components.

--- a/core/src/test/java/dev/hardwood/BuilderCombinationTest.java
+++ b/core/src/test/java/dev/hardwood/BuilderCombinationTest.java
@@ -240,6 +240,16 @@ class BuilderCombinationTest {
 
     @Test
     void physicalMultiFileSkipDoesNotReadMiddleSkippedFileData() throws Exception {
+        // Footer-only read cost of part1, derived rather than hard-coded: a
+        // single-file open reads exactly the footer via the same metadata reader
+        // the multi-file seek uses lazily for a skipped file.
+        CountingInputFile probe = new CountingInputFile(InputFile.of(
+                Paths.get("src/test/resources/multi_file_part1.parquet")));
+        try (ParquetFileReader ignored = ParquetFileReader.open(probe)) {
+            // open() reads the footer
+        }
+        int footerOnlyReads = probe.readCount();
+
         CountingInputFile file0 = new CountingInputFile(InputFile.of(
                 Paths.get("src/test/resources/multi_file_part0.parquet")));
         CountingInputFile skippedMiddle = new CountingInputFile(InputFile.of(
@@ -251,8 +261,8 @@ class BuilderCombinationTest {
             assertThat(ids(reader.buildRowReader().skip(250).head(1)))
                     .containsExactly(150L);
             assertThat(skippedMiddle.readCount())
-                    .as("middle file should only be opened for metadata")
-                    .isEqualTo(3);
+                    .as("middle file should only be read for its footer, no data pages")
+                    .isEqualTo(footerOnlyReads);
             assertThat(skippedMiddle.bytesRead())
                     .as("middle file should not have data pages fetched")
                     .isLessThan(skippedMiddle.length());

--- a/core/src/test/java/dev/hardwood/BuilderCombinationTest.java
+++ b/core/src/test/java/dev/hardwood/BuilderCombinationTest.java
@@ -7,10 +7,14 @@
  */
 package dev.hardwood;
 
+import java.io.IOException;
+import java.nio.ByteBuffer;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicLong;
 import java.util.function.Consumer;
 import java.util.stream.LongStream;
 import java.util.stream.Stream;
@@ -194,9 +198,9 @@ class BuilderCombinationTest {
         }
     }
 
-    /// Multi-file boundary cells (#577) — physical `skip` (no filter) indexes into the first file
-    /// only, logical `skip` (with a filter) counts matches across *all* files in order, and
-    /// `tail` is single-file-only (throws).
+    /// Multi-file boundary cells (#577, #672) — physical `skip` (no filter) is a
+    /// global offset across all files, logical `skip` (with a filter) counts matches
+    /// across *all* files in order, and `tail` is single-file-only (throws).
     /// `id` is the global row position: file 0 holds 0..149, file 1 holds 150..249.
     @Test
     void multiFileBoundaries() throws Exception {
@@ -205,11 +209,56 @@ class BuilderCombinationTest {
                     .containsExactlyElementsOf(longRange(125, 249));
             assertThat(ids(reader.buildRowReader().filter(FilterPredicate.gt("id", 99L)).skip(60)))
                     .containsExactlyElementsOf(longRange(160, 249));
-            // skip beyond file0 row count - does NOT carry into file1, which streams in full
             assertThat(ids(reader.buildRowReader().skip(160)))
-                    .containsExactlyElementsOf(longRange(150, 249));
+                    .containsExactlyElementsOf(longRange(160, 249));
+            assertThat(ids(reader.buildRowReader().skip(250)))
+                    .isEmpty();
+            assertThat(ids(reader.buildRowReader().skip(300)))
+                    .isEmpty();
             assertThatThrownBy(reader.buildRowReader().tail(50)::build)
                     .isInstanceOf(UnsupportedOperationException.class);
+        }
+    }
+
+    @Test
+    void physicalMultiFileSkipDoesNotReadSkippedFileData() throws Exception {
+        CountingInputFile file0 = new CountingInputFile(InputFile.of(
+                Paths.get("src/test/resources/multi_file_part0.parquet")));
+        CountingInputFile file1 = new CountingInputFile(InputFile.of(
+                Paths.get("src/test/resources/multi_file_part1.parquet")));
+
+        try (ParquetFileReader reader = ParquetFileReader.openAll(List.of(file0, file1))) {
+            int file0ReadsAfterOpen = file0.readCount();
+
+            assertThat(ids(reader.buildRowReader().skip(160).head(1)))
+                    .containsExactly(160L);
+            assertThat(file0.readCount())
+                    .as("file 0 should only have the footer reads from openAll")
+                    .isEqualTo(file0ReadsAfterOpen);
+        }
+    }
+
+    @Test
+    void physicalMultiFileSkipDoesNotReadMiddleSkippedFileData() throws Exception {
+        CountingInputFile file0 = new CountingInputFile(InputFile.of(
+                Paths.get("src/test/resources/multi_file_part0.parquet")));
+        CountingInputFile skippedMiddle = new CountingInputFile(InputFile.of(
+                Paths.get("src/test/resources/multi_file_part1.parquet")));
+        CountingInputFile target = new CountingInputFile(InputFile.of(
+                Paths.get("src/test/resources/multi_file_part1.parquet")));
+
+        try (ParquetFileReader reader = ParquetFileReader.openAll(List.of(file0, skippedMiddle, target))) {
+            assertThat(ids(reader.buildRowReader().skip(250).head(1)))
+                    .containsExactly(150L);
+            assertThat(skippedMiddle.readCount())
+                    .as("middle file should only be opened for metadata")
+                    .isEqualTo(3);
+            assertThat(skippedMiddle.bytesRead())
+                    .as("middle file should not have data pages fetched")
+                    .isLessThan(skippedMiddle.length());
+            assertThat(target.readCount())
+                    .as("target file should be read beyond metadata to produce a row")
+                    .isGreaterThan(skippedMiddle.readCount());
         }
     }
 
@@ -226,5 +275,50 @@ class BuilderCombinationTest {
 
     private static List<Long> longRange(long fromInclusive, long toInclusive) {
         return LongStream.rangeClosed(fromInclusive, toInclusive).boxed().toList();
+    }
+
+    private static final class CountingInputFile implements InputFile {
+        private final InputFile delegate;
+        private final AtomicInteger readCount = new AtomicInteger();
+        private final AtomicLong bytesRead = new AtomicLong();
+
+        private CountingInputFile(InputFile delegate) {
+            this.delegate = delegate;
+        }
+
+        int readCount() {
+            return readCount.get();
+        }
+
+        long bytesRead() {
+            return bytesRead.get();
+        }
+
+        @Override
+        public void open() throws IOException {
+            delegate.open();
+        }
+
+        @Override
+        public ByteBuffer readRange(long offset, int length) throws IOException {
+            readCount.incrementAndGet();
+            bytesRead.addAndGet(length);
+            return delegate.readRange(offset, length);
+        }
+
+        @Override
+        public long length() throws IOException {
+            return delegate.length();
+        }
+
+        @Override
+        public String name() {
+            return delegate.name();
+        }
+
+        @Override
+        public void close() throws IOException {
+            delegate.close();
+        }
     }
 }

--- a/core/src/test/java/dev/hardwood/ColumnProjectionTest.java
+++ b/core/src/test/java/dev/hardwood/ColumnProjectionTest.java
@@ -365,6 +365,35 @@ public class ColumnProjectionTest {
     }
 
     @Test
+    void physicalSkipKeepsMandatoryMapKeyForValueOnlyProjection() throws Exception {
+        // Regression guard: a no-filter `skip` must complete containers exactly
+        // like the skip-less read path, so a MAP's mandatory key leaf is kept when
+        // only the value sub-field is projected. Same fixture as
+        // mapValueSubFieldProjectionShouldReadKeysAndValue; skip(1) drops row 0
+        // (employee1, employee2), leaving row 1 ({manager}) and the empty-map row 2.
+        Path parquetFile = Paths.get("src/test/resources/map_struct_value_test.parquet");
+
+        try (ParquetFileReader reader = ParquetFileReader.open(InputFile.of(parquetFile));
+             RowReader rows = reader.buildRowReader()
+                     .projection(ColumnProjection.columns("people.key_value.value.age"))
+                     .skip(1).build()) {
+
+            List<String> keys = new ArrayList<>();
+            List<Integer> ages = new ArrayList<>();
+            while (rows.hasNext()) {
+                rows.next();
+                PqMap people = rows.getMap("people");
+                for (PqMap.Entry entry : people.getEntries()) {
+                    keys.add(entry.getStringKey());
+                    ages.add(entry.getStructValue().getInt("age"));
+                }
+            }
+            assertThat(keys).containsExactly("manager");
+            assertThat(ages).containsExactly(45);
+        }
+    }
+
+    @Test
     void mapKeyOnlyProjectionDoesNotPullInValue() throws Exception {
         // Same map_struct_value_test.parquet fixture. Projecting only the key
         // sub-field people.key_value.value... is the mirror of the value-side

--- a/docs/content/how-to/query-controls.md
+++ b/docs/content/how-to/query-controls.md
@@ -315,7 +315,7 @@ try (ParquetFileReader fileReader = ParquetFileReader.open(InputFile.of(path));
 }
 ```
 
-`skip == 0` is the no-op default. `skip >= totalRows` produces an empty reader (a SQL `OFFSET` past the end of the file, or of the concatenated relation for multi-file readers). Within the target row group, the reader still decodes the leading residue rows and discards them via `next()`; page-level skip via the OffsetIndex is tracked separately.
+`skip == 0` is the no-op default. `skip >= totalRows` produces an empty reader (a SQL `OFFSET` past the end of the file, or of the concatenated relation for multi-file readers). The seek lands at row-group granularity: rows before the offset within the target row group are still read.
 
 For multi-file readers, physical `skip(N)` is a global offset across the input files in order. Hardwood reads the footers of skipped files to count their rows, but skipped files' data pages are not fetched or decoded.
 

--- a/docs/content/how-to/query-controls.md
+++ b/docs/content/how-to/query-controls.md
@@ -315,10 +315,9 @@ try (ParquetFileReader fileReader = ParquetFileReader.open(InputFile.of(path));
 }
 ```
 
-`skip == 0` is the no-op default. `skip >= totalRows` produces an empty reader (a SQL `OFFSET` past the end of the file). Within the target row group, the reader still decodes the leading residue rows and discards them via `next()`; page-level skip via the OffsetIndex is tracked separately.
+`skip == 0` is the no-op default. `skip >= totalRows` produces an empty reader (a SQL `OFFSET` past the end of the file, or of the concatenated relation for multi-file readers). Within the target row group, the reader still decodes the leading residue rows and discards them via `next()`; page-level skip via the OffsetIndex is tracked separately.
 
-!!! warning "Multi-file readers: first file only"
-    For the no-filter (physical) case, `skip(N)` indexes into the **first** file's rows only — it never carries across a file boundary. A `skip` at or beyond the first file's row count therefore does not empty the reader: it drops the first file and streams the remaining files in full. To skip whole files, omit them from the input list; to skip within a non-first file, open it separately.
+For multi-file readers, physical `skip(N)` is a global offset across the input files in order. Hardwood reads the footers of skipped files to count their rows, but skipped files' data pages are not fetched or decoded.
 
 **With a filter,** `skip(n)` is a *logical* offset over the matched rows — it discards the first `n` rows that match the predicate and returns the rest, exactly like SQL `OFFSET` after a `WHERE`. The O(1 row-group) seek does **not** apply: row-group statistics bound min/max values, not match *counts*, so the reader decodes earlier groups to count matches (groups whose statistics prove no match are still pruned). A `skip` past the number of matching rows yields an empty reader rather than throwing.
 

--- a/docs/content/release-notes.md
+++ b/docs/content/release-notes.md
@@ -13,6 +13,10 @@
 
 See [GitHub Releases](https://github.com/hardwood-hq/hardwood/releases) for downloads and more information.
 
+## 1.1.0-SNAPSHOT
+
+- Physical `skip(N)` on multi-file row readers is now a true global offset over the concatenated input files; skipped files have their footers read for row counts, but their data pages are not decoded.
+
 ## 1.0.0.Final (2026-06-25)
 
 [Announcement blog post](https://www.morling.dev/blog/hardwood-1-0-fast-lightweight-apache-parquet-reader-for-the-jvm/) · [API changes](/api-changes/1.0.0.Final/)


### PR DESCRIPTION
## Summary

Fixes #672.

This changes physical no-filter `skip(N)` on multi-file row readers to behave as a true global offset across the concatenated input files. Hardwood now walks file footers until it finds the target file/row group, then starts reading from there. Skipped files have their footers read for row counts, but their data pages are not fetched or decoded.

## Changes

- Resolves physical multi-file `skip(N)` globally instead of relative to file 0.
- Returns an empty reader when `skip >= total rows across all files`.
- Preserves filtered `skip(N)` as logical `OFFSET` over matching rows.
- Adds regression coverage for multi-file boundary behavior and skipped-file read counts.
- Updates JavaDoc, query-control docs, and release notes.

## Verification

- Manual compile checks passed for changed production/test files with `javac --release 21`.
- JShell smoke checks passed for:
  - `skip(160)` yielding ids `160..249`
  - `skip(250)` yielding empty
  - skipped file data not being read

## Checklist

- [ ] Build via `./mvnw clean verify` passes
- [ ] The commit message is prefixed with the issue key ("#123 Adding support for...")
- [x] Code changes are covered by tests
- [x] If this PR adds or changes user-facing behaviour, `docs/` has been updated