### PR TITLE
#721 Skip materializing all-present definition levels

### DIFF
--- a/core/src/main/java/dev/hardwood/internal/encoding/RleBitPackingHybridDecoder.java
+++ b/core/src/main/java/dev/hardwood/internal/encoding/RleBitPackingHybridDecoder.java
@@ -359,6 +359,39 @@ public class RleBitPackingHybridDecoder {
         }
     }
 
+    /// Returns `true` if the first `count` values of this stream are all equal
+    /// to `value`, as proven by a single leading RLE run that covers them.
+    ///
+    /// Used to detect all-present definition levels (one RLE run of `maxDef`)
+    /// without materializing the level array. This is a read-only probe: it
+    /// inspects the first run and then restores the decoder to its original
+    /// state, so the same instance can afterwards be read from the beginning —
+    /// via [#readInts] or otherwise — exactly as if the probe had never run.
+    public boolean isSingleRleRunOf(int value, int count) {
+        if (count == 0) {
+            return true;
+        }
+        if (bitWidth == 0 || pos >= dataEnd) {
+            return false;
+        }
+        // Snapshot the run state readNextRun is about to mutate, then restore it
+        // before returning so the probe leaves no trace. bitBuffer/bitsInBuffer
+        // are untouched by readNextRun, so they need no saving.
+        int savedPos = pos;
+        int savedRemainingInRun = remainingInRun;
+        int savedCurrentValue = currentValue;
+        boolean savedIsRleRun = isRleRun;
+
+        readNextRun();
+        boolean match = isRleRun && currentValue == value && remainingInRun >= count;
+
+        pos = savedPos;
+        remainingInRun = savedRemainingInRun;
+        currentValue = savedCurrentValue;
+        isRleRun = savedIsRleRun;
+        return match;
+    }
+
     private long readUnsignedVarInt() {
         long result = 0;
         int shift = 0;

--- a/core/src/main/java/dev/hardwood/internal/reader/PageDecoder.java
+++ b/core/src/main/java/dev/hardwood/internal/reader/PageDecoder.java
@@ -141,9 +141,31 @@ public class PageDecoder {
     }
 
     /// Decode levels using RLE/Bit-Packing Hybrid encoding.
-    private int[] decodeLevels(byte[] levelData, int offset, int length, int numValues, int maxLevel) {
+    private int[] decodeRepetitionLevels(byte[] levelData, int offset, int length, int numValues, int maxLevel) {
         int[] levels = new int[numValues];
         RleBitPackingHybridDecoder decoder = new RleBitPackingHybridDecoder(levelData, offset, length, getBitWidth(maxLevel));
+        decoder.readInts(levels, 0, numValues);
+        return levels;
+    }
+
+    /// Decode definition levels, applying the all-present fast path: when the
+    /// stream is a single RLE run of `maxDef` (the common case for an optional
+    /// but fully-populated column), skip materializing the per-value level array
+    /// and represent "all present" as a `null` level array — the same
+    /// representation used for required columns throughout the reader.
+    ///
+    /// Restricted to flat columns; nested record assembly consumes the def-level
+    /// array directly and stays on the materializing path.
+    private int[] decodeDefinitionLevels(byte[] levelData, int offset, int length, int numValues) {
+        int maxDef = column.maxDefinitionLevel();
+        int bitWidth = getBitWidth(maxDef);
+        RleBitPackingHybridDecoder decoder = new RleBitPackingHybridDecoder(levelData, offset, length, bitWidth);
+        // The probe loads the first run; if it is not the all-present fast path,
+        // readInts below resumes from that same loaded run on the same instance.
+        if (column.maxRepetitionLevel() == 0 && decoder.isSingleRleRunOf(maxDef, numValues)) {
+            return null;
+        }
+        int[] levels = new int[numValues];
         decoder.readInts(levels, 0, numValues);
         return levels;
     }
@@ -177,7 +199,7 @@ public class PageDecoder {
         if (column.maxRepetitionLevel() > 0) {
             int repLevelLength = ByteBuffer.wrap(data, offset, 4).order(ByteOrder.LITTLE_ENDIAN).getInt();
             offset += 4;
-            repetitionLevels = decodeLevels(data, offset, repLevelLength, header.numValues(), column.maxRepetitionLevel());
+            repetitionLevels = decodeRepetitionLevels(data, offset, repLevelLength, header.numValues(), column.maxRepetitionLevel());
             offset += repLevelLength;
         }
 
@@ -185,7 +207,7 @@ public class PageDecoder {
         if (column.maxDefinitionLevel() > 0) {
             int defLevelLength = ByteBuffer.wrap(data, offset, 4).order(ByteOrder.LITTLE_ENDIAN).getInt();
             offset += 4;
-            definitionLevels = decodeLevels(data, offset, defLevelLength, header.numValues(), column.maxDefinitionLevel());
+            definitionLevels = decodeDefinitionLevels(data, offset, defLevelLength, header.numValues());
             offset += defLevelLength;
         }
 
@@ -205,14 +227,14 @@ public class PageDecoder {
         if (column.maxRepetitionLevel() > 0 && repLevelLen > 0) {
             byte[] repLevelData = new byte[repLevelLen];
             pageData.slice(0, repLevelLen).get(repLevelData);
-            repetitionLevels = decodeLevels(repLevelData, 0, repLevelLen, header.numValues(), column.maxRepetitionLevel());
+            repetitionLevels = decodeRepetitionLevels(repLevelData, 0, repLevelLen, header.numValues(), column.maxRepetitionLevel());
         }
 
         int[] definitionLevels = null;
         if (column.maxDefinitionLevel() > 0 && defLevelLen > 0) {
             byte[] defLevelData = new byte[defLevelLen];
             pageData.slice(repLevelLen, defLevelLen).get(defLevelData);
-            definitionLevels = decodeLevels(defLevelData, 0, defLevelLen, header.numValues(), column.maxDefinitionLevel());
+            definitionLevels = decodeDefinitionLevels(defLevelData, 0, defLevelLen, header.numValues());
         }
 
         byte[] valuesData;

--- a/core/src/test/java/dev/hardwood/internal/encoding/RleBitPackingHybridDecoderSingleRunTest.java
+++ b/core/src/test/java/dev/hardwood/internal/encoding/RleBitPackingHybridDecoderSingleRunTest.java
@@ -1,0 +1,187 @@
+/*
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Copyright The original authors
+ *
+ *  Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package dev.hardwood.internal.encoding;
+
+import java.io.ByteArrayOutputStream;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/// Tests for [RleBitPackingHybridDecoder#isSingleRleRunOf], the all-present
+/// definition-level probe.
+class RleBitPackingHybridDecoderSingleRunTest {
+
+    @Test
+    void detectsRleRunMatchingValueAndCovering() {
+        byte[] encoded = encodeRleRun(1, 1000, 1);
+        assertThat(decoder(encoded, 1).isSingleRleRunOf(1, 1000)).isTrue();
+    }
+
+    @Test
+    void detectsRleRunLongerThanRequested() {
+        byte[] encoded = encodeRleRun(1, 1000, 1);
+        assertThat(decoder(encoded, 1).isSingleRleRunOf(1, 500)).isTrue();
+    }
+
+    @Test
+    void rejectsRleRunShorterThanRequested() {
+        byte[] encoded = encodeRleRun(1, 500, 1);
+        assertThat(decoder(encoded, 1).isSingleRleRunOf(1, 1000)).isFalse();
+    }
+
+    @Test
+    void rejectsRleRunOfDifferentValue() {
+        // An all-null page: def levels are a single RLE run of 0, not maxDef.
+        byte[] encoded = encodeRleRun(0, 1000, 1);
+        assertThat(decoder(encoded, 1).isSingleRleRunOf(1, 1000)).isFalse();
+    }
+
+    @Test
+    void rejectsLeadingBitPackedRun() {
+        byte[] encoded = encodeBitPackedRun(new int[] {1, 0, 1, 1, 0, 1, 0, 1}, 1);
+        assertThat(decoder(encoded, 1).isSingleRleRunOf(1, 8)).isFalse();
+    }
+
+    @Test
+    void rejectsRunFollowedByMoreWhenCoverageExceedsFirstRun() {
+        // First run covers 8 values; asking for 16 must fail (the second run
+        // could differ, and only the first run header is inspected).
+        byte[] encoded = concat(
+                encodeRleRun(1, 8, 1),
+                encodeRleRun(0, 8, 1));
+        assertThat(decoder(encoded, 1).isSingleRleRunOf(1, 8)).isTrue();
+        assertThat(decoder(encoded, 1).isSingleRleRunOf(1, 16)).isFalse();
+    }
+
+    @Test
+    void handlesMaxDefGreaterThanOne() {
+        byte[] encoded = encodeRleRun(2, 100, 2);
+        assertThat(decoder(encoded, 2).isSingleRleRunOf(2, 100)).isTrue();
+        assertThat(decoder(encoded, 2).isSingleRleRunOf(1, 100)).isFalse();
+    }
+
+    @Test
+    void zeroCountIsTriviallyTrue() {
+        assertThat(decoder(new byte[0], 1).isSingleRleRunOf(1, 0)).isTrue();
+    }
+
+    @Test
+    void rejectsWhenNoDataButCountPositive() {
+        assertThat(decoder(new byte[0], 1).isSingleRleRunOf(1, 1)).isFalse();
+    }
+
+    @Test
+    void readIntsAfterProbeStillReadsWholeStreamAtEndOfData() {
+        // A single RLE run of a non-max value covering the whole page (e.g. an
+        // all-def-1 page with maxDef=2). The probe must leave the decoder
+        // untouched so a following readInts reads the run from the beginning.
+        byte[] encoded = encodeRleRun(1, 100, 2);
+        RleBitPackingHybridDecoder decoder = decoder(encoded, 2);
+
+        assertThat(decoder.isSingleRleRunOf(2, 100)).isFalse();
+
+        int[] decoded = new int[100];
+        decoder.readInts(decoded, 0, 100);
+        assertThat(decoded).containsOnly(1);
+    }
+
+    @Test
+    void readIntsAfterProbeStillReadsAllRuns() {
+        byte[] encoded = concat(
+                encodeRleRun(1, 8, 2),
+                encodeBitPackedRun(new int[] {0, 1, 2, 3, 3, 2, 1, 0}, 2),
+                encodeRleRun(2, 4, 2));
+        RleBitPackingHybridDecoder decoder = decoder(encoded, 2);
+
+        assertThat(decoder.isSingleRleRunOf(3, 20)).isFalse();
+
+        int[] decoded = new int[20];
+        decoder.readInts(decoded, 0, 20);
+        assertThat(decoded).containsExactly(
+                1, 1, 1, 1, 1, 1, 1, 1, 0, 1, 2, 3, 3, 2, 1, 0, 2, 2, 2, 2);
+    }
+
+    @Test
+    void probeIsReadOnlyAndRepeatable() {
+        // The probe must not advance decoder state: repeated calls agree, and a
+        // full read afterwards still returns every value.
+        byte[] encoded = concat(
+                encodeRleRun(1, 8, 2),
+                encodeRleRun(2, 4, 2));
+        RleBitPackingHybridDecoder decoder = decoder(encoded, 2);
+
+        assertThat(decoder.isSingleRleRunOf(3, 12)).isFalse();
+        assertThat(decoder.isSingleRleRunOf(3, 12)).isFalse();
+        assertThat(decoder.isSingleRleRunOf(1, 8)).isTrue();
+
+        int[] decoded = new int[12];
+        decoder.readInts(decoded, 0, 12);
+        assertThat(decoded).containsExactly(1, 1, 1, 1, 1, 1, 1, 1, 2, 2, 2, 2);
+    }
+
+    private static RleBitPackingHybridDecoder decoder(byte[] data, int bitWidth) {
+        return new RleBitPackingHybridDecoder(data, 0, data.length, bitWidth);
+    }
+
+    private static byte[] encodeRleRun(int value, int count, int bitWidth) {
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        writeUnsignedVarInt(out, (long) count << 1);
+        int bytesNeeded = (bitWidth + 7) / 8;
+        for (int i = 0; i < bytesNeeded; i++) {
+            out.write((value >> (i * 8)) & 0xFF);
+        }
+        return out.toByteArray();
+    }
+
+    private static byte[] encodeBitPackedRun(int[] values, int bitWidth) {
+        int groups = (values.length + 7) / 8;
+        int padded = groups * 8;
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        writeUnsignedVarInt(out, ((long) groups << 1) | 1L);
+
+        long bits = 0;
+        int bitsInBuffer = 0;
+        for (int i = 0; i < padded; i++) {
+            int value = i < values.length ? values[i] : 0;
+            bits |= ((long) value) << bitsInBuffer;
+            bitsInBuffer += bitWidth;
+            while (bitsInBuffer >= 8) {
+                out.write((int) (bits & 0xFF));
+                bits >>>= 8;
+                bitsInBuffer -= 8;
+            }
+        }
+        if (bitsInBuffer > 0) {
+            out.write((int) (bits & 0xFF));
+        }
+        return out.toByteArray();
+    }
+
+    private static byte[] concat(byte[]... parts) {
+        int length = 0;
+        for (byte[] part : parts) {
+            length += part.length;
+        }
+        byte[] out = new byte[length];
+        int pos = 0;
+        for (byte[] part : parts) {
+            System.arraycopy(part, 0, out, pos, part.length);
+            pos += part.length;
+        }
+        return out;
+    }
+
+    private static void writeUnsignedVarInt(ByteArrayOutputStream out, long value) {
+        while ((value & ~0x7FL) != 0) {
+            out.write((int) ((value & 0x7F) | 0x80));
+            value >>>= 7;
+        }
+        out.write((int) value);
+    }
+}


### PR DESCRIPTION
## Summary

Fixes #721.

Optional-but-fully-populated columns encode their definition levels as a single all-present RLE run (`value == maxDefinitionLevel`). `PageDecoder` still materialized an `int[numValues]` of `maxDef` for every such page and ran the per-element gated value scatter and validity build over it — work that is a no-op when there are no nulls.

This wires the all-present case onto the reader's existing "all present" representation — a `null` definition-level array, already used for required columns and honoured by `Page.isNull`, `FlatColumnWorker.markNulls`, `Dictionary.decodePage`, and `countNonNullValues`:

- `RleBitPackingHybridDecoder.isSingleRleRunOf(value, count)` — an O(1) probe of the first level run.
- `PageDecoder.decodeDefinitionLevels(...)` — returns `null` when the def levels are a single all-present RLE run, otherwise materializes as before. Restricted to flat columns (`maxRepetitionLevel == 0`); nested record assembly consumes the def-level array directly and stays on the materializing path.

This is a first chunk of a more general rework where we'd represent RLE runs as a logical abstract ("10x <value xyz>") rather than expanding them into an array, see #726. This will be a larger refactoring though, hence leveraging the idea only for the particular case above for now.

Yields a mild improvement for columnar reader and row reader with named access on my machine. Before:

```
Before 

  FlatScanBenchmark — columnar (raw decode)
    hardwoodColumnar          │██████████████████████████████ 42.2

  FlatScanBenchmark — record (materialization)
    hardwoodRowReaderIndexed  │██████████████████████████████ 25.2
    hardwoodRowReaderNamed    │███████ 6.2
```

And after:

```
  FlatScanBenchmark — columnar (raw decode)
    hardwoodColumnar          │██████████████████████████████ 43.3

  FlatScanBenchmark — record (materialization)
    hardwoodRowReaderIndexed  │██████████████████████████████ 25.2
    hardwoodRowReaderNamed    │████████ 6.4
```