### PR TITLE
#9 write support stage 3: row-group cadence and ColumnBatch API

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -187,8 +187,8 @@ For field-level `parquet.thrift` metadata coverage (which spec fields are read/p
 
 ### 6.2 Write Flow
 - [ ] Record buffering
-- [ ] Row group size tracking
-- [ ] Automatic row group flushing
+- [x] Row group size tracking
+- [x] Automatic row group flushing
 - [ ] Dictionary page writing
 - [x] Data page encoding and writing
 - [ ] Page compression

--- a/_designs/WRITER_SUPPORT.md
+++ b/_designs/WRITER_SUPPORT.md
@@ -22,8 +22,10 @@ batch API**:
 - **Flat columns only** — `REQUIRED` and `OPTIONAL` fields. No repetition, therefore
   no Dremel shredding and no repetition levels. This is the write-side counterpart of
   the reader's `FlatRowReader` fast path and covers the majority of analytics files.
-- **Columnar batch input** — the user supplies typed arrays per column, mirroring
-  `ColumnReader`. A row-oriented writer and integration adapters layer on top later.
+- **Columnar batch input** — the user fills a `ColumnBatch` the writer hands to a
+  filler: an aligned slice carrying one typed array per column, addressed by index or
+  name, mirroring `ColumnReader`. The writer re-chunks batches into pages and row groups
+  internally. A row-oriented writer and integration adapters layer on top later.
 - **DataPage V1** as the written page format, for maximum reader compatibility.
 
 Logical-type annotations (STRING, DATE, TIMESTAMP, DECIMAL, UUID, …) are in scope
@@ -62,6 +64,46 @@ row-group size (default 128 MiB of uncompressed data) bounds peak memory — thi
 the write-side inverse of the reader's whole-file mmap. Page size (default 1 MiB)
 bounds the granularity within a column chunk.
 
+Three nested layout tiers stack here — a **page** encodes/compresses a slice of a
+column, a **column chunk** is one column's pages for one row group, and a **row group**
+holds one column chunk per column. All three are internal; only the page-size and
+row-group-size targets are user-visible, as `WriterConfig` knobs.
+
+### Ingestion cadence
+
+Data arrives as **`ColumnBatch` objects** — an aligned slice carrying one typed array
+per column. `ParquetFileWriter.writeBatch` takes a filler: it creates the batch bound to
+the schema, passes it to the filler to be populated, then submits it, so there is no
+separate build or submit step to forget. Because the batch is schema-bound, its columns
+can be addressed by index or name and every identifier is validated as values are added:
+an unknown name, an out-of-range index, a non-`INT32` column, or setting the same column
+twice (by either index or name) all fail eagerly rather than at write time. A batch is
+atomic: every column's array must have the same length, which is the batch's row count,
+and a ragged batch is rejected. The batch is only an *arrival* unit and is independent of the three
+layout tiers: the writer distributes a batch's values into the per-column page buffers,
+cuts pages at the page-size target, and appends encoded pages to the per-column column
+chunk buffers. When the buffered row group crosses the row-group-size target it is
+flushed — column chunks written in schema order, offsets recorded — and the buffers
+reset. A batch larger than the row-group target is split at the boundary, so peak
+memory stays bounded by the row-group size regardless of batch size.
+
+Row-group boundaries are chosen by the writer from the size target; there is no
+explicit boundary method. A caller holding whole columns submits them as one large
+batch and the writer slices it into pages and row groups; a streaming producer submits
+many small batches and discards each after handing it over.
+
+Internally a batch's per-column arrays sit behind a bulk **value-source seam**
+(`IntColumnSource` and its per-type siblings: a `size()` plus a `copyInto` that fills a
+reused page-sized primitive buffer), with an `int[]`-backed implementation. Encoders,
+statistics and dictionary building consume page-sized ranges through this seam rather
+than the caller's array directly, so intermediate memory stays bounded to one page. A
+public `ColumnVector` / `IntColumn` SPI over the same seam — letting a caller write from
+a custom columnar container without an intervening copy, plus a zero-copy fast path when
+a caller's buffer already holds contiguous little-endian `PLAIN` bytes — is a later
+additive layer, sequenced after nulls and dictionary settle the value and validity
+facets it must expose. The primitive-array setters are sugar over the seam, so adding
+the SPI never changes the `writeBatch` signature or the row-group machinery.
+
 ### OutputFile abstraction
 
 A sequential write counterpart to `InputFile`, far simpler than the random-access
@@ -94,10 +136,10 @@ the thrift codec sit alongside their decode counterparts as shared substrate.
 
 | Layer | Package | Components |
 |-------|---------|------------|
-| Public API | `dev.hardwood.writer` | `ParquetFileWriter`, `ColumnBatchWriter`, `WriterConfig` |
+| Public API | `dev.hardwood.writer` | `ParquetFileWriter`, `ColumnBatch`, `WriterConfig` |
 | Public API | `dev.hardwood` | `OutputFile` |
 | Public API | `dev.hardwood.schema` | `FileSchema.Builder` (produces the existing immutable `FileSchema`) |
-| Orchestration | `dev.hardwood.internal.writer` | `RowGroupBuffer`, `ColumnChunkBuffer`, `PageBuilder`, `StatisticsCollector`, `OutputFile` backends |
+| Orchestration | `dev.hardwood.internal.writer` | `RowGroupBuffer`, `ColumnChunkBuffer`, `PageBuilder`, `IntColumnSource` (value-source seam), `StatisticsCollector`, `OutputFile` backends |
 | Value encoding | `dev.hardwood.internal.encoding` | `PlainEncoder`, `RleBitPackingHybridEncoder`, `LevelEncoder`, `DictionaryEncoder` (alongside the existing decoders) |
 | Compression | `dev.hardwood.internal.compression` | `Compressor` / `CompressorFactory` (alongside `Decompressor`) |
 | Metadata serialization | `dev.hardwood.internal.thrift` | `ThriftCompactWriter`, `FileMetaDataWriter`, `SchemaElementWriter`, `RowGroupWriter`, `ColumnChunkWriter`, `ColumnMetaDataWriter`, `PageHeaderWriter` (the `*Writer` inverses of the existing `*Reader`s) |
@@ -199,9 +241,8 @@ validation above, so `main` never holds functionality that cannot produce a read
 file.
 
 The sequencing is **dimension-first**: prove the thinnest slice through each
-architectural dimension — paging, the columnar API contract (nulls + streaming),
-dictionary pages, compression, statistics — on a single type (`INT32`) before going
-wide. Type, encoding, and codec **breadth** is the same proven mechanism repeated, so
+architectural dimension — paging, row-group cadence, nulls, dictionary pages,
+compression, statistics — on a single type (`INT32`) before going wide. Type, encoding, and codec **breadth** is the same proven mechanism repeated, so
 it is deferred until every dimension is settled; otherwise a late dimension would
 reshape an already-multiplied surface (adding nulls or the streaming API after N typed
 methods exist rewrites all N). Each increment carries a **Kind**: *Dimension* (changes
@@ -212,20 +253,22 @@ API), *Optimization*, *Spike* (design-only), or *Docs* (user-facing documentatio
 |---|-----------|------|----------------|---------------|-----------|
 | 1 | Tracer: flat `REQUIRED INT32`, one page / one row group, `PLAIN`, uncompressed. `OutputFile` (local + in-memory), `ThriftCompactWriter`, page-header + footer serialization. | Dimension | Produces a real, readable file | 1 (ThriftCompactWriter), 3.2 (page header ser.), 4.1/4.2 (chunk/row-group ser.), 5.2 (FileMetaData ser.) | [x] |
 | 2 | Page chunking within a column chunk: a large `INT32` column written as multiple size-bounded `PLAIN` pages instead of one, replacing the single-page guard. Internal — the columnar API is unchanged. Each page carries a CRC-32 checksum over its on-disk body. | Dimension | Large columns written safely, bounded page size | 6.2 (multi-page data writing), 3.2 (CRC write) | [x] |
-| 3 | **Columnar API contract** (`INT32` only): nullable columns (definition levels via `LevelEncoder`) **and** multi-row-group append with size-based flushing **and** `WriterConfig`, designed together. Locks how the caller supplies nulls and feeds data. | Dimension | The public write contract is settled | 2.3, 3.3, 6.1, 6.2 | [ ] |
-| 4 | Dictionary encoding (`INT32`): dictionary page + `RLE_DICTIONARY` indices + plain fallback. | Dimension | Dictionary column-chunk layout proven | 2.2 | [ ] |
-| 5 | Compression on the write path (`INT32`, one codec). | Dimension | Compress step + compressed/uncompressed size accounting proven | 6.2 (page compression) | [ ] |
-| 6 | Column statistics (`INT32`: `min`/`max`/`null_count`, `ColumnOrder`-correct) accumulated during encode. | Dimension | Produced files support pushdown | 9.1 (stats) | [ ] |
-| 7 | Nested design spike: confirm the columnar API contract extends to repetition levels and shredding. Design only, no implementation. | Spike | De-risks the nested milestone before breadth locks the API | 6.3 (design) | [ ] |
-| 8 | All primitive physical types (incl. `FIXED_LEN_BYTE_ARRAY` type length and `BYTE_ARRAY` min/max truncation), each inheriting paging, nulls, dictionary, compression and stats. | Breadth | Write any flat column type | 2.1, 9.1 (truncation) | [ ] |
-| 9 | Logical-type annotations: `LogicalTypeWriter` serializes the `LogicalType` union and legacy `converted_type`/`scale`/`precision`; `FileSchema.Builder` logical-type overload. | Breadth | Columns read back with their logical type (STRING, DATE, TIMESTAMP, DECIMAL, …) | 6.4 (annotation) | [ ] |
-| 10 | Remaining codecs + optional delta and byte-stream-split encoders. | Breadth | Full codec / encoding choice | 2.4, 2.5 | [ ] |
-| 11 | Parallel column encoding + row-group pipelining. | Optimization | Write throughput | — | [ ] |
-| 12 | Row-oriented `ParquetWriter` ergonomic layer on the columnar core, including logical-type value conversion (inverse of `LogicalTypeConverter`). | Layer | Mainstream-friendly API | 6.1 (`ParquetWriter`), 6.4 (value conversion) | [ ] |
-| 13 | User-facing documentation under `docs/content/` for the writer public API (`OutputFile`, `ParquetFileWriter`, `FileSchema.Builder`): a `how-to` guide and a `reference` page, covering the settled surface including the row-oriented layer. | Docs | Documented, stable public API | — | [ ] |
+| 3 | **Row-group cadence** (`REQUIRED INT32` only): the `ColumnBatch` submission API, multi-row-group append, size-based auto-flush (page + row-group targets), and `WriterConfig`. Locks how the caller feeds data and how the file is banded into row groups. | Dimension | The public write cadence is settled | 6.2 (row-group size tracking, automatic flushing) | [x] |
+| 4 | Nullable columns (`OPTIONAL INT32`): definition levels via `LevelEncoder`, and how nulls ride inside a `ColumnBatch`. | Dimension | The null / def-level data model is settled | 2.3, 3.3 | [ ] |
+| 5 | Nested design spike: confirm the settled `ColumnBatch` contract extends to repetition levels and shredding. Design only, no implementation. | Spike | De-risks the nested milestone as soon as the contract is settled | 6.3 (design) | [ ] |
+| 6 | Dictionary encoding (`INT32`, `REQUIRED` and `OPTIONAL`): dictionary page + `RLE_DICTIONARY` indices + plain fallback, exercised on a nullable column so the def-level / dictionary-index page layout is proven together. | Dimension | Dictionary column-chunk layout proven, including with nulls | 2.2 | [ ] |
+| 7 | Compression on the write path (`INT32`, one codec). | Dimension | Compress step + compressed/uncompressed size accounting proven | 6.2 (page compression) | [ ] |
+| 8 | Column statistics (`INT32`: `min`/`max`/`null_count`, `ColumnOrder`-correct) accumulated during encode. | Dimension | Produced files support pushdown | 9.1 (stats) | [ ] |
+| 9 | All primitive physical types (incl. `FIXED_LEN_BYTE_ARRAY` type length and `BYTE_ARRAY` min/max truncation), each inheriting paging, nulls, dictionary, compression and stats. Variable-width values end the constant-bytes-per-row assumption, so the row-group flush moves from the fixed rows-per-group proxy (`rowGroupTargetBytes / (columnCount × 4)`) to tracking the actual buffered uncompressed bytes. | Breadth | Write any flat column type | 2.1, 9.1 (truncation) | [ ] |
+| 10 | Logical-type annotations: `LogicalTypeWriter` serializes the `LogicalType` union and legacy `converted_type`/`scale`/`precision`; `FileSchema.Builder` logical-type overload. | Breadth | Columns read back with their logical type (STRING, DATE, TIMESTAMP, DECIMAL, …) | 6.4 (annotation) | [ ] |
+| 11 | Remaining codecs + optional delta and byte-stream-split encoders. | Breadth | Full codec / encoding choice | 2.4, 2.5 | [ ] |
+| 12 | Parallel column encoding + row-group pipelining. | Optimization | Write throughput | — | [ ] |
+| 13 | Row-oriented `ParquetWriter` ergonomic layer on the columnar core, including logical-type value conversion (inverse of `LogicalTypeConverter`). | Layer | Mainstream-friendly API | 6.1 (`ParquetWriter`), 6.4 (value conversion) | [ ] |
+| 14 | User-facing documentation under `docs/content/` for the writer public API (`OutputFile`, `ParquetFileWriter`, `FileSchema.Builder`): a `how-to` guide and a `reference` page, covering the settled surface including the row-oriented layer. | Docs | Documented, stable public API | — | [ ] |
 
-Increments 1–6 prove every architectural dimension on `INT32`; 7 is a design checkpoint;
-8–12 are breadth and layers that build on the settled shape; 13 documents the finished
+Increments 1–8 settle every architectural dimension on `INT32`, with stage 5 a
+design-only checkpoint confirming the settled contract extends to nested repetition;
+9–13 are breadth and layers that build on the settled shape; 14 documents the finished
 public surface. Together they constitute the flat-writer milestone (1.1). Later milestones, each their own design and sequence: nested
 shredding implementation (Dremel: structs → lists → maps), DataPage V2, the optional index
 structures and Bloom filters, the Avro write adapter, a CLI write/convert command, and the
@@ -234,12 +277,12 @@ S3 `OutputFile` backend.
 ## User documentation
 
 User-facing documentation under `docs/content/` is delivered as the closing increment
-of the milestone (stage 13), once the full public surface — including the row-oriented
+of the milestone (stage 14), once the full public surface — including the row-oriented
 layer — is settled. Documenting the provisional `INT32`-only surface earlier would be
 throwaway, so deferring is a recorded, intentional exception to the CLAUDE.md rule that
 a new public API ships with a docs update — not an oversight. The public surface
 (`OutputFile`, `ParquetFileWriter`, `FileSchema.Builder`) gets its `how-to`/`reference`
-pages at stage 13.
+pages at stage 14.
 
 ## Roadmap reconciliation
 

--- a/core/src/main/java/dev/hardwood/internal/encoding/PlainEncoder.java
+++ b/core/src/main/java/dev/hardwood/internal/encoding/PlainEncoder.java
@@ -24,9 +24,23 @@ public final class PlainEncoder {
     /// @throws ArithmeticException if the encoded size overflows an `int`
     ///         (more than `Integer.MAX_VALUE / 4` values)
     public static byte[] encodeInts(int[] values) {
-        ByteBuffer buffer = ByteBuffer.allocate(Math.multiplyExact(values.length, Integer.BYTES))
+        return encodeInts(values, 0, values.length);
+    }
+
+    /// Encode `length` INT32 values starting at `offset` as little-endian 4-byte words,
+    /// matching [PlainDecoder#readInts]. Encoding a sub-range avoids copying a page's
+    /// values out of a larger backing array before encoding.
+    ///
+    /// @param values the backing array
+    /// @param offset the index of the first value to encode
+    /// @param length the number of values to encode
+    /// @return the PLAIN-encoded bytes
+    /// @throws ArithmeticException if the encoded size overflows an `int`
+    ///         (more than `Integer.MAX_VALUE / 4` values)
+    public static byte[] encodeInts(int[] values, int offset, int length) {
+        ByteBuffer buffer = ByteBuffer.allocate(Math.multiplyExact(length, Integer.BYTES))
                 .order(ByteOrder.LITTLE_ENDIAN);
-        buffer.asIntBuffer().put(values);
+        buffer.asIntBuffer().put(values, offset, length);
         return buffer.array();
     }
 }

--- a/core/src/main/java/dev/hardwood/internal/writer/ChannelOutputFile.java
+++ b/core/src/main/java/dev/hardwood/internal/writer/ChannelOutputFile.java
@@ -22,11 +22,21 @@ import dev.hardwood.OutputFile;
 /// Bytes are streamed to a temporary sibling file and atomically renamed onto the
 /// target path on [#close()], so a failed or abandoned write never leaves a
 /// truncated file presented as a valid Parquet file at the target path.
+///
+/// Writes are coalesced through an in-memory buffer and flushed to the channel in
+/// bulk, so the many small `write` calls a Parquet footer produces do not each incur a
+/// channel write. A write at least as large as the buffer bypasses it and goes straight
+/// to the channel, so a whole column chunk is not chopped into buffer-sized pieces.
 public final class ChannelOutputFile implements OutputFile {
+
+    /// Size of the coalescing buffer. Small enough to stay off the heap's radar, large
+    /// enough that a footer's handful of small writes flush as one channel write.
+    private static final int BUFFER_SIZE = 64 * 1024;
 
     private final Path target;
     private final Path tempPath;
     private FileChannel channel;
+    private ByteBuffer buffer;
     private long position;
 
     public ChannelOutputFile(Path target) {
@@ -43,15 +53,27 @@ public final class ChannelOutputFile implements OutputFile {
                 StandardOpenOption.CREATE,
                 StandardOpenOption.WRITE,
                 StandardOpenOption.TRUNCATE_EXISTING);
+        buffer = ByteBuffer.allocate(BUFFER_SIZE);
         position = 0;
     }
 
     @Override
     public void write(ByteBuffer data) throws IOException {
         requireCreated();
-        while (data.hasRemaining()) {
-            position += channel.write(data);
+        int accepted = data.remaining();
+        if (data.remaining() >= buffer.capacity()) {
+            // Too big to be worth buffering: flush what's pending to keep byte order,
+            // then hand the data straight to the channel.
+            flushBuffer();
+            writeFully(data);
         }
+        else {
+            if (data.remaining() > buffer.remaining()) {
+                flushBuffer();
+            }
+            buffer.put(data);
+        }
+        position += accepted;
     }
 
     @Override
@@ -65,8 +87,10 @@ public final class ChannelOutputFile implements OutputFile {
         if (channel == null) {
             return;
         }
+        flushBuffer();
         channel.close();
         channel = null;
+        buffer = null;
         Files.move(tempPath, target,
                 StandardCopyOption.REPLACE_EXISTING,
                 StandardCopyOption.ATOMIC_MOVE);
@@ -77,10 +101,26 @@ public final class ChannelOutputFile implements OutputFile {
         if (channel == null) {
             return;
         }
+        // Drop the buffered bytes unwritten; the temp file is thrown away anyway.
         channel.close();
         channel = null;
-        // Drop the partially written temp file; nothing is published at the target.
+        buffer = null;
         Files.deleteIfExists(tempPath);
+    }
+
+    private void flushBuffer() throws IOException {
+        if (buffer.position() == 0) {
+            return;
+        }
+        buffer.flip();
+        writeFully(buffer);
+        buffer.clear();
+    }
+
+    private void writeFully(ByteBuffer data) throws IOException {
+        while (data.hasRemaining()) {
+            channel.write(data);
+        }
     }
 
     private void requireCreated() {

--- a/core/src/main/java/dev/hardwood/internal/writer/ColumnChunkBuffer.java
+++ b/core/src/main/java/dev/hardwood/internal/writer/ColumnChunkBuffer.java
@@ -1,0 +1,105 @@
+/*
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Copyright The original authors
+ *
+ *  Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package dev.hardwood.internal.writer;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.util.List;
+import java.util.Map;
+import java.util.zip.CRC32;
+
+import dev.hardwood.OutputFile;
+import dev.hardwood.internal.encoding.PlainEncoder;
+import dev.hardwood.internal.thrift.PageHeaderWriter;
+import dev.hardwood.internal.thrift.ThriftCompactWriter;
+import dev.hardwood.metadata.ColumnMetaData;
+import dev.hardwood.metadata.CompressionCodec;
+import dev.hardwood.metadata.Encoding;
+import dev.hardwood.metadata.PhysicalType;
+import dev.hardwood.schema.ColumnSchema;
+
+/// Accumulates one `REQUIRED INT32` column's values for the current row group, packing
+/// them into uncompressed `PLAIN` data pages of at most the page-value capacity. Values
+/// arrive across one or more batches; a page is sealed each time the pending buffer
+/// fills, and the tail is sealed at flush. The encoded pages are held until the row
+/// group is flushed, since a column chunk's `data_page_offset` is only known when its
+/// bytes are written.
+final class ColumnChunkBuffer {
+
+    private final int[] pending;
+    private final ByteArrayOutputStream pages = new ByteArrayOutputStream();
+    private int pendingCount;
+    private long numValues;
+
+    /// @param pageValues maximum number of `INT32` values per data page
+    ColumnChunkBuffer(int pageValues) {
+        this.pending = new int[pageValues];
+    }
+
+    /// Appends `count` values starting at `srcPos` in `source`, sealing pages as the
+    /// pending buffer fills.
+    void append(IntColumnSource source, int srcPos, int count) {
+        int remaining = count;
+        int from = srcPos;
+        while (remaining > 0) {
+            int space = pending.length - pendingCount;
+            int n = Math.min(space, remaining);
+            source.copyInto(from, pending, pendingCount, n);
+            pendingCount += n;
+            from += n;
+            remaining -= n;
+            if (pendingCount == pending.length) {
+                sealPage();
+            }
+        }
+    }
+
+    /// Seals the trailing page, writes the whole column chunk to `out` at the current
+    /// position, and returns its metadata. The caller captures `dataPageOffset` before
+    /// invoking this, as it is the offset of the first page.
+    ColumnMetaData flushTo(OutputFile out, ColumnSchema column, long dataPageOffset) throws IOException {
+        sealPage();
+        long totalSize = pages.size();
+        out.write(ByteBuffer.wrap(pages.toByteArray()));
+        // Pages are stored uncompressed, so compressed and uncompressed sizes are equal.
+        return new ColumnMetaData(
+                PhysicalType.INT32,
+                List.of(Encoding.PLAIN),
+                column.fieldPath(),
+                CompressionCodec.UNCOMPRESSED,
+                numValues,
+                totalSize,
+                totalSize,
+                Map.of(),
+                dataPageOffset,
+                null,
+                null,
+                null,
+                null,
+                null);
+    }
+
+    private void sealPage() {
+        if (pendingCount == 0) {
+            return;
+        }
+        byte[] valueBytes = PlainEncoder.encodeInts(pending, 0, pendingCount);
+        // CRC-32 over the page body as stored on disk (uncompressed here), matching what
+        // the reader validates.
+        CRC32 crc = new CRC32();
+        crc.update(valueBytes);
+        ThriftCompactWriter header = new ThriftCompactWriter();
+        PageHeaderWriter.writeDataPageV1(header, pendingCount, valueBytes.length, valueBytes.length,
+                (int) crc.getValue(), Encoding.PLAIN);
+        pages.writeBytes(header.toByteArray());
+        pages.writeBytes(valueBytes);
+        numValues += pendingCount;
+        pendingCount = 0;
+    }
+}

--- a/core/src/main/java/dev/hardwood/internal/writer/IntArrayColumnSource.java
+++ b/core/src/main/java/dev/hardwood/internal/writer/IntArrayColumnSource.java
@@ -1,0 +1,29 @@
+/*
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Copyright The original authors
+ *
+ *  Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package dev.hardwood.internal.writer;
+
+/// An [IntColumnSource] backed by a plain `int[]`. The array is referenced, not copied,
+/// so the caller must not mutate it until the batch has been written.
+public final class IntArrayColumnSource implements IntColumnSource {
+
+    private final int[] values;
+
+    public IntArrayColumnSource(int[] values) {
+        this.values = values;
+    }
+
+    @Override
+    public int size() {
+        return values.length;
+    }
+
+    @Override
+    public void copyInto(int srcPos, int[] dest, int destPos, int length) {
+        System.arraycopy(values, srcPos, dest, destPos, length);
+    }
+}

--- a/core/src/main/java/dev/hardwood/internal/writer/IntColumnSource.java
+++ b/core/src/main/java/dev/hardwood/internal/writer/IntColumnSource.java
@@ -1,0 +1,31 @@
+/*
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Copyright The original authors
+ *
+ *  Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package dev.hardwood.internal.writer;
+
+/// A read-only, bulk view over a column's `INT32` values that the writer pulls from
+/// while packing pages. The writer never reads a value at a time: it asks for
+/// page-sized ranges via [#copyInto], so a source implemented over a foreign columnar
+/// container (an Arrow vector, an off-heap buffer) is copied in bounded, primitive
+/// chunks rather than one boxed element at a time.
+///
+/// This is the internal seam behind the public `ColumnBatch` primitive-array setters. A
+/// public `ColumnVector` SPI over the same shape — letting callers write from their own
+/// containers without an intervening copy — is a later additive layer.
+public interface IntColumnSource {
+
+    /// The number of values in this source.
+    int size();
+
+    /// Copies `length` values starting at `srcPos` into `dest` starting at `destPos`.
+    ///
+    /// @param srcPos index of the first value to copy from this source
+    /// @param dest destination array
+    /// @param destPos index in `dest` at which to place the first value
+    /// @param length number of values to copy
+    void copyInto(int srcPos, int[] dest, int destPos, int length);
+}

--- a/core/src/main/java/dev/hardwood/internal/writer/RowGroupBuffer.java
+++ b/core/src/main/java/dev/hardwood/internal/writer/RowGroupBuffer.java
@@ -1,0 +1,74 @@
+/*
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Copyright The original authors
+ *
+ *  Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package dev.hardwood.internal.writer;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+
+import dev.hardwood.OutputFile;
+import dev.hardwood.metadata.ColumnChunk;
+import dev.hardwood.metadata.ColumnMetaData;
+import dev.hardwood.metadata.RowGroup;
+import dev.hardwood.schema.FileSchema;
+
+/// Buffers the column chunks of a single row group. Values are appended in aligned
+/// ranges across all columns; at flush the column chunks are written contiguously in
+/// schema order, each recording the file offset at which its first page lands.
+public final class RowGroupBuffer {
+
+    private final FileSchema schema;
+    private final ColumnChunkBuffer[] columns;
+    private int rowCount;
+
+    /// @param schema the flat file schema
+    /// @param pageValues maximum number of `INT32` values per data page
+    public RowGroupBuffer(FileSchema schema, int pageValues) {
+        this.schema = schema;
+        this.columns = new ColumnChunkBuffer[schema.getColumnCount()];
+        for (int c = 0; c < columns.length; c++) {
+            columns[c] = new ColumnChunkBuffer(pageValues);
+        }
+    }
+
+    /// Appends the same row range to every column and advances the row count.
+    ///
+    /// @param sources one value source per column, in schema order
+    /// @param from index of the first row to append
+    /// @param count number of rows to append
+    public void appendRows(IntColumnSource[] sources, int from, int count) {
+        for (int c = 0; c < columns.length; c++) {
+            columns[c].append(sources[c], from, count);
+        }
+        rowCount += count;
+    }
+
+    /// The number of rows buffered so far.
+    public int rowCount() {
+        return rowCount;
+    }
+
+    /// Whether no rows have been buffered.
+    public boolean isEmpty() {
+        return rowCount == 0;
+    }
+
+    /// Writes the buffered column chunks to `out` in schema order and returns the row
+    /// group's metadata.
+    public RowGroup flushTo(OutputFile out) throws IOException {
+        List<ColumnChunk> chunks = new ArrayList<>(columns.length);
+        long totalByteSize = 0;
+        for (int c = 0; c < columns.length; c++) {
+            long dataPageOffset = out.position();
+            ColumnMetaData meta = columns[c].flushTo(out, schema.getColumn(c), dataPageOffset);
+            chunks.add(new ColumnChunk(meta, null, null, null, null));
+            totalByteSize += meta.totalUncompressedSize();
+        }
+        return new RowGroup(chunks, totalByteSize, rowCount);
+    }
+}

--- a/core/src/main/java/dev/hardwood/writer/ColumnBatch.java
+++ b/core/src/main/java/dev/hardwood/writer/ColumnBatch.java
@@ -1,0 +1,127 @@
+/*
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Copyright The original authors
+ *
+ *  Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package dev.hardwood.writer;
+
+import dev.hardwood.internal.writer.IntArrayColumnSource;
+import dev.hardwood.internal.writer.IntColumnSource;
+import dev.hardwood.metadata.PhysicalType;
+import dev.hardwood.schema.ColumnSchema;
+import dev.hardwood.schema.FileSchema;
+
+/// One aligned slice of a file's columns. Every column in a batch must have the same
+/// number of values, which is the batch's row count.
+///
+/// A batch is not constructed directly: [ParquetFileWriter#writeBatch] creates it, bound
+/// to the schema, hands it to a filler that populates the columns, then submits it — so
+/// there is no separate build or submit step to forget. Columns are addressed by index or
+/// by name, and the schema binding lets every identifier be validated as it is added — an
+/// unknown name, an out-of-range index, a non-`INT32` column, or setting the same column
+/// twice (whether by index or name) all fail eagerly rather than at write time.
+///
+/// ```java
+/// writer.writeBatch(b -> b
+///         .ints(0, idColumn)
+///         .ints("value", valueColumn));
+/// ```
+public final class ColumnBatch {
+
+    private final FileSchema schema;
+    private final IntColumnSource[] sources;
+    private int rowCount = -1;
+    private boolean consumed;
+
+    ColumnBatch(FileSchema schema) {
+        this.schema = schema;
+        this.sources = new IntColumnSource[schema.getColumnCount()];
+    }
+
+    /// Adds the values for a `REQUIRED INT32` column, addressed by index.
+    ///
+    /// The array is referenced, not copied, so it must not be mutated until the batch
+    /// has been written.
+    ///
+    /// @param columnIndex zero-based leaf-column index
+    /// @param values the column's values for this batch
+    /// @return this batch, for chaining
+    /// @throws IllegalArgumentException if the index is out of range, the column is
+    ///         already set, or the length does not match the other columns in this batch
+    public ColumnBatch ints(int columnIndex, int[] values) {
+        if (columnIndex < 0 || columnIndex >= sources.length) {
+            throw new IllegalArgumentException(
+                    "Column index " + columnIndex + " is out of range [0, " + sources.length + ")");
+        }
+        set(columnIndex, values);
+        return this;
+    }
+
+    /// Adds the values for a `REQUIRED INT32` column, addressed by name.
+    ///
+    /// The array is referenced, not copied, so it must not be mutated until the batch
+    /// has been written.
+    ///
+    /// @param columnName the column's name
+    /// @param values the column's values for this batch
+    /// @return this batch, for chaining
+    /// @throws IllegalArgumentException if no column has that name, the column is already
+    ///         set (by name or index), or the length does not match the other columns
+    public ColumnBatch ints(String columnName, int[] values) {
+        // getColumn(String) throws on an unknown name, so the identifier is validated here.
+        set(schema.getColumn(columnName).columnIndex(), values);
+        return this;
+    }
+
+    private void set(int columnIndex, int[] values) {
+        if (consumed) {
+            throw new IllegalStateException("Batch has already been written and cannot be modified");
+        }
+        if (values == null) {
+            throw new IllegalArgumentException("values must not be null for column " + describe(columnIndex));
+        }
+        ColumnSchema column = schema.getColumn(columnIndex);
+        if (column.type() != PhysicalType.INT32) {
+            throw new IllegalArgumentException("Column " + describe(columnIndex) + " is " + column.type()
+                    + ", not INT32");
+        }
+        if (sources[columnIndex] != null) {
+            throw new IllegalArgumentException("Column " + describe(columnIndex) + " is already set in this batch");
+        }
+        if (rowCount < 0) {
+            rowCount = values.length;
+        }
+        else if (rowCount != values.length) {
+            throw new IllegalArgumentException("Ragged batch: column " + describe(columnIndex) + " has "
+                    + values.length + " values but the batch row count is " + rowCount);
+        }
+        sources[columnIndex] = new IntArrayColumnSource(values);
+    }
+
+    private String describe(int columnIndex) {
+        return columnIndex + " (" + schema.getColumn(columnIndex).name() + ")";
+    }
+
+    /// Marks the batch written, so a filler that stashed a reference and mutates it after
+    /// `writeBatch` returns fails loudly instead of silently doing nothing.
+    void markConsumed() {
+        consumed = true;
+    }
+
+    /// The number of rows in this batch (zero if no columns were added).
+    int rowCount() {
+        return rowCount < 0 ? 0 : rowCount;
+    }
+
+    /// The value sources in column order, after checking every column was set.
+    IntColumnSource[] completedSources() {
+        for (int c = 0; c < sources.length; c++) {
+            if (sources[c] == null) {
+                throw new IllegalArgumentException("Batch is missing column " + describe(c));
+            }
+        }
+        return sources;
+    }
+}

--- a/core/src/main/java/dev/hardwood/writer/ParquetFileWriter.java
+++ b/core/src/main/java/dev/hardwood/writer/ParquetFileWriter.java
@@ -13,20 +13,15 @@ import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
-import java.util.zip.CRC32;
+import java.util.function.Consumer;
 
 import dev.hardwood.OutputFile;
-import dev.hardwood.internal.encoding.PlainEncoder;
 import dev.hardwood.internal.thrift.FileMetaDataWriter;
-import dev.hardwood.internal.thrift.PageHeaderWriter;
 import dev.hardwood.internal.thrift.ThriftCompactWriter;
-import dev.hardwood.metadata.ColumnChunk;
-import dev.hardwood.metadata.ColumnMetaData;
-import dev.hardwood.metadata.CompressionCodec;
-import dev.hardwood.metadata.Encoding;
+import dev.hardwood.internal.writer.IntColumnSource;
+import dev.hardwood.internal.writer.RowGroupBuffer;
 import dev.hardwood.metadata.FileMetaData;
 import dev.hardwood.metadata.PhysicalType;
 import dev.hardwood.metadata.RepetitionType;
@@ -34,128 +29,110 @@ import dev.hardwood.metadata.RowGroup;
 import dev.hardwood.schema.ColumnSchema;
 import dev.hardwood.schema.FileSchema;
 
-/// Writes a Parquet file through a columnar API.
+/// Writes a Parquet file through a columnar batch API.
 ///
-/// This increment writes flat schemas of `REQUIRED INT32` columns as a single row
-/// group of uncompressed, PLAIN-encoded data pages. A column larger than the target
-/// page size is split across multiple size-bounded data pages. Each column's values
-/// are supplied once via [#writeInts]; the row group and footer are finalized on
-/// [#close()].
+/// This increment writes flat schemas of `REQUIRED INT32` columns. Data is supplied as
+/// [ColumnBatch] slices; the writer packs each column into size-bounded, uncompressed
+/// `PLAIN` data pages and flushes a row group once its buffered data reaches the
+/// configured target, so peak memory is bounded regardless of how much is written. The
+/// row groups and footer are finalized on [#close()].
 ///
 /// The file is produced front to back and is valid only after `close()` returns.
 public final class ParquetFileWriter implements Closeable {
 
     private static final byte[] MAGIC = "PAR1".getBytes(StandardCharsets.UTF_8);
     private static final int FORMAT_VERSION = 1;
-    private static final String CREATED_BY = "hardwood";
-
-    /// Target uncompressed size of a single data page; a column larger than this is
-    /// split across multiple pages. Keeping a page well under the i32 wire limit also
-    /// means a page's size and value-count fields can never overflow. Becomes a
-    /// `WriterConfig` knob in a later increment.
-    private static final int TARGET_PAGE_BYTES = 1 << 20; // 1 MiB
-
-    /// Number of `INT32` values that fit in one page at [#TARGET_PAGE_BYTES].
-    private static final int INT32_VALUES_PER_PAGE = TARGET_PAGE_BYTES / Integer.BYTES;
 
     private final OutputFile out;
     private final FileSchema schema;
-    private final ColumnMetaData[] columnMeta;
-    private long numRows = -1;
+    private final WriterConfig config;
+    private final int pageValues;
+    private final int maxRowsPerGroup;
+    private final List<RowGroup> rowGroups = new ArrayList<>();
+
+    private RowGroupBuffer current;
+    private long numRows;
     private boolean closed;
 
-    private ParquetFileWriter(OutputFile out, FileSchema schema) {
+    private ParquetFileWriter(OutputFile out, FileSchema schema, WriterConfig config) {
         this.out = out;
         this.schema = schema;
-        this.columnMeta = new ColumnMetaData[schema.getColumnCount()];
+        this.config = config;
+        this.pageValues = config.pageTargetBytes() / Integer.BYTES;
+        this.maxRowsPerGroup = maxRowsPerGroup(config.rowGroupTargetBytes(), schema.getColumnCount());
+        this.current = new RowGroupBuffer(schema, pageValues);
+    }
+
+    /// Opens a writer with the default [WriterConfig].
+    ///
+    /// @param out the destination
+    /// @param schema the flat schema to write
+    /// @return an open writer
+    /// @throws IOException if the destination cannot be opened
+    /// @throws UnsupportedOperationException if the schema is not a flat schema of
+    ///         `REQUIRED INT32` columns
+    public static ParquetFileWriter create(OutputFile out, FileSchema schema) throws IOException {
+        return create(out, schema, WriterConfig.defaults());
     }
 
     /// Opens a writer, writing the leading magic bytes.
     ///
     /// @param out the destination
     /// @param schema the flat schema to write
+    /// @param config the writer configuration
     /// @return an open writer
     /// @throws IOException if the destination cannot be opened
-    /// @throws UnsupportedOperationException if the schema is not flat
-    public static ParquetFileWriter create(OutputFile out, FileSchema schema) throws IOException {
+    /// @throws UnsupportedOperationException if the schema is not a flat schema of
+    ///         `REQUIRED INT32` columns
+    public static ParquetFileWriter create(OutputFile out, FileSchema schema, WriterConfig config)
+            throws IOException {
         if (!schema.isFlatSchema()) {
             throw new UnsupportedOperationException("Only flat schemas are supported by the writer");
         }
+        for (int c = 0; c < schema.getColumnCount(); c++) {
+            ColumnSchema column = schema.getColumn(c);
+            if (column.type() != PhysicalType.INT32) {
+                throw new UnsupportedOperationException(
+                        "Only INT32 columns are supported; column " + column.name() + " is " + column.type());
+            }
+            if (column.repetitionType() != RepetitionType.REQUIRED) {
+                throw new UnsupportedOperationException("Only REQUIRED columns are supported; column "
+                        + column.name() + " is " + column.repetitionType());
+            }
+        }
         out.create();
         out.write(ByteBuffer.wrap(MAGIC));
-        return new ParquetFileWriter(out, schema);
+        return new ParquetFileWriter(out, schema, config);
     }
 
-    /// Writes the full contents of a `REQUIRED INT32` column.
+    /// Writes one aligned batch of column values, flushing row groups as the buffered
+    /// data crosses the row-group target. A batch that would overflow the current row
+    /// group is split at the boundary.
     ///
-    /// @param columnIndex zero-based leaf-column index
-    /// @param values the column values; its length must match every other column
+    /// The writer creates the batch — bound to the schema — passes it to `filler` to be
+    /// populated (columns addressed by index or name), then submits it. There is no
+    /// separate build or submit step to forget.
+    ///
+    /// @param filler populates the batch's columns; must cover every column exactly once
     /// @throws IOException if the write fails
-    public void writeInts(int columnIndex, int[] values) throws IOException {
+    /// @throws IllegalArgumentException if the batch does not cover every column
+    public void writeBatch(Consumer<ColumnBatch> filler) throws IOException {
         ensureOpen();
-        ColumnSchema column = column(columnIndex);
-        if (column.type() != PhysicalType.INT32) {
-            throw new UnsupportedOperationException(
-                    "Only INT32 columns are supported; column " + column.name() + " is " + column.type());
-        }
-        if (column.repetitionType() != RepetitionType.REQUIRED) {
-            throw new UnsupportedOperationException(
-                    "Only REQUIRED columns are supported; column " + column.name() + " is " + column.repetitionType());
-        }
-        if (columnMeta[columnIndex] != null) {
-            throw new IllegalStateException("Column already written: " + column.name());
-        }
-        checkRowCount(values.length, column);
-
-        // data_page_offset points at the first page; the chunk's pages follow
-        // contiguously. A column larger than one page is split into several.
-        long dataPageOffset = out.position();
-        long chunkSize = 0;
+        ColumnBatch batch = new ColumnBatch(schema);
+        filler.accept(batch);
+        IntColumnSource[] sources = batch.completedSources();
+        batch.markConsumed();
+        int rows = batch.rowCount();
         int pos = 0;
-        do {
-            int count = Math.min(INT32_VALUES_PER_PAGE, values.length - pos);
-            chunkSize += writeIntDataPage(values, pos, count);
-            pos += count;
+        while (pos < rows) {
+            int space = maxRowsPerGroup - current.rowCount();
+            int n = Math.min(space, rows - pos);
+            current.appendRows(sources, pos, n);
+            pos += n;
+            if (current.rowCount() >= maxRowsPerGroup) {
+                flushRowGroup();
+            }
         }
-        while (pos < values.length);
-
-        // total_*_size cover the whole column chunk including page headers; pages
-        // are stored uncompressed so the two sizes are equal.
-        columnMeta[columnIndex] = new ColumnMetaData(
-                PhysicalType.INT32,
-                List.of(Encoding.PLAIN),
-                column.fieldPath(),
-                CompressionCodec.UNCOMPRESSED,
-                values.length,
-                chunkSize,
-                chunkSize,
-                Map.of(),
-                dataPageOffset,
-                null,
-                null,
-                null,
-                null,
-                null);
-    }
-
-    /// Encodes `count` values starting at `from` as one uncompressed PLAIN V1 data
-    /// page and writes it. Returns the bytes written (page header + body).
-    private long writeIntDataPage(int[] values, int from, int count) throws IOException {
-        int[] pageValues = (from == 0 && count == values.length)
-                ? values
-                : Arrays.copyOfRange(values, from, from + count);
-        byte[] valueBytes = PlainEncoder.encodeInts(pageValues);
-        // CRC-32 over the page body as stored on disk (uncompressed here), which is
-        // what the reader validates against.
-        CRC32 crc = new CRC32();
-        crc.update(valueBytes);
-        ThriftCompactWriter header = new ThriftCompactWriter();
-        PageHeaderWriter.writeDataPageV1(header, count, valueBytes.length, valueBytes.length,
-                (int) crc.getValue(), Encoding.PLAIN);
-        byte[] headerBytes = header.toByteArray();
-        out.write(ByteBuffer.wrap(headerBytes));
-        out.write(ByteBuffer.wrap(valueBytes));
-        return (long) headerBytes.length + valueBytes.length;
     }
 
     @Override
@@ -165,11 +142,12 @@ public final class ParquetFileWriter implements Closeable {
         }
         closed = true;
         try {
+            flushRowGroup();
             writeFooter();
         }
         catch (IOException | RuntimeException e) {
-            // The footer is incomplete, so the file is not valid. Discard it
-            // rather than letting out.close() publish a truncated file.
+            // The footer is incomplete, so the file is not valid. Discard it rather than
+            // letting out.close() publish a truncated file.
             try {
                 out.discard();
             }
@@ -181,26 +159,24 @@ public final class ParquetFileWriter implements Closeable {
         out.close();
     }
 
-    private void writeFooter() throws IOException {
-        List<ColumnChunk> chunks = new ArrayList<>(columnMeta.length);
-        long totalByteSize = 0;
-        for (int i = 0; i < columnMeta.length; i++) {
-            if (columnMeta[i] == null) {
-                throw new IllegalStateException("Column not written: " + column(i).name());
-            }
-            chunks.add(new ColumnChunk(columnMeta[i], null, null, null, null));
-            totalByteSize += columnMeta[i].totalUncompressedSize();
+    private void flushRowGroup() throws IOException {
+        if (current.isEmpty()) {
+            return;
         }
-        long rows = numRows < 0 ? 0 : numRows;
-        RowGroup rowGroup = new RowGroup(chunks, totalByteSize, rows);
+        RowGroup rowGroup = current.flushTo(out);
+        rowGroups.add(rowGroup);
+        numRows += rowGroup.numRows();
+        current = new RowGroupBuffer(schema, pageValues);
+    }
 
+    private void writeFooter() throws IOException {
         FileMetaData metaData = new FileMetaData(
                 FORMAT_VERSION,
                 schema.toSchemaElements(),
-                rows,
-                List.of(rowGroup),
+                numRows,
+                List.copyOf(rowGroups),
                 Map.of(),
-                CREATED_BY,
+                config.createdBy(),
                 List.of());
 
         ThriftCompactWriter footer = new ThriftCompactWriter();
@@ -212,22 +188,15 @@ public final class ParquetFileWriter implements Closeable {
         out.write(ByteBuffer.wrap(MAGIC));
     }
 
-    private void checkRowCount(int length, ColumnSchema column) {
-        if (numRows < 0) {
-            numRows = length;
+    /// Number of rows whose values fit within the row-group target, at least one so the
+    /// writer always makes progress even with a tiny target or a wide schema.
+    private static int maxRowsPerGroup(long rowGroupTargetBytes, int columnCount) {
+        if (columnCount == 0) {
+            return Integer.MAX_VALUE;
         }
-        else if (numRows != length) {
-            throw new IllegalArgumentException("Column " + column.name() + " has " + length
-                    + " values but the row group already has " + numRows + " rows");
-        }
-    }
-
-    private ColumnSchema column(int columnIndex) {
-        if (columnIndex < 0 || columnIndex >= columnMeta.length) {
-            throw new IndexOutOfBoundsException(
-                    "Column index " + columnIndex + " out of range [0, " + columnMeta.length + ")");
-        }
-        return schema.getColumn(columnIndex);
+        long bytesPerRow = (long) columnCount * Integer.BYTES;
+        long rows = rowGroupTargetBytes / bytesPerRow;
+        return (int) Math.max(1, Math.min(rows, Integer.MAX_VALUE));
     }
 
     private void ensureOpen() {

--- a/core/src/main/java/dev/hardwood/writer/WriterConfig.java
+++ b/core/src/main/java/dev/hardwood/writer/WriterConfig.java
@@ -1,0 +1,110 @@
+/*
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Copyright The original authors
+ *
+ *  Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package dev.hardwood.writer;
+
+/// Tuning knobs for [ParquetFileWriter].
+///
+/// The two size targets bound the writer's output granularity and peak memory:
+///
+/// - **Page target** — the writer splits a column chunk into data pages of at most this
+///   many uncompressed bytes.
+/// - **Row-group target** — the writer flushes a row group once its buffered
+///   uncompressed data reaches this many bytes, bounding how much it holds in memory.
+///
+/// Obtain the defaults with [#defaults] or override individual knobs through [#builder].
+public final class WriterConfig {
+
+    /// Default page target: 1 MiB of uncompressed values per data page.
+    public static final int DEFAULT_PAGE_TARGET_BYTES = 1 << 20;
+
+    /// Default row-group target: 128 MiB of uncompressed data per row group.
+    public static final long DEFAULT_ROW_GROUP_TARGET_BYTES = 128L << 20;
+
+    /// Default `created_by` identifier written into the file footer.
+    public static final String DEFAULT_CREATED_BY = "hardwood";
+
+    private final int pageTargetBytes;
+    private final long rowGroupTargetBytes;
+    private final String createdBy;
+
+    private WriterConfig(Builder builder) {
+        this.pageTargetBytes = builder.pageTargetBytes;
+        this.rowGroupTargetBytes = builder.rowGroupTargetBytes;
+        this.createdBy = builder.createdBy;
+    }
+
+    /// The default configuration.
+    public static WriterConfig defaults() {
+        return builder().build();
+    }
+
+    /// A builder pre-populated with the defaults.
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    /// Maximum uncompressed bytes of values per data page.
+    public int pageTargetBytes() {
+        return pageTargetBytes;
+    }
+
+    /// Uncompressed byte threshold at which a row group is flushed.
+    public long rowGroupTargetBytes() {
+        return rowGroupTargetBytes;
+    }
+
+    /// The `created_by` identifier written into the file footer.
+    public String createdBy() {
+        return createdBy;
+    }
+
+    /// Builder for [WriterConfig].
+    public static final class Builder {
+
+        private int pageTargetBytes = DEFAULT_PAGE_TARGET_BYTES;
+        private long rowGroupTargetBytes = DEFAULT_ROW_GROUP_TARGET_BYTES;
+        private String createdBy = DEFAULT_CREATED_BY;
+
+        private Builder() {
+        }
+
+        /// Sets the page target; must be at least one `INT32` (4 bytes).
+        public Builder pageTargetBytes(int pageTargetBytes) {
+            if (pageTargetBytes < Integer.BYTES) {
+                throw new IllegalArgumentException(
+                        "pageTargetBytes must be at least " + Integer.BYTES + " but was " + pageTargetBytes);
+            }
+            this.pageTargetBytes = pageTargetBytes;
+            return this;
+        }
+
+        /// Sets the row-group target; must be positive.
+        public Builder rowGroupTargetBytes(long rowGroupTargetBytes) {
+            if (rowGroupTargetBytes <= 0) {
+                throw new IllegalArgumentException(
+                        "rowGroupTargetBytes must be positive but was " + rowGroupTargetBytes);
+            }
+            this.rowGroupTargetBytes = rowGroupTargetBytes;
+            return this;
+        }
+
+        /// Sets the `created_by` footer identifier; must be non-null.
+        public Builder createdBy(String createdBy) {
+            if (createdBy == null) {
+                throw new IllegalArgumentException("createdBy must not be null");
+            }
+            this.createdBy = createdBy;
+            return this;
+        }
+
+        /// Builds the immutable configuration.
+        public WriterConfig build() {
+            return new WriterConfig(this);
+        }
+    }
+}

--- a/core/src/test/java/dev/hardwood/internal/writer/ChannelOutputFileTest.java
+++ b/core/src/test/java/dev/hardwood/internal/writer/ChannelOutputFileTest.java
@@ -1,0 +1,92 @@
+/*
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Copyright The original authors
+ *
+ *  Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package dev.hardwood.internal.writer;
+
+import java.io.ByteArrayOutputStream;
+import java.nio.ByteBuffer;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Arrays;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/// Buffering behaviour of [ChannelOutputFile]: writes are coalesced but must reach the
+/// file byte-for-byte and in order, whether they are buffered, span a flush boundary, or
+/// bypass the buffer entirely.
+class ChannelOutputFileTest {
+
+    @Test
+    void mixedSmallAndLargeWritesConcatenateInOrder(@TempDir Path dir) throws Exception {
+        Path file = dir.resolve("out.bin");
+        byte[] small = filled(10, (byte) 1);
+        byte[] large = ramp(200_000); // larger than the 64 KiB buffer -> bypasses it
+        byte[] tail = filled(5, (byte) 2);
+
+        ChannelOutputFile out = new ChannelOutputFile(file);
+        out.create();
+        out.write(ByteBuffer.wrap(small));
+        assertThat(out.position()).isEqualTo(10);
+        out.write(ByteBuffer.wrap(large));
+        out.write(ByteBuffer.wrap(tail));
+        assertThat(out.position()).isEqualTo(10L + large.length + 5);
+        out.close();
+
+        byte[] all = Files.readAllBytes(file);
+        assertThat(all).hasSize(10 + large.length + 5);
+        assertThat(Arrays.copyOfRange(all, 0, 10)).isEqualTo(small);
+        assertThat(Arrays.copyOfRange(all, 10, 10 + large.length)).isEqualTo(large);
+        assertThat(Arrays.copyOfRange(all, 10 + large.length, all.length)).isEqualTo(tail);
+    }
+
+    @Test
+    void manySmallWritesFlushAcrossBufferBoundary(@TempDir Path dir) throws Exception {
+        Path file = dir.resolve("out.bin");
+        ByteArrayOutputStream expected = new ByteArrayOutputStream();
+
+        ChannelOutputFile out = new ChannelOutputFile(file);
+        out.create();
+        // 200 KiB of 1 KiB writes forces several buffer flushes.
+        for (int i = 0; i < 200; i++) {
+            byte[] chunk = filled(1024, (byte) i);
+            expected.writeBytes(chunk);
+            out.write(ByteBuffer.wrap(chunk));
+        }
+        out.close();
+
+        assertThat(Files.readAllBytes(file)).isEqualTo(expected.toByteArray());
+    }
+
+    @Test
+    void discardDropsBufferedBytesAndLeavesNoFile(@TempDir Path dir) throws Exception {
+        Path file = dir.resolve("out.bin");
+        ChannelOutputFile out = new ChannelOutputFile(file);
+        out.create();
+        out.write(ByteBuffer.wrap(filled(100, (byte) 7))); // buffered, never flushed
+        out.discard();
+
+        assertThat(Files.exists(file)).isFalse();
+        assertThat(Files.exists(dir.resolve("out.bin.hardwood-tmp"))).isFalse();
+    }
+
+    private static byte[] filled(int size, byte value) {
+        byte[] b = new byte[size];
+        Arrays.fill(b, value);
+        return b;
+    }
+
+    private static byte[] ramp(int size) {
+        byte[] b = new byte[size];
+        for (int i = 0; i < size; i++) {
+            b[i] = (byte) i;
+        }
+        return b;
+    }
+}

--- a/core/src/test/java/dev/hardwood/writer/WriterConfigTest.java
+++ b/core/src/test/java/dev/hardwood/writer/WriterConfigTest.java
@@ -1,0 +1,52 @@
+/*
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Copyright The original authors
+ *
+ *  Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package dev.hardwood.writer;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/// Validation of [WriterConfig.Builder]: the size targets and `created_by` are checked
+/// eagerly, so a misconfigured writer fails at build time rather than mid-write.
+class WriterConfigTest {
+
+    @Test
+    void defaultsMatchTheDeclaredConstants() {
+        WriterConfig config = WriterConfig.defaults();
+        assertThat(config.pageTargetBytes()).isEqualTo(WriterConfig.DEFAULT_PAGE_TARGET_BYTES);
+        assertThat(config.rowGroupTargetBytes()).isEqualTo(WriterConfig.DEFAULT_ROW_GROUP_TARGET_BYTES);
+        assertThat(config.createdBy()).isEqualTo(WriterConfig.DEFAULT_CREATED_BY);
+    }
+
+    @Test
+    void acceptsTheSmallestValidPageTarget() {
+        assertThat(WriterConfig.builder().pageTargetBytes(Integer.BYTES).build().pageTargetBytes())
+                .isEqualTo(Integer.BYTES);
+    }
+
+    @Test
+    void rejectsPageTargetSmallerThanOneInt32() {
+        assertThatThrownBy(() -> WriterConfig.builder().pageTargetBytes(Integer.BYTES - 1))
+                .isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Test
+    void rejectsNonPositiveRowGroupTarget() {
+        assertThatThrownBy(() -> WriterConfig.builder().rowGroupTargetBytes(0))
+                .isInstanceOf(IllegalArgumentException.class);
+        assertThatThrownBy(() -> WriterConfig.builder().rowGroupTargetBytes(-1))
+                .isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Test
+    void rejectsNullCreatedBy() {
+        assertThatThrownBy(() -> WriterConfig.builder().createdBy(null))
+                .isInstanceOf(IllegalArgumentException.class);
+    }
+}

--- a/core/src/test/java/dev/hardwood/writer/WriterDifferentialTest.java
+++ b/core/src/test/java/dev/hardwood/writer/WriterDifferentialTest.java
@@ -50,8 +50,7 @@ class WriterDifferentialTest {
 
         Path file = dir.resolve("written.parquet");
         try (ParquetFileWriter writer = ParquetFileWriter.create(OutputFile.of(file), schema)) {
-            writer.writeInts(0, r);
-            writer.writeInts(1, v);
+            writer.writeBatch(batch -> batch.ints(0, r).ints(1, v));
         }
 
         List<Integer> actual = new ArrayList<>();
@@ -92,7 +91,38 @@ class WriterDifferentialTest {
                 .build();
         Path file = dir.resolve("multipage.parquet");
         try (ParquetFileWriter writer = ParquetFileWriter.create(OutputFile.of(file), schema)) {
-            writer.writeInts(0, v);
+            writer.writeBatch(batch -> batch.ints(0, v));
+        }
+
+        try (Connection conn = DriverManager.getConnection("jdbc:duckdb:");
+                Statement stmt = conn.createStatement();
+                ResultSet rs = stmt.executeQuery(
+                        "SELECT count(*) AS n, sum(v) AS s, max(v) AS mx FROM read_parquet('"
+                                + file.toAbsolutePath() + "')")) {
+            rs.next();
+            assertThat(rs.getLong("n")).isEqualTo(n);
+            assertThat(rs.getLong("s")).isEqualTo((long) n * (n - 1) / 2);
+            assertThat(rs.getInt("mx")).isEqualTo(n - 1);
+        }
+    }
+
+    @Test
+    void duckDbReadsMultipleRowGroups(@TempDir Path dir) throws Exception {
+        int n = 5_000;
+        int[] v = new int[n];
+        for (int i = 0; i < n; i++) {
+            v[i] = i;
+        }
+
+        FileSchema schema = FileSchema.builder("schema")
+                .addColumn("v", PhysicalType.INT32, RepetitionType.REQUIRED)
+                .build();
+        // A tiny row-group target forces the single batch to be split across many row
+        // groups; DuckDB must read across all of them transparently.
+        WriterConfig config = WriterConfig.builder().rowGroupTargetBytes(4096).build();
+        Path file = dir.resolve("multirowgroup.parquet");
+        try (ParquetFileWriter writer = ParquetFileWriter.create(OutputFile.of(file), schema, config)) {
+            writer.writeBatch(batch -> batch.ints(0, v));
         }
 
         try (Connection conn = DriverManager.getConnection("jdbc:duckdb:");

--- a/core/src/test/java/dev/hardwood/writer/WriterRoundTripTest.java
+++ b/core/src/test/java/dev/hardwood/writer/WriterRoundTripTest.java
@@ -7,6 +7,7 @@
  */
 package dev.hardwood.writer;
 
+import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -25,6 +26,7 @@ import dev.hardwood.internal.writer.ByteBufferOutputFile;
 import dev.hardwood.metadata.ColumnMetaData;
 import dev.hardwood.metadata.PhysicalType;
 import dev.hardwood.metadata.RepetitionType;
+import dev.hardwood.metadata.RowGroup;
 import dev.hardwood.reader.ColumnReader;
 import dev.hardwood.reader.ParquetFileReader;
 import dev.hardwood.schema.FileSchema;
@@ -36,20 +38,27 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 /// then read it back with [ParquetFileReader] and assert the values survive.
 class WriterRoundTripTest {
 
-    @Test
-    void writesAndReadsBackTwoIntColumns() throws Exception {
-        FileSchema schema = FileSchema.builder("schema")
+    private static FileSchema twoColumns() {
+        return FileSchema.builder("schema")
                 .addColumn("a", PhysicalType.INT32, RepetitionType.REQUIRED)
                 .addColumn("b", PhysicalType.INT32, RepetitionType.REQUIRED)
                 .build();
+    }
 
+    private static FileSchema oneColumn() {
+        return FileSchema.builder("schema")
+                .addColumn("id", PhysicalType.INT32, RepetitionType.REQUIRED)
+                .build();
+    }
+
+    @Test
+    void writesAndReadsBackTwoIntColumns() throws Exception {
         int[] a = { 1, 2, 3, 4, 5 };
         int[] b = { 10, 20, 30, 40, 50 };
 
         ByteBufferOutputFile out = new ByteBufferOutputFile();
-        try (ParquetFileWriter writer = ParquetFileWriter.create(out, schema)) {
-            writer.writeInts(0, a);
-            writer.writeInts(1, b);
+        try (ParquetFileWriter writer = ParquetFileWriter.create(out, twoColumns())) {
+            writer.writeBatch(batch -> batch.ints(0, a).ints(1, b));
         }
 
         ByteBuffer bytes = ByteBuffer.wrap(out.toByteArray());
@@ -65,15 +74,29 @@ class WriterRoundTripTest {
     }
 
     @Test
+    void writesColumnsAddressedByName() throws Exception {
+        int[] a = { 1, 2, 3 };
+        int[] b = { 4, 5, 6 };
+
+        ByteBufferOutputFile out = new ByteBufferOutputFile();
+        try (ParquetFileWriter writer = ParquetFileWriter.create(out, twoColumns())) {
+            // Names may be given in any order; they resolve to the schema's columns.
+            writer.writeBatch(batch -> batch.ints("b", b).ints("a", a));
+        }
+
+        try (ParquetFileReader reader = ParquetFileReader.open(InputFile.of(ByteBuffer.wrap(out.toByteArray())))) {
+            assertThat(readInts(reader, 0)).containsExactly(a);
+            assertThat(readInts(reader, 1)).containsExactly(b);
+        }
+    }
+
+    @Test
     void writesToLocalFileWithAtomicRename(@TempDir Path dir) throws Exception {
-        FileSchema schema = FileSchema.builder("schema")
-                .addColumn("id", PhysicalType.INT32, RepetitionType.REQUIRED)
-                .build();
         int[] ids = { 7, 8, 9 };
 
         Path file = dir.resolve("out.parquet");
-        try (ParquetFileWriter writer = ParquetFileWriter.create(OutputFile.of(file), schema)) {
-            writer.writeInts(0, ids);
+        try (ParquetFileWriter writer = ParquetFileWriter.create(OutputFile.of(file), oneColumn())) {
+            writer.writeBatch(batch -> batch.ints(0, ids));
         }
 
         try (ParquetFileReader reader = ParquetFileReader.open(InputFile.of(file))) {
@@ -83,98 +106,137 @@ class WriterRoundTripTest {
     }
 
     @Test
-    void emptyColumnRoundTrips() throws Exception {
-        FileSchema schema = FileSchema.builder("schema")
-                .addColumn("id", PhysicalType.INT32, RepetitionType.REQUIRED)
-                .build();
-
+    void multipleBatchesAccumulateIntoOneRowGroup() throws Exception {
         ByteBufferOutputFile out = new ByteBufferOutputFile();
-        try (ParquetFileWriter writer = ParquetFileWriter.create(out, schema)) {
-            writer.writeInts(0, new int[0]);
+        try (ParquetFileWriter writer = ParquetFileWriter.create(out, oneColumn())) {
+            writer.writeBatch(batch -> batch.ints(0, new int[] { 1, 2 }));
+            writer.writeBatch(batch -> batch.ints(0, new int[] { 3, 4 }));
+            writer.writeBatch(batch -> batch.ints(0, new int[] { 5 }));
+        }
+
+        try (ParquetFileReader reader = ParquetFileReader.open(InputFile.of(ByteBuffer.wrap(out.toByteArray())))) {
+            assertThat(reader.getFileMetaData().numRows()).isEqualTo(5);
+            // Default 128 MiB target: the three small batches stay in one row group.
+            assertThat(reader.getFileMetaData().rowGroups()).hasSize(1);
+            assertThat(readInts(reader, 0)).containsExactly(1, 2, 3, 4, 5);
+        }
+    }
+
+    @Test
+    void emptyBatchProducesEmptyFile() throws Exception {
+        ByteBufferOutputFile out = new ByteBufferOutputFile();
+        try (ParquetFileWriter writer = ParquetFileWriter.create(out, oneColumn())) {
+            writer.writeBatch(batch -> batch.ints(0, new int[0]));
         }
 
         try (ParquetFileReader reader = ParquetFileReader.open(InputFile.of(ByteBuffer.wrap(out.toByteArray())))) {
             assertThat(reader.getFileMetaData().numRows()).isEqualTo(0);
+            assertThat(reader.getFileMetaData().rowGroups()).isEmpty();
         }
     }
 
     @Test
-    void rejectsWritingTheSameColumnTwice() throws Exception {
-        FileSchema schema = FileSchema.builder("schema")
-                .addColumn("id", PhysicalType.INT32, RepetitionType.REQUIRED)
-                .build();
-        try (ParquetFileWriter writer = ParquetFileWriter.create(new ByteBufferOutputFile(), schema)) {
-            writer.writeInts(0, new int[] { 1, 2, 3 });
-            assertThatThrownBy(() -> writer.writeInts(0, new int[] { 4, 5, 6 }))
-                    .isInstanceOf(IllegalStateException.class);
+    void rejectsDuplicateColumnInBatch() throws Exception {
+        try (ParquetFileWriter writer = ParquetFileWriter.create(new ByteBufferOutputFile(), oneColumn())) {
+            assertThatThrownBy(() -> writer.writeBatch(
+                    batch -> batch.ints(0, new int[] { 1, 2, 3 }).ints(0, new int[] { 4, 5, 6 })))
+                    .isInstanceOf(IllegalArgumentException.class);
         }
     }
 
     @Test
-    void rejectsRowCountMismatchAcrossColumns() throws Exception {
-        FileSchema schema = FileSchema.builder("schema")
-                .addColumn("a", PhysicalType.INT32, RepetitionType.REQUIRED)
-                .addColumn("b", PhysicalType.INT32, RepetitionType.REQUIRED)
-                .build();
-        ParquetFileWriter writer = ParquetFileWriter.create(new ByteBufferOutputFile(), schema);
-        writer.writeInts(0, new int[] { 1, 2, 3 });
-        assertThatThrownBy(() -> writer.writeInts(1, new int[] { 1, 2 }))
-                .isInstanceOf(IllegalArgumentException.class);
+    void rejectsSameColumnByIndexAndName() throws Exception {
+        // The schema binding lets the batch see that "id" is column 0, so the collision
+        // is caught eagerly rather than at write time.
+        try (ParquetFileWriter writer = ParquetFileWriter.create(new ByteBufferOutputFile(), oneColumn())) {
+            assertThatThrownBy(() -> writer.writeBatch(
+                    batch -> batch.ints(0, new int[] { 1, 2, 3 }).ints("id", new int[] { 4, 5, 6 })))
+                    .isInstanceOf(IllegalArgumentException.class);
+        }
     }
 
     @Test
-    void rejectsNonInt32Column() throws Exception {
+    void rejectsUnknownColumnName() throws Exception {
+        try (ParquetFileWriter writer = ParquetFileWriter.create(new ByteBufferOutputFile(), oneColumn())) {
+            assertThatThrownBy(() -> writer.writeBatch(batch -> batch.ints("nope", new int[] { 1 })))
+                    .isInstanceOf(IllegalArgumentException.class);
+        }
+    }
+
+    @Test
+    void rejectsRaggedBatch() throws Exception {
+        try (ParquetFileWriter writer = ParquetFileWriter.create(new ByteBufferOutputFile(), twoColumns())) {
+            assertThatThrownBy(() -> writer.writeBatch(
+                    batch -> batch.ints(0, new int[] { 1, 2, 3 }).ints(1, new int[] { 1, 2 })))
+                    .isInstanceOf(IllegalArgumentException.class);
+        }
+    }
+
+    @Test
+    void rejectsBatchNotCoveringAllColumns() throws Exception {
+        try (ParquetFileWriter writer = ParquetFileWriter.create(new ByteBufferOutputFile(), twoColumns())) {
+            assertThatThrownBy(() -> writer.writeBatch(batch -> batch.ints(0, new int[] { 1, 2, 3 })))
+                    .isInstanceOf(IllegalArgumentException.class);
+        }
+    }
+
+    @Test
+    void rejectsNonInt32Schema() {
         FileSchema schema = FileSchema.builder("schema")
                 .addColumn("v", PhysicalType.INT64, RepetitionType.REQUIRED)
                 .build();
-        ParquetFileWriter writer = ParquetFileWriter.create(new ByteBufferOutputFile(), schema);
-        assertThatThrownBy(() -> writer.writeInts(0, new int[] { 1 }))
+        assertThatThrownBy(() -> ParquetFileWriter.create(new ByteBufferOutputFile(), schema))
                 .isInstanceOf(UnsupportedOperationException.class);
     }
 
     @Test
-    void rejectsNonRequiredColumn() throws Exception {
+    void rejectsNonRequiredSchema() {
         FileSchema schema = FileSchema.builder("schema")
                 .addColumn("v", PhysicalType.INT32, RepetitionType.OPTIONAL)
                 .build();
-        ParquetFileWriter writer = ParquetFileWriter.create(new ByteBufferOutputFile(), schema);
-        assertThatThrownBy(() -> writer.writeInts(0, new int[] { 1 }))
+        assertThatThrownBy(() -> ParquetFileWriter.create(new ByteBufferOutputFile(), schema))
                 .isInstanceOf(UnsupportedOperationException.class);
+    }
+
+    @Test
+    void rejectsMutatingBatchAfterWrite() throws Exception {
+        // A filler that stashes the batch and mutates it after writeBatch returns must
+        // fail loudly rather than silently drop the values.
+        try (ParquetFileWriter writer = ParquetFileWriter.create(new ByteBufferOutputFile(), oneColumn())) {
+            ColumnBatch[] escaped = new ColumnBatch[1];
+            writer.writeBatch(batch -> {
+                escaped[0] = batch;
+                batch.ints(0, new int[] { 1, 2, 3 });
+            });
+            assertThatThrownBy(() -> escaped[0].ints(0, new int[] { 4 })).isInstanceOf(IllegalStateException.class);
+        }
     }
 
     @Test
     void rejectsUseAfterClose() throws Exception {
-        FileSchema schema = FileSchema.builder("schema")
-                .addColumn("id", PhysicalType.INT32, RepetitionType.REQUIRED)
-                .build();
-        ParquetFileWriter writer = ParquetFileWriter.create(new ByteBufferOutputFile(), schema);
-        writer.writeInts(0, new int[] { 1, 2, 3 });
+        ParquetFileWriter writer = ParquetFileWriter.create(new ByteBufferOutputFile(), oneColumn());
+        writer.writeBatch(batch -> batch.ints(0, new int[] { 1, 2, 3 }));
         writer.close();
-        assertThatThrownBy(() -> writer.writeInts(0, new int[] { 4 }))
+        assertThatThrownBy(() -> writer.writeBatch(batch -> batch.ints(0, new int[] { 4 })))
                 .isInstanceOf(IllegalStateException.class);
     }
 
     @Test
     void failedCloseLeavesNoFileAtTarget(@TempDir Path dir) throws Exception {
-        FileSchema schema = FileSchema.builder("schema")
-                .addColumn("a", PhysicalType.INT32, RepetitionType.REQUIRED)
-                .addColumn("b", PhysicalType.INT32, RepetitionType.REQUIRED)
-                .build();
         Path file = dir.resolve("partial.parquet");
 
-        ParquetFileWriter writer = ParquetFileWriter.create(OutputFile.of(file), schema);
-        writer.writeInts(0, new int[] { 1, 2, 3 }); // column "b" never written
+        // Fail while writing the footer's trailing magic: the data pages and part of the
+        // footer are on disk, so close() must discard rather than publish a broken file.
+        FailOnSecondMagic out = new FailOnSecondMagic(OutputFile.of(file));
+        ParquetFileWriter writer = ParquetFileWriter.create(out, oneColumn());
+        writer.writeBatch(batch -> batch.ints(0, new int[] { 1, 2, 3 }));
 
-        assertThatThrownBy(writer::close).isInstanceOf(IllegalStateException.class);
-        // The footer never completed, so nothing must be published at the target.
+        assertThatThrownBy(writer::close).isInstanceOf(IOException.class);
         assertThat(Files.exists(file)).isFalse();
     }
 
     @Test
     void largeColumnIsSplitAcrossMultiplePages() throws Exception {
-        FileSchema schema = FileSchema.builder("schema")
-                .addColumn("id", PhysicalType.INT32, RepetitionType.REQUIRED)
-                .build();
         // Comfortably more than one target page (262,144 INT32 values per 1 MiB page).
         int n = 600_000;
         int[] values = new int[n];
@@ -183,15 +245,17 @@ class WriterRoundTripTest {
         }
 
         ByteBufferOutputFile out = new ByteBufferOutputFile();
-        try (ParquetFileWriter writer = ParquetFileWriter.create(out, schema)) {
-            writer.writeInts(0, values);
+        try (ParquetFileWriter writer = ParquetFileWriter.create(out, oneColumn())) {
+            writer.writeBatch(batch -> batch.ints(0, values));
         }
         byte[] bytes = out.toByteArray();
 
         try (ParquetFileReader reader = ParquetFileReader.open(InputFile.of(ByteBuffer.wrap(bytes)))) {
             assertThat(reader.getFileMetaData().numRows()).isEqualTo(n);
+            // One 128 MiB row group; 600k values at 262,144 per 1 MiB page ⇒ exactly 3 pages.
+            assertThat(reader.getFileMetaData().rowGroups()).hasSize(1);
             ColumnMetaData meta = reader.getFileMetaData().rowGroups().get(0).columns().get(0).metaData();
-            assertThat(countDataPages(bytes, meta.dataPageOffset(), meta.numValues())).isGreaterThan(1);
+            assertThat(countDataPages(bytes, meta.dataPageOffset(), meta.numValues())).isEqualTo(3);
             // Arrays.equals over containsExactly: the latter is O(n) with per-element
             // boxing/description and is needlessly slow at 600k elements.
             assertThat(Arrays.equals(readInts(reader, 0), values)).isTrue();
@@ -199,14 +263,35 @@ class WriterRoundTripTest {
     }
 
     @Test
-    void writesCorrectPageCrc() throws Exception {
-        FileSchema schema = FileSchema.builder("schema")
-                .addColumn("id", PhysicalType.INT32, RepetitionType.REQUIRED)
-                .build();
+    void largeColumnIsSplitAcrossMultipleRowGroups() throws Exception {
+        int n = 5_000;
+        int[] values = new int[n];
+        for (int i = 0; i < n; i++) {
+            values[i] = i;
+        }
 
+        // 4 KiB target ⇒ 1024 rows per row group ⇒ the single batch spans several groups.
+        WriterConfig config = WriterConfig.builder().rowGroupTargetBytes(4096).build();
         ByteBufferOutputFile out = new ByteBufferOutputFile();
-        try (ParquetFileWriter writer = ParquetFileWriter.create(out, schema)) {
-            writer.writeInts(0, new int[] { 1, 2, 3, 4, 5 });
+        try (ParquetFileWriter writer = ParquetFileWriter.create(out, oneColumn(), config)) {
+            writer.writeBatch(batch -> batch.ints(0, values));
+        }
+
+        try (ParquetFileReader reader = ParquetFileReader.open(InputFile.of(ByteBuffer.wrap(out.toByteArray())))) {
+            assertThat(reader.getFileMetaData().numRows()).isEqualTo(n);
+            // 5000 rows at 1024 per group ⇒ four full groups and a 904-row tail, pinning
+            // the cadence arithmetic rather than merely asserting "more than one".
+            assertThat(reader.getFileMetaData().rowGroups().stream().map(RowGroup::numRows))
+                    .containsExactly(1024L, 1024L, 1024L, 1024L, 904L);
+            assertThat(Arrays.equals(readInts(reader, 0), values)).isTrue();
+        }
+    }
+
+    @Test
+    void writesCorrectPageCrc() throws Exception {
+        ByteBufferOutputFile out = new ByteBufferOutputFile();
+        try (ParquetFileWriter writer = ParquetFileWriter.create(out, oneColumn())) {
+            writer.writeBatch(batch -> batch.ints(0, new int[] { 1, 2, 3, 4, 5 }));
         }
         byte[] bytes = out.toByteArray();
 
@@ -253,6 +338,54 @@ class WriterRoundTripTest {
                 pos += count;
             }
             return result;
+        }
+    }
+
+    /// An [OutputFile] that throws while writing the second `PAR1` magic — the footer's
+    /// trailing marker — leaving a file whose footer never completed.
+    private static final class FailOnSecondMagic implements OutputFile {
+
+        private final OutputFile delegate;
+        private int magicWrites;
+
+        FailOnSecondMagic(OutputFile delegate) {
+            this.delegate = delegate;
+        }
+
+        @Override
+        public void create() throws IOException {
+            delegate.create();
+        }
+
+        @Override
+        public void write(ByteBuffer data) throws IOException {
+            if (isMagic(data) && ++magicWrites == 2) {
+                throw new IOException("injected footer write failure");
+            }
+            delegate.write(data);
+        }
+
+        @Override
+        public long position() {
+            return delegate.position();
+        }
+
+        @Override
+        public void close() throws IOException {
+            delegate.close();
+        }
+
+        @Override
+        public void discard() throws IOException {
+            delegate.discard();
+        }
+
+        private static boolean isMagic(ByteBuffer data) {
+            if (data.remaining() != 4) {
+                return false;
+            }
+            int p = data.position();
+            return data.get(p) == 'P' && data.get(p + 1) == 'A' && data.get(p + 2) == 'R' && data.get(p + 3) == '1';
         }
     }
 }


### PR DESCRIPTION
Stage 3 of the writer milestone (#9): settles the **columnar write cadence**. Design of record: [`_designs/WRITER_SUPPORT.md`](../blob/9-writer-row-group-cadence/_designs/WRITER_SUPPORT.md) (stage 3).

## What changes

Replaces the tracer's whole-column `writeInts(col, int[])`, which could not bound memory beyond a single row group, with an aligned-batch contract:

```java
try (ParquetFileWriter w = ParquetFileWriter.create(out, schema, cfg)) {
    w.writeBatch(ColumnBatch.of().ints(0, a).ints(1, b));   // aligned slice, atomic
    // more batches; row groups flush automatically at the target
}
```

- **`ColumnBatch`** — one aligned slice across all columns. Ragged (length mismatch) and duplicate-column are rejected at build; a batch missing a schema column is rejected at `writeBatch`.
- **Writer-owned row-group flushing** — the writer re-chunks batches into pages and accumulates row groups, auto-flushing once a group reaches `WriterConfig.rowGroupTargetBytes` (default 128 MiB). An oversized single batch is split at the boundary, so peak writer buffering is bounded by the row-group size regardless of batch size. No explicit boundary method.
- **`WriterConfig`** — page target (default 1 MiB) and row-group target (default 128 MiB) plus `created_by`, via a validated builder. Dictionary/codec/version knobs arrive with later stages.
- **Fail-early** — non-`INT32`/non-`REQUIRED` schemas are rejected at `create()`, not mid-write.

## Custom-vector seam (internal)

Column values flow through an internal `IntColumnSource` seam (`int[]`-backed via `IntArrayColumnSource`), pulled in page-sized ranges rather than read straight from the caller's array. This keeps the door open for a later **public `ColumnVector` SPI** — letting callers write from their own columnar containers (Arrow, off-heap) without an intervening copy, plus a zero-copy PLAIN fast path — sequenced after nulls and dictionary define the value/validity facets. The primitive-array setters are sugar over the seam, so adding the SPI won't change `writeBatch`.

## Testing

- **Round-trip** (`WriterRoundTripTest`, 14): two-column, local-file atomic rename, multi-batch-into-one-row-group, empty-batch, ragged/duplicate/missing-column rejection, use-after-close, discard-on-failed-footer-write, multi-page and multi-row-group splitting, page CRC.
- **DuckDB differential** (`WriterDifferentialTest`, 3): boundary INT32 values, multi-page column, and a **multi-row-group** file — an independent engine reading hardwood-written bytes proves spec-correctness.
- Full `core` suite green (1535 tests).

## Roadmap

Ticks *row-group size tracking* and *automatic row-group flushing* (6.2). `WriterConfig` left unticked until it gains the dictionary/codec knobs from stages 5–6.
