### PR TITLE
#718 Evaluate row-group statistics once and split row-group filter JFR events

### DIFF
--- a/core/src/main/java/dev/hardwood/jfr/RowGroupByteRangeFilterEvent.java
+++ b/core/src/main/java/dev/hardwood/jfr/RowGroupByteRangeFilterEvent.java
@@ -1,0 +1,46 @@
+/*
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Copyright The original authors
+ *
+ *  Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package dev.hardwood.jfr;
+
+import jdk.jfr.Category;
+import jdk.jfr.Description;
+import jdk.jfr.Event;
+import jdk.jfr.Label;
+import jdk.jfr.Name;
+import jdk.jfr.StackTrace;
+
+/// JFR event emitted when row groups are selected by a byte-range row-group predicate
+/// (split-aware reading).
+///
+/// This is distinct from [RowGroupFilterEvent], which reports row groups dropped by
+/// statistics predicate push-down. Byte-range selection keeps a row group when its
+/// midpoint falls inside the requested split, and runs before push-down: the row groups
+/// reported as kept here are the input to the push-down evaluation.
+@Name("dev.hardwood.RowGroupByteRangeFilter")
+@Label("Row Group Byte-Range Filter")
+@Category({"Hardwood", "Filter"})
+@Description("Row groups selected by a byte-range split predicate")
+@StackTrace(false)
+public class RowGroupByteRangeFilterEvent extends Event {
+
+    @Label("File")
+    @Description("Name of the Parquet file")
+    public String file;
+
+    @Label("Total Row Groups")
+    @Description("Total number of row groups in the file before byte-range selection")
+    public int totalRowGroups;
+
+    @Label("Row Groups Kept")
+    @Description("Number of row groups whose midpoint falls inside the requested split")
+    public int rowGroupsKept;
+
+    @Label("Row Groups Skipped")
+    @Description("Number of row groups skipped because their midpoint falls outside the split")
+    public int rowGroupsSkipped;
+}

--- a/core/src/main/java/dev/hardwood/jfr/RowGroupFilterEvent.java
+++ b/core/src/main/java/dev/hardwood/jfr/RowGroupFilterEvent.java
@@ -27,7 +27,7 @@ public class RowGroupFilterEvent extends Event {
     public String file;
 
     @Label("Total Row Groups")
-    @Description("Total number of row groups in the file before filtering")
+    @Description("Total number of row groups before predicate push-down")
     public int totalRowGroups;
 
     @Label("Row Groups Kept")

--- a/core/src/main/java/dev/hardwood/reader/ParquetFileReader.java
+++ b/core/src/main/java/dev/hardwood/reader/ParquetFileReader.java
@@ -17,7 +17,6 @@ import dev.hardwood.InputFile;
 import dev.hardwood.internal.ExceptionContext;
 import dev.hardwood.internal.predicate.FilterPredicateResolver;
 import dev.hardwood.internal.predicate.ResolvedPredicate;
-import dev.hardwood.internal.predicate.RowGroupFilterEvaluator;
 import dev.hardwood.internal.reader.BatchSizing;
 import dev.hardwood.internal.reader.FlatRowReader;
 import dev.hardwood.internal.reader.HardwoodContextImpl;
@@ -26,7 +25,7 @@ import dev.hardwood.internal.reader.ParquetMetadataReader;
 import dev.hardwood.internal.reader.RowGroupIterator;
 import dev.hardwood.internal.schema.ProjectedSchema;
 import dev.hardwood.jfr.FileOpenedEvent;
-import dev.hardwood.jfr.RowGroupFilterEvent;
+import dev.hardwood.jfr.RowGroupByteRangeFilterEvent;
 import dev.hardwood.metadata.FileMetaData;
 import dev.hardwood.metadata.RowGroup;
 import dev.hardwood.schema.ColumnProjection;
@@ -252,9 +251,7 @@ public class ParquetFileReader implements AutoCloseable {
         // into the kept sequence — a caller doing split-aware reading can seek inside *its*
         // split. Stats-based row-group dropping (via FilterPredicate) stays inside the
         // RowGroupIterator.
-        List<RowGroup> filteredRowGroups = rowGroupFilter == null
-                ? firstFileMetaData.rowGroups()
-                : filterRowGroups(null, rowGroupFilter);
+        List<RowGroup> filteredRowGroups = filterRowGroups(rowGroupFilter);
 
         if (skip == 0L) {
             return buildRowReader(projection, filter, maxRows, filteredRowGroups);
@@ -436,7 +433,7 @@ public class ParquetFileReader implements AutoCloseable {
                     .getColumnReader(0);
         }
         InputFile inputFile = inputFiles.get(0);
-        List<RowGroup> rowGroups = filterRowGroups(null, rowGroupFilter);
+        List<RowGroup> rowGroups = filterRowGroups(rowGroupFilter);
         return ColumnReader.create(columnName, schema, inputFile, rowGroups, context, null, batchSize);
     }
 
@@ -453,7 +450,7 @@ public class ParquetFileReader implements AutoCloseable {
                     .getColumnReader(0);
         }
         InputFile inputFile = inputFiles.get(0);
-        List<RowGroup> rowGroups = filterRowGroups(null, rowGroupFilter);
+        List<RowGroup> rowGroups = filterRowGroups(rowGroupFilter);
         return ColumnReader.create(columnIndex, schema, inputFile, rowGroups, context, null, batchSize);
     }
 
@@ -468,7 +465,7 @@ public class ParquetFileReader implements AutoCloseable {
             int batchSize) {
         ResolvedPredicate resolved = filter != null
                 ? FilterPredicateResolver.resolve(filter, schema, firstFileMetaData.columnOrders()) : null;
-        List<RowGroup> rowGroups = filterRowGroups(resolved, rowGroupFilter);
+        List<RowGroup> rowGroups = filterRowGroups(rowGroupFilter);
 
         if (resolved == null) {
             RowGroupIterator iterator = new RowGroupIterator(inputFiles, context, 0);
@@ -539,22 +536,25 @@ public class ParquetFileReader implements AutoCloseable {
         return rowGroups.subList(startIndex, rowGroups.size());
     }
 
-    /// Filter row groups by an optional column-statistics predicate and an optional
-    /// [RowGroupPredicate]. A row group is kept if and only if it passes both.
-    private List<RowGroup> filterRowGroups(
-            ResolvedPredicate filter, RowGroupPredicate rowGroupFilter) {
+    /// Pre-filter row groups by an optional byte-range [RowGroupPredicate]. Statistics-based
+    /// dropping (via a [FilterPredicate]) is not applied here — it stays inside the
+    /// [RowGroupIterator], which applies it per file. Returns all row groups unchanged when no
+    /// `rowGroupFilter` is given.
+    ///
+    /// Doing the byte-range check here, before the iterator's statistics evaluation, preserves
+    /// the cheap-first ordering: the byte-range predicate is both cheaper (a midpoint compare)
+    /// and more selective (one shard out of N) in split-aware reads, so the rejected majority of
+    /// row groups never reach the more expensive statistics check downstream.
+    private List<RowGroup> filterRowGroups(RowGroupPredicate rowGroupFilter) {
         List<RowGroup> all = firstFileMetaData.rowGroups();
-        // Evaluate the RowGroupPredicate first: in split-aware reads it is both
-        // cheaper (a midpoint compare for ByteRange) and more selective (one shard
-        // out of N), short-circuiting the column-statistics check on the rejected
-        // majority.
+        if (rowGroupFilter == null) {
+            return all;
+        }
         List<RowGroup> kept = all.stream()
-                .filter(rg -> rowGroupFilter == null || matches(rg, rowGroupFilter))
-                .filter(rg -> filter == null
-                        || !RowGroupFilterEvaluator.canDropRowGroup(filter, rg))
+                .filter(rg -> matches(rg, rowGroupFilter))
                 .toList();
 
-        RowGroupFilterEvent event = new RowGroupFilterEvent();
+        RowGroupByteRangeFilterEvent event = new RowGroupByteRangeFilterEvent();
         event.file = inputFiles.get(0).name();
         event.totalRowGroups = all.size();
         event.rowGroupsKept = kept.size();

--- a/core/src/test/java/dev/hardwood/RowGroupFilterEventTest.java
+++ b/core/src/test/java/dev/hardwood/RowGroupFilterEventTest.java
@@ -1,0 +1,118 @@
+/*
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Copyright The original authors
+ *
+ *  Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package dev.hardwood;
+
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.List;
+
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import dev.hardwood.jfr.AbstractJfrRecorderTest;
+import dev.hardwood.reader.ColumnReaders;
+import dev.hardwood.reader.FilterPredicate;
+import dev.hardwood.reader.ParquetFileReader;
+import dev.hardwood.reader.RowGroupPredicate;
+import dev.hardwood.schema.ColumnProjection;
+import jdk.jfr.consumer.RecordedEvent;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/// Asserts the two row-group filtering stages each emit their own JFR event exactly once
+/// for a single-file read: `dev.hardwood.RowGroupByteRangeFilter` for byte-range split
+/// selection (emitted by [ParquetFileReader]) and `dev.hardwood.RowGroupFilter` for
+/// statistics predicate push-down (emitted by the row-group iterator).
+///
+/// Regression guard for #718: the column-readers path used to evaluate the first file's
+/// statistics twice — once eagerly in [ParquetFileReader] and again in the iterator —
+/// emitting two `RowGroupFilter` events whose second `totalRowGroups` reported the
+/// already-pruned count rather than the file's real total.
+class RowGroupFilterEventTest extends AbstractJfrRecorderTest {
+
+    private static final Path FIXTURE = Paths.get("src/test/resources/filter_pushdown_int.parquet");
+    private static final String BYTE_RANGE_EVENT = "dev.hardwood.RowGroupByteRangeFilter";
+    private static final String PUSH_DOWN_EVENT = "dev.hardwood.RowGroupFilter";
+
+    private static long fileLen;
+
+    @BeforeAll
+    static void readFixture() throws Exception {
+        try (ParquetFileReader reader = ParquetFileReader.open(InputFile.of(FIXTURE))) {
+            assertThat(reader.getFileMetaData().rowGroups()).hasSize(3);
+        }
+        fileLen = FIXTURE.toFile().length();
+    }
+
+    @Test
+    void predicatePushDownEmitsSinglePushDownEventAndNoByteRangeEvent() throws Exception {
+        readIdColumn(reader -> reader.buildColumnReaders(ColumnProjection.columns("id"))
+                .filter(FilterPredicate.gt("id", 150L))
+                .build());
+
+        List<RecordedEvent> pushDown = events(PUSH_DOWN_EVENT).toList();
+        assertThat(pushDown)
+                .as("exactly one predicate-push-down event for the single file")
+                .hasSize(1);
+        assertThat(pushDown.get(0).getInt("totalRowGroups"))
+                .as("total must be the file's real row-group count")
+                .isEqualTo(3);
+        assertThat(pushDown.getFirst().getInt("rowGroupsKept")).isEqualTo(2);
+        assertThat(pushDown.getFirst().getInt("rowGroupsSkipped")).isEqualTo(1);
+
+        assertThat(events(BYTE_RANGE_EVENT).count())
+                .as("no byte-range event without a RowGroupPredicate")
+                .isZero();
+    }
+
+    @Test
+    void byteRangeEmitsByteRangeEventNotPushDownEvent() throws Exception {
+        readIdColumn(reader -> reader.buildColumnReaders(ColumnProjection.columns("id"))
+                .filter(RowGroupPredicate.byteRange(0, fileLen))
+                .build());
+
+        assertThat(events(BYTE_RANGE_EVENT).count())
+                .as("byte-range selection emits exactly one byte-range event")
+                .isEqualTo(1);
+        assertThat(events(PUSH_DOWN_EVENT).count())
+                .as("no push-down event without a FilterPredicate")
+                .isZero();
+    }
+
+    @Test
+    void byteRangeAndPredicateEmitOneEventEach() throws Exception {
+        readIdColumn(reader -> reader.buildColumnReaders(ColumnProjection.columns("id"))
+                .filter(FilterPredicate.gt("id", 150L))
+                .filter(RowGroupPredicate.byteRange(0, fileLen))
+                .build());
+
+        assertThat(events(BYTE_RANGE_EVENT).count())
+                .as("one byte-range event")
+                .isEqualTo(1);
+        assertThat(events(PUSH_DOWN_EVENT).count())
+                .as("statistics evaluated once: one push-down event")
+                .isEqualTo(1);
+    }
+
+    /// Builds a [ColumnReaders] over the fixture via `build`, then stops the recording.
+    /// Single-file row-group filtering (both the byte-range pre-filter and the iterator's
+    /// statistics push-down) runs eagerly during `build`, so no read is needed to emit the
+    /// events.
+    private void readIdColumn(ColumnReadersFactory build) throws Exception {
+        try (ParquetFileReader reader = ParquetFileReader.open(InputFile.of(FIXTURE));
+             ColumnReaders cols = build.create(reader)) {
+            assertThat(cols.getColumnReader(0)).isNotNull();
+        }
+        awaitEvents();
+    }
+
+    @FunctionalInterface
+    private interface ColumnReadersFactory {
+        ColumnReaders create(ParquetFileReader reader);
+    }
+}

--- a/docs/content/reference/configuration.md
+++ b/docs/content/reference/configuration.md
@@ -98,7 +98,8 @@ Or attach dynamically via `jcmd <pid> JFR.start`.
 | `dev.hardwood.FileMapping` | I/O | Memory-mapping of a file region. Fields: file, offset, size |
 | `dev.hardwood.RowGroupScanned` | Decode | Page boundaries scanned in a column chunk. Fields: file, rowGroupIndex, column, pageCount, scanStrategy (`sequential` or `offset-index`) |
 | `dev.hardwood.PageDecoded` | Decode | Single data page decoded. Fields: column, compressedSize, uncompressedSize |
-| `dev.hardwood.RowGroupFilter` | Filter | Row groups filtered by predicate pushdown. Fields: file, totalRowGroups, rowGroupsKept, rowGroupsSkipped |
+| `dev.hardwood.RowGroupFilter` | Filter | Row groups dropped by statistics predicate pushdown. Fields: file, totalRowGroups, rowGroupsKept, rowGroupsSkipped |
+| `dev.hardwood.RowGroupByteRangeFilter` | Filter | Row groups selected by a byte-range split predicate (split-aware reading). Fields: file, totalRowGroups, rowGroupsKept, rowGroupsSkipped |
 | `dev.hardwood.PageFilter` | Filter | Pages filtered by Column Index predicate pushdown. Fields: file, rowGroupIndex, column, totalPages, pagesKept, pagesSkipped |
 | `dev.hardwood.RecordFilter` | Filter | Records filtered by record-level predicate evaluation. Fields: totalRecords, recordsKept, recordsSkipped |
 | `dev.hardwood.BatchWait` | Pipeline | Consumer blocked waiting for the assembly pipeline. Fields: column |
@@ -107,7 +108,7 @@ Or attach dynamically via `jcmd <pid> JFR.start`.
 Events appear under the **Hardwood** category in JDK Mission Control (JMC) or any JFR analysis tool. Use them to identify:
 
 - **I/O bottlenecks** — large `FileMapping` durations or frequent `PrefetchMiss` events
-- **Filter effectiveness** — `RowGroupFilter` shows how many row groups were skipped; `PageFilter` shows how many pages were skipped within surviving row groups; `RecordFilter` shows how many individual records were filtered out
+- **Filter effectiveness** — `RowGroupFilter` shows how many row groups were dropped by statistics pushdown and `RowGroupByteRangeFilter` how many were excluded by split selection; `PageFilter` shows how many pages were skipped within surviving row groups; `RecordFilter` shows how many individual records were filtered out
 - **Decode hotspots** — `PageDecoded` events with large uncompressed sizes or high frequency
 - **Pipeline stalls** — `BatchWait` events indicate the reader is waiting for decoded data
 


### PR DESCRIPTION
Fixes #718.

## Problem

On the column-readers path, the **first file's** row groups had their column statistics evaluated twice: once eagerly in `ParquetFileReader.filterRowGroups` and again in `RowGroupIterator`. The second pass re-ran `RowGroupFilterEvaluator.canDropRowGroup` over an already-pruned list — pure redundant work.

It was also observable in JFR: the first file emitted **two** `dev.hardwood.RowGroupFilter` events, and the second one reported the already-pruned count as its `totalRowGroups` rather than the file's real row-group count, so the record was self-inconsistent (every other file emitted one).

## Fix

- Statistics push-down now lives **solely in `RowGroupIterator`** — the single component that evaluates every file uniformly. `ParquetFileReader.filterRowGroups` is reduced to the cheap byte-range `RowGroupPredicate` pre-filter.
- The two filtering stages now emit **distinct** events, each self-describing and fired exactly once:
  - `dev.hardwood.RowGroupByteRangeFilter` — byte-range split selection (`ParquetFileReader`)
  - `dev.hardwood.RowGroupFilter` — statistics predicate push-down (`RowGroupIterator`)

## Behavior changes (intended)

- A fully unfiltered `columnReaders(projection)` read no longer emits a row-group filter event — consistent with the `RowReader` path, which already emitted none.
- Byte-range split pruning is now reported under `RowGroupByteRangeFilter` instead of `RowGroupFilter`. Documented in `reference/configuration.md`.

## Testing

- New `RowGroupFilterEventTest` (written failing-first) asserts each stage emits exactly one event and that `totalRowGroups` is the file's real count — guards the regression directly.
- `RowGroupFilterTest`, `PredicatePushDownTest`, `ColumnReadersTest`, `ColumnReaderExactFilterTest` (118 tests) all pass; single-file split correctness (`columnReaderByteRangeKeepsTwoComplementaryHalvesExactly`) is unaffected.