### PR TITLE
#672 Make multi-file skip a global offset

### DIFF
--- a/core/src/main/java/dev/hardwood/internal/reader/RowGroupIterator.java
+++ b/core/src/main/java/dev/hardwood/internal/reader/RowGroupIterator.java
@@ -81,6 +81,19 @@ public class RowGroupIterator {
     /// [#setTailSkip(long)] once the gate decision is in.
     private long tailSkip;
 
+    /// Physical row offset (SQL `OFFSET` without a filter) over the concatenated
+    /// relation. Applied in [#buildWorkList]: row groups whose cumulative end is
+    /// at or before this offset are dropped (their footers are read to count
+    /// rows, but no data page of theirs is fetched), and the row group the offset
+    /// lands in becomes the first work item. `0` disables the seek.
+    private final long physicalSkip;
+
+    /// Leading rows of the first kept row group that fall before [#physicalSkip]
+    /// and must be decoded and discarded by the row reader after the iterator has
+    /// seeked to that row group. Computed in [#buildWorkList]; `0` unless a
+    /// no-filter `skip` lands inside a row group.
+    private long firstRowGroupResidue;
+
     // Set after first file
     private FileSchema referenceSchema;
     private ProjectedSchema projectedSchema;
@@ -155,7 +168,7 @@ public class RowGroupIterator {
     /// @param context the Hardwood context
     /// @param maxRows maximum rows to read (0 = unlimited)
     public RowGroupIterator(List<InputFile> inputFiles, HardwoodContextImpl context, long maxRows) {
-        this(inputFiles, context, maxRows, 0);
+        this(inputFiles, context, maxRows, 0, 0);
     }
 
     /// Creates a RowGroupIterator with a tail-skip budget applied to the first
@@ -171,21 +184,63 @@ public class RowGroupIterator {
     ///        cross-column alignment.
     public RowGroupIterator(List<InputFile> inputFiles, HardwoodContextImpl context,
                             long maxRows, long tailSkip) {
+        this(inputFiles, context, maxRows, tailSkip, 0);
+    }
+
+    /// Creates a RowGroupIterator with a physical-skip offset over the
+    /// concatenated relation, seeking past whole leading row groups.
+    ///
+    /// @param inputFiles one or more input files (must not be empty)
+    /// @param context the Hardwood context
+    /// @param maxRows maximum rows to read (0 = unlimited)
+    /// @param tailSkip leading rows of the first row group to skip via per-page
+    ///        masking (0 = unused); mutually exclusive with `physicalSkip`
+    /// @param physicalSkip absolute row offset to seek to before reading
+    ///        (0 = unused). Earlier row groups are dropped without fetching
+    ///        their data; the residue within the landing row group is exposed
+    ///        via [#residueRows] for the reader to discard.
+    public RowGroupIterator(List<InputFile> inputFiles, HardwoodContextImpl context,
+                            long maxRows, long tailSkip, long physicalSkip) {
         if (inputFiles.isEmpty()) {
             throw new IllegalArgumentException("At least one file must be provided");
         }
         if (tailSkip < 0) {
             throw new IllegalArgumentException("tailSkip must be non-negative, got " + tailSkip);
         }
+        if (physicalSkip < 0) {
+            throw new IllegalArgumentException("physicalSkip must be non-negative, got " + physicalSkip);
+        }
+        if (tailSkip > 0 && physicalSkip > 0) {
+            throw new IllegalArgumentException(
+                    "tailSkip and physicalSkip are mutually exclusive, got tailSkip=" + tailSkip
+                            + ", physicalSkip=" + physicalSkip);
+        }
         this.inputFiles = new ArrayList<>(inputFiles);
         this.context = context;
         this.maxRows = maxRows;
         this.tailSkip = tailSkip;
+        this.physicalSkip = physicalSkip;
     }
 
     /// Returns the maximum rows limit (0 = unlimited).
     public long maxRows() {
         return maxRows;
+    }
+
+    /// Leading rows of the first kept row group that precede the physical `skip`
+    /// offset and must be discarded by the row reader once the iterator has
+    /// seeked to that row group. `0` unless a no-filter `skip` landed inside a
+    /// row group. Valid only after [#initialize].
+    public long residueRows() {
+        return firstRowGroupResidue;
+    }
+
+    /// The row reader's `maxRows` cap adjusted for the physical-skip residue: the
+    /// reader yields the residue rows (later discarded) ahead of the caller's
+    /// rows, so its LIMIT must cover both. Returns `0` (unlimited) when `maxRows`
+    /// is unset. Valid only after [#initialize].
+    public long effectiveMaxRows() {
+        return maxRows <= 0 ? maxRows : Math.addExact(maxRows, firstRowGroupResidue);
     }
 
     /// Sets the reference schema and pre-prepared first file, skipping [#openFirst()].
@@ -814,14 +869,18 @@ public class RowGroupIterator {
     /// LIMIT), so a matching row can sit past the first `N` scanned rows and
     /// every surviving page must remain fetchable. Statistics pushdown still
     /// prunes pages and row groups, and the matched-row cap is enforced at the
-    /// reader. Without a filter, returns `max(0, maxRows - workItem.rowsConsumedBefore())`,
-    /// which naturally trims the last partially-needed row group's fetch plan
-    /// while being a no-op (all pages kept) for fully-needed earlier ones.
+    /// reader. Without a filter, returns
+    /// `max(0, effectiveMaxRows - workItem.rowsConsumedBefore())`, which naturally
+    /// trims the last partially-needed row group's fetch plan while being a no-op
+    /// (all pages kept) for fully-needed earlier ones. The budget is the
+    /// residue-adjusted [#effectiveMaxRows], not the raw `maxRows`: the
+    /// physical-skip residue is fetched from the first kept row group and
+    /// discarded downstream, so it counts against the fetch budget too.
     private long perRgMaxRows(WorkItem workItem) {
         if (maxRows <= 0 || filterPredicate != null) {
             return 0;
         }
-        return Math.max(0, maxRows - workItem.rowsConsumedBefore());
+        return Math.max(0, effectiveMaxRows() - workItem.rowsConsumedBefore());
     }
 
     /// Returns the context.
@@ -855,10 +914,25 @@ public class RowGroupIterator {
     // ==================== Internal ====================
 
     /// Builds the work list by iterating all files and row groups.
+    ///
+    /// A no-filter [#physicalSkip] is applied here as a global offset over the
+    /// concatenated relation: row groups whose cumulative end is at or before the
+    /// offset are dropped (their footers are read to count rows, but no data page
+    /// of theirs is fetched), and the row group the offset lands in becomes the
+    /// first work item, with [#firstRowGroupResidue] recording how many of its
+    /// leading rows the reader must still discard. `rowsConsumedBefore` is rebased
+    /// so the first kept row group sits at local position `0`, keeping
+    /// [#perRgMaxRows] correct relative to the post-skip relation. A filter turns
+    /// `skip` into a logical OFFSET over matched rows (applied by the reader), so
+    /// it never seeks here.
     private void buildWorkList() {
-        long rowBudget = maxRows > 0 ? maxRows : Long.MAX_VALUE;
-        long rowsConsumed = 0;
         boolean hasFilter = filterPredicate != null;
+        long skip = hasFilter ? 0L : physicalSkip;
+
+        long cumulative = 0L;            // global, footer-derived rows walked so far
+        long localConsumed = 0L;         // rows in kept row groups (post-skip relation)
+        long rowBudget = Long.MAX_VALUE; // finalized once the offset's row group is found
+        boolean started = false;         // reached the row group the offset lands in?
 
         for (int fileIndex = 0; fileIndex < inputFiles.size() && rowBudget > 0; fileIndex++) {
             PreparedFile prepared = getPreparedFile(fileIndex);
@@ -866,6 +940,23 @@ public class RowGroupIterator {
 
             for (int rgIndex = 0; rgIndex < rowGroups.size() && rowBudget > 0; rgIndex++) {
                 RowGroup rg = rowGroups.get(rgIndex);
+                long rgRows = rg.numRows();
+
+                if (!started && cumulative + rgRows <= skip) {
+                    // Entire row group precedes the offset: counted, never fetched.
+                    cumulative += rgRows;
+                    continue;
+                }
+                if (!started) {
+                    started = true;
+                    firstRowGroupResidue = skip - cumulative;
+                    // Residue rows are fetched then discarded by the reader, so the
+                    // fetch budget covers them on top of the yielded maxRows.
+                    rowBudget = (maxRows > 0 && !hasFilter)
+                            ? Math.addExact(maxRows, firstRowGroupResidue)
+                            : Long.MAX_VALUE;
+                }
+
                 workItems.add(new WorkItem(
                         prepared.inputFile,
                         rg,
@@ -873,15 +964,16 @@ public class RowGroupIterator {
                         fileIndex,
                         rgIndex,
                         workItems.size(),
-                        rowsConsumed));
+                        localConsumed));
 
                 // maxRows limiting: deduct row count from budget.
                 // With a filter active, actual match count is unpredictable,
                 // so all row groups remain available.
-                if (!hasFilter) {
-                    rowBudget -= rg.numRows();
+                if (!hasFilter && maxRows > 0) {
+                    rowBudget -= rgRows;
                 }
-                rowsConsumed += rg.numRows();
+                localConsumed += rgRows;
+                cumulative += rgRows;
             }
 
             // Trigger prefetch of next file

--- a/core/src/main/java/dev/hardwood/reader/ParquetFileReader.java
+++ b/core/src/main/java/dev/hardwood/reader/ParquetFileReader.java
@@ -269,40 +269,40 @@ public class ParquetFileReader implements AutoCloseable {
             return discardLeadingRows(reader, skip);
         }
 
-        // No filter: `skip` is a physical row offset. Locate the row group containing
-        // `skip` by walking cumulative RowGroup.numRows() over the filtered list, open
-        // from there, and discard the within-group residue — earlier row groups are
-        // never opened (O(1 row-group) seek). After the loop, `cumulative` equals the
-        // total row count of `filteredRowGroups` if no target was found.
-        long cumulative = 0L;
-        int targetRg = -1;
-        long withinRg = 0L;
-        for (int i = 0; i < filteredRowGroups.size(); i++) {
-            long rgRows = filteredRowGroups.get(i).numRows();
-            if (skip < cumulative + rgRows) {
-                targetRg = i;
-                withinRg = skip - cumulative;
-                break;
-            }
-            cumulative += rgRows;
-        }
-        if (targetRg < 0) {
-            // skip >= total rows — a SQL OFFSET past the end of the relation, so an
-            // empty reader (consistent with the filtered case overshooting the matches).
-            return buildRowReader(projection, filter, maxRows, List.<RowGroup>of());
-        }
-        List<RowGroup> rowGroups = targetRg == 0
-                ? filteredRowGroups
-                : filteredRowGroups.subList(targetRg, filteredRowGroups.size());
-        // The reader yields from the start of `targetRg`. We bump maxRows
-        // by the within-RG skip distance because head(N) bounds *yielded*
-        // rows; the residue rows we discard via next() count too.
-        long maxRowsAdjusted = maxRows == 0 ? 0 : maxRows + withinRg;
-        RowReader reader = buildRowReader(projection, filter, maxRowsAdjusted, rowGroups);
-        // Walk past the within-RG residue. These rows *are* decoded —
-        // page-level skip via OffsetIndex (#381) would let us drop the
-        // leading pages at the byte level instead.
-        return discardLeadingRows(reader, withinRg);
+        // No filter: `skip` is a physical absolute row offset over the
+        // concatenated relation. The iterator seeks to the row group the offset
+        // lands in, dropping earlier row groups across files — their footers are
+        // read to count rows, but no data page of theirs is fetched — and reports
+        // the within-row-group residue we still decode and discard. A `skip` at or
+        // beyond the total row count produces an empty work list, hence an empty
+        // reader (a SQL OFFSET past the end of the relation).
+        return buildPhysicalSkipRowReader(projection, maxRows, filteredRowGroups, skip);
+    }
+
+    /// Builds a no-filter [RowReader] positioned at physical row offset `skip`
+    /// over the concatenated relation. Row groups fully before the offset are
+    /// dropped inside the [RowGroupIterator] (footers read, data never fetched);
+    /// the residue within the landing row group is decoded and discarded here.
+    /// Page-level skip via OffsetIndex (#381) would let us drop the leading pages
+    /// at the byte level instead.
+    private RowReader buildPhysicalSkipRowReader(ColumnProjection projection, long maxRows,
+                                                 List<RowGroup> firstFileRowGroups, long skip) {
+        // completeContainers=true: this is a row-assembly path, so a projection that
+        // touches a MAP value or VARIANT subfield must pull in the mandatory sibling
+        // leaves (MAP key, full VARIANT) — same as the skip-less buildRowReader path.
+        ProjectedSchema projectedSchema = ProjectedSchema.create(schema, projection, true);
+
+        RowGroupIterator iterator = new RowGroupIterator(inputFiles, context, maxRows, 0L, skip);
+        iterator.setFirstFile(schema, firstFileRowGroups);
+        iterator.initialize(projectedSchema, null);
+        rowGroupIterators.add(iterator);
+
+        // The reader yields the residue rows too — head(N) bounds *yielded* rows,
+        // and the residue we discard via next() counts — so cap it at the
+        // residue-adjusted limit, then walk past the residue.
+        RowReader reader = createRowReader(
+                iterator, schema, projectedSchema, context, null, iterator.effectiveMaxRows());
+        return discardLeadingRows(reader, iterator.residueRows());
     }
 
     /// Advances `reader` past its first `count` rows via `next()` and returns it,
@@ -687,13 +687,12 @@ public class ParquetFileReader implements AutoCloseable {
         /// Skip leading rows before reading — SQL `OFFSET`. Its meaning depends on
         /// whether a [#filter(FilterPredicate)] is present:
         ///
-        /// - **Without a filter:** a physical absolute row index. Earlier row groups
-        ///   are not opened — an O(1 row-group) seek on remote backends (the leading
-        ///   residue within the target row group is still decoded). For a single-file
-        ///   reader, `skip >= totalRows` yields an empty reader. For a multi-file reader
-        ///   the offset resolves against the first file only and never carries across
-        ///   a file boundary. `skip` at or beyond the first file's row count drops
-        ///   it entirely and streams the remaining files in full.
+        /// - **Without a filter:** a physical absolute row index over the concatenated
+        ///   input relation. Earlier row groups are not opened — an O(1 row-group)
+        ///   seek on remote backends (the leading residue within the target row group
+        ///   is still decoded). For a multi-file reader, footers of skipped files are
+        ///   read until the target file is found, but skipped files' data pages are
+        ///   not fetched or decoded. `skip >= totalRows` yields an empty reader.
         /// - **With a filter:** a *logical* offset over the matched rows — discards the
         ///   first `n` rows matching the predicate, symmetric with [#head] as `LIMIT`.
         ///   The O(1) seek does not apply: the reader decodes earlier groups to count

--- a/core/src/test/java/dev/hardwood/BuilderCombinationTest.java
+++ b/core/src/test/java/dev/hardwood/BuilderCombinationTest.java
@@ -7,10 +7,13 @@
  */
 package dev.hardwood;
 
+import java.io.IOException;
+import java.nio.ByteBuffer;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Consumer;
 import java.util.stream.LongStream;
 import java.util.stream.Stream;
@@ -194,9 +197,9 @@ class BuilderCombinationTest {
         }
     }
 
-    /// Multi-file boundary cells (#577) — physical `skip` (no filter) indexes into the first file
-    /// only, logical `skip` (with a filter) counts matches across *all* files in order, and
-    /// `tail` is single-file-only (throws).
+    /// Multi-file boundary cells (#577, #672) — physical `skip` (no filter) is a
+    /// global offset across all files, logical `skip` (with a filter) counts matches
+    /// across *all* files in order, and `tail` is single-file-only (throws).
     /// `id` is the global row position: file 0 holds 0..149, file 1 holds 150..249.
     @Test
     void multiFileBoundaries() throws Exception {
@@ -205,11 +208,32 @@ class BuilderCombinationTest {
                     .containsExactlyElementsOf(longRange(125, 249));
             assertThat(ids(reader.buildRowReader().filter(FilterPredicate.gt("id", 99L)).skip(60)))
                     .containsExactlyElementsOf(longRange(160, 249));
-            // skip beyond file0 row count - does NOT carry into file1, which streams in full
             assertThat(ids(reader.buildRowReader().skip(160)))
-                    .containsExactlyElementsOf(longRange(150, 249));
+                    .containsExactlyElementsOf(longRange(160, 249));
+            assertThat(ids(reader.buildRowReader().skip(250)))
+                    .isEmpty();
+            assertThat(ids(reader.buildRowReader().skip(300)))
+                    .isEmpty();
             assertThatThrownBy(reader.buildRowReader().tail(50)::build)
                     .isInstanceOf(UnsupportedOperationException.class);
+        }
+    }
+
+    @Test
+    void physicalMultiFileSkipDoesNotReadSkippedFileData() throws Exception {
+        CountingInputFile file0 = new CountingInputFile(InputFile.of(
+                Paths.get("src/test/resources/multi_file_part0.parquet")));
+        CountingInputFile file1 = new CountingInputFile(InputFile.of(
+                Paths.get("src/test/resources/multi_file_part1.parquet")));
+
+        try (ParquetFileReader reader = ParquetFileReader.openAll(List.of(file0, file1))) {
+            int file0ReadsAfterOpen = file0.readCount();
+
+            assertThat(ids(reader.buildRowReader().skip(160).head(1)))
+                    .containsExactly(160L);
+            assertThat(file0.readCount())
+                    .as("file 0 should only have the footer reads from openAll")
+                    .isEqualTo(file0ReadsAfterOpen);
         }
     }
 
@@ -226,5 +250,44 @@ class BuilderCombinationTest {
 
     private static List<Long> longRange(long fromInclusive, long toInclusive) {
         return LongStream.rangeClosed(fromInclusive, toInclusive).boxed().toList();
+    }
+
+    private static final class CountingInputFile implements InputFile {
+        private final InputFile delegate;
+        private final AtomicInteger readCount = new AtomicInteger();
+
+        private CountingInputFile(InputFile delegate) {
+            this.delegate = delegate;
+        }
+
+        int readCount() {
+            return readCount.get();
+        }
+
+        @Override
+        public void open() throws IOException {
+            delegate.open();
+        }
+
+        @Override
+        public ByteBuffer readRange(long offset, int length) throws IOException {
+            readCount.incrementAndGet();
+            return delegate.readRange(offset, length);
+        }
+
+        @Override
+        public long length() throws IOException {
+            return delegate.length();
+        }
+
+        @Override
+        public String name() {
+            return delegate.name();
+        }
+
+        @Override
+        public void close() throws IOException {
+            delegate.close();
+        }
     }
 }

--- a/core/src/test/java/dev/hardwood/BuilderCombinationTest.java
+++ b/core/src/test/java/dev/hardwood/BuilderCombinationTest.java
@@ -237,6 +237,44 @@ class BuilderCombinationTest {
         }
     }
 
+    /// A file that is skipped but is *not* the first file: its footer is read
+    /// lazily to count rows while the global offset is being located, but none
+    /// of its data pages are fetched. `openAll` pre-reads file 0's footer, so
+    /// only a non-first skipped file exercises the lazy footer-without-data path.
+    @Test
+    void physicalMultiFileSkipDoesNotReadSkippedNonFirstFileData() throws Exception {
+        // Footer-only read cost of part1, derived rather than hard-coded: a
+        // single-file open reads exactly the footer via the same metadata reader
+        // the multi-file seek uses lazily.
+        CountingInputFile probe = new CountingInputFile(InputFile.of(
+                Paths.get("src/test/resources/multi_file_part1.parquet")));
+        try (ParquetFileReader ignored = ParquetFileReader.open(probe)) {
+            // open() reads the footer
+        }
+        int footerOnlyReads = probe.readCount();
+
+        // [part0 (0..149), part1 (150..249), part0 (0..149)] — 400 global rows.
+        // skip(260) lands in the third file at local offset 10; part1 in the
+        // middle is fully below the offset, so it is skipped.
+        CountingInputFile file0 = new CountingInputFile(InputFile.of(
+                Paths.get("src/test/resources/multi_file_part0.parquet")));
+        CountingInputFile file1 = new CountingInputFile(InputFile.of(
+                Paths.get("src/test/resources/multi_file_part1.parquet")));
+        CountingInputFile file2 = new CountingInputFile(InputFile.of(
+                Paths.get("src/test/resources/multi_file_part0.parquet")));
+
+        try (ParquetFileReader reader = ParquetFileReader.openAll(List.of(file0, file1, file2))) {
+            assertThat(ids(reader.buildRowReader().skip(260).head(1)))
+                    .containsExactly(10L);
+            assertThat(file1.readCount())
+                    .as("skipped non-first file: footer read for its row count, no data pages fetched")
+                    .isEqualTo(footerOnlyReads);
+            assertThat(file2.readCount())
+                    .as("target file's data pages are fetched")
+                    .isGreaterThan(footerOnlyReads);
+        }
+    }
+
     private static List<Long> ids(RowReaderBuilder builder) {
         List<Long> rows = new ArrayList<>();
         try (RowReader r = builder.build()) {

--- a/core/src/test/java/dev/hardwood/ColumnProjectionTest.java
+++ b/core/src/test/java/dev/hardwood/ColumnProjectionTest.java
@@ -365,6 +365,36 @@ public class ColumnProjectionTest {
     }
 
     @Test
+    void physicalSkipKeepsMandatoryMapKeyForValueOnlyProjection() throws Exception {
+        // Regression: a no-filter `skip` builds its own projected schema and must
+        // complete containers exactly like the skip-less path — otherwise a MAP's
+        // mandatory key leaf is dropped when only the value sub-field is projected,
+        // and the map assembles without keys. Same fixture as the skip-less case:
+        // skip(1) drops row 0 (employee1, employee2), leaving row 1 ({manager}) and
+        // the empty-map row 2.
+        Path parquetFile = Paths.get("src/test/resources/map_struct_value_test.parquet");
+
+        try (ParquetFileReader reader = ParquetFileReader.open(InputFile.of(parquetFile));
+             RowReader rows = reader.buildRowReader()
+                     .projection(ColumnProjection.columns("people.key_value.value.age"))
+                     .skip(1).build()) {
+
+            List<String> keys = new ArrayList<>();
+            List<Integer> ages = new ArrayList<>();
+            while (rows.hasNext()) {
+                rows.next();
+                PqMap people = rows.getMap("people");
+                for (PqMap.Entry entry : people.getEntries()) {
+                    keys.add(entry.getStringKey());
+                    ages.add(entry.getStructValue().getInt("age"));
+                }
+            }
+            assertThat(keys).containsExactly("manager");
+            assertThat(ages).containsExactly(45);
+        }
+    }
+
+    @Test
     void mapKeyOnlyProjectionDoesNotPullInValue() throws Exception {
         // Same map_struct_value_test.parquet fixture. Projecting only the key
         // sub-field people.key_value.value... is the mirror of the value-side

--- a/docs/content/how-to/query-controls.md
+++ b/docs/content/how-to/query-controls.md
@@ -315,10 +315,9 @@ try (ParquetFileReader fileReader = ParquetFileReader.open(InputFile.of(path));
 }
 ```
 
-`skip == 0` is the no-op default. `skip >= totalRows` produces an empty reader (a SQL `OFFSET` past the end of the file). Within the target row group, the reader still decodes the leading residue rows and discards them via `next()`; page-level skip via the OffsetIndex is tracked separately.
+`skip == 0` is the no-op default. `skip >= totalRows` produces an empty reader (a SQL `OFFSET` past the end of the file, or of the concatenated relation for multi-file readers). Within the target row group, the reader still decodes the leading residue rows and discards them via `next()`; page-level skip via the OffsetIndex is tracked separately.
 
-!!! warning "Multi-file readers: first file only"
-    For the no-filter (physical) case, `skip(N)` indexes into the **first** file's rows only — it never carries across a file boundary. A `skip` at or beyond the first file's row count therefore does not empty the reader: it drops the first file and streams the remaining files in full. To skip whole files, omit them from the input list; to skip within a non-first file, open it separately.
+For multi-file readers, physical `skip(N)` is a global offset across the input files in order. Hardwood reads the footers of skipped files to count their rows, but skipped files' data pages are not fetched or decoded.
 
 **With a filter,** `skip(n)` is a *logical* offset over the matched rows — it discards the first `n` rows that match the predicate and returns the rest, exactly like SQL `OFFSET` after a `WHERE`. The O(1 row-group) seek does **not** apply: row-group statistics bound min/max values, not match *counts*, so the reader decodes earlier groups to count matches (groups whose statistics prove no match are still pruned). A `skip` past the number of matching rows yields an empty reader rather than throwing.
 

--- a/docs/content/release-notes.md
+++ b/docs/content/release-notes.md
@@ -13,6 +13,10 @@
 
 See [GitHub Releases](https://github.com/hardwood-hq/hardwood/releases) for downloads and more information.
 
+## 1.1.0-SNAPSHOT
+
+- Physical `skip(N)` on multi-file row readers is now a true global offset over the concatenated input files; skipped files have their footers read for row counts, but their data pages are not decoded.
+
 ## 1.0.0.Final (2026-06-25)
 
 [Announcement blog post](https://www.morling.dev/blog/hardwood-1-0-fast-lightweight-apache-parquet-reader-for-the-jvm/) · [API changes](/api-changes/1.0.0.Final/)


### PR DESCRIPTION
Fixes #672. Supersedes #707.

Physical `skip(N)` without a filter currently resolves against the **first file only** and never carries across a file boundary, so a multi-file reader can never be emptied by `skip`. This makes it a true global offset over the concatenated input relation: `skip(160)` on the two-file fixture yields ids 160..249, and `skip >= totalRows` yields an empty reader.

## Approach

Rather than walk footers at build time and inject a synthetic "first file" (as #707 did), the offset is threaded into `RowGroupIterator` as a budget alongside `maxRows` and `tailSkip`. `buildWorkList` already opens files lazily, reads each footer, validates schemas, and accumulates row counts, so it is the natural owner of the seek:

- Row groups whose cumulative end is at or before the offset are dropped — their footers are read to count rows, but **no data page of theirs is fetched**.
- The row group the offset lands in becomes the first work item; the within-row-group residue is decoded and discarded by the reader (`head(N)` after `skip` is handled via a residue-adjusted `maxRows`).
- `skip >= totalRows` falls out as an empty work list, hence an empty reader. The async file prefetch is preserved.

`ParquetFileReader`'s no-filter branch collapses to one helper plus the existing `discardLeadingRows` — no new build-time construction paths, records, or duplicated schema-validation / metadata-read helpers.

## Credit

The test commit is by @arnabnandy7 (carried over from #707): the global-offset boundary cases, empty-on-overshoot, and the assertion that a skipped file's data pages are not fetched. The second commit reworks that PR onto the iterator-based approach and adds a case for a skipped **non-first** file (footer read for its row count, no data fetched).

## Verification

`./mvnw -pl core verify` — 1445 tests + ITs green; formatter, impsort, and error-prone (`NoVar`, `NoLegacyJavadoc`) gates pass.

## Checklist

- [x] Build via `./mvnw clean verify` passes
- [x] The commit message is prefixed with the issue key
- [x] Code changes are covered by tests
- [x] If this PR adds or changes user-facing behaviour, `docs/` has been updated
