### PR TITLE
#9 Flat INT32 writer: first increment of write support

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -42,12 +42,12 @@ For field-level `parquet.thrift` metadata coverage (which spec fields are read/p
   - [x] `SchemaElementReader`
   - [x] `LogicalTypeReader` (union deserialization with nested structs)
 - [ ] Implement `ThriftCompactWriter`
-  - [ ] Varint encoding
-  - [ ] Zigzag encoding
-  - [ ] Field header writing
-  - [ ] Struct writing
-  - [ ] List/Map container writing
-  - [ ] String/Binary writing
+  - [x] Varint encoding
+  - [x] Zigzag encoding
+  - [x] Field header writing
+  - [x] Struct writing
+  - [ ] List/Map container writing (list done; map writing pending)
+  - [x] String/Binary writing
 
 ---
 
@@ -84,24 +84,24 @@ For field-level `parquet.thrift` metadata coverage (which spec fields are read/p
   - [x] Block/miniblock structure
   - [x] Min delta calculation per block
   - [x] Bit width calculation per miniblock
-  - [ ] Encoder implementation
+  - [ ] Encoder implementation (optional encoding; sequenced after the flat writer milestone)
   - [x] Decoder implementation
 - [x] DELTA_LENGTH_BYTE_ARRAY
   - [x] Length encoding with DELTA_BINARY_PACKED
   - [x] Raw byte concatenation
-  - [ ] Encoder implementation
+  - [ ] Encoder implementation (optional encoding; sequenced after the flat writer milestone)
   - [x] Decoder implementation
 - [x] DELTA_BYTE_ARRAY
   - [x] Prefix length calculation
   - [x] Suffix extraction
-  - [ ] Encoder implementation
+  - [ ] Encoder implementation (optional encoding; sequenced after the flat writer milestone)
   - [x] Decoder implementation
 
 ### 2.5 Byte Stream Split (BYTE_STREAM_SPLIT)
 - [x] Float byte separation/interleaving
 - [x] Double byte separation/interleaving
 - [x] FIXED_LEN_BYTE_ARRAY support
-- [ ] Encoder implementation
+- [ ] Encoder implementation (optional encoding; sequenced after the flat writer milestone)
 - [x] Decoder implementation
 
 ---
@@ -118,7 +118,7 @@ For field-level `parquet.thrift` metadata coverage (which spec fields are read/p
 - [x] Define `DataPageHeader` Thrift structure
 - [x] Define `DataPageHeaderV2` Thrift structure
 - [x] Define `DictionaryPageHeader` Thrift structure
-- [ ] Page header serialization
+- [x] Page header serialization
 - [x] Page header deserialization
 - [x] CRC32 validation on read (`CrcValidator`)
 - [ ] CRC32 calculation for writing
@@ -140,14 +140,14 @@ For field-level `parquet.thrift` metadata coverage (which spec fields are read/p
   - [x] Codec, num values, sizes
   - [x] Page offsets (data, index, dictionary)
   - [x] Statistics
-- [ ] Column chunk serialization
+- [x] Column chunk serialization
 - [x] Column chunk deserialization
 
 ### 4.2 Row Group
 - [x] Implement `RowGroup` class
-- [ ] Row group metadata serialization
+- [x] Row group metadata serialization
 - [x] Row group metadata deserialization
-- [ ] Sorting column tracking (optional)
+- [ ] Sorting column tracking (optional; non-goal for the flat writer milestone)
 
 ---
 
@@ -167,12 +167,16 @@ For field-level `parquet.thrift` metadata coverage (which spec fields are read/p
   - [x] Key-value metadata
   - [x] Created by string
   - [x] Column orders (decoded onto `FileMetaData.columnOrders`; #595)
-- [ ] FileMetaData serialization
+- [x] FileMetaData serialization
 - [x] FileMetaData deserialization
 
 ---
 
 ## Phase 6: Writer Implementation
+
+> Architecture and delivery sequencing for write support live in
+> [_designs/WRITER_SUPPORT.md](_designs/WRITER_SUPPORT.md) (#9), which is the plan of
+> record. The boxes below are the fine-grained inventory ticked as increments land.
 
 ### 6.1 Writer Architecture
 - [ ] Implement `ParquetWriter<T>` main class
@@ -199,6 +203,12 @@ For field-level `parquet.thrift` metadata coverage (which spec fields are read/p
 - [ ] Nested structure handling
 - [ ] Repeated field handling
 - [ ] Optional field handling
+
+### 6.4 Logical Type Writing
+- [ ] Implement `LogicalTypeWriter` (`LogicalType` union serialization; inverse of `LogicalTypeReader`)
+- [ ] Serialize legacy `converted_type` / `scale` / `precision` on `SchemaElement`
+- [ ] `FileSchema.Builder` logical-type overload (and `FIXED_LEN_BYTE_ARRAY` type length)
+- [ ] Logical-type value conversion in the writer API (inverse of `LogicalTypeConverter`)
 
 ---
 
@@ -341,16 +351,18 @@ For field-level `parquet.thrift` metadata coverage (which spec fields are read/p
 ## Phase 10: Public API Design
 
 ### 10.1 Schema Builder API
+> Superseded for the flat writer by `FileSchema.Builder` (#9); the items below
+> describe the fuller fluent/nested builder that lands with nested-write support.
 - [ ] Implement fluent `Types.buildMessage()` API
-- [ ] Primitive type builders with logical type support
+- [ ] Primitive type builders with logical type support (see Phase 6.4)
 - [ ] Group builders for nested structures
 - [ ] List and Map convenience builders
 
 ### 10.2 Writer API
 - [ ] Implement `ParquetWriter.builder(path)` fluent API
 - [ ] Configuration methods (schema, codec, sizes, etc.)
-- [ ] GenericRecord support
-- [ ] Custom record materializer support
+- [ ] GenericRecord support (Avro write adapter; later milestone)
+- [ ] Custom record materializer support (non-goal for now)
 
 ### 10.3 Reader API
 - [x] `ParquetFileReader` with static `open()` factory methods

--- a/_designs/WRITER_SUPPORT.md
+++ b/_designs/WRITER_SUPPORT.md
@@ -1,0 +1,249 @@
+# Writer support (#9)
+
+**Status: In progress.** Tracking issue: #9.
+
+## Context
+
+Hardwood is a read-only Parquet library: every file in the test corpus is produced
+ahead of time by `tools/simple-datagen.py` (PyArrow). The 1.0 line shipped reading;
+write support is the 1.1 goal.
+
+The read pipeline memory-maps a file of known size and fans out random-access
+`readRange(offset, length)` calls across columns and row groups. Writing inverts
+this: the output size is unknown until the file is finished, and the Parquet
+container is laid out for forward-only production. This document describes the
+end-state writer architecture and the order in which it is delivered.
+
+## Scope
+
+The first writer milestone (1.1) targets **flat schemas written through a columnar
+batch API**:
+
+- **Flat columns only** — `REQUIRED` and `OPTIONAL` fields. No repetition, therefore
+  no Dremel shredding and no repetition levels. This is the write-side counterpart of
+  the reader's `FlatRowReader` fast path and covers the majority of analytics files.
+- **Columnar batch input** — the user supplies typed arrays per column, mirroring
+  `ColumnReader`. A row-oriented writer and integration adapters layer on top later.
+- **DataPage V1** as the written page format, for maximum reader compatibility.
+
+Logical-type annotations (STRING, DATE, TIMESTAMP, DECIMAL, UUID, …) are in scope
+for the flat milestone: a column's physical bytes are written by the primitive-type
+increment, and the annotation is serialized onto the schema and converted at the API
+boundary.
+
+Explicitly out of the first milestone, sequenced as later work: nested data
+(structs, lists, maps), DataPage V2, the Avro write API, the optional index
+structures (OffsetIndex, ColumnIndex, Bloom filters), the optional delta and
+byte-stream-split encoders, and the S3 `OutputFile` backend. Sorting-column
+metadata and custom record materializers are non-goals.
+
+## Write model
+
+### Forward-only, footer-last
+
+The Parquet container is written front to back and never seeked backward:
+
+```
+PAR1 | <row group 0 pages> | <row group 1 pages> | ... | FileMetaData (thrift) | <footer length: 4 bytes LE> | PAR1
+```
+
+Every offset a reader needs lives in the `FileMetaData` footer, which is emitted
+last. The writer maintains a running byte position, records page and column-chunk
+offsets as it streams them out, and serializes the accumulated metadata at the end.
+No random access and no memory mapping are required on the write path.
+
+### Row-group buffering bounds memory
+
+A row group's column chunks are written contiguously, and each column chunk's
+metadata (compressed and uncompressed sizes, page offsets, statistics) is only known
+once its bytes have been encoded. The writer therefore **encodes and buffers a full
+row group's columns in memory, then flushes them in column order**. The configured
+row-group size (default 128 MiB of uncompressed data) bounds peak memory — this is
+the write-side inverse of the reader's whole-file mmap. Page size (default 1 MiB)
+bounds the granularity within a column chunk.
+
+### OutputFile abstraction
+
+A sequential write counterpart to `InputFile`, far simpler than the random-access
+read interface:
+
+```java
+public interface OutputFile extends Closeable {
+    void create() throws IOException;        // Acquire resources
+    void write(ByteBuffer data) throws IOException;
+    long position();                          // Running byte offset written so far
+    void close() throws IOException;          // Finalize; file is valid only after this returns
+}
+```
+
+- **Local backend** (`internal.writer.ChannelOutputFile`): a buffered `FileChannel`.
+  Writes to a temporary sibling path and atomically renames on `close()`, so a failed
+  write never leaves a truncated file presented as valid.
+- **In-memory backend** (`internal.writer.ByteBufferOutputFile`): a growable buffer,
+  the write-side counterpart to `ByteBufferInputFile`, used for tests and round-trips.
+- **S3 backend** (later): sequential writes buffer to the multipart part size and
+  upload parts; `close()` completes the multipart upload.
+
+A file is valid only after `close()` returns successfully. A writer abandoned before
+`close()` produces no footer and therefore no readable file.
+
+## Component architecture
+
+Writer components live in `core`, in packages parallel to the reader, so encoders and
+the thrift codec sit alongside their decode counterparts as shared substrate.
+
+| Layer | Package | Components |
+|-------|---------|------------|
+| Public API | `dev.hardwood.writer` | `ParquetFileWriter`, `ColumnBatchWriter`, `WriterConfig` |
+| Public API | `dev.hardwood` | `OutputFile` |
+| Public API | `dev.hardwood.schema` | `FileSchema.Builder` (produces the existing immutable `FileSchema`) |
+| Orchestration | `dev.hardwood.internal.writer` | `RowGroupBuffer`, `ColumnChunkBuffer`, `PageBuilder`, `StatisticsCollector`, `OutputFile` backends |
+| Value encoding | `dev.hardwood.internal.encoding` | `PlainEncoder`, `RleBitPackingHybridEncoder`, `LevelEncoder`, `DictionaryEncoder` (alongside the existing decoders) |
+| Compression | `dev.hardwood.internal.compression` | `Compressor` / `CompressorFactory` (alongside `Decompressor`) |
+| Metadata serialization | `dev.hardwood.internal.thrift` | `ThriftCompactWriter`, `FileMetaDataWriter`, `SchemaElementWriter`, `RowGroupWriter`, `ColumnChunkWriter`, `ColumnMetaDataWriter`, `PageHeaderWriter` (the `*Writer` inverses of the existing `*Reader`s) |
+
+The thrift `*Writer` classes are pure struct serializers, the inverse of the
+`*Reader`s and co-located with them; the `internal.writer` orchestration types
+carry the distinct `*Buffer` / `*Builder` names so they do not collide.
+
+### Schema construction
+
+The writer reuses the immutable `FileSchema` / `SchemaNode` model unchanged — files
+it writes are read back through the same model. A `FileSchema.Builder` constructs
+that model programmatically and computes max definition levels. The initial builder
+takes a field name, physical type and repetition; a logical-type overload (and the
+`FIXED_LEN_BYTE_ARRAY` type length plus `DECIMAL` scale/precision) arrives with the
+logical-type increment. The builder rejects repeated fields until nested support
+lands, so unsupported schemas fail at construction rather than mid-write.
+
+Logical types are written in two parts. The **annotation** — the `LogicalType` union
+and the legacy `converted_type`/`scale`/`precision` fields on `SchemaElement` — is
+serialized by a `LogicalTypeWriter` (the inverse of the existing `LogicalTypeReader`),
+so a written column reads back as `STRING`/`DATE`/`DECIMAL`/etc. The **value
+conversion** — accepting `String`/`LocalDate`/`Instant`/`BigDecimal` and lowering them
+to physical values — is the inverse of the reader's `LogicalTypeConverter` and rides
+with the row-oriented API; the columnar API takes physical values directly.
+
+### Encoding strategy and `WriterConfig`
+
+The writer auto-selects sensible per-column encodings and exposes overrides through
+`WriterConfig`; the CLI surface stays minimal.
+
+- **Levels**: definition levels are RLE/bit-packed via `LevelEncoder` (flat schemas
+  have no repetition levels).
+- **Values**: `PLAIN` is the correctness baseline. `RLE_DICTIONARY` with plain
+  fallback (on dictionary-size overflow) is the default for eligible columns, matching
+  the reader's dictionary fast paths. The delta and byte-stream-split encodings are
+  optional and deferred to after the flat milestone.
+- **Compression**: `UNCOMPRESSED` first, then `SNAPPY` / `ZSTD` / `GZIP` / `LZ4` —
+  the existing codec libraries are bidirectional, so the encode side reuses them.
+  Default codec is `ZSTD`.
+
+`WriterConfig` knobs: row-group size, page size, dictionary page-size limit, codec,
+and the written `created_by` string.
+
+### Statistics
+
+`StatisticsCollector` accumulates `min` / `max` / `null_count` per column chunk
+during encoding and writes them into `ColumnMetaData`, so produced files support
+reader-side predicate pushdown. `min`/`max` ordering follows the column's
+`ColumnOrder` (the same ordering the reader honors on read), so written statistics
+are pruning-correct. Long `BYTE_ARRAY` `min`/`max` are truncated per the format's
+binary min/max truncation rule, keeping statistics bounded while remaining valid for
+pruning. OffsetIndex, ColumnIndex, and Bloom filters are deferred; a file is valid
+without them.
+
+## Threading model
+
+The first implementation is **single-threaded**. Correctness is the priority for a
+writer, and a half-correct file is worthless.
+
+The architecture leaves parallelism open without a public-API change: within a row
+group, columns are encoded independently into separate byte buffers and only
+concatenated in column order at flush, mirroring the reader's per-column workers. A
+later increment can encode columns in parallel and pipeline row-group encoding
+against the flush of the previous group. This machinery is added only once the
+single-threaded writer is correct.
+
+## Validation strategy
+
+Every increment lands with tests that prove the produced bytes are a valid Parquet
+file readable by an independent engine, so no unverified write code accumulates in
+`main`. The cross-engine differential is the primary check; the read-side oracle is
+established in `_designs/DIFFERENTIAL_TESTING.md` and the writer runs it in reverse.
+
+1. **DuckDB differential (primary)**: hardwood writes a file, then DuckDB reads it
+   through `read_parquet('<path>')` and the values are asserted to agree. This is the
+   exact inverse of [DifferentialReadTest], which has DuckDB read fixtures hardwood
+   also reads; here DuckDB is the consumer of hardwood-written bytes. Because DuckDB
+   shares no code with hardwood, agreement proves the bytes are spec-correct rather
+   than merely self-consistent. Each row carries a synthetic index column so the
+   comparison is robust to scan order (`ORDER BY` that column). Boundary values
+   (signed extremes, all-null columns once nullable columns land, empty row groups)
+   are written explicitly to stress the encoders.
+2. **Round-trip**: write with hardwood, read back with hardwood, assert value and
+   null equality. This is the fast inner-loop check and pins reader/writer agreement
+   on details DuckDB does not surface (e.g. exact encodings, statistics).
+3. **Property/fuzz** (later increments): random in-scope schemas and data round-tripped
+   and run through the DuckDB differential, to surface edge cases beyond the
+   hand-written cases (dictionary overflow, page and row-group boundaries).
+
+DuckDB is already a `test`-scope dependency (`org.duckdb:duckdb_jdbc`); no new tooling
+is required. Reading hardwood-written files with PyArrow is used for ad-hoc
+verification but is not part of the automated suite.
+
+## Delivery plan
+
+Each increment is a shippable PR that adds user-visible capability and lands with the
+validation above, so `main` never holds functionality that cannot produce a readable
+file.
+
+The sequencing is **dimension-first**: prove the thinnest slice through each
+architectural dimension — paging, the columnar API contract (nulls + streaming),
+dictionary pages, compression, statistics — on a single type (`INT32`) before going
+wide. Type, encoding, and codec **breadth** is the same proven mechanism repeated, so
+it is deferred until every dimension is settled; otherwise a late dimension would
+reshape an already-multiplied surface (adding nulls or the streaming API after N typed
+methods exist rewrites all N). Each increment carries a **Kind**: *Dimension* (changes
+the shape of the solution), *Breadth* (more of a proven mechanism), *Layer* (additive
+API), *Optimization*, *Spike* (design-only), or *Docs* (user-facing documentation).
+
+| # | Increment | Kind | New capability | Roadmap boxes | Completed |
+|---|-----------|------|----------------|---------------|-----------|
+| 1 | Tracer: flat `REQUIRED INT32`, one page / one row group, `PLAIN`, uncompressed. `OutputFile` (local + in-memory), `ThriftCompactWriter`, page-header + footer serialization. | Dimension | Produces a real, readable file | 1 (ThriftCompactWriter), 3.2 (page header ser.), 4.1/4.2 (chunk/row-group ser.), 5.2 (FileMetaData ser.) | [x] |
+| 2 | Page chunking within a column chunk: a large `INT32` column written as multiple size-bounded `PLAIN` pages instead of one, replacing the single-page guard. Internal — the columnar API is unchanged. | Dimension | Large columns written safely, bounded page size | 6.2 (multi-page data writing) | [ ] |
+| 3 | **Columnar API contract** (`INT32` only): nullable columns (definition levels via `LevelEncoder`) **and** multi-row-group append with size-based flushing **and** `WriterConfig`, designed together. Locks how the caller supplies nulls and feeds data. | Dimension | The public write contract is settled | 2.3, 3.3, 6.1, 6.2 | [ ] |
+| 4 | Dictionary encoding (`INT32`): dictionary page + `RLE_DICTIONARY` indices + plain fallback. | Dimension | Dictionary column-chunk layout proven | 2.2 | [ ] |
+| 5 | Compression on the write path (`INT32`, one codec). | Dimension | Compress step + compressed/uncompressed size accounting proven | 6.2 (page compression) | [ ] |
+| 6 | Column statistics (`INT32`: `min`/`max`/`null_count`, `ColumnOrder`-correct) accumulated during encode, + CRC32. | Dimension | Produced files support pushdown | 9.1 (stats), 3.2 (CRC write) | [ ] |
+| 7 | Nested design spike: confirm the columnar API contract extends to repetition levels and shredding. Design only, no implementation. | Spike | De-risks the nested milestone before breadth locks the API | 6.3 (design) | [ ] |
+| 8 | All primitive physical types (incl. `FIXED_LEN_BYTE_ARRAY` type length and `BYTE_ARRAY` min/max truncation), each inheriting paging, nulls, dictionary, compression and stats. | Breadth | Write any flat column type | 2.1, 9.1 (truncation) | [ ] |
+| 9 | Logical-type annotations: `LogicalTypeWriter` serializes the `LogicalType` union and legacy `converted_type`/`scale`/`precision`; `FileSchema.Builder` logical-type overload. | Breadth | Columns read back with their logical type (STRING, DATE, TIMESTAMP, DECIMAL, …) | 6.4 (annotation) | [ ] |
+| 10 | Remaining codecs + optional delta and byte-stream-split encoders. | Breadth | Full codec / encoding choice | 2.4, 2.5 | [ ] |
+| 11 | Parallel column encoding + row-group pipelining. | Optimization | Write throughput | — | [ ] |
+| 12 | Row-oriented `ParquetWriter` ergonomic layer on the columnar core, including logical-type value conversion (inverse of `LogicalTypeConverter`). | Layer | Mainstream-friendly API | 6.1 (`ParquetWriter`), 6.4 (value conversion) | [ ] |
+| 13 | User-facing documentation under `docs/content/` for the writer public API (`OutputFile`, `ParquetFileWriter`, `FileSchema.Builder`): a `how-to` guide and a `reference` page, covering the settled surface including the row-oriented layer. | Docs | Documented, stable public API | — | [ ] |
+
+Increments 1–6 prove every architectural dimension on `INT32`; 7 is a design checkpoint;
+8–12 are breadth and layers that build on the settled shape; 13 documents the finished
+public surface. Together they constitute the flat-writer milestone (1.1). Later milestones, each their own design and sequence: nested
+shredding implementation (Dremel: structs → lists → maps), DataPage V2, the optional index
+structures and Bloom filters, the Avro write adapter, a CLI write/convert command, and the
+S3 `OutputFile` backend.
+
+## User documentation
+
+User-facing documentation under `docs/content/` is delivered as the closing increment
+of the milestone (stage 13), once the full public surface — including the row-oriented
+layer — is settled. Documenting the provisional `INT32`-only surface earlier would be
+throwaway, so deferring is a recorded, intentional exception to the CLAUDE.md rule that
+a new public API ships with a docs update — not an oversight. The public surface
+(`OutputFile`, `ParquetFileWriter`, `FileSchema.Builder`) gets its `how-to`/`reference`
+pages at stage 13.
+
+## Roadmap reconciliation
+
+`ROADMAP.md` remains the fine-grained capability inventory; this document is the plan
+of record for writer architecture and sequencing. The mapping column above ties each
+increment to the roadmap boxes it completes, so those boxes are ticked as increments
+land. Phase 6 of `ROADMAP.md` points here.

--- a/core/src/main/java/dev/hardwood/OutputFile.java
+++ b/core/src/main/java/dev/hardwood/OutputFile.java
@@ -1,0 +1,71 @@
+/*
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Copyright The original authors
+ *
+ *  Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package dev.hardwood;
+
+import java.io.Closeable;
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.nio.file.Path;
+
+import dev.hardwood.internal.writer.ChannelOutputFile;
+
+/// Abstraction for writing Parquet file data.
+///
+/// This is the write-side counterpart to [InputFile]. Where reading requires
+/// random access, the Parquet container is produced front to back and never
+/// seeked backward: the footer carries every offset a reader needs and is
+/// emitted last. An `OutputFile` is therefore a purely sequential sink.
+///
+/// An `OutputFile` starts in an uncreated state. [#create()] must be called
+/// before [#write] or [#position]; the writer framework
+/// ([dev.hardwood.writer.ParquetFileWriter]) calls it automatically.
+///
+/// A file is valid only after [#close()] returns successfully. A writer
+/// abandoned before `close()` produces no footer and therefore no readable file.
+public interface OutputFile extends Closeable {
+
+    /// Performs resource acquisition (e.g. opening a file channel).
+    /// Must be called before [#write] or [#position].
+    ///
+    /// @throws IOException if the resource cannot be acquired
+    void create() throws IOException;
+
+    /// Appends the remaining bytes of `data` to the file.
+    ///
+    /// The buffer is consumed (its position advances to its limit).
+    ///
+    /// @param data the bytes to append
+    /// @throws IOException if the write fails
+    /// @throws IllegalStateException if [#create()] has not been called
+    void write(ByteBuffer data) throws IOException;
+
+    /// Returns the number of bytes written so far, which is the offset at which
+    /// the next [#write] will begin.
+    ///
+    /// @return the running byte offset
+    /// @throws IllegalStateException if [#create()] has not been called
+    long position();
+
+    /// Discards everything written and releases resources without publishing a
+    /// file at the destination. This is the failure counterpart to [#close()]:
+    /// [#close()] finalizes (commits) the file, `discard()` throws it away. The
+    /// writer calls `discard()` when it cannot finish a valid file, so a partially
+    /// written file is never presented as valid. After `discard()` the destination
+    /// is left as if nothing was written; calling `close()` afterwards is a no-op.
+    ///
+    /// @throws IOException if resources cannot be released
+    void discard() throws IOException;
+
+    /// Creates an uncreated [OutputFile] for a local file path.
+    ///
+    /// @param path the file to write
+    /// @return a new uncreated OutputFile
+    static OutputFile of(Path path) {
+        return new ChannelOutputFile(path);
+    }
+}

--- a/core/src/main/java/dev/hardwood/internal/encoding/PlainEncoder.java
+++ b/core/src/main/java/dev/hardwood/internal/encoding/PlainEncoder.java
@@ -1,0 +1,32 @@
+/*
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Copyright The original authors
+ *
+ *  Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package dev.hardwood.internal.encoding;
+
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
+
+/// Encoder for the PLAIN encoding, the inverse of [PlainDecoder].
+public final class PlainEncoder {
+
+    private PlainEncoder() {
+    }
+
+    /// Encode INT32 values as little-endian 4-byte words, matching
+    /// [PlainDecoder#readInts].
+    ///
+    /// @param values the values to encode
+    /// @return the PLAIN-encoded bytes
+    /// @throws ArithmeticException if the encoded size overflows an `int`
+    ///         (more than `Integer.MAX_VALUE / 4` values)
+    public static byte[] encodeInts(int[] values) {
+        ByteBuffer buffer = ByteBuffer.allocate(Math.multiplyExact(values.length, Integer.BYTES))
+                .order(ByteOrder.LITTLE_ENDIAN);
+        buffer.asIntBuffer().put(values);
+        return buffer.array();
+    }
+}

--- a/core/src/main/java/dev/hardwood/internal/thrift/ColumnChunkWriter.java
+++ b/core/src/main/java/dev/hardwood/internal/thrift/ColumnChunkWriter.java
@@ -1,0 +1,34 @@
+/*
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Copyright The original authors
+ *
+ *  Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package dev.hardwood.internal.thrift;
+
+import dev.hardwood.metadata.ColumnChunk;
+
+/// Writer for ColumnChunk to Thrift Compact Protocol, the inverse of
+/// [ColumnChunkReader].
+public class ColumnChunkWriter {
+
+    public static void write(ThriftCompactWriter writer, ColumnChunk chunk) {
+        short saved = writer.pushFieldIdContext();
+        try {
+            // 2: file_offset (required). For a single-page chunk with no dictionary
+            // this is the offset of the data page, matching data_page_offset.
+            writer.writeFieldBegin(2, ThriftCompactConstants.FieldType.I64);
+            writer.writeI64(chunk.metaData().dataPageOffset());
+
+            // 3: meta_data
+            writer.writeFieldBegin(3, ThriftCompactConstants.FieldType.STRUCT);
+            ColumnMetaDataWriter.write(writer, chunk.metaData());
+
+            writer.writeFieldStop();
+        }
+        finally {
+            writer.popFieldIdContext(saved);
+        }
+    }
+}

--- a/core/src/main/java/dev/hardwood/internal/thrift/ColumnMetaDataWriter.java
+++ b/core/src/main/java/dev/hardwood/internal/thrift/ColumnMetaDataWriter.java
@@ -1,0 +1,66 @@
+/*
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Copyright The original authors
+ *
+ *  Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package dev.hardwood.internal.thrift;
+
+import dev.hardwood.metadata.ColumnMetaData;
+import dev.hardwood.metadata.Encoding;
+
+/// Writer for ColumnMetaData to Thrift Compact Protocol, the inverse of
+/// [ColumnMetaDataReader]. Serializes the required fields only; optional
+/// statistics, index offsets and dictionary offsets are written by later
+/// increments.
+public class ColumnMetaDataWriter {
+
+    public static void write(ThriftCompactWriter writer, ColumnMetaData metaData) {
+        short saved = writer.pushFieldIdContext();
+        try {
+            // 1: type
+            writer.writeFieldBegin(1, ThriftCompactConstants.FieldType.I32);
+            writer.writeI32(ThriftEnumLookup.thriftValue(metaData.type()));
+
+            // 2: encodings (list<Encoding>)
+            writer.writeFieldBegin(2, ThriftCompactConstants.FieldType.LIST);
+            writer.writeListBegin(metaData.encodings().size(), ThriftCompactConstants.ElementType.I32);
+            for (Encoding encoding : metaData.encodings()) {
+                writer.writeI32(ThriftEnumLookup.thriftValue(encoding));
+            }
+
+            // 3: path_in_schema (list<string>)
+            writer.writeFieldBegin(3, ThriftCompactConstants.FieldType.LIST);
+            writer.writeListBegin(metaData.pathInSchema().elements().size(), ThriftCompactConstants.ElementType.BINARY);
+            for (String segment : metaData.pathInSchema().elements()) {
+                writer.writeString(segment);
+            }
+
+            // 4: codec
+            writer.writeFieldBegin(4, ThriftCompactConstants.FieldType.I32);
+            writer.writeI32(ThriftEnumLookup.thriftValue(metaData.codec()));
+
+            // 5: num_values
+            writer.writeFieldBegin(5, ThriftCompactConstants.FieldType.I64);
+            writer.writeI64(metaData.numValues());
+
+            // 6: total_uncompressed_size
+            writer.writeFieldBegin(6, ThriftCompactConstants.FieldType.I64);
+            writer.writeI64(metaData.totalUncompressedSize());
+
+            // 7: total_compressed_size
+            writer.writeFieldBegin(7, ThriftCompactConstants.FieldType.I64);
+            writer.writeI64(metaData.totalCompressedSize());
+
+            // 9: data_page_offset
+            writer.writeFieldBegin(9, ThriftCompactConstants.FieldType.I64);
+            writer.writeI64(metaData.dataPageOffset());
+
+            writer.writeFieldStop();
+        }
+        finally {
+            writer.popFieldIdContext(saved);
+        }
+    }
+}

--- a/core/src/main/java/dev/hardwood/internal/thrift/FileMetaDataWriter.java
+++ b/core/src/main/java/dev/hardwood/internal/thrift/FileMetaDataWriter.java
@@ -1,0 +1,51 @@
+/*
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Copyright The original authors
+ *
+ *  Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package dev.hardwood.internal.thrift;
+
+import dev.hardwood.metadata.FileMetaData;
+import dev.hardwood.metadata.RowGroup;
+import dev.hardwood.metadata.SchemaElement;
+
+/// Writer for FileMetaData (the file footer struct) to Thrift Compact Protocol,
+/// the inverse of [FileMetaDataReader].
+public class FileMetaDataWriter {
+
+    public static void write(ThriftCompactWriter writer, FileMetaData metaData) {
+        writer.pushFieldIdContext();
+
+        // 1: version
+        writer.writeFieldBegin(1, ThriftCompactConstants.FieldType.I32);
+        writer.writeI32(metaData.version());
+
+        // 2: schema (list<SchemaElement>)
+        writer.writeFieldBegin(2, ThriftCompactConstants.FieldType.LIST);
+        writer.writeListBegin(metaData.schema().size(), ThriftCompactConstants.ElementType.STRUCT);
+        for (SchemaElement element : metaData.schema()) {
+            SchemaElementWriter.write(writer, element);
+        }
+
+        // 3: num_rows
+        writer.writeFieldBegin(3, ThriftCompactConstants.FieldType.I64);
+        writer.writeI64(metaData.numRows());
+
+        // 4: row_groups (list<RowGroup>)
+        writer.writeFieldBegin(4, ThriftCompactConstants.FieldType.LIST);
+        writer.writeListBegin(metaData.rowGroups().size(), ThriftCompactConstants.ElementType.STRUCT);
+        for (RowGroup rowGroup : metaData.rowGroups()) {
+            RowGroupWriter.write(writer, rowGroup);
+        }
+
+        // 6: created_by (optional)
+        if (metaData.createdBy() != null) {
+            writer.writeFieldBegin(6, ThriftCompactConstants.FieldType.BINARY);
+            writer.writeString(metaData.createdBy());
+        }
+
+        writer.writeFieldStop();
+    }
+}

--- a/core/src/main/java/dev/hardwood/internal/thrift/PageHeaderWriter.java
+++ b/core/src/main/java/dev/hardwood/internal/thrift/PageHeaderWriter.java
@@ -1,0 +1,78 @@
+/*
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Copyright The original authors
+ *
+ *  Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package dev.hardwood.internal.thrift;
+
+import dev.hardwood.metadata.Encoding;
+
+/// Writer for a DataPage V1 PageHeader to Thrift Compact Protocol, the inverse of
+/// the PageHeader/DataPageHeader parsing in [PageHeaderReader] and
+/// [DataPageHeaderReader].
+public class PageHeaderWriter {
+
+    /// Thrift `PageType.DATA_PAGE`.
+    private static final int PAGE_TYPE_DATA_PAGE = 0;
+
+    /// Serialize a DataPage V1 page header.
+    ///
+    /// @param writer the destination
+    /// @param numValues number of values in the page
+    /// @param uncompressedSize uncompressed size of the page body (levels + values)
+    /// @param compressedSize compressed size of the page body; equals the
+    ///        uncompressed size when the page is stored uncompressed
+    /// @param valuesEncoding the encoding of the values
+    public static void writeDataPageV1(ThriftCompactWriter writer, int numValues,
+                                       int uncompressedSize, int compressedSize, Encoding valuesEncoding) {
+        writer.pushFieldIdContext();
+
+        // 1: type
+        writer.writeFieldBegin(1, ThriftCompactConstants.FieldType.I32);
+        writer.writeI32(PAGE_TYPE_DATA_PAGE);
+
+        // 2: uncompressed_page_size
+        writer.writeFieldBegin(2, ThriftCompactConstants.FieldType.I32);
+        writer.writeI32(uncompressedSize);
+
+        // 3: compressed_page_size
+        writer.writeFieldBegin(3, ThriftCompactConstants.FieldType.I32);
+        writer.writeI32(compressedSize);
+
+        // 5: data_page_header
+        writer.writeFieldBegin(5, ThriftCompactConstants.FieldType.STRUCT);
+        writeDataPageHeader(writer, numValues, valuesEncoding);
+
+        writer.writeFieldStop();
+    }
+
+    private static void writeDataPageHeader(ThriftCompactWriter writer, int numValues, Encoding valuesEncoding) {
+        short saved = writer.pushFieldIdContext();
+        try {
+            // 1: num_values
+            writer.writeFieldBegin(1, ThriftCompactConstants.FieldType.I32);
+            writer.writeI32(numValues);
+
+            // 2: encoding
+            writer.writeFieldBegin(2, ThriftCompactConstants.FieldType.I32);
+            writer.writeI32(ThriftEnumLookup.thriftValue(valuesEncoding));
+
+            // 3: definition_level_encoding (RLE). For a REQUIRED column there are
+            // no definition levels, but the field is required by the V1 header.
+            writer.writeFieldBegin(3, ThriftCompactConstants.FieldType.I32);
+            writer.writeI32(ThriftEnumLookup.thriftValue(Encoding.RLE));
+
+            // 4: repetition_level_encoding (RLE). Likewise no repetition levels
+            // for a flat column.
+            writer.writeFieldBegin(4, ThriftCompactConstants.FieldType.I32);
+            writer.writeI32(ThriftEnumLookup.thriftValue(Encoding.RLE));
+
+            writer.writeFieldStop();
+        }
+        finally {
+            writer.popFieldIdContext(saved);
+        }
+    }
+}

--- a/core/src/main/java/dev/hardwood/internal/thrift/RowGroupWriter.java
+++ b/core/src/main/java/dev/hardwood/internal/thrift/RowGroupWriter.java
@@ -1,0 +1,41 @@
+/*
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Copyright The original authors
+ *
+ *  Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package dev.hardwood.internal.thrift;
+
+import dev.hardwood.metadata.ColumnChunk;
+import dev.hardwood.metadata.RowGroup;
+
+/// Writer for RowGroup to Thrift Compact Protocol, the inverse of
+/// [RowGroupReader].
+public class RowGroupWriter {
+
+    public static void write(ThriftCompactWriter writer, RowGroup rowGroup) {
+        short saved = writer.pushFieldIdContext();
+        try {
+            // 1: columns (list<ColumnChunk>)
+            writer.writeFieldBegin(1, ThriftCompactConstants.FieldType.LIST);
+            writer.writeListBegin(rowGroup.columns().size(), ThriftCompactConstants.ElementType.STRUCT);
+            for (ColumnChunk chunk : rowGroup.columns()) {
+                ColumnChunkWriter.write(writer, chunk);
+            }
+
+            // 2: total_byte_size
+            writer.writeFieldBegin(2, ThriftCompactConstants.FieldType.I64);
+            writer.writeI64(rowGroup.totalByteSize());
+
+            // 3: num_rows
+            writer.writeFieldBegin(3, ThriftCompactConstants.FieldType.I64);
+            writer.writeI64(rowGroup.numRows());
+
+            writer.writeFieldStop();
+        }
+        finally {
+            writer.popFieldIdContext(saved);
+        }
+    }
+}

--- a/core/src/main/java/dev/hardwood/internal/thrift/SchemaElementWriter.java
+++ b/core/src/main/java/dev/hardwood/internal/thrift/SchemaElementWriter.java
@@ -1,0 +1,57 @@
+/*
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Copyright The original authors
+ *
+ *  Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package dev.hardwood.internal.thrift;
+
+import dev.hardwood.metadata.SchemaElement;
+
+/// Writer for SchemaElement to Thrift Compact Protocol, the inverse of
+/// [SchemaElementReader].
+public class SchemaElementWriter {
+
+    public static void write(ThriftCompactWriter writer, SchemaElement element) {
+        rejectUnsupported(element);
+
+        short saved = writer.pushFieldIdContext();
+        try {
+            if (element.type() != null) {
+                writer.writeFieldBegin(1, ThriftCompactConstants.FieldType.I32);
+                writer.writeI32(ThriftEnumLookup.thriftValue(element.type()));
+            }
+            if (element.typeLength() != null) {
+                writer.writeFieldBegin(2, ThriftCompactConstants.FieldType.I32);
+                writer.writeI32(element.typeLength());
+            }
+            if (element.repetitionType() != null) {
+                writer.writeFieldBegin(3, ThriftCompactConstants.FieldType.I32);
+                writer.writeI32(ThriftEnumLookup.thriftValue(element.repetitionType()));
+            }
+            // name is required
+            writer.writeFieldBegin(4, ThriftCompactConstants.FieldType.BINARY);
+            writer.writeString(element.name());
+            if (element.numChildren() != null) {
+                writer.writeFieldBegin(5, ThriftCompactConstants.FieldType.I32);
+                writer.writeI32(element.numChildren());
+            }
+            writer.writeFieldStop();
+        }
+        finally {
+            writer.popFieldIdContext(saved);
+        }
+    }
+
+    /// Fail fast on annotations the writer cannot yet serialize, rather than
+    /// silently dropping them and producing a schema that does not round-trip.
+    private static void rejectUnsupported(SchemaElement element) {
+        if (element.convertedType() != null || element.logicalType() != null
+                || element.scale() != null || element.precision() != null
+                || element.fieldId() != null) {
+            throw new UnsupportedOperationException(
+                    "Writer does not yet support converted/logical types or field ids: " + element.name());
+        }
+    }
+}

--- a/core/src/main/java/dev/hardwood/internal/thrift/ThriftCompactConstants.java
+++ b/core/src/main/java/dev/hardwood/internal/thrift/ThriftCompactConstants.java
@@ -1,0 +1,101 @@
+/*
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Copyright The original authors
+ *
+ *  Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package dev.hardwood.internal.thrift;
+
+/// Thrift Compact Protocol type codes, defined once and shared by the reader and
+/// writer so the wire constants are not duplicated.
+/// Reference: https://github.com/apache/thrift/blob/master/doc/specs/thrift-compact-protocol.md
+final class ThriftCompactConstants {
+
+    /// Type codes for struct field headers.
+    public enum FieldType {
+
+        BOOLEAN_TRUE(Codes.BOOLEAN_TRUE),
+        BOOLEAN_FALSE(Codes.BOOLEAN_FALSE),
+        BYTE(Codes.BYTE),
+        I16(Codes.I16),
+        I32(Codes.I32),
+        I64(Codes.I64),
+        DOUBLE(Codes.DOUBLE),
+        BINARY(Codes.BINARY),
+        LIST(Codes.LIST),
+        SET(Codes.SET),
+        MAP(Codes.MAP),
+        STRUCT(Codes.STRUCT),
+        UUID(Codes.UUID);
+
+        private final byte code;
+
+        FieldType(byte code) {
+            this.code = code;
+        }
+
+        /// The Thrift Compact Protocol wire code for this type.
+        byte code() {
+            return code;
+        }
+
+        /// Wire type codes as compile-time constants. Callers that dispatch in a
+        /// `switch` on the raw wire byte — notably [ThriftCompactReader] — reference
+        /// these so the codes are defined once, without re-declaring the literals.
+        /// The [FieldType] and [ElementType] enums are built from them too.
+        static final class Codes {
+
+            static final byte BOOLEAN_TRUE = 0x01;
+            static final byte BOOLEAN_FALSE = 0x02;
+            static final byte BYTE = 0x03;
+            static final byte I16 = 0x04;
+            static final byte I32 = 0x05;
+            static final byte I64 = 0x06;
+            static final byte DOUBLE = 0x07;
+            static final byte BINARY = 0x08;
+            static final byte LIST = 0x09;
+            static final byte SET = 0x0A;
+            static final byte MAP = 0x0B;
+            static final byte STRUCT = 0x0C;
+            static final byte UUID = 0x0D;
+
+            private Codes() {
+            }
+        }
+    }
+
+    /// Type codes for list/set/map elements. These mirror [FieldType] except boolean:
+    /// a collection has a single [#BOOL] element type, whereas a field packs
+    /// true/false into the type. `BOOL` is written as `1` — the de-facto standard;
+    /// the spec's original code was `2` and readers should accept either.
+    public enum ElementType {
+
+        BOOL(FieldType.Codes.BOOLEAN_TRUE),
+        BYTE(FieldType.Codes.BYTE),
+        I16(FieldType.Codes.I16),
+        I32(FieldType.Codes.I32),
+        I64(FieldType.Codes.I64),
+        DOUBLE(FieldType.Codes.DOUBLE),
+        BINARY(FieldType.Codes.BINARY),
+        LIST(FieldType.Codes.LIST),
+        SET(FieldType.Codes.SET),
+        MAP(FieldType.Codes.MAP),
+        STRUCT(FieldType.Codes.STRUCT),
+        UUID(FieldType.Codes.UUID);
+
+        private final byte code;
+
+        ElementType(byte code) {
+            this.code = code;
+        }
+
+        /// The Thrift Compact Protocol wire code for this element type.
+        byte code() {
+            return code;
+        }
+    }
+
+    private ThriftCompactConstants() {
+    }
+}

--- a/core/src/main/java/dev/hardwood/internal/thrift/ThriftCompactReader.java
+++ b/core/src/main/java/dev/hardwood/internal/thrift/ThriftCompactReader.java
@@ -13,22 +13,27 @@ import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
 import java.nio.charset.StandardCharsets;
 
+import dev.hardwood.internal.thrift.ThriftCompactConstants.FieldType.Codes;
+
 /// Reader for Thrift Compact Protocol using direct ByteBuffer access.
 /// Reference: https://github.com/apache/thrift/blob/master/doc/specs/thrift-compact-protocol.md
 public class ThriftCompactReader {
 
-    private static final byte TYPE_BOOLEAN_TRUE = 0x01;
-    private static final byte TYPE_BOOLEAN_FALSE = 0x02;
-    private static final byte TYPE_BYTE = 0x03;
-    private static final byte TYPE_I16 = 0x04;
-    private static final byte TYPE_I32 = 0x05;
-    private static final byte TYPE_I64 = 0x06;
-    private static final byte TYPE_DOUBLE = 0x07;
-    private static final byte TYPE_BINARY = 0x08;
-    private static final byte TYPE_LIST = 0x09;
-    private static final byte TYPE_SET = 0x0A;
-    private static final byte TYPE_MAP = 0x0B;
-    private static final byte TYPE_STRUCT = 0x0C;
+    // The reader dispatches on the raw wire byte in a switch, whose case labels must
+    // be compile-time constants, so it references the shared byte codes in
+    // [ThriftCompactConstants.FieldType.Codes] rather than the enum values.
+    private static final byte TYPE_BOOLEAN_TRUE = Codes.BOOLEAN_TRUE;
+    private static final byte TYPE_BOOLEAN_FALSE = Codes.BOOLEAN_FALSE;
+    private static final byte TYPE_BYTE = Codes.BYTE;
+    private static final byte TYPE_I16 = Codes.I16;
+    private static final byte TYPE_I32 = Codes.I32;
+    private static final byte TYPE_I64 = Codes.I64;
+    private static final byte TYPE_DOUBLE = Codes.DOUBLE;
+    private static final byte TYPE_BINARY = Codes.BINARY;
+    private static final byte TYPE_LIST = Codes.LIST;
+    private static final byte TYPE_SET = Codes.SET;
+    private static final byte TYPE_MAP = Codes.MAP;
+    private static final byte TYPE_STRUCT = Codes.STRUCT;
 
     private final ByteBuffer buffer;
     private final int startPosition;

--- a/core/src/main/java/dev/hardwood/internal/thrift/ThriftCompactWriter.java
+++ b/core/src/main/java/dev/hardwood/internal/thrift/ThriftCompactWriter.java
@@ -1,0 +1,113 @@
+/*
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Copyright The original authors
+ *
+ *  Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package dev.hardwood.internal.thrift;
+
+import java.io.ByteArrayOutputStream;
+import java.nio.charset.StandardCharsets;
+
+/// Writer for Thrift Compact Protocol, the inverse of [ThriftCompactReader].
+/// Reference: https://github.com/apache/thrift/blob/master/doc/specs/thrift-compact-protocol.md
+public class ThriftCompactWriter {
+
+
+    private final ByteArrayOutputStream out = new ByteArrayOutputStream();
+    private short lastFieldId = 0;
+
+    /// Write a field header. Field ids within a struct must be written in
+    /// increasing order so the compact short-form delta encoding applies.
+    ///
+    /// @param fieldId the Thrift field id
+    /// @param type the field type
+    public void writeFieldBegin(int fieldId, ThriftCompactConstants.FieldType type) {
+        int delta = fieldId - lastFieldId;
+        if (delta > 0 && delta <= 15) {
+            out.write((delta << 4) | type.code());
+        }
+        else {
+            out.write(type.code());
+            writeZigzag(fieldId);
+        }
+        lastFieldId = (short) fieldId;
+    }
+
+    /// Write the STOP marker that terminates a struct's fields.
+    public void writeFieldStop() {
+        out.write(0);
+    }
+
+    /// Write a list header.
+    ///
+    /// @param size number of elements
+    /// @param elementType the element type
+    public void writeListBegin(int size, ThriftCompactConstants.ElementType elementType) {
+        if (size < 15) {
+            out.write((size << 4) | elementType.code());
+        }
+        else {
+            out.write(0xF0 | elementType.code());
+            writeVarint(size);
+        }
+    }
+
+    /// Write a zigzag-encoded i32 value (no field header).
+    public void writeI32(int value) {
+        writeZigzag(value);
+    }
+
+    /// Write a zigzag-encoded i64 value (no field header).
+    public void writeI64(long value) {
+        writeZigzag(value);
+    }
+
+    /// Write a length-prefixed binary value (no field header).
+    public void writeBinary(byte[] value) {
+        writeVarint(value.length);
+        out.writeBytes(value);
+    }
+
+    /// Write a length-prefixed UTF-8 string value (no field header).
+    public void writeString(String value) {
+        writeBinary(value.getBytes(StandardCharsets.UTF_8));
+    }
+
+    /// Save the current last field id and reset it for writing a nested struct,
+    /// mirroring [ThriftCompactReader#pushFieldIdContext].
+    public short pushFieldIdContext() {
+        short saved = lastFieldId;
+        lastFieldId = 0;
+        return saved;
+    }
+
+    /// Restore the last field id after writing a nested struct.
+    public void popFieldIdContext(short savedFieldId) {
+        lastFieldId = savedFieldId;
+    }
+
+    /// Returns the serialized bytes written so far.
+    public byte[] toByteArray() {
+        return out.toByteArray();
+    }
+
+    /// Returns the number of bytes written so far.
+    public int size() {
+        return out.size();
+    }
+
+    private void writeZigzag(long value) {
+        writeVarint((value << 1) ^ (value >> 63));
+    }
+
+    private void writeVarint(long value) {
+        long v = value;
+        while ((v & ~0x7FL) != 0) {
+            out.write((int) ((v & 0x7F) | 0x80));
+            v >>>= 7;
+        }
+        out.write((int) (v & 0x7F));
+    }
+}

--- a/core/src/main/java/dev/hardwood/internal/thrift/ThriftEnumLookup.java
+++ b/core/src/main/java/dev/hardwood/internal/thrift/ThriftEnumLookup.java
@@ -127,4 +127,29 @@ class ThriftEnumLookup {
         }
         throw new IllegalArgumentException("Unknown compression codec: " + value);
     }
+
+    static int thriftValue(PhysicalType type) {
+        return indexOf(PHYSICAL_TYPES, type, "physical type");
+    }
+
+    static int thriftValue(RepetitionType type) {
+        return indexOf(REPETITION_TYPES, type, "repetition type");
+    }
+
+    static int thriftValue(Encoding encoding) {
+        return indexOf(ENCODINGS, encoding, "encoding");
+    }
+
+    static int thriftValue(CompressionCodec codec) {
+        return indexOf(COMPRESSION_CODECS, codec, "compression codec");
+    }
+
+    private static <T> int indexOf(T[] table, T value, String what) {
+        for (int i = 0; i < table.length; i++) {
+            if (table[i] == value) {
+                return i;
+            }
+        }
+        throw new IllegalArgumentException("No Thrift value for " + what + ": " + value);
+    }
 }

--- a/core/src/main/java/dev/hardwood/internal/writer/ByteBufferOutputFile.java
+++ b/core/src/main/java/dev/hardwood/internal/writer/ByteBufferOutputFile.java
@@ -1,0 +1,80 @@
+/*
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Copyright The original authors
+ *
+ *  Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package dev.hardwood.internal.writer;
+
+import java.io.ByteArrayOutputStream;
+import java.nio.ByteBuffer;
+
+import dev.hardwood.OutputFile;
+
+/// [OutputFile] backed by a growable in-memory buffer.
+///
+/// The write-side counterpart to `ByteBufferInputFile`, used for round-trip tests
+/// and for producing Parquet bytes without touching the filesystem. The accumulated
+/// bytes are retrieved with [#toByteArray()] after [#close()].
+public final class ByteBufferOutputFile implements OutputFile {
+
+    private final ByteArrayOutputStream sink = new ByteArrayOutputStream();
+    private boolean created;
+    private boolean closed;
+    private boolean discarded;
+
+    @Override
+    public void create() {
+        if (created) {
+            throw new IllegalStateException("OutputFile already created");
+        }
+        created = true;
+    }
+
+    @Override
+    public void write(ByteBuffer data) {
+        requireCreated();
+        int length = data.remaining();
+        byte[] chunk = new byte[length];
+        data.get(chunk);
+        sink.writeBytes(chunk);
+    }
+
+    @Override
+    public long position() {
+        requireCreated();
+        return sink.size();
+    }
+
+    @Override
+    public void close() {
+        if (discarded) {
+            return;
+        }
+        closed = true;
+    }
+
+    @Override
+    public void discard() {
+        discarded = true;
+        sink.reset();
+    }
+
+    /// Returns a copy of the bytes written so far.
+    public byte[] toByteArray() {
+        if (discarded) {
+            throw new IllegalStateException("OutputFile was discarded");
+        }
+        if (!closed) {
+            throw new IllegalStateException("OutputFile not closed");
+        }
+        return sink.toByteArray();
+    }
+
+    private void requireCreated() {
+        if (!created) {
+            throw new IllegalStateException("OutputFile not created");
+        }
+    }
+}

--- a/core/src/main/java/dev/hardwood/internal/writer/ChannelOutputFile.java
+++ b/core/src/main/java/dev/hardwood/internal/writer/ChannelOutputFile.java
@@ -1,0 +1,91 @@
+/*
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Copyright The original authors
+ *
+ *  Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package dev.hardwood.internal.writer;
+
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.nio.channels.FileChannel;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardCopyOption;
+import java.nio.file.StandardOpenOption;
+
+import dev.hardwood.OutputFile;
+
+/// [OutputFile] backed by a local file channel.
+///
+/// Bytes are streamed to a temporary sibling file and atomically renamed onto the
+/// target path on [#close()], so a failed or abandoned write never leaves a
+/// truncated file presented as a valid Parquet file at the target path.
+public final class ChannelOutputFile implements OutputFile {
+
+    private final Path target;
+    private final Path tempPath;
+    private FileChannel channel;
+    private long position;
+
+    public ChannelOutputFile(Path target) {
+        this.target = target;
+        this.tempPath = target.resolveSibling(target.getFileName() + ".hardwood-tmp");
+    }
+
+    @Override
+    public void create() throws IOException {
+        if (channel != null) {
+            throw new IllegalStateException("OutputFile already created: " + target);
+        }
+        channel = FileChannel.open(tempPath,
+                StandardOpenOption.CREATE,
+                StandardOpenOption.WRITE,
+                StandardOpenOption.TRUNCATE_EXISTING);
+        position = 0;
+    }
+
+    @Override
+    public void write(ByteBuffer data) throws IOException {
+        requireCreated();
+        while (data.hasRemaining()) {
+            position += channel.write(data);
+        }
+    }
+
+    @Override
+    public long position() {
+        requireCreated();
+        return position;
+    }
+
+    @Override
+    public void close() throws IOException {
+        if (channel == null) {
+            return;
+        }
+        channel.close();
+        channel = null;
+        Files.move(tempPath, target,
+                StandardCopyOption.REPLACE_EXISTING,
+                StandardCopyOption.ATOMIC_MOVE);
+    }
+
+    @Override
+    public void discard() throws IOException {
+        if (channel == null) {
+            return;
+        }
+        channel.close();
+        channel = null;
+        // Drop the partially written temp file; nothing is published at the target.
+        Files.deleteIfExists(tempPath);
+    }
+
+    private void requireCreated() {
+        if (channel == null) {
+            throw new IllegalStateException("OutputFile not created: " + target);
+        }
+    }
+}

--- a/core/src/main/java/dev/hardwood/schema/FileSchema.java
+++ b/core/src/main/java/dev/hardwood/schema/FileSchema.java
@@ -127,6 +127,35 @@ public class FileSchema {
         return true;
     }
 
+    /// Creates a builder for constructing a flat schema programmatically, for use
+    /// with the writer.
+    ///
+    /// @param name the schema (message) name, conventionally `"schema"`
+    public static Builder builder(String name) {
+        return new Builder(name);
+    }
+
+    /// Flattens this schema back into the depth-first [SchemaElement] list written
+    /// to the file footer, the inverse of [#fromSchemaElements].
+    ///
+    /// Only flat schemas are supported; nested schemas are handled by a later
+    /// writer increment.
+    ///
+    /// @throws UnsupportedOperationException if the schema is not flat
+    public List<SchemaElement> toSchemaElements() {
+        if (!isFlatSchema()) {
+            throw new UnsupportedOperationException("Only flat schemas can be serialized by the writer");
+        }
+        List<SchemaElement> elements = new ArrayList<>(columns.size() + 1);
+        elements.add(new SchemaElement(name, null, null, RepetitionType.REQUIRED, columns.size(),
+                null, null, null, null, null));
+        for (ColumnSchema column : columns) {
+            elements.add(new SchemaElement(column.name(), column.type(), column.typeLength(),
+                    column.repetitionType(), null, null, null, null, null, column.logicalType()));
+        }
+        return elements;
+    }
+
     /// Reconstruct schema from Thrift SchemaElement list.
     public static FileSchema fromSchemaElements(List<SchemaElement> elements) {
         if (elements.isEmpty()) {
@@ -398,6 +427,49 @@ public class FileSchema {
                 }
                 sb.append(";\n");
             }
+        }
+    }
+
+    /// Builder for constructing a flat [FileSchema] programmatically.
+    ///
+    /// Each added column becomes a top-level primitive leaf. Nested groups and
+    /// repeated columns are handled by a later writer increment.
+    public static final class Builder {
+
+        private final String name;
+        private final List<SchemaElement> columns = new ArrayList<>();
+
+        private Builder(String name) {
+            this.name = name;
+        }
+
+        /// Append a primitive column.
+        ///
+        /// @param columnName the column name
+        /// @param type the physical type
+        /// @param repetition `REQUIRED` or `OPTIONAL`
+        /// @throws IllegalArgumentException if `repetition` is `REPEATED`
+        public Builder addColumn(String columnName, PhysicalType type, RepetitionType repetition) {
+            if (repetition == RepetitionType.REPEATED) {
+                throw new IllegalArgumentException(
+                        "Repeated columns are not yet supported by the writer: " + columnName);
+            }
+            columns.add(new SchemaElement(columnName, type, null, repetition, null, null, null, null, null, null));
+            return this;
+        }
+
+        /// Build the schema.
+        ///
+        /// @throws IllegalArgumentException if no columns were added
+        public FileSchema build() {
+            if (columns.isEmpty()) {
+                throw new IllegalArgumentException("Schema must have at least one column");
+            }
+            List<SchemaElement> elements = new ArrayList<>(columns.size() + 1);
+            elements.add(new SchemaElement(name, null, null, RepetitionType.REQUIRED, columns.size(),
+                    null, null, null, null, null));
+            elements.addAll(columns);
+            return fromSchemaElements(elements);
         }
     }
 }

--- a/core/src/main/java/dev/hardwood/writer/ParquetFileWriter.java
+++ b/core/src/main/java/dev/hardwood/writer/ParquetFileWriter.java
@@ -1,0 +1,223 @@
+/*
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Copyright The original authors
+ *
+ *  Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package dev.hardwood.writer;
+
+import java.io.Closeable;
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+import dev.hardwood.OutputFile;
+import dev.hardwood.internal.encoding.PlainEncoder;
+import dev.hardwood.internal.thrift.FileMetaDataWriter;
+import dev.hardwood.internal.thrift.PageHeaderWriter;
+import dev.hardwood.internal.thrift.ThriftCompactWriter;
+import dev.hardwood.metadata.ColumnChunk;
+import dev.hardwood.metadata.ColumnMetaData;
+import dev.hardwood.metadata.CompressionCodec;
+import dev.hardwood.metadata.Encoding;
+import dev.hardwood.metadata.FileMetaData;
+import dev.hardwood.metadata.PhysicalType;
+import dev.hardwood.metadata.RepetitionType;
+import dev.hardwood.metadata.RowGroup;
+import dev.hardwood.schema.ColumnSchema;
+import dev.hardwood.schema.FileSchema;
+
+/// Writes a Parquet file through a columnar API.
+///
+/// This first increment writes flat schemas of `REQUIRED INT32` columns as a
+/// single row group with one uncompressed, PLAIN-encoded data page per column.
+/// Each column's values are supplied once via [#writeInts]; the row group and
+/// footer are finalized on [#close()].
+///
+/// The file is produced front to back and is valid only after `close()` returns.
+public final class ParquetFileWriter implements Closeable {
+
+    private static final byte[] MAGIC = "PAR1".getBytes(StandardCharsets.UTF_8);
+    private static final int FORMAT_VERSION = 1;
+    private static final String CREATED_BY = "hardwood";
+
+    /// A data page's body length and value count are i32 on the wire, so a single
+    /// page cannot exceed this many bytes. Until multi-page writing lands a column
+    /// is written as one page, so this also bounds a single column's values.
+    private static final long MAX_DATA_PAGE_BYTES = Integer.MAX_VALUE;
+
+    private final OutputFile out;
+    private final FileSchema schema;
+    private final ColumnMetaData[] columnMeta;
+    private long numRows = -1;
+    private boolean closed;
+
+    private ParquetFileWriter(OutputFile out, FileSchema schema) {
+        this.out = out;
+        this.schema = schema;
+        this.columnMeta = new ColumnMetaData[schema.getColumnCount()];
+    }
+
+    /// Opens a writer, writing the leading magic bytes.
+    ///
+    /// @param out the destination
+    /// @param schema the flat schema to write
+    /// @return an open writer
+    /// @throws IOException if the destination cannot be opened
+    /// @throws UnsupportedOperationException if the schema is not flat
+    public static ParquetFileWriter create(OutputFile out, FileSchema schema) throws IOException {
+        if (!schema.isFlatSchema()) {
+            throw new UnsupportedOperationException("Only flat schemas are supported by the writer");
+        }
+        out.create();
+        out.write(ByteBuffer.wrap(MAGIC));
+        return new ParquetFileWriter(out, schema);
+    }
+
+    /// Writes the full contents of a `REQUIRED INT32` column.
+    ///
+    /// @param columnIndex zero-based leaf-column index
+    /// @param values the column values; its length must match every other column
+    /// @throws IOException if the write fails
+    public void writeInts(int columnIndex, int[] values) throws IOException {
+        ensureOpen();
+        ColumnSchema column = column(columnIndex);
+        if (column.type() != PhysicalType.INT32) {
+            throw new UnsupportedOperationException(
+                    "Only INT32 columns are supported; column " + column.name() + " is " + column.type());
+        }
+        if (column.repetitionType() != RepetitionType.REQUIRED) {
+            throw new UnsupportedOperationException(
+                    "Only REQUIRED columns are supported; column " + column.name() + " is " + column.repetitionType());
+        }
+        if (columnMeta[columnIndex] != null) {
+            throw new IllegalStateException("Column already written: " + column.name());
+        }
+        checkRowCount(values.length, column);
+        checkPageFits(values.length, Integer.BYTES, column.name());
+
+        byte[] valueBytes = PlainEncoder.encodeInts(values);
+        ThriftCompactWriter header = new ThriftCompactWriter();
+        PageHeaderWriter.writeDataPageV1(header, values.length, valueBytes.length, valueBytes.length, Encoding.PLAIN);
+        byte[] headerBytes = header.toByteArray();
+
+        long dataPageOffset = out.position();
+        out.write(ByteBuffer.wrap(headerBytes));
+        out.write(ByteBuffer.wrap(valueBytes));
+
+        // total_*_size cover the whole column chunk including page headers; the
+        // page is stored uncompressed so the two sizes are equal.
+        long chunkSize = (long) headerBytes.length + valueBytes.length;
+        columnMeta[columnIndex] = new ColumnMetaData(
+                PhysicalType.INT32,
+                List.of(Encoding.PLAIN),
+                column.fieldPath(),
+                CompressionCodec.UNCOMPRESSED,
+                values.length,
+                chunkSize,
+                chunkSize,
+                Map.of(),
+                dataPageOffset,
+                null,
+                null,
+                null,
+                null,
+                null);
+    }
+
+    @Override
+    public void close() throws IOException {
+        if (closed) {
+            return;
+        }
+        closed = true;
+        try {
+            writeFooter();
+        }
+        catch (IOException | RuntimeException e) {
+            // The footer is incomplete, so the file is not valid. Discard it
+            // rather than letting out.close() publish a truncated file.
+            try {
+                out.discard();
+            }
+            catch (IOException suppressed) {
+                e.addSuppressed(suppressed);
+            }
+            throw e;
+        }
+        out.close();
+    }
+
+    private void writeFooter() throws IOException {
+        List<ColumnChunk> chunks = new ArrayList<>(columnMeta.length);
+        long totalByteSize = 0;
+        for (int i = 0; i < columnMeta.length; i++) {
+            if (columnMeta[i] == null) {
+                throw new IllegalStateException("Column not written: " + column(i).name());
+            }
+            chunks.add(new ColumnChunk(columnMeta[i], null, null, null, null));
+            totalByteSize += columnMeta[i].totalUncompressedSize();
+        }
+        long rows = numRows < 0 ? 0 : numRows;
+        RowGroup rowGroup = new RowGroup(chunks, totalByteSize, rows);
+
+        FileMetaData metaData = new FileMetaData(
+                FORMAT_VERSION,
+                schema.toSchemaElements(),
+                rows,
+                List.of(rowGroup),
+                Map.of(),
+                CREATED_BY,
+                List.of());
+
+        ThriftCompactWriter footer = new ThriftCompactWriter();
+        FileMetaDataWriter.write(footer, metaData);
+        byte[] footerBytes = footer.toByteArray();
+
+        out.write(ByteBuffer.wrap(footerBytes));
+        out.write(ByteBuffer.allocate(4).order(ByteOrder.LITTLE_ENDIAN).putInt(footerBytes.length).flip());
+        out.write(ByteBuffer.wrap(MAGIC));
+    }
+
+    private void checkRowCount(int length, ColumnSchema column) {
+        if (numRows < 0) {
+            numRows = length;
+        }
+        else if (numRows != length) {
+            throw new IllegalArgumentException("Column " + column.name() + " has " + length
+                    + " values but the row group already has " + numRows + " rows");
+        }
+    }
+
+    /// Fail fast when a column's values would not fit in a single data page. The
+    /// writer emits one page per column today, so an oversized column must be
+    /// rejected loudly rather than silently producing a page with overflowed i32
+    /// size fields. Multi-page writing removes this limit.
+    static void checkPageFits(int numValues, int bytesPerValue, String columnName) {
+        long pageBytes = (long) numValues * bytesPerValue;
+        if (pageBytes > MAX_DATA_PAGE_BYTES) {
+            throw new IllegalArgumentException("Column '" + columnName + "' has " + numValues
+                    + " values (" + pageBytes + " bytes), exceeding the single data-page limit of "
+                    + MAX_DATA_PAGE_BYTES + " bytes. Writing a column as multiple pages is not yet implemented.");
+        }
+    }
+
+    private ColumnSchema column(int columnIndex) {
+        if (columnIndex < 0 || columnIndex >= columnMeta.length) {
+            throw new IndexOutOfBoundsException(
+                    "Column index " + columnIndex + " out of range [0, " + columnMeta.length + ")");
+        }
+        return schema.getColumn(columnIndex);
+    }
+
+    private void ensureOpen() {
+        if (closed) {
+            throw new IllegalStateException("Writer is closed");
+        }
+    }
+}

--- a/core/src/main/java/dev/hardwood/writer/package-info.java
+++ b/core/src/main/java/dev/hardwood/writer/package-info.java
@@ -1,0 +1,14 @@
+/*
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Copyright The original authors
+ *
+ *  Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+/// Parquet file writer with a columnar API.
+///
+/// [ParquetFileWriter] writes a flat schema to a [dev.hardwood.OutputFile] as a
+/// single row group, taking each column's values through a typed columnar method.
+/// Build the target schema with [dev.hardwood.schema.FileSchema#builder].
+package dev.hardwood.writer;

--- a/core/src/test/java/dev/hardwood/writer/WriterDifferentialTest.java
+++ b/core/src/test/java/dev/hardwood/writer/WriterDifferentialTest.java
@@ -1,0 +1,80 @@
+/*
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Copyright The original authors
+ *
+ *  Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package dev.hardwood.writer;
+
+import java.nio.file.Path;
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.ResultSet;
+import java.sql.Statement;
+import java.util.ArrayList;
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import dev.hardwood.OutputFile;
+import dev.hardwood.metadata.PhysicalType;
+import dev.hardwood.metadata.RepetitionType;
+import dev.hardwood.schema.FileSchema;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/// Differential test for the writer, the inverse direction of [dev.hardwood.DifferentialReadTest]:
+/// hardwood writes a Parquet file and DuckDB reads it back through `read_parquet`.
+/// DuckDB is an independent engine, so agreement proves the produced bytes are
+/// spec-correct, not merely consistent with hardwood's own reader.
+///
+/// Each row carries a synthetic `r` index column so the comparison is robust to
+/// scan order via `ORDER BY r`.
+class WriterDifferentialTest {
+
+    @Test
+    void duckDbReadsWrittenInts(@TempDir Path dir) throws Exception {
+        // Boundary values exercise the signed little-endian PLAIN INT32 encoding.
+        int[] v = { 0, 1, -1, 42, -100_000, 123_456, Integer.MAX_VALUE, Integer.MIN_VALUE };
+        int[] r = new int[v.length];
+        for (int i = 0; i < r.length; i++) {
+            r[i] = i;
+        }
+
+        FileSchema schema = FileSchema.builder("schema")
+                .addColumn("r", PhysicalType.INT32, RepetitionType.REQUIRED)
+                .addColumn("v", PhysicalType.INT32, RepetitionType.REQUIRED)
+                .build();
+
+        Path file = dir.resolve("written.parquet");
+        try (ParquetFileWriter writer = ParquetFileWriter.create(OutputFile.of(file), schema)) {
+            writer.writeInts(0, r);
+            writer.writeInts(1, v);
+        }
+
+        List<Integer> actual = new ArrayList<>();
+        long rowCount;
+        try (Connection conn = DriverManager.getConnection("jdbc:duckdb:");
+                Statement stmt = conn.createStatement()) {
+            String from = "read_parquet('" + file.toAbsolutePath() + "')";
+            try (ResultSet rs = stmt.executeQuery("SELECT v FROM " + from + " ORDER BY r")) {
+                while (rs.next()) {
+                    actual.add(rs.getInt("v"));
+                }
+            }
+            try (ResultSet rs = stmt.executeQuery("SELECT count(*) AS n FROM " + from)) {
+                rs.next();
+                rowCount = rs.getLong("n");
+            }
+        }
+
+        List<Integer> expected = new ArrayList<>(v.length);
+        for (int value : v) {
+            expected.add(value);
+        }
+        assertThat(rowCount).isEqualTo(v.length);
+        assertThat(actual).containsExactlyElementsOf(expected);
+    }
+}

--- a/core/src/test/java/dev/hardwood/writer/WriterRoundTripTest.java
+++ b/core/src/test/java/dev/hardwood/writer/WriterRoundTripTest.java
@@ -1,0 +1,194 @@
+/*
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Copyright The original authors
+ *
+ *  Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package dev.hardwood.writer;
+
+import java.nio.ByteBuffer;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import dev.hardwood.InputFile;
+import dev.hardwood.OutputFile;
+import dev.hardwood.internal.writer.ByteBufferOutputFile;
+import dev.hardwood.metadata.PhysicalType;
+import dev.hardwood.metadata.RepetitionType;
+import dev.hardwood.reader.ColumnReader;
+import dev.hardwood.reader.ParquetFileReader;
+import dev.hardwood.schema.FileSchema;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/// Round-trip tests: write a flat `REQUIRED INT32` file with [ParquetFileWriter],
+/// then read it back with [ParquetFileReader] and assert the values survive.
+class WriterRoundTripTest {
+
+    @Test
+    void writesAndReadsBackTwoIntColumns() throws Exception {
+        FileSchema schema = FileSchema.builder("schema")
+                .addColumn("a", PhysicalType.INT32, RepetitionType.REQUIRED)
+                .addColumn("b", PhysicalType.INT32, RepetitionType.REQUIRED)
+                .build();
+
+        int[] a = { 1, 2, 3, 4, 5 };
+        int[] b = { 10, 20, 30, 40, 50 };
+
+        ByteBufferOutputFile out = new ByteBufferOutputFile();
+        try (ParquetFileWriter writer = ParquetFileWriter.create(out, schema)) {
+            writer.writeInts(0, a);
+            writer.writeInts(1, b);
+        }
+
+        ByteBuffer bytes = ByteBuffer.wrap(out.toByteArray());
+        try (ParquetFileReader reader = ParquetFileReader.open(InputFile.of(bytes))) {
+            assertThat(reader.getFileMetaData().numRows()).isEqualTo(5);
+            assertThat(reader.getFileMetaData().createdBy()).isEqualTo("hardwood");
+            assertThat(reader.getFileSchema().getColumnCount()).isEqualTo(2);
+            assertThat(reader.getFileSchema().isFlatSchema()).isTrue();
+
+            assertThat(readInts(reader, 0)).containsExactly(a);
+            assertThat(readInts(reader, 1)).containsExactly(b);
+        }
+    }
+
+    @Test
+    void writesToLocalFileWithAtomicRename(@TempDir Path dir) throws Exception {
+        FileSchema schema = FileSchema.builder("schema")
+                .addColumn("id", PhysicalType.INT32, RepetitionType.REQUIRED)
+                .build();
+        int[] ids = { 7, 8, 9 };
+
+        Path file = dir.resolve("out.parquet");
+        try (ParquetFileWriter writer = ParquetFileWriter.create(OutputFile.of(file), schema)) {
+            writer.writeInts(0, ids);
+        }
+
+        try (ParquetFileReader reader = ParquetFileReader.open(InputFile.of(file))) {
+            assertThat(reader.getFileMetaData().numRows()).isEqualTo(3);
+            assertThat(readInts(reader, 0)).containsExactly(ids);
+        }
+    }
+
+    @Test
+    void emptyColumnRoundTrips() throws Exception {
+        FileSchema schema = FileSchema.builder("schema")
+                .addColumn("id", PhysicalType.INT32, RepetitionType.REQUIRED)
+                .build();
+
+        ByteBufferOutputFile out = new ByteBufferOutputFile();
+        try (ParquetFileWriter writer = ParquetFileWriter.create(out, schema)) {
+            writer.writeInts(0, new int[0]);
+        }
+
+        try (ParquetFileReader reader = ParquetFileReader.open(InputFile.of(ByteBuffer.wrap(out.toByteArray())))) {
+            assertThat(reader.getFileMetaData().numRows()).isEqualTo(0);
+        }
+    }
+
+    @Test
+    void rejectsWritingTheSameColumnTwice() throws Exception {
+        FileSchema schema = FileSchema.builder("schema")
+                .addColumn("id", PhysicalType.INT32, RepetitionType.REQUIRED)
+                .build();
+        try (ParquetFileWriter writer = ParquetFileWriter.create(new ByteBufferOutputFile(), schema)) {
+            writer.writeInts(0, new int[] { 1, 2, 3 });
+            assertThatThrownBy(() -> writer.writeInts(0, new int[] { 4, 5, 6 }))
+                    .isInstanceOf(IllegalStateException.class);
+        }
+    }
+
+    @Test
+    void rejectsRowCountMismatchAcrossColumns() throws Exception {
+        FileSchema schema = FileSchema.builder("schema")
+                .addColumn("a", PhysicalType.INT32, RepetitionType.REQUIRED)
+                .addColumn("b", PhysicalType.INT32, RepetitionType.REQUIRED)
+                .build();
+        ParquetFileWriter writer = ParquetFileWriter.create(new ByteBufferOutputFile(), schema);
+        writer.writeInts(0, new int[] { 1, 2, 3 });
+        assertThatThrownBy(() -> writer.writeInts(1, new int[] { 1, 2 }))
+                .isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Test
+    void rejectsNonInt32Column() throws Exception {
+        FileSchema schema = FileSchema.builder("schema")
+                .addColumn("v", PhysicalType.INT64, RepetitionType.REQUIRED)
+                .build();
+        ParquetFileWriter writer = ParquetFileWriter.create(new ByteBufferOutputFile(), schema);
+        assertThatThrownBy(() -> writer.writeInts(0, new int[] { 1 }))
+                .isInstanceOf(UnsupportedOperationException.class);
+    }
+
+    @Test
+    void rejectsNonRequiredColumn() throws Exception {
+        FileSchema schema = FileSchema.builder("schema")
+                .addColumn("v", PhysicalType.INT32, RepetitionType.OPTIONAL)
+                .build();
+        ParquetFileWriter writer = ParquetFileWriter.create(new ByteBufferOutputFile(), schema);
+        assertThatThrownBy(() -> writer.writeInts(0, new int[] { 1 }))
+                .isInstanceOf(UnsupportedOperationException.class);
+    }
+
+    @Test
+    void rejectsUseAfterClose() throws Exception {
+        FileSchema schema = FileSchema.builder("schema")
+                .addColumn("id", PhysicalType.INT32, RepetitionType.REQUIRED)
+                .build();
+        ParquetFileWriter writer = ParquetFileWriter.create(new ByteBufferOutputFile(), schema);
+        writer.writeInts(0, new int[] { 1, 2, 3 });
+        writer.close();
+        assertThatThrownBy(() -> writer.writeInts(0, new int[] { 4 }))
+                .isInstanceOf(IllegalStateException.class);
+    }
+
+    @Test
+    void failedCloseLeavesNoFileAtTarget(@TempDir Path dir) throws Exception {
+        FileSchema schema = FileSchema.builder("schema")
+                .addColumn("a", PhysicalType.INT32, RepetitionType.REQUIRED)
+                .addColumn("b", PhysicalType.INT32, RepetitionType.REQUIRED)
+                .build();
+        Path file = dir.resolve("partial.parquet");
+
+        ParquetFileWriter writer = ParquetFileWriter.create(OutputFile.of(file), schema);
+        writer.writeInts(0, new int[] { 1, 2, 3 }); // column "b" never written
+
+        assertThatThrownBy(writer::close).isInstanceOf(IllegalStateException.class);
+        // The footer never completed, so nothing must be published at the target.
+        assertThat(Files.exists(file)).isFalse();
+    }
+
+    @Test
+    void rejectsColumnLargerThanOneDataPage() {
+        // 600M INT32 values = 2.4 GB > the 2 GB single-page limit. Checked via the
+        // helper so the boundary is exercised without a multi-GB allocation.
+        assertThatThrownBy(() -> ParquetFileWriter.checkPageFits(600_000_000, Integer.BYTES, "big"))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("multiple pages");
+
+        assertThatCode(() -> ParquetFileWriter.checkPageFits(1_000, Integer.BYTES, "small"))
+                .doesNotThrowAnyException();
+    }
+
+    private static int[] readInts(ParquetFileReader reader, int columnIndex) {
+        try (ColumnReader column = reader.columnReader(columnIndex)) {
+            int[] result = new int[reader.getFileMetaData().numRows() < 0 ? 0
+                    : Math.toIntExact(reader.getFileMetaData().numRows())];
+            int pos = 0;
+            while (column.nextBatch()) {
+                int count = column.getValueCount();
+                int[] batch = column.getInts();
+                System.arraycopy(batch, 0, result, pos, count);
+                pos += count;
+            }
+            return result;
+        }
+    }
+}


### PR DESCRIPTION
First increment of write support (#9), delivered as a narrow but complete vertical slice so `main` never holds non-functional writer code.

## What this adds
Writes a **flat schema of `REQUIRED INT32` columns** as a single uncompressed, PLAIN-encoded row group through a columnar API:

```java
FileSchema schema = FileSchema.builder("schema")
        .addColumn("id", PhysicalType.INT32, RepetitionType.REQUIRED)
        .build();
try (ParquetFileWriter w = ParquetFileWriter.create(OutputFile.of(path), schema)) {
    w.writeInts(0, new int[] {1, 2, 3});
}
```

This exercises the whole stack end to end: `OutputFile` (local atomic-rename + in-memory backends), `ThriftCompactWriter`, the `*Writer` metadata serializers (inverse of the existing `*Reader`s), `PlainEncoder`, the V1 data page, and the footer.

## Validation
- **DuckDB differential** (`WriterDifferentialTest`): hardwood writes, DuckDB reads via `read_parquet` and the values must agree — the inverse of `DifferentialReadTest`. Covers signed boundary values (`Integer.MIN/MAX`). An independent engine accepting the bytes proves spec-correctness, not just self-consistency.
- **Round-trip** (`WriterRoundTripTest`): write → read back with hardwood (in-memory, on-disk, empty column).
- All thrift field ids / enum codes cross-checked against upstream `parquet.thrift`.
- Full core suite green (1444 tests).

## Design
`_designs/WRITER_SUPPORT.md` is the plan of record: forward-only/footer-last write model, the row-group-buffering memory bound (the write-side inverse of the reader's mmap), the parallel-package layout, and the incremental delivery ladder. `ROADMAP.md` Phase 6 points to it.

## Scope / deferred
Flat-only, columnar-only, DataPage V1, single row group, uncompressed, PLAIN. Other primitive types, nullable columns, compression, dictionary, multiple row groups, `WriterConfig`, the row-oriented API, and nested (Dremel) shredding are later rungs on the ladder.

Draft pending review of the design and the increment-1 surface before continuing to increment 2.