### PR TITLE
#9 write support stage 4: nullable OPTIONAL INT32 columns

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -69,11 +69,11 @@ For field-level `parquet.thrift` metadata coverage (which spec fields are read/p
 - [ ] Fallback to plain encoding when dictionary grows too large
 
 ### 2.3 RLE/Bit-Packing Hybrid
-- [ ] Implement `RleBitPackingHybridEncoder`
-  - [ ] Bit width calculation
-  - [ ] RLE encoding (repeated values)
-  - [ ] Bit-packing encoding (groups of 8)
-  - [ ] Automatic mode switching
+- [x] Implement `RleBitPackingHybridEncoder`
+  - [x] Bit width calculation
+  - [x] RLE encoding (repeated values)
+  - [x] Bit-packing encoding (groups of 8)
+  - [x] Automatic mode switching
 - [x] Implement `RleBitPackingHybridDecoder`
   - [x] Header byte parsing (RLE vs bit-packed)
   - [x] RLE decoding
@@ -84,24 +84,24 @@ For field-level `parquet.thrift` metadata coverage (which spec fields are read/p
   - [x] Block/miniblock structure
   - [x] Min delta calculation per block
   - [x] Bit width calculation per miniblock
-  - [ ] Encoder implementation (optional encoding; sequenced after the flat writer milestone)
+  - [ ] Encoder implementation (optional encoding; sequenced as a late writer-breadth increment)
   - [x] Decoder implementation
 - [x] DELTA_LENGTH_BYTE_ARRAY
   - [x] Length encoding with DELTA_BINARY_PACKED
   - [x] Raw byte concatenation
-  - [ ] Encoder implementation (optional encoding; sequenced after the flat writer milestone)
+  - [ ] Encoder implementation (optional encoding; sequenced as a late writer-breadth increment)
   - [x] Decoder implementation
 - [x] DELTA_BYTE_ARRAY
   - [x] Prefix length calculation
   - [x] Suffix extraction
-  - [ ] Encoder implementation (optional encoding; sequenced after the flat writer milestone)
+  - [ ] Encoder implementation (optional encoding; sequenced as a late writer-breadth increment)
   - [x] Decoder implementation
 
 ### 2.5 Byte Stream Split (BYTE_STREAM_SPLIT)
 - [x] Float byte separation/interleaving
 - [x] Double byte separation/interleaving
 - [x] FIXED_LEN_BYTE_ARRAY support
-- [ ] Encoder implementation (optional encoding; sequenced after the flat writer milestone)
+- [ ] Encoder implementation (optional encoding; sequenced as a late writer-breadth increment)
 - [x] Decoder implementation
 
 ---
@@ -124,7 +124,7 @@ For field-level `parquet.thrift` metadata coverage (which spec fields are read/p
 - [x] CRC32 calculation for writing
 
 ### 3.3 Definition & Repetition Levels
-- [ ] Implement `LevelEncoder` using RLE/bit-packing hybrid
+- [x] Implement `LevelEncoder` using RLE/bit-packing hybrid (definition levels; repetition levels with nested write support)
 - [x] Implement `LevelDecoder`
 - [x] Max level calculation from schema
 - [x] Null detection from definition levels
@@ -147,7 +147,7 @@ For field-level `parquet.thrift` metadata coverage (which spec fields are read/p
 - [x] Implement `RowGroup` class
 - [x] Row group metadata serialization
 - [x] Row group metadata deserialization
-- [ ] Sorting column tracking (optional; non-goal for the flat writer milestone)
+- [ ] Sorting column tracking (optional; non-goal for write support)
 
 ---
 
@@ -360,8 +360,8 @@ For field-level `parquet.thrift` metadata coverage (which spec fields are read/p
 ## Phase 10: Public API Design
 
 ### 10.1 Schema Builder API
-> Superseded for the flat writer by `FileSchema.Builder` (#9); the items below
-> describe the fuller fluent/nested builder that lands with nested-write support.
+> Superseded by `FileSchema.Builder` (#9); the items below describe the fuller
+> fluent/nested builder that would land with the nested-write increments.
 - [ ] Implement fluent `Types.buildMessage()` API
 - [ ] Primitive type builders with logical type support (see Phase 6.4)
 - [ ] Group builders for nested structures

--- a/_designs/VALIDITY_WORD_BITMAP.md
+++ b/_designs/VALIDITY_WORD_BITMAP.md
@@ -34,7 +34,7 @@ This gives perf-sensitive consumers three loop shapes against the same `Validity
 
 ## Components
 
-### `Validity` (`core/src/main/java/dev/hardwood/reader/Validity.java`)
+### `Validity` (`core/src/main/java/dev/hardwood/Validity.java`)
 
 `Backed` stores `long[] words` instead of `BitSet bits`. Method implementations:
 

--- a/_designs/WRITER_SUPPORT.md
+++ b/_designs/WRITER_SUPPORT.md
@@ -16,28 +16,31 @@ end-state writer architecture and the order in which it is delivered.
 
 ## Scope
 
-The first writer milestone (1.1) targets **flat schemas written through a columnar
-batch API**:
+The writer milestone (#9) delivers write support for the **full schema model the reader
+supports — flat and nested — through a columnar batch API**:
 
-- **Flat columns only** — `REQUIRED` and `OPTIONAL` fields. No repetition, therefore
-  no Dremel shredding and no repetition levels. This is the write-side counterpart of
-  the reader's `FlatRowReader` fast path and covers the majority of analytics files.
+- **All column shapes** — `REQUIRED`, `OPTIONAL`, and `REPEATED` fields, and nested
+  groups (structs, lists, maps): definition levels, repetition levels, and Dremel
+  shredding, mirroring the reader's nested model. Flat columns (`REQUIRED` / `OPTIONAL`,
+  no repetition) — the write-side counterpart of the reader's `FlatRowReader` fast path,
+  covering the majority of analytics files — are delivered first as the thinnest slice,
+  and nesting is built on that settled contract.
 - **Columnar batch input** — the user fills a `ColumnBatch` the writer hands to a
   filler: an aligned slice carrying one typed array per column, addressed by index or
-  name, mirroring `ColumnReader`. The writer re-chunks batches into pages and row groups
-  internally. A row-oriented writer and integration adapters layer on top later.
+  name, mirroring `ColumnReader`. Nested columns carry per-layer validity and offsets,
+  the write-side analog of the reader's `getLayerValidity` / `getLayerOffsets`. The
+  writer re-chunks batches into pages and row groups internally. A row-oriented writer
+  and integration adapters layer on top later.
 - **DataPage V1** as the written page format, for maximum reader compatibility.
 
-Logical-type annotations (STRING, DATE, TIMESTAMP, DECIMAL, UUID, …) are in scope
-for the flat milestone: a column's physical bytes are written by the primitive-type
-increment, and the annotation is serialized onto the schema and converted at the API
-boundary.
+Logical-type annotations (STRING, DATE, TIMESTAMP, DECIMAL, UUID, …) are in scope: a
+column's physical bytes are written by the primitive-type increment, and the annotation
+is serialized onto the schema and converted at the API boundary.
 
-Explicitly out of the first milestone, sequenced as later work: nested data
-(structs, lists, maps), DataPage V2, the Avro write API, the optional index
-structures (OffsetIndex, ColumnIndex, Bloom filters), the optional delta and
-byte-stream-split encoders, and the S3 `OutputFile` backend. Sorting-column
-metadata and custom record materializers are non-goals.
+Sequenced as later work, each its own design: DataPage V2, the Avro write API, the
+optional index structures (OffsetIndex, ColumnIndex, Bloom filters), the optional delta
+and byte-stream-split encoders, a CLI write/convert command, and the S3 `OutputFile`
+backend. Sorting-column metadata and custom record materializers are non-goals.
 
 ## Write model
 
@@ -92,6 +95,39 @@ explicit boundary method. A caller holding whole columns submits them as one lar
 batch and the writer slices it into pages and row groups; a streaming producer submits
 many small batches and discards each after handing it over.
 
+### Null representation
+
+An `OPTIONAL` column carries its nulls as a `Validity` — the same type the reader returns
+from `getLeafValidity()`, promoted to the neutral `dev.hardwood` package so it is shared
+read/write vocabulary rather than reader-owned. Because `Validity` is an interface, the
+representation is chosen by the factory the caller uses: `NO_NULLS` (a singleton, no
+allocation), `of(long[])` for a packed present-bitmap, `ofNulls(boolean[])` to bridge a
+plain mask, and, in a later increment, a sparse form for the few-nulls case. The writer
+consumes whichever it is given the same way — `nextNull(from, end)` walks the null
+positions per page — so a new representation is a drop-in with no change to the write API.
+The polarity is null-centric (`Validity.isNull`), matching the reader, so a value read
+back as null is written by marking that row null.
+
+The values array is full length — one slot per row — and the entry at a null row is
+ignored. The common all-present case needs no `Validity` at all: the mask-less setter is
+the all-present form for both `REQUIRED` and `OPTIONAL` columns. A `boolean[]` overload is
+kept as convenience sugar over `Validity.ofNulls` (`nulls[i] == true` ⇒ null); it is the
+only null form whose length is validated against the values, since a `Validity` has no
+intrinsic length. A null mask is rejected on a `REQUIRED` column. `Validity` remains
+`@Experimental` — its shape may still shift — so the writer overload that takes it is
+experimental too until the concept is stabilized alongside the zero-copy `ColumnVector`
+SPI.
+
+The mask is lowered to definition levels at page seal: a flat `OPTIONAL` column has
+`maxDefinitionLevel == 1`, so each row's level is `1` when present and `0` when null. The
+levels are RLE/bit-packed (bit width 1) by `LevelEncoder` over the shared
+`RleBitPackingHybridEncoder`, and only the non-null values are `PLAIN`-encoded. A DataPage
+V1 body is therefore `[4-byte LE def-level length][RLE def-levels][PLAIN non-null values]`,
+with the page header's `num_values` counting all rows including nulls — the exact layout
+the reader parses. An all-present optional column encodes its levels as a single RLE run,
+which is what lets the reader take its all-present fast path. A `REQUIRED` column has no
+level stream and writes its values directly.
+
 Internally a batch's per-column arrays sit behind a bulk **value-source seam**
 (`IntColumnSource` and its per-type siblings: a `size()` plus a `copyInto` that fills a
 reused page-sized primitive buffer), with an `int[]`-backed implementation. Encoders,
@@ -103,6 +139,17 @@ a caller's buffer already holds contiguous little-endian `PLAIN` bytes — is a 
 additive layer, sequenced after nulls and dictionary settle the value and validity
 facets it must expose. The primitive-array setters are sugar over the seam, so adding
 the SPI never changes the `writeBatch` signature or the row-group machinery.
+
+### Nested representation
+
+`REPEATED` fields and nested groups shred into the same page layout as flat columns,
+with a repetition-level stream ahead of the definition levels — a DataPage V1 body of
+`[rep levels][def levels][values]`, both level streams RLE/bit-packed via `LevelEncoder`.
+Rep and def levels are computed from the batch's per-layer validity and offsets (the
+write-side inverse of the reader's Dremel assembly) by a `RecordShredder`. The detailed
+shredding algorithm and the nested `ColumnBatch` input contract are settled in
+`_designs/WRITER_NESTED.md` (delivery stage 5) and implemented structs → lists → maps in
+stages 6–8.
 
 ### OutputFile abstraction
 
@@ -139,7 +186,7 @@ the thrift codec sit alongside their decode counterparts as shared substrate.
 | Public API | `dev.hardwood.writer` | `ParquetFileWriter`, `ColumnBatch`, `WriterConfig` |
 | Public API | `dev.hardwood` | `OutputFile` |
 | Public API | `dev.hardwood.schema` | `FileSchema.Builder` (produces the existing immutable `FileSchema`) |
-| Orchestration | `dev.hardwood.internal.writer` | `RowGroupBuffer`, `ColumnChunkBuffer`, `PageBuilder`, `IntColumnSource` (value-source seam), `StatisticsCollector`, `OutputFile` backends |
+| Orchestration | `dev.hardwood.internal.writer` | `RowGroupBuffer`, `ColumnChunkBuffer`, `PageBuilder`, `RecordShredder` (rep/def-level computation for nested columns), `IntColumnSource` (value-source seam), `StatisticsCollector`, `OutputFile` backends |
 | Value encoding | `dev.hardwood.internal.encoding` | `PlainEncoder`, `RleBitPackingHybridEncoder`, `LevelEncoder`, `DictionaryEncoder` (alongside the existing decoders) |
 | Compression | `dev.hardwood.internal.compression` | `Compressor` / `CompressorFactory` (alongside `Decompressor`) |
 | Metadata serialization | `dev.hardwood.internal.thrift` | `ThriftCompactWriter`, `FileMetaDataWriter`, `SchemaElementWriter`, `RowGroupWriter`, `ColumnChunkWriter`, `ColumnMetaDataWriter`, `PageHeaderWriter` (the `*Writer` inverses of the existing `*Reader`s) |
@@ -148,15 +195,34 @@ The thrift `*Writer` classes are pure struct serializers, the inverse of the
 `*Reader`s and co-located with them; the `internal.writer` orchestration types
 carry the distinct `*Buffer` / `*Builder` names so they do not collide.
 
+### Page construction
+
+Assembling a data page — lowering definition levels, `PLAIN`- or dictionary-encoding
+the values, framing the header (`num_values`, sizes, CRC) and, later, compressing the
+body — is a single seam, `PageBuilder`. It is a **per-seal operation over already-filled
+buffers, not a stateful object that owns them**: the value, null, and level arrays stay
+in `ColumnChunkBuffer`, primitive and type-specialized, so appends remain bulk
+`copyInto` copies rather than per-value calls and each physical type keeps its own
+primitive buffer without a generic boxed page. This keeps two independent axes apart —
+per-type *buffer management* in the chunk buffer, per-encoding *body assembly* in
+`PageBuilder`.
+
+Through stage 4 the only page shape is `[def levels?][PLAIN values]`, so
+`ColumnChunkBuffer` assembles it inline (its `sealPage`). `PageBuilder` is introduced at
+**stage 6**, when `RLE_DICTIONARY` bodies — and compressed bodies at stage 7 — add the
+body and framing variants that would otherwise accrete as branches inside the chunk
+buffer. Extracting the seam at that point, rather than earlier, lets it take its shape
+from the variants it must actually span instead of from the single `PLAIN` case.
+
 ### Schema construction
 
 The writer reuses the immutable `FileSchema` / `SchemaNode` model unchanged — files
 it writes are read back through the same model. A `FileSchema.Builder` constructs
-that model programmatically and computes max definition levels. The initial builder
-takes a field name, physical type and repetition; a logical-type overload (and the
-`FIXED_LEN_BYTE_ARRAY` type length plus `DECIMAL` scale/precision) arrives with the
-logical-type increment. The builder rejects repeated fields until nested support
-lands, so unsupported schemas fail at construction rather than mid-write.
+that model programmatically and computes max definition and repetition levels. It takes
+both flat fields (name, physical type, repetition) and nested groups (structs, lists,
+maps); a logical-type overload (and the `FIXED_LEN_BYTE_ARRAY` type length plus `DECIMAL`
+scale/precision) arrives with the logical-type increment. A schema the writer cannot yet
+produce is rejected at construction rather than mid-write.
 
 Logical types are written in two parts. The **annotation** — the `LogicalType` union
 and the legacy `converted_type`/`scale`/`precision` fields on `SchemaElement` — is
@@ -171,12 +237,12 @@ with the row-oriented API; the columnar API takes physical values directly.
 The writer auto-selects sensible per-column encodings and exposes overrides through
 `WriterConfig`; the CLI surface stays minimal.
 
-- **Levels**: definition levels are RLE/bit-packed via `LevelEncoder` (flat schemas
-  have no repetition levels).
+- **Levels**: definition and repetition levels are RLE/bit-packed via `LevelEncoder`
+  (flat schemas have no repetition levels; nested columns add a repetition-level stream).
 - **Values**: `PLAIN` is the correctness baseline. `RLE_DICTIONARY` with plain
   fallback (on dictionary-size overflow) is the default for eligible columns, matching
   the reader's dictionary fast paths. The delta and byte-stream-split encodings are
-  optional and deferred to after the flat milestone.
+  optional and deferred to a later breadth increment.
 - **Compression**: `UNCOMPRESSED` first, then `SNAPPY` / `ZSTD` / `GZIP` / `LZ4` —
   the existing codec libraries are bidirectional, so the encode side reuses them.
   Default codec is `ZSTD`.
@@ -241,11 +307,11 @@ validation above, so `main` never holds functionality that cannot produce a read
 file.
 
 The sequencing is **dimension-first**: prove the thinnest slice through each
-architectural dimension — paging, row-group cadence, nulls, dictionary pages,
+architectural dimension — paging, row-group cadence, nulls, nesting, dictionary pages,
 compression, statistics — on a single type (`INT32`) before going wide. Type, encoding, and codec **breadth** is the same proven mechanism repeated, so
 it is deferred until every dimension is settled; otherwise a late dimension would
-reshape an already-multiplied surface (adding nulls or the streaming API after N typed
-methods exist rewrites all N). Each increment carries a **Kind**: *Dimension* (changes
+reshape an already-multiplied surface (adding nulls, repetition levels, or the streaming
+API after N typed methods exist rewrites all N). Each increment carries a **Kind**: *Dimension* (changes
 the shape of the solution), *Breadth* (more of a proven mechanism), *Layer* (additive
 API), *Optimization*, *Spike* (design-only), or *Docs* (user-facing documentation).
 
@@ -254,35 +320,39 @@ API), *Optimization*, *Spike* (design-only), or *Docs* (user-facing documentatio
 | 1 | Tracer: flat `REQUIRED INT32`, one page / one row group, `PLAIN`, uncompressed. `OutputFile` (local + in-memory), `ThriftCompactWriter`, page-header + footer serialization. | Dimension | Produces a real, readable file | 1 (ThriftCompactWriter), 3.2 (page header ser.), 4.1/4.2 (chunk/row-group ser.), 5.2 (FileMetaData ser.) | [x] |
 | 2 | Page chunking within a column chunk: a large `INT32` column written as multiple size-bounded `PLAIN` pages instead of one, replacing the single-page guard. Internal — the columnar API is unchanged. Each page carries a CRC-32 checksum over its on-disk body. | Dimension | Large columns written safely, bounded page size | 6.2 (multi-page data writing), 3.2 (CRC write) | [x] |
 | 3 | **Row-group cadence** (`REQUIRED INT32` only): the `ColumnBatch` submission API, multi-row-group append, size-based auto-flush (page + row-group targets), and `WriterConfig`. Locks how the caller feeds data and how the file is banded into row groups. | Dimension | The public write cadence is settled | 6.2 (row-group size tracking, automatic flushing) | [x] |
-| 4 | Nullable columns (`OPTIONAL INT32`): definition levels via `LevelEncoder`, and how nulls ride inside a `ColumnBatch`. | Dimension | The null / def-level data model is settled | 2.3, 3.3 | [ ] |
-| 5 | Nested design spike: confirm the settled `ColumnBatch` contract extends to repetition levels and shredding. Design only, no implementation. | Spike | De-risks the nested milestone as soon as the contract is settled | 6.3 (design) | [ ] |
-| 6 | Dictionary encoding (`INT32`, `REQUIRED` and `OPTIONAL`): dictionary page + `RLE_DICTIONARY` indices + plain fallback, exercised on a nullable column so the def-level / dictionary-index page layout is proven together. | Dimension | Dictionary column-chunk layout proven, including with nulls | 2.2 | [ ] |
-| 7 | Compression on the write path (`INT32`, one codec). | Dimension | Compress step + compressed/uncompressed size accounting proven | 6.2 (page compression) | [ ] |
-| 8 | Column statistics (`INT32`: `min`/`max`/`null_count`, `ColumnOrder`-correct) accumulated during encode. | Dimension | Produced files support pushdown | 9.1 (stats) | [ ] |
-| 9 | All primitive physical types (incl. `FIXED_LEN_BYTE_ARRAY` type length and `BYTE_ARRAY` min/max truncation), each inheriting paging, nulls, dictionary, compression and stats. Variable-width values end the constant-bytes-per-row assumption, so the row-group flush moves from the fixed rows-per-group proxy (`rowGroupTargetBytes / (columnCount × 4)`) to tracking the actual buffered uncompressed bytes. | Breadth | Write any flat column type | 2.1, 9.1 (truncation) | [ ] |
-| 10 | Logical-type annotations: `LogicalTypeWriter` serializes the `LogicalType` union and legacy `converted_type`/`scale`/`precision`; `FileSchema.Builder` logical-type overload. | Breadth | Columns read back with their logical type (STRING, DATE, TIMESTAMP, DECIMAL, …) | 6.4 (annotation) | [ ] |
-| 11 | Remaining codecs + optional delta and byte-stream-split encoders. | Breadth | Full codec / encoding choice | 2.4, 2.5 | [ ] |
-| 12 | Parallel column encoding + row-group pipelining. | Optimization | Write throughput | — | [ ] |
-| 13 | Row-oriented `ParquetWriter` ergonomic layer on the columnar core, including logical-type value conversion (inverse of `LogicalTypeConverter`). | Layer | Mainstream-friendly API | 6.1 (`ParquetWriter`), 6.4 (value conversion) | [ ] |
-| 14 | User-facing documentation under `docs/content/` for the writer public API (`OutputFile`, `ParquetFileWriter`, `FileSchema.Builder`): a `how-to` guide and a `reference` page, covering the settled surface including the row-oriented layer. | Docs | Documented, stable public API | — | [ ] |
+| 4 | Nullable columns (`OPTIONAL INT32`): definition levels via `LevelEncoder`, and how nulls ride inside a `ColumnBatch`. | Dimension | The null / def-level data model is settled | 2.3, 3.3 | [x] |
+| 5 | **Nested write design**: the shredding model (rep/def-level computation from struct / list / map nesting), the nested `ColumnBatch` input contract (per-layer validity + offsets, the write-side analog of `getLayerValidity` / `getLayerOffsets`), and `FileSchema.Builder` group / repeated-field support. Produces `_designs/WRITER_NESTED.md`, the reference the shredding increments implement against. | Spike | The nested write contract is settled | 6.3 (design) | [ ] |
+| 6 | **Struct shredding** (`INT32` leaves): `REQUIRED` / `OPTIONAL` nested groups — definition levels of depth > 1 and per-layer validity, no repetition yet. | Dimension | Nested structs written and read back | 3.3 (multi-level def), 6.3 | [ ] |
+| 7 | **List shredding** (`INT32` leaves): `REPEATED` fields — repetition levels via `LevelEncoder`, offset-driven nested input. | Dimension | The repetition-level data model is settled | 3.3 (rep levels), 6.3 | [ ] |
+| 8 | **Map shredding** (`INT32` leaves): key/value repeated group, reusing the list machinery. | Dimension | The full nested shape (structs, lists, maps) is settled | 6.3 | [ ] |
+| 9 | Dictionary encoding (`INT32`): dictionary page + `RLE_DICTIONARY` indices + plain fallback, exercised on nullable and nested columns so the level + dictionary-index page layout is proven together. | Dimension | Dictionary column-chunk layout proven, incl. nulls and nesting | 2.2 | [ ] |
+| 10 | Compression on the write path (`INT32`, one codec). | Dimension | Compress step + compressed/uncompressed size accounting proven | 6.2 (page compression) | [ ] |
+| 11 | Column statistics (`INT32`: `min`/`max`/`null_count`, `ColumnOrder`-correct) accumulated during encode. | Dimension | Produced files support pushdown | 9.1 (stats) | [ ] |
+| 12 | All primitive physical types (incl. `FIXED_LEN_BYTE_ARRAY` type length and `BYTE_ARRAY` min/max truncation), each inheriting paging, nulls, nesting, dictionary, compression and stats. Variable-width values end the constant-bytes-per-row assumption, so the row-group flush moves from the fixed rows-per-group proxy (`rowGroupTargetBytes / (columnCount × 4)`) to tracking the actual buffered uncompressed bytes. | Breadth | Write any column type, flat or nested | 2.1, 9.1 (truncation) | [ ] |
+| 13 | Logical-type annotations: `LogicalTypeWriter` serializes the `LogicalType` union and legacy `converted_type`/`scale`/`precision`; `FileSchema.Builder` logical-type overload. | Breadth | Columns read back with their logical type (STRING, DATE, TIMESTAMP, DECIMAL, …) | 6.4 (annotation) | [ ] |
+| 14 | Remaining codecs + optional delta and byte-stream-split encoders. | Breadth | Full codec / encoding choice | 2.4, 2.5 | [ ] |
+| 15 | Parallel column encoding + row-group pipelining. | Optimization | Write throughput | — | [ ] |
+| 16 | Row-oriented `ParquetWriter` ergonomic layer on the columnar core, including nested record materialization and logical-type value conversion (inverse of `LogicalTypeConverter`). | Layer | Mainstream-friendly API | 6.1 (`ParquetWriter`), 6.4 (value conversion) | [ ] |
+| 17 | User-facing documentation under `docs/content/` for the writer public API (`OutputFile`, `ParquetFileWriter`, `FileSchema.Builder`): a `how-to` guide and a `reference` page, covering the settled surface including nesting and the row-oriented layer. | Docs | Documented, stable public API | — | [ ] |
 
-Increments 1–8 settle every architectural dimension on `INT32`, with stage 5 a
-design-only checkpoint confirming the settled contract extends to nested repetition;
-9–13 are breadth and layers that build on the settled shape; 14 documents the finished
-public surface. Together they constitute the flat-writer milestone (1.1). Later milestones, each their own design and sequence: nested
-shredding implementation (Dremel: structs → lists → maps), DataPage V2, the optional index
-structures and Bloom filters, the Avro write adapter, a CLI write/convert command, and the
-S3 `OutputFile` backend.
+Increments 1–4 settle the flat dimensions on `INT32`; 5–8 settle the nested shape —
+design, then struct / list / map shredding — on `INT32`; 9–11 finish the remaining
+dimensions (dictionary, compression, statistics) on the now flat-and-nested shape; 12–16
+are breadth and layers that build on the settled shape; 17 documents the finished public
+surface. Together they constitute the write-support milestone (#9). Sequenced as later
+work, each its own design and sequence: DataPage V2, the optional index structures and
+Bloom filters, the Avro write adapter, a CLI write/convert command, and the S3
+`OutputFile` backend.
 
 ## User documentation
 
 User-facing documentation under `docs/content/` is delivered as the closing increment
-of the milestone (stage 14), once the full public surface — including the row-oriented
-layer — is settled. Documenting the provisional `INT32`-only surface earlier would be
-throwaway, so deferring is a recorded, intentional exception to the CLAUDE.md rule that
-a new public API ships with a docs update — not an oversight. The public surface
+of the milestone (stage 17), once the full public surface — including nesting and the
+row-oriented layer — is settled. Documenting the provisional `INT32`-only surface earlier
+would be throwaway, so deferring is a recorded, intentional exception to the CLAUDE.md
+rule that a new public API ships with a docs update — not an oversight. The public surface
 (`OutputFile`, `ParquetFileWriter`, `FileSchema.Builder`) gets its `how-to`/`reference`
-pages at stage 14.
+pages at stage 17.
 
 ## Roadmap reconciliation
 

--- a/core/src/main/java/dev/hardwood/Validity.java
+++ b/core/src/main/java/dev/hardwood/Validity.java
@@ -5,14 +5,14 @@
  *
  *  Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
  */
-package dev.hardwood.reader;
+package dev.hardwood;
 
-import dev.hardwood.Experimental;
-import dev.hardwood.internal.reader.BackedValidity;
-import dev.hardwood.internal.reader.NoNullsValidity;
+import dev.hardwood.internal.BackedValidity;
+import dev.hardwood.internal.NoNullsValidity;
 
-/// Per-item null bitmap at a [ColumnReader] scope (a `STRUCT` /
-/// `REPEATED` layer or the leaf).
+/// Per-item nullability over a run of items, shared by the reader and the writer: the
+/// reader returns it (a column-reader leaf or `STRUCT` / `REPEATED` layer scope), and the
+/// writer accepts it as a column's null mask.
 ///
 /// A `Validity` is one of two shapes:
 ///

--- a/core/src/main/java/dev/hardwood/Validity.java
+++ b/core/src/main/java/dev/hardwood/Validity.java
@@ -57,6 +57,35 @@ public interface Validity {
         return words == null ? NO_NULLS : new BackedValidity(words);
     }
 
+    /// Builds a `Validity` over a per-item null mask, where `nulls[i] == true` marks item
+    /// `i` null — the null-centric polarity of [#isNull]. Returns [#NO_NULLS] when no item
+    /// is null, so the all-present fast path is preserved. This is the convenience bridge
+    /// for callers holding a plain `boolean[]`; the packed [#of] and future sparse
+    /// factories give more compact shapes for their respective cases.
+    ///
+    /// @param nulls the per-item null mask; not retained
+    /// @return a `Validity` with the given nulls, or [#NO_NULLS] if there are none
+    static Validity ofNulls(boolean[] nulls) {
+        boolean hasNull = false;
+        for (boolean isNull : nulls) {
+            if (isNull) {
+                hasNull = true;
+                break;
+            }
+        }
+        if (!hasNull) {
+            return NO_NULLS;
+        }
+        // set-bit = present, so set a bit for every non-null item and leave nulls clear.
+        long[] words = new long[(nulls.length + 63) >>> 6];
+        for (int i = 0; i < nulls.length; i++) {
+            if (!nulls[i]) {
+                words[i >>> 6] |= 1L << i;
+            }
+        }
+        return new BackedValidity(words);
+    }
+
     /// `true` iff at least one item at this scope is null in the current
     /// batch. O(1). May help on hot loops as a per-batch fast-path gate:
     /// ```java

--- a/core/src/main/java/dev/hardwood/internal/BackedValidity.java
+++ b/core/src/main/java/dev/hardwood/internal/BackedValidity.java
@@ -5,9 +5,9 @@
  *
  *  Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
  */
-package dev.hardwood.internal.reader;
+package dev.hardwood.internal;
 
-import dev.hardwood.reader.Validity;
+import dev.hardwood.Validity;
 
 /// [Validity] whose per-item nullability is stored in a packed `long[]`
 /// (set bit = item is present). Constructed by [Validity#of] when at least

--- a/core/src/main/java/dev/hardwood/internal/NoNullsValidity.java
+++ b/core/src/main/java/dev/hardwood/internal/NoNullsValidity.java
@@ -5,9 +5,9 @@
  *
  *  Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
  */
-package dev.hardwood.internal.reader;
+package dev.hardwood.internal;
 
-import dev.hardwood.reader.Validity;
+import dev.hardwood.Validity;
 
 /// [Validity] for the case where every item at a scope is non-null in the
 /// current batch. Stateless; use the [#INSTANCE] singleton (exposed to

--- a/core/src/main/java/dev/hardwood/internal/encoding/LevelEncoder.java
+++ b/core/src/main/java/dev/hardwood/internal/encoding/LevelEncoder.java
@@ -1,0 +1,42 @@
+/*
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Copyright The original authors
+ *
+ *  Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package dev.hardwood.internal.encoding;
+
+/// Encodes definition (or repetition) levels for a DataPage V1 body, the inverse of the
+/// level decoding in the reader's page decoder. Levels are always RLE/bit-packed hybrid
+/// in V1, with a bit width derived from the maximum level.
+///
+/// The returned bytes are the bare hybrid stream; the caller frames a page by prefixing
+/// the 4-byte little-endian length, exactly as the reader expects it.
+public final class LevelEncoder {
+
+    private LevelEncoder() {
+    }
+
+    /// Encodes `count` levels starting at `offset`, using the bit width for `maxLevel`.
+    ///
+    /// @param levels the level values
+    /// @param offset index of the first level to encode
+    /// @param count number of levels to encode
+    /// @param maxLevel the column's maximum level, which fixes the bit width
+    /// @return the RLE/bit-packed hybrid bytes, without the 4-byte length prefix
+    public static byte[] encode(int[] levels, int offset, int count, int maxLevel) {
+        RleBitPackingHybridEncoder encoder = new RleBitPackingHybridEncoder(bitWidth(maxLevel));
+        encoder.writeInts(levels, offset, count);
+        return encoder.toByteArray();
+    }
+
+    /// Minimum number of bits needed to represent levels in `[0, maxLevel]`, matching the
+    /// reader's `getBitWidth`.
+    public static int bitWidth(int maxLevel) {
+        if (maxLevel == 0) {
+            return 0;
+        }
+        return 32 - Integer.numberOfLeadingZeros(maxLevel);
+    }
+}

--- a/core/src/main/java/dev/hardwood/internal/encoding/RleBitPackingHybridDecoder.java
+++ b/core/src/main/java/dev/hardwood/internal/encoding/RleBitPackingHybridDecoder.java
@@ -55,7 +55,9 @@ public class RleBitPackingHybridDecoder {
         this.dataEnd = offset + length;
         this.pos = offset;
         this.bitWidth = bitWidth;
-        this.bitMask = (bitWidth == 0) ? 0 : (1 << bitWidth) - 1;
+        // (1 << 32) - 1 wraps to 0 in Java (the shift count is taken mod 32), so a width of
+        // 32 needs an explicit all-ones mask, matching the encoder's 32-bit handling.
+        this.bitMask = (bitWidth == 0) ? 0 : (bitWidth == 32) ? -1 : (1 << bitWidth) - 1;
     }
 
     public void readInts(int[] buffer, int offset, int count) {

--- a/core/src/main/java/dev/hardwood/internal/encoding/RleBitPackingHybridEncoder.java
+++ b/core/src/main/java/dev/hardwood/internal/encoding/RleBitPackingHybridEncoder.java
@@ -1,0 +1,183 @@
+/*
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Copyright The original authors
+ *
+ *  Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package dev.hardwood.internal.encoding;
+
+import java.util.Arrays;
+
+/// Encoder for RLE/Bit-Packing Hybrid encoding, the inverse of
+/// [RleBitPackingHybridDecoder]. Used for definition/repetition levels (via
+/// [LevelEncoder]) and, later, dictionary indices.
+///
+/// Values that repeat at least eight times in a row are emitted as an RLE run; shorter
+/// stretches are bit-packed in groups of eight. Emitting a single RLE run for a constant
+/// stream is what lets the reader take its all-present fast path on a fully-populated
+/// optional column. The bit-packed byte layout is little-endian bit order, matching the
+/// decoder: value `i` of a group occupies bits `[i·bitWidth, (i+1)·bitWidth)`.
+public final class RleBitPackingHybridEncoder {
+
+    private final int bitWidth;
+    private final long mask;
+
+    private byte[] buffer = new byte[64];
+    private int length;
+
+    // Values buffered for the current, not-yet-decided run (up to one group of eight).
+    private final int[] bufferedValues = new int[8];
+    private int numBufferedValues;
+
+    // Run-length tracking for the value currently being repeated.
+    private int previousValue;
+    private int repeatCount;
+
+    // Open bit-packed run: the index of its header byte (-1 when none is open) and the
+    // number of eight-value groups written into it so far.
+    private int bitPackedRunHeaderIndex = -1;
+    private int bitPackedGroupCount;
+
+    private boolean finished;
+
+    /// @param bitWidth number of bits per value, 0–32
+    public RleBitPackingHybridEncoder(int bitWidth) {
+        if (bitWidth < 0 || bitWidth > 32) {
+            throw new IllegalArgumentException("Invalid RLE bit width: " + bitWidth + ". Must be between 0 and 32");
+        }
+        this.bitWidth = bitWidth;
+        this.mask = bitWidth == 0 ? 0 : (bitWidth == 32 ? 0xFFFFFFFFL : (1L << bitWidth) - 1);
+    }
+
+    /// Appends `count` values starting at `offset`.
+    public void writeInts(int[] values, int offset, int count) {
+        for (int i = 0; i < count; i++) {
+            writeInt(values[offset + i]);
+        }
+    }
+
+    /// Appends a single value.
+    public void writeInt(int value) {
+        if (finished) {
+            throw new IllegalStateException("Encoder already finished");
+        }
+        if (bitWidth == 0) {
+            // A 0-bit stream carries no information — the decoder reads nothing — so there
+            // is nothing to buffer or emit.
+            return;
+        }
+        if (value == previousValue) {
+            repeatCount++;
+            if (repeatCount >= 8) {
+                // Certain to become an RLE run; keep counting and defer the emit.
+                return;
+            }
+        }
+        else {
+            if (repeatCount >= 8) {
+                writeRleRun();
+            }
+            repeatCount = 1;
+            previousValue = value;
+        }
+
+        bufferedValues[numBufferedValues++] = value;
+        if (numBufferedValues == 8) {
+            writeOrAppendBitPackedRun();
+        }
+    }
+
+    /// Finishes the stream and returns the encoded bytes. The encoder must not be written
+    /// to afterwards.
+    public byte[] toByteArray() {
+        if (!finished) {
+            if (repeatCount >= 8) {
+                writeRleRun();
+            }
+            else if (numBufferedValues > 0) {
+                Arrays.fill(bufferedValues, numBufferedValues, 8, 0);
+                writeOrAppendBitPackedRun();
+                endPreviousBitPackedRun();
+            }
+            else {
+                endPreviousBitPackedRun();
+            }
+            finished = true;
+        }
+        return Arrays.copyOf(buffer, length);
+    }
+
+    private void writeOrAppendBitPackedRun() {
+        if (bitPackedGroupCount >= 63) {
+            // A bit-packed run header counts groups in the upper bits of one byte, so a
+            // run holds at most 63 groups; start a fresh one past that.
+            endPreviousBitPackedRun();
+        }
+        if (bitPackedRunHeaderIndex == -1) {
+            // Reserve the header byte; its final value is only known once the run ends.
+            write(0);
+            bitPackedRunHeaderIndex = length - 1;
+        }
+        packGroup();
+        numBufferedValues = 0;
+        // The buffered values are now written as a bit-packed group, so they must not also
+        // be counted toward a later RLE run.
+        repeatCount = 0;
+        bitPackedGroupCount++;
+    }
+
+    private void endPreviousBitPackedRun() {
+        if (bitPackedRunHeaderIndex == -1) {
+            return;
+        }
+        buffer[bitPackedRunHeaderIndex] = (byte) ((bitPackedGroupCount << 1) | 1);
+        bitPackedRunHeaderIndex = -1;
+        bitPackedGroupCount = 0;
+    }
+
+    private void writeRleRun() {
+        // Close any open bit-packed run before switching to an RLE run.
+        endPreviousBitPackedRun();
+        writeUnsignedVarInt(repeatCount << 1);
+        int byteCount = (bitWidth + 7) / 8;
+        for (int i = 0; i < byteCount; i++) {
+            write((previousValue >>> (i * 8)) & 0xFF);
+        }
+        repeatCount = 0;
+        numBufferedValues = 0;
+    }
+
+    /// Packs the eight buffered values into `bitWidth` bytes, LSB-first, matching the
+    /// decoder's little-endian bit order.
+    private void packGroup() {
+        long acc = 0;
+        int bits = 0;
+        for (int i = 0; i < 8; i++) {
+            acc |= (bufferedValues[i] & mask) << bits;
+            bits += bitWidth;
+            while (bits >= 8) {
+                write((int) (acc & 0xFF));
+                acc >>>= 8;
+                bits -= 8;
+            }
+        }
+        // 8·bitWidth is a whole number of bytes, so no partial byte remains.
+    }
+
+    private void writeUnsignedVarInt(int value) {
+        int v = value;
+        while ((v & ~0x7F) != 0) {
+            write((v & 0x7F) | 0x80);
+            v >>>= 7;
+        }
+        write(v);
+    }
+
+    private void write(int b) {
+        if (length == buffer.length) {
+            buffer = Arrays.copyOf(buffer, buffer.length * 2);
+        }
+        buffer[length++] = (byte) b;
+    }
+}

--- a/core/src/main/java/dev/hardwood/internal/writer/ColumnChunkBuffer.java
+++ b/core/src/main/java/dev/hardwood/internal/writer/ColumnChunkBuffer.java
@@ -10,11 +10,15 @@ package dev.hardwood.internal.writer;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
+import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 import java.util.zip.CRC32;
 
 import dev.hardwood.OutputFile;
+import dev.hardwood.Validity;
+import dev.hardwood.internal.encoding.LevelEncoder;
 import dev.hardwood.internal.encoding.PlainEncoder;
 import dev.hardwood.internal.thrift.PageHeaderWriter;
 import dev.hardwood.internal.thrift.ThriftCompactWriter;
@@ -24,33 +28,64 @@ import dev.hardwood.metadata.Encoding;
 import dev.hardwood.metadata.PhysicalType;
 import dev.hardwood.schema.ColumnSchema;
 
-/// Accumulates one `REQUIRED INT32` column's values for the current row group, packing
-/// them into uncompressed `PLAIN` data pages of at most the page-value capacity. Values
-/// arrive across one or more batches; a page is sealed each time the pending buffer
-/// fills, and the tail is sealed at flush. The encoded pages are held until the row
-/// group is flushed, since a column chunk's `data_page_offset` is only known when its
-/// bytes are written.
+/// Accumulates one flat `INT32` column's values for the current row group, packing them
+/// into uncompressed `PLAIN` data pages of at most the page-value capacity. Values arrive
+/// across one or more batches; a page is sealed each time the pending buffer fills, and
+/// the tail is sealed at flush. The encoded pages are held until the row group is flushed,
+/// since a column chunk's `data_page_offset` is only known when its bytes are written.
+///
+/// For an `OPTIONAL` column each page carries a definition-level stream ahead of its
+/// values: `[4-byte LE def-level length][RLE def-levels][PLAIN of the non-null values]`.
+/// A `REQUIRED` column has no levels and writes its values directly.
 final class ColumnChunkBuffer {
 
     private final int[] pending;
+    private final int maxDefLevel;
+    private final int[] defLevels;
+    private final int[] compactValues;
     private final ByteArrayOutputStream pages = new ByteArrayOutputStream();
     private int pendingCount;
     private long numValues;
 
-    /// @param pageValues maximum number of `INT32` values per data page
-    ColumnChunkBuffer(int pageValues) {
+    /// @param pageValues maximum number of rows per data page
+    /// @param maxDefLevel the column's maximum definition level (0 for `REQUIRED`, 1 for a
+    ///        flat `OPTIONAL` column), which selects whether pages carry def levels
+    ColumnChunkBuffer(int pageValues, int maxDefLevel) {
         this.pending = new int[pageValues];
+        this.maxDefLevel = maxDefLevel;
+        if (maxDefLevel > 0) {
+            this.defLevels = new int[pageValues];
+            this.compactValues = new int[pageValues];
+        }
+        else {
+            this.defLevels = null;
+            this.compactValues = null;
+        }
     }
 
-    /// Appends `count` values starting at `srcPos` in `source`, sealing pages as the
-    /// pending buffer fills.
-    void append(IntColumnSource source, int srcPos, int count) {
+    /// Appends `count` rows starting at `srcPos` in `source`, sealing pages as the pending
+    /// buffer fills. `validity` carries the rows' nulls (indexed absolutely into the batch)
+    /// or is `null` when every appended row is present.
+    void append(IntColumnSource source, Validity validity, int srcPos, int count) {
         int remaining = count;
         int from = srcPos;
         while (remaining > 0) {
             int space = pending.length - pendingCount;
             int n = Math.min(space, remaining);
             source.copyInto(from, pending, pendingCount, n);
+            if (defLevels != null) {
+                // Lower the nulls straight into def levels: start all-present (also clearing
+                // the reused slots from a prior page), then drop to level 0 wherever the
+                // validity reports a null over this range — representation agnostic, so a
+                // dense or a future sparse validity feed the same code.
+                Arrays.fill(defLevels, pendingCount, pendingCount + n, maxDefLevel);
+                if (validity != null) {
+                    int end = from + n;
+                    for (int i = validity.nextNull(from, end); i != -1; i = validity.nextNull(i + 1, end)) {
+                        defLevels[pendingCount + (i - from)] = 0;
+                    }
+                }
+            }
             pendingCount += n;
             from += n;
             remaining -= n;
@@ -67,10 +102,13 @@ final class ColumnChunkBuffer {
         sealPage();
         long totalSize = pages.size();
         out.write(ByteBuffer.wrap(pages.toByteArray()));
+        List<Encoding> encodings = defLevels == null
+                ? List.of(Encoding.PLAIN)
+                : List.of(Encoding.RLE, Encoding.PLAIN);
         // Pages are stored uncompressed, so compressed and uncompressed sizes are equal.
         return new ColumnMetaData(
                 PhysicalType.INT32,
-                List.of(Encoding.PLAIN),
+                encodings,
                 column.fieldPath(),
                 CompressionCodec.UNCOMPRESSED,
                 numValues,
@@ -89,17 +127,38 @@ final class ColumnChunkBuffer {
         if (pendingCount == 0) {
             return;
         }
-        byte[] valueBytes = PlainEncoder.encodeInts(pending, 0, pendingCount);
+        byte[] body = maxDefLevel > 0 ? optionalBody() : PlainEncoder.encodeInts(pending, 0, pendingCount);
         // CRC-32 over the page body as stored on disk (uncompressed here), matching what
         // the reader validates.
         CRC32 crc = new CRC32();
-        crc.update(valueBytes);
+        crc.update(body);
         ThriftCompactWriter header = new ThriftCompactWriter();
-        PageHeaderWriter.writeDataPageV1(header, pendingCount, valueBytes.length, valueBytes.length,
+        PageHeaderWriter.writeDataPageV1(header, pendingCount, body.length, body.length,
                 (int) crc.getValue(), Encoding.PLAIN);
         pages.writeBytes(header.toByteArray());
-        pages.writeBytes(valueBytes);
+        pages.writeBytes(body);
         numValues += pendingCount;
         pendingCount = 0;
+    }
+
+    /// Builds an `OPTIONAL` page body: the def-level length prefix, the RLE def-level
+    /// stream, then the `PLAIN` values of the non-null rows only. The def levels were
+    /// already lowered into `defLevels` as rows were appended; here they only drive the
+    /// compaction of the non-null values.
+    private byte[] optionalBody() {
+        int nonNull = 0;
+        for (int i = 0; i < pendingCount; i++) {
+            if (defLevels[i] != 0) {
+                compactValues[nonNull++] = pending[i];
+            }
+        }
+        byte[] defBytes = LevelEncoder.encode(defLevels, 0, pendingCount, maxDefLevel);
+        byte[] valueBytes = PlainEncoder.encodeInts(compactValues, 0, nonNull);
+
+        ByteArrayOutputStream body = new ByteArrayOutputStream(4 + defBytes.length + valueBytes.length);
+        body.writeBytes(ByteBuffer.allocate(4).order(ByteOrder.LITTLE_ENDIAN).putInt(defBytes.length).array());
+        body.writeBytes(defBytes);
+        body.writeBytes(valueBytes);
+        return body.toByteArray();
     }
 }

--- a/core/src/main/java/dev/hardwood/internal/writer/RowGroupBuffer.java
+++ b/core/src/main/java/dev/hardwood/internal/writer/RowGroupBuffer.java
@@ -12,6 +12,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 import dev.hardwood.OutputFile;
+import dev.hardwood.Validity;
 import dev.hardwood.metadata.ColumnChunk;
 import dev.hardwood.metadata.ColumnMetaData;
 import dev.hardwood.metadata.RowGroup;
@@ -27,23 +28,25 @@ public final class RowGroupBuffer {
     private int rowCount;
 
     /// @param schema the flat file schema
-    /// @param pageValues maximum number of `INT32` values per data page
+    /// @param pageValues maximum number of rows per data page
     public RowGroupBuffer(FileSchema schema, int pageValues) {
         this.schema = schema;
         this.columns = new ColumnChunkBuffer[schema.getColumnCount()];
         for (int c = 0; c < columns.length; c++) {
-            columns[c] = new ColumnChunkBuffer(pageValues);
+            columns[c] = new ColumnChunkBuffer(pageValues, schema.getColumn(c).maxDefinitionLevel());
         }
     }
 
     /// Appends the same row range to every column and advances the row count.
     ///
     /// @param sources one value source per column, in schema order
+    /// @param validities one [Validity] per column, in schema order; an entry is `null` for
+    ///        an all-present column
     /// @param from index of the first row to append
     /// @param count number of rows to append
-    public void appendRows(IntColumnSource[] sources, int from, int count) {
+    public void appendRows(IntColumnSource[] sources, Validity[] validities, int from, int count) {
         for (int c = 0; c < columns.length; c++) {
-            columns[c].append(sources[c], from, count);
+            columns[c].append(sources[c], validities[c], from, count);
         }
         rowCount += count;
     }

--- a/core/src/main/java/dev/hardwood/reader/ColumnReader.java
+++ b/core/src/main/java/dev/hardwood/reader/ColumnReader.java
@@ -12,6 +12,7 @@ import java.util.List;
 
 import dev.hardwood.Experimental;
 import dev.hardwood.InputFile;
+import dev.hardwood.Validity;
 import dev.hardwood.internal.ExceptionContext;
 import dev.hardwood.internal.predicate.ResolvedPredicate;
 import dev.hardwood.internal.reader.BatchExchange;

--- a/core/src/main/java/dev/hardwood/reader/SelectionEngine.java
+++ b/core/src/main/java/dev/hardwood/reader/SelectionEngine.java
@@ -20,6 +20,7 @@ import java.util.Map;
 import java.util.Set;
 import java.util.UUID;
 
+import dev.hardwood.Validity;
 import dev.hardwood.internal.predicate.BatchFilterCompiler;
 import dev.hardwood.internal.predicate.ColumnBatchMatcher;
 import dev.hardwood.internal.predicate.CompiledBatchFilter;

--- a/core/src/main/java/dev/hardwood/writer/ColumnBatch.java
+++ b/core/src/main/java/dev/hardwood/writer/ColumnBatch.java
@@ -7,9 +7,12 @@
  */
 package dev.hardwood.writer;
 
+import dev.hardwood.Experimental;
+import dev.hardwood.Validity;
 import dev.hardwood.internal.writer.IntArrayColumnSource;
 import dev.hardwood.internal.writer.IntColumnSource;
 import dev.hardwood.metadata.PhysicalType;
+import dev.hardwood.metadata.RepetitionType;
 import dev.hardwood.schema.ColumnSchema;
 import dev.hardwood.schema.FileSchema;
 
@@ -28,16 +31,38 @@ import dev.hardwood.schema.FileSchema;
 ///         .ints(0, idColumn)
 ///         .ints("value", valueColumn));
 /// ```
+///
+/// An `OPTIONAL` column carries its nulls as a [Validity] alongside its values. The values
+/// array is full length — one slot per row — and the entry at a null row is ignored. The
+/// [Validity] uses the null-centric polarity the reader exposes (`Validity#isNull`), so a
+/// value read back as null is written by marking that row null. Because [Validity] is an
+/// interface, the caller picks the representation through its factory: [Validity#NO_NULLS]
+/// for none, [Validity#ofNulls] to bridge a plain `boolean[]` mask, [Validity#of] for a
+/// packed present-bitmap — and, in the future, a sparse form — all consumed identically by
+/// the writer.
+///
+/// ```java
+/// writer.writeBatch(b -> b
+///         .ints(0, idColumn)
+///         .ints("value", valueColumn, valueNulls));       // boolean[] nulls, true = null
+/// ```
+///
+/// The [#ints(int, int[], boolean[])] overload is convenience sugar over
+/// [Validity#ofNulls]. The mask-less [#ints(int, int[])] setter is the all-present form for
+/// both `REQUIRED` and `OPTIONAL` columns; a null mask is only accepted for an `OPTIONAL`
+/// column.
 public final class ColumnBatch {
 
     private final FileSchema schema;
     private final IntColumnSource[] sources;
+    private final Validity[] validities;
     private int rowCount = -1;
     private boolean consumed;
 
     ColumnBatch(FileSchema schema) {
         this.schema = schema;
         this.sources = new IntColumnSource[schema.getColumnCount()];
+        this.validities = new Validity[schema.getColumnCount()];
     }
 
     /// Adds the values for a `REQUIRED INT32` column, addressed by index.
@@ -51,11 +76,7 @@ public final class ColumnBatch {
     /// @throws IllegalArgumentException if the index is out of range, the column is
     ///         already set, or the length does not match the other columns in this batch
     public ColumnBatch ints(int columnIndex, int[] values) {
-        if (columnIndex < 0 || columnIndex >= sources.length) {
-            throw new IllegalArgumentException(
-                    "Column index " + columnIndex + " is out of range [0, " + sources.length + ")");
-        }
-        set(columnIndex, values);
+        store(checkedIndex(columnIndex), values, null);
         return this;
     }
 
@@ -71,11 +92,111 @@ public final class ColumnBatch {
     ///         set (by name or index), or the length does not match the other columns
     public ColumnBatch ints(String columnName, int[] values) {
         // getColumn(String) throws on an unknown name, so the identifier is validated here.
-        set(schema.getColumn(columnName).columnIndex(), values);
+        store(schema.getColumn(columnName).columnIndex(), values, null);
         return this;
     }
 
-    private void set(int columnIndex, int[] values) {
+    /// Adds the values for an `OPTIONAL INT32` column, addressed by index.
+    ///
+    /// The values array is referenced, not copied, so it must not be mutated until the
+    /// batch has been written; it is full length — one slot per row — and the entry at a
+    /// null row is ignored.
+    ///
+    /// @param columnIndex zero-based leaf-column index
+    /// @param values the column's values for this batch
+    /// @param nulls the column's nulls; `nulls.isNull(i)` marks row `i` null
+    /// @return this batch, for chaining
+    /// @throws IllegalArgumentException if the index is out of range, the column is not
+    ///         `OPTIONAL`, or the column is already set
+    @Experimental
+    public ColumnBatch ints(int columnIndex, int[] values, Validity nulls) {
+        storeNullable(checkedIndex(columnIndex), values, nulls);
+        return this;
+    }
+
+    /// Adds the values for an `OPTIONAL INT32` column, addressed by name.
+    ///
+    /// @param columnName the column's name
+    /// @param values the column's values for this batch
+    /// @param nulls the column's nulls; `nulls.isNull(i)` marks row `i` null
+    /// @return this batch, for chaining
+    /// @throws IllegalArgumentException if no column has that name, the column is not
+    ///         `OPTIONAL`, or the column is already set
+    @Experimental
+    public ColumnBatch ints(String columnName, int[] values, Validity nulls) {
+        storeNullable(schema.getColumn(columnName).columnIndex(), values, nulls);
+        return this;
+    }
+
+    /// Adds the values for an `OPTIONAL INT32` column, addressed by index, with nulls given
+    /// as a plain mask. Convenience sugar over [#ints(int, int[], Validity)] and
+    /// [Validity#ofNulls]; unlike the [Validity] form, the mask length is checked against
+    /// the values.
+    ///
+    /// @param columnIndex zero-based leaf-column index
+    /// @param values the column's values for this batch
+    /// @param nulls the per-row null mask; `nulls[i] == true` marks row `i` null
+    /// @return this batch, for chaining
+    /// @throws IllegalArgumentException if the index is out of range, the column is not
+    ///         `OPTIONAL`, the column is already set, or the lengths do not agree
+    @Experimental
+    public ColumnBatch ints(int columnIndex, int[] values, boolean[] nulls) {
+        int idx = checkedIndex(columnIndex);
+        storeNullable(idx, values, maskToValidity(idx, values, nulls));
+        return this;
+    }
+
+    /// Adds the values for an `OPTIONAL INT32` column, addressed by name, with nulls given
+    /// as a plain mask. Convenience sugar over [#ints(String, int[], Validity)] and
+    /// [Validity#ofNulls].
+    ///
+    /// @param columnName the column's name
+    /// @param values the column's values for this batch
+    /// @param nulls the per-row null mask; `nulls[i] == true` marks row `i` null
+    /// @return this batch, for chaining
+    /// @throws IllegalArgumentException if no column has that name, the column is not
+    ///         `OPTIONAL`, the column is already set, or the lengths do not agree
+    @Experimental
+    public ColumnBatch ints(String columnName, int[] values, boolean[] nulls) {
+        int idx = schema.getColumn(columnName).columnIndex();
+        storeNullable(idx, values, maskToValidity(idx, values, nulls));
+        return this;
+    }
+
+    private int checkedIndex(int columnIndex) {
+        if (columnIndex < 0 || columnIndex >= sources.length) {
+            throw new IllegalArgumentException(
+                    "Column index " + columnIndex + " is out of range [0, " + sources.length + ")");
+        }
+        return columnIndex;
+    }
+
+    private Validity maskToValidity(int columnIndex, int[] values, boolean[] nulls) {
+        if (nulls == null) {
+            throw new IllegalArgumentException("nulls must not be null for column " + describe(columnIndex)
+                    + "; use the mask-less ints(...) for an all-present column");
+        }
+        if (values != null && values.length != nulls.length) {
+            throw new IllegalArgumentException("Column " + describe(columnIndex) + " has " + values.length
+                    + " values but " + nulls.length + " null flags");
+        }
+        return Validity.ofNulls(nulls);
+    }
+
+    private void storeNullable(int columnIndex, int[] values, Validity nulls) {
+        ColumnSchema column = schema.getColumn(columnIndex);
+        if (column.repetitionType() != RepetitionType.OPTIONAL) {
+            throw new IllegalArgumentException("Column " + describe(columnIndex) + " is "
+                    + column.repetitionType() + "; a null mask is only valid for an OPTIONAL column");
+        }
+        if (nulls == null) {
+            throw new IllegalArgumentException("nulls must not be null for column " + describe(columnIndex)
+                    + "; use the mask-less ints(...) for an all-present column");
+        }
+        store(columnIndex, values, nulls);
+    }
+
+    private void store(int columnIndex, int[] values, Validity validity) {
         if (consumed) {
             throw new IllegalStateException("Batch has already been written and cannot be modified");
         }
@@ -98,6 +219,7 @@ public final class ColumnBatch {
                     + values.length + " values but the batch row count is " + rowCount);
         }
         sources[columnIndex] = new IntArrayColumnSource(values);
+        validities[columnIndex] = validity;
     }
 
     private String describe(int columnIndex) {
@@ -123,5 +245,11 @@ public final class ColumnBatch {
             }
         }
         return sources;
+    }
+
+    /// The per-column nulls in column order, parallel to [#completedSources]. An entry is
+    /// `null` for an all-present column (`REQUIRED`, or `OPTIONAL` set without a mask).
+    Validity[] validities() {
+        return validities;
     }
 }

--- a/core/src/main/java/dev/hardwood/writer/ParquetFileWriter.java
+++ b/core/src/main/java/dev/hardwood/writer/ParquetFileWriter.java
@@ -18,24 +18,26 @@ import java.util.Map;
 import java.util.function.Consumer;
 
 import dev.hardwood.OutputFile;
+import dev.hardwood.Validity;
+import dev.hardwood.internal.encoding.LevelEncoder;
 import dev.hardwood.internal.thrift.FileMetaDataWriter;
 import dev.hardwood.internal.thrift.ThriftCompactWriter;
 import dev.hardwood.internal.writer.IntColumnSource;
 import dev.hardwood.internal.writer.RowGroupBuffer;
 import dev.hardwood.metadata.FileMetaData;
 import dev.hardwood.metadata.PhysicalType;
-import dev.hardwood.metadata.RepetitionType;
 import dev.hardwood.metadata.RowGroup;
 import dev.hardwood.schema.ColumnSchema;
 import dev.hardwood.schema.FileSchema;
 
 /// Writes a Parquet file through a columnar batch API.
 ///
-/// This increment writes flat schemas of `REQUIRED INT32` columns. Data is supplied as
-/// [ColumnBatch] slices; the writer packs each column into size-bounded, uncompressed
-/// `PLAIN` data pages and flushes a row group once its buffered data reaches the
-/// configured target, so peak memory is bounded regardless of how much is written. The
-/// row groups and footer are finalized on [#close()].
+/// This increment writes flat schemas of `REQUIRED` and `OPTIONAL INT32` columns. Data is
+/// supplied as [ColumnBatch] slices; the writer packs each column into size-bounded,
+/// uncompressed `PLAIN` data pages — an `OPTIONAL` column's pages carrying an RLE
+/// definition-level stream ahead of the non-null values — and flushes a row group once
+/// its buffered data reaches the configured target, so peak memory is bounded regardless
+/// of how much is written. The row groups and footer are finalized on [#close()].
 ///
 /// The file is produced front to back and is valid only after `close()` returns.
 public final class ParquetFileWriter implements Closeable {
@@ -58,8 +60,8 @@ public final class ParquetFileWriter implements Closeable {
         this.out = out;
         this.schema = schema;
         this.config = config;
-        this.pageValues = config.pageTargetBytes() / Integer.BYTES;
-        this.maxRowsPerGroup = maxRowsPerGroup(config.rowGroupTargetBytes(), schema.getColumnCount());
+        this.pageValues = pageRowCapacity(config.pageTargetBytes(), schema);
+        this.maxRowsPerGroup = maxRowsPerGroup(config.rowGroupTargetBytes(), schema);
         this.current = new RowGroupBuffer(schema, pageValues);
     }
 
@@ -69,8 +71,8 @@ public final class ParquetFileWriter implements Closeable {
     /// @param schema the flat schema to write
     /// @return an open writer
     /// @throws IOException if the destination cannot be opened
-    /// @throws UnsupportedOperationException if the schema is not a flat schema of
-    ///         `REQUIRED INT32` columns
+    /// @throws UnsupportedOperationException if the schema is not a flat schema of `INT32`
+    ///         columns
     public static ParquetFileWriter create(OutputFile out, FileSchema schema) throws IOException {
         return create(out, schema, WriterConfig.defaults());
     }
@@ -82,8 +84,8 @@ public final class ParquetFileWriter implements Closeable {
     /// @param config the writer configuration
     /// @return an open writer
     /// @throws IOException if the destination cannot be opened
-    /// @throws UnsupportedOperationException if the schema is not a flat schema of
-    ///         `REQUIRED INT32` columns
+    /// @throws UnsupportedOperationException if the schema is not a flat schema of `INT32`
+    ///         columns
     public static ParquetFileWriter create(OutputFile out, FileSchema schema, WriterConfig config)
             throws IOException {
         if (!schema.isFlatSchema()) {
@@ -94,10 +96,6 @@ public final class ParquetFileWriter implements Closeable {
             if (column.type() != PhysicalType.INT32) {
                 throw new UnsupportedOperationException(
                         "Only INT32 columns are supported; column " + column.name() + " is " + column.type());
-            }
-            if (column.repetitionType() != RepetitionType.REQUIRED) {
-                throw new UnsupportedOperationException("Only REQUIRED columns are supported; column "
-                        + column.name() + " is " + column.repetitionType());
             }
         }
         out.create();
@@ -121,13 +119,14 @@ public final class ParquetFileWriter implements Closeable {
         ColumnBatch batch = new ColumnBatch(schema);
         filler.accept(batch);
         IntColumnSource[] sources = batch.completedSources();
+        Validity[] validities = batch.validities();
         batch.markConsumed();
         int rows = batch.rowCount();
         int pos = 0;
         while (pos < rows) {
             int space = maxRowsPerGroup - current.rowCount();
             int n = Math.min(space, rows - pos);
-            current.appendRows(sources, pos, n);
+            current.appendRows(sources, validities, pos, n);
             pos += n;
             if (current.rowCount() >= maxRowsPerGroup) {
                 flushRowGroup();
@@ -188,14 +187,35 @@ public final class ParquetFileWriter implements Closeable {
         out.write(ByteBuffer.wrap(MAGIC));
     }
 
-    /// Number of rows whose values fit within the row-group target, at least one so the
-    /// writer always makes progress even with a tiny target or a wide schema.
-    private static int maxRowsPerGroup(long rowGroupTargetBytes, int columnCount) {
+    /// Rows per data page whose encoded body fits the page target. A page costs
+    /// `Integer.SIZE` bits per row for its `PLAIN` values plus, for an `OPTIONAL` column,
+    /// its RLE definition-level stream; sizing to the widest column's per-row bit cost
+    /// keeps every column's page within the target. At least one row so a tiny target
+    /// still makes progress.
+    private static int pageRowCapacity(long pageTargetBytes, FileSchema schema) {
+        int maxColumnBitsPerRow = Integer.SIZE;
+        for (int c = 0; c < schema.getColumnCount(); c++) {
+            int defBits = LevelEncoder.bitWidth(schema.getColumn(c).maxDefinitionLevel());
+            maxColumnBitsPerRow = Math.max(maxColumnBitsPerRow, Integer.SIZE + defBits);
+        }
+        long rows = pageTargetBytes * Byte.SIZE / maxColumnBitsPerRow;
+        return (int) Math.max(1, Math.min(rows, Integer.MAX_VALUE));
+    }
+
+    /// Number of rows whose buffered row-group data fits the row-group target, counting
+    /// every column's `PLAIN` values plus the RLE definition-level stream of each
+    /// `OPTIONAL` column. At least one so the writer always makes progress even with a
+    /// tiny target or a wide schema.
+    private static int maxRowsPerGroup(long rowGroupTargetBytes, FileSchema schema) {
+        int columnCount = schema.getColumnCount();
         if (columnCount == 0) {
             return Integer.MAX_VALUE;
         }
-        long bytesPerRow = (long) columnCount * Integer.BYTES;
-        long rows = rowGroupTargetBytes / bytesPerRow;
+        long bitsPerRow = (long) columnCount * Integer.SIZE;
+        for (int c = 0; c < columnCount; c++) {
+            bitsPerRow += LevelEncoder.bitWidth(schema.getColumn(c).maxDefinitionLevel());
+        }
+        long rows = rowGroupTargetBytes * Byte.SIZE / bitsPerRow;
         return (int) Math.max(1, Math.min(rows, Integer.MAX_VALUE));
     }
 

--- a/core/src/main/java/dev/hardwood/writer/package-info.java
+++ b/core/src/main/java/dev/hardwood/writer/package-info.java
@@ -8,7 +8,8 @@
 
 /// Parquet file writer with a columnar API.
 ///
-/// [ParquetFileWriter] writes a flat schema to a [dev.hardwood.OutputFile] as a
-/// single row group, taking each column's values through a typed columnar method.
-/// Build the target schema with [dev.hardwood.schema.FileSchema#builder].
+/// [ParquetFileWriter] writes a flat schema of `REQUIRED` and `OPTIONAL INT32` columns to
+/// a [dev.hardwood.OutputFile], taking each column's values through [ColumnBatch] slices
+/// and banding them into size-bounded pages and row groups. Build the target schema with
+/// [dev.hardwood.schema.FileSchema#builder].
 package dev.hardwood.writer;

--- a/core/src/test/java/dev/hardwood/ColumnReaderBatchArrayIdentityTest.java
+++ b/core/src/test/java/dev/hardwood/ColumnReaderBatchArrayIdentityTest.java
@@ -20,7 +20,7 @@ import dev.hardwood.reader.ParquetFileReader;
 import static org.assertj.core.api.Assertions.assertThat;
 
 /// Pins the public-API non-aliasing contract documented on [ColumnReader]:
-/// every array and [dev.hardwood.reader.Validity] handed back by an accessor
+/// every array and [dev.hardwood.Validity] handed back by an accessor
 /// is freshly allocated by the [ColumnReader#nextBatch()] that produced it,
 /// and a later `nextBatch()` never reuses or overwrites an array returned for
 /// an earlier batch. That guarantee is what lets a caller retain a returned
@@ -37,7 +37,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 /// family plus a `list<int32>`, four rows with the null pattern
 /// `present / null / null / present`. Read with `batchSize(2)` it yields two
 /// batches that each carry a real (backed) validity bitmap — never the shared
-/// [dev.hardwood.reader.Validity#NO_NULLS] singleton — so the validity check
+/// [dev.hardwood.Validity#NO_NULLS] singleton — so the validity check
 /// compares freshly allocated backing `long[]`s rather than the always-fresh
 /// wrapper.
 class ColumnReaderBatchArrayIdentityTest {
@@ -73,7 +73,7 @@ class ColumnReaderBatchArrayIdentityTest {
     /// The leaf validity is reported through an always-fresh wrapper, so the
     /// load-bearing pin is its backing bitmap: `getLeafValidity().words()` must
     /// be a distinct `long[]` per batch. Both batches carry nulls, so neither
-    /// collapses to the [dev.hardwood.reader.Validity#NO_NULLS] singleton.
+    /// collapses to the [dev.hardwood.Validity#NO_NULLS] singleton.
     @Test
     void leafValidityBitmapFreshPerBatch() throws Exception {
         assertBackingFreshPerBatch("ints", col -> col.getLeafValidity().words());

--- a/core/src/test/java/dev/hardwood/ColumnReaderLayerModelTest.java
+++ b/core/src/test/java/dev/hardwood/ColumnReaderLayerModelTest.java
@@ -16,7 +16,6 @@ import org.junit.jupiter.api.Test;
 import dev.hardwood.reader.ColumnReader;
 import dev.hardwood.reader.LayerKind;
 import dev.hardwood.reader.ParquetFileReader;
-import dev.hardwood.reader.Validity;
 
 import static org.assertj.core.api.Assertions.assertThat;
 

--- a/core/src/test/java/dev/hardwood/ColumnReadersTest.java
+++ b/core/src/test/java/dev/hardwood/ColumnReadersTest.java
@@ -16,7 +16,6 @@ import org.junit.jupiter.api.Test;
 import dev.hardwood.reader.ColumnReader;
 import dev.hardwood.reader.ColumnReaders;
 import dev.hardwood.reader.ParquetFileReader;
-import dev.hardwood.reader.Validity;
 import dev.hardwood.schema.ColumnProjection;
 
 import static org.assertj.core.api.Assertions.assertThat;

--- a/core/src/test/java/dev/hardwood/FixedSizeListFastPathReadTest.java
+++ b/core/src/test/java/dev/hardwood/FixedSizeListFastPathReadTest.java
@@ -21,7 +21,6 @@ import dev.hardwood.reader.LayerKind;
 import dev.hardwood.reader.ParquetFileReader;
 import dev.hardwood.reader.ReaderConfig;
 import dev.hardwood.reader.RowReader;
-import dev.hardwood.reader.Validity;
 import dev.hardwood.row.PqList;
 
 import static org.assertj.core.api.Assertions.assertThat;

--- a/core/src/test/java/dev/hardwood/NestedDictBatchBoundaryTest.java
+++ b/core/src/test/java/dev/hardwood/NestedDictBatchBoundaryTest.java
@@ -17,7 +17,6 @@ import org.junit.jupiter.api.Test;
 
 import dev.hardwood.reader.ColumnReader;
 import dev.hardwood.reader.ParquetFileReader;
-import dev.hardwood.reader.Validity;
 
 import static org.assertj.core.api.Assertions.assertThat;
 

--- a/core/src/test/java/dev/hardwood/ParquetReaderTest.java
+++ b/core/src/test/java/dev/hardwood/ParquetReaderTest.java
@@ -22,7 +22,6 @@ import dev.hardwood.reader.FilterPredicate;
 import dev.hardwood.reader.LayerKind;
 import dev.hardwood.reader.ParquetFileReader;
 import dev.hardwood.reader.RowReader;
-import dev.hardwood.reader.Validity;
 import dev.hardwood.schema.ColumnProjection;
 import dev.hardwood.schema.ColumnSchema;
 import dev.hardwood.schema.FileSchema;

--- a/core/src/test/java/dev/hardwood/ValidityTest.java
+++ b/core/src/test/java/dev/hardwood/ValidityTest.java
@@ -219,4 +219,50 @@ class ValidityTest {
         assertThat(v.nextNull(0, 64)).isEqualTo(17);
         assertThat(v.nextNotNull(17, 64)).isEqualTo(18);
     }
+
+    @Test
+    void ofNullsWithNoNullsIsNoNullsSingleton() {
+        assertThat(Validity.ofNulls(new boolean[] { false, false, false })).isSameAs(Validity.NO_NULLS);
+    }
+
+    @Test
+    void ofNullsEmptyMaskIsNoNullsSingleton() {
+        assertThat(Validity.ofNulls(new boolean[0])).isSameAs(Validity.NO_NULLS);
+    }
+
+    @Test
+    void ofNullsMixedMaskReportsNulls() {
+        // Null at indices 1 and 3; present elsewhere. ofNulls stores set-bit = present.
+        Validity v = Validity.ofNulls(new boolean[] { false, true, false, true, false });
+
+        assertThat(v.hasNulls()).isTrue();
+        assertThat(v.isNull(0)).isFalse();
+        assertThat(v.isNull(1)).isTrue();
+        assertThat(v.isNull(3)).isTrue();
+        assertThat(v.isNotNull(4)).isTrue();
+        assertThat(v.nullCount(5)).isEqualTo(2);
+        assertThat(v.nextNull(0, 5)).isEqualTo(1);
+        assertThat(v.nextNull(2, 5)).isEqualTo(3);
+    }
+
+    @Test
+    void ofNullsAllNullReportsEveryItemNull() {
+        Validity v = Validity.ofNulls(new boolean[] { true, true, true });
+
+        assertThat(v.hasNulls()).isTrue();
+        assertThat(v.nullCount(3)).isEqualTo(3);
+        assertThat(v.nextNotNull(0, 3)).isEqualTo(-1);
+    }
+
+    @Test
+    void ofNullsSpansWordBoundary() {
+        boolean[] nulls = new boolean[130];
+        nulls[65] = true;
+        nulls[128] = true;
+        Validity v = Validity.ofNulls(nulls);
+
+        assertThat(v.nullCount(130)).isEqualTo(2);
+        assertThat(v.nextNull(0, 130)).isEqualTo(65);
+        assertThat(v.nextNull(66, 130)).isEqualTo(128);
+    }
 }

--- a/core/src/test/java/dev/hardwood/ValidityTest.java
+++ b/core/src/test/java/dev/hardwood/ValidityTest.java
@@ -9,8 +9,6 @@ package dev.hardwood;
 
 import org.junit.jupiter.api.Test;
 
-import dev.hardwood.reader.Validity;
-
 import static org.assertj.core.api.Assertions.assertThat;
 
 /// Unit tests for [Validity]'s predicate and index-helper methods. The

--- a/core/src/test/java/dev/hardwood/internal/encoding/RleBitPackingHybridEncoderTest.java
+++ b/core/src/test/java/dev/hardwood/internal/encoding/RleBitPackingHybridEncoderTest.java
@@ -1,0 +1,151 @@
+/*
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Copyright The original authors
+ *
+ *  Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package dev.hardwood.internal.encoding;
+
+import java.util.Arrays;
+import java.util.Random;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/// Round-trips [RleBitPackingHybridEncoder] against [RleBitPackingHybridDecoder]: the two
+/// share no code, so agreement pins the encoded byte layout to what the reader decodes.
+class RleBitPackingHybridEncoderTest {
+
+    @Test
+    void encodesConstantStreamAsSingleRleRun() {
+        int[] values = new int[1000];
+        Arrays.fill(values, 1);
+        byte[] encoded = encode(values, 1);
+
+        // A constant stream must collapse to one RLE run so the reader's all-present
+        // definition-level fast path fires.
+        assertThat(new RleBitPackingHybridDecoder(encoded, 1).isSingleRleRunOf(1, 1000)).isTrue();
+        assertRoundTrip(values, 1, encoded);
+    }
+
+    @Test
+    void encodesAlternatingStreamViaBitPacking() {
+        int[] values = new int[64];
+        for (int i = 0; i < values.length; i++) {
+            values[i] = i % 2;
+        }
+        assertRoundTrip(values, 1);
+    }
+
+    @Test
+    void encodesCountNotMultipleOfEight() {
+        int[] values = { 1, 0, 1, 1, 0 };
+        assertRoundTrip(values, 1);
+    }
+
+    @Test
+    void encodesEmptyStream() {
+        assertRoundTrip(new int[0], 1);
+    }
+
+    @Test
+    void encodesMixedRunsAndBitPacking() {
+        // Long constant runs interleaved with noisy stretches exercise both run types and
+        // the transitions between them.
+        int[] values = new int[300];
+        int i = 0;
+        while (i < 100) {
+            values[i++] = 3;
+        }
+        for (int j = 0; j < 100; j++) {
+            values[i++] = j % 4;
+        }
+        while (i < 300) {
+            values[i++] = 0;
+        }
+        assertRoundTrip(values, 2);
+    }
+
+    @Test
+    void encodesAcrossBitWidths() {
+        Random random = new Random(42);
+        for (int bitWidth = 1; bitWidth <= 20; bitWidth++) {
+            int max = bitWidth == 32 ? Integer.MAX_VALUE : (1 << bitWidth) - 1;
+            int[] values = new int[500];
+            for (int i = 0; i < values.length; i++) {
+                values[i] = random.nextInt(max + 1);
+            }
+            assertRoundTrip(values, bitWidth);
+        }
+    }
+
+    @Test
+    void encodesWideBitWidthsThroughFullWidth() {
+        // Widths 21-32 exercise the encoder's upper range that the def-level path (width 1)
+        // never reaches but the dictionary-index path will: notably the bitWidth == 32
+        // full-word mask branch and values that set the top bit (negative as signed ints).
+        Random random = new Random(99);
+        for (int bitWidth = 21; bitWidth <= 32; bitWidth++) {
+            long mask = bitWidth == 32 ? 0xFFFFFFFFL : (1L << bitWidth) - 1;
+            int[] values = new int[500];
+            for (int i = 0; i < values.length; i++) {
+                values[i] = (int) (random.nextInt() & mask);
+            }
+            // Pin the widest value so the top bit of the range is always covered.
+            values[0] = (int) mask;
+            assertRoundTrip(values, bitWidth);
+        }
+    }
+
+    @Test
+    void spansManyBitPackedGroupsBeyondOneRunHeader() {
+        // More than 63 eight-value groups forces a second bit-packed run header.
+        int[] values = new int[8 * 100];
+        Random random = new Random(7);
+        for (int i = 0; i < values.length; i++) {
+            values[i] = random.nextInt(8);
+        }
+        assertRoundTrip(values, 3);
+    }
+
+    @Test
+    void bitWidthZeroEncodesNothing() {
+        byte[] encoded = encode(new int[] { 0, 0, 0 }, 0);
+        assertThat(encoded).isEmpty();
+    }
+
+    @Test
+    void rejectsWritingAfterFinish() {
+        RleBitPackingHybridEncoder encoder = new RleBitPackingHybridEncoder(1);
+        encoder.writeInt(1);
+        encoder.toByteArray();
+        assertThatThrownBy(() -> encoder.writeInt(0)).isInstanceOf(IllegalStateException.class);
+    }
+
+    @Test
+    void rejectsInvalidBitWidth() {
+        assertThatThrownBy(() -> new RleBitPackingHybridEncoder(33))
+                .isInstanceOf(IllegalArgumentException.class);
+        assertThatThrownBy(() -> new RleBitPackingHybridEncoder(-1))
+                .isInstanceOf(IllegalArgumentException.class);
+    }
+
+    private static byte[] encode(int[] values, int bitWidth) {
+        RleBitPackingHybridEncoder encoder = new RleBitPackingHybridEncoder(bitWidth);
+        encoder.writeInts(values, 0, values.length);
+        return encoder.toByteArray();
+    }
+
+    private static void assertRoundTrip(int[] values, int bitWidth) {
+        assertRoundTrip(values, bitWidth, encode(values, bitWidth));
+    }
+
+    private static void assertRoundTrip(int[] values, int bitWidth, byte[] encoded) {
+        int[] decoded = new int[values.length];
+        new RleBitPackingHybridDecoder(encoded, bitWidth).readInts(decoded, 0, values.length);
+        assertThat(decoded).containsExactly(values);
+    }
+}

--- a/core/src/test/java/dev/hardwood/writer/WriterDifferentialTest.java
+++ b/core/src/test/java/dev/hardwood/writer/WriterDifferentialTest.java
@@ -107,6 +107,75 @@ class WriterDifferentialTest {
     }
 
     @Test
+    void duckDbReadsNullableInts(@TempDir Path dir) throws Exception {
+        // Interior, leading and trailing nulls, with signed extremes at present rows.
+        int[] v = { 0, 0, -1, 0, Integer.MAX_VALUE, Integer.MIN_VALUE, 0 };
+        boolean[] nulls = { true, false, false, true, false, false, true };
+        int[] r = new int[v.length];
+        for (int i = 0; i < r.length; i++) {
+            r[i] = i;
+        }
+
+        FileSchema schema = FileSchema.builder("schema")
+                .addColumn("r", PhysicalType.INT32, RepetitionType.REQUIRED)
+                .addColumn("v", PhysicalType.INT32, RepetitionType.OPTIONAL)
+                .build();
+
+        Path file = dir.resolve("nullable.parquet");
+        try (ParquetFileWriter writer = ParquetFileWriter.create(OutputFile.of(file), schema)) {
+            writer.writeBatch(batch -> batch.ints(0, r).ints(1, v, nulls));
+        }
+
+        List<Integer> actual = new ArrayList<>();
+        try (Connection conn = DriverManager.getConnection("jdbc:duckdb:");
+                Statement stmt = conn.createStatement();
+                ResultSet rs = stmt.executeQuery(
+                        "SELECT v FROM read_parquet('" + file.toAbsolutePath() + "') ORDER BY r")) {
+            while (rs.next()) {
+                int value = rs.getInt("v");
+                actual.add(rs.wasNull() ? null : value);
+            }
+        }
+
+        List<Integer> expected = new ArrayList<>(v.length);
+        for (int i = 0; i < v.length; i++) {
+            expected.add(nulls[i] ? null : v[i]);
+        }
+        assertThat(actual).containsExactlyElementsOf(expected);
+    }
+
+    @Test
+    void duckDbReadsAllNullColumn(@TempDir Path dir) throws Exception {
+        int n = 1_000;
+        int[] r = new int[n];
+        boolean[] nulls = new boolean[n];
+        for (int i = 0; i < n; i++) {
+            r[i] = i;
+            nulls[i] = true;
+        }
+
+        FileSchema schema = FileSchema.builder("schema")
+                .addColumn("r", PhysicalType.INT32, RepetitionType.REQUIRED)
+                .addColumn("v", PhysicalType.INT32, RepetitionType.OPTIONAL)
+                .build();
+
+        Path file = dir.resolve("allnull.parquet");
+        try (ParquetFileWriter writer = ParquetFileWriter.create(OutputFile.of(file), schema)) {
+            writer.writeBatch(batch -> batch.ints(0, r).ints(1, new int[n], nulls));
+        }
+
+        try (Connection conn = DriverManager.getConnection("jdbc:duckdb:");
+                Statement stmt = conn.createStatement();
+                ResultSet rs = stmt.executeQuery(
+                        "SELECT count(*) AS n, count(v) AS present FROM read_parquet('"
+                                + file.toAbsolutePath() + "')")) {
+            rs.next();
+            assertThat(rs.getLong("n")).isEqualTo(n);
+            assertThat(rs.getLong("present")).isZero();
+        }
+    }
+
+    @Test
     void duckDbReadsMultipleRowGroups(@TempDir Path dir) throws Exception {
         int n = 5_000;
         int[] v = new int[n];

--- a/core/src/test/java/dev/hardwood/writer/WriterRoundTripTest.java
+++ b/core/src/test/java/dev/hardwood/writer/WriterRoundTripTest.java
@@ -19,6 +19,7 @@ import org.junit.jupiter.api.io.TempDir;
 
 import dev.hardwood.InputFile;
 import dev.hardwood.OutputFile;
+import dev.hardwood.Validity;
 import dev.hardwood.internal.metadata.PageHeader;
 import dev.hardwood.internal.thrift.PageHeaderReader;
 import dev.hardwood.internal.thrift.ThriftCompactReader;
@@ -42,6 +43,12 @@ class WriterRoundTripTest {
         return FileSchema.builder("schema")
                 .addColumn("a", PhysicalType.INT32, RepetitionType.REQUIRED)
                 .addColumn("b", PhysicalType.INT32, RepetitionType.REQUIRED)
+                .build();
+    }
+
+    private static FileSchema oneOptionalColumn() {
+        return FileSchema.builder("schema")
+                .addColumn("v", PhysicalType.INT32, RepetitionType.OPTIONAL)
                 .build();
     }
 
@@ -190,12 +197,198 @@ class WriterRoundTripTest {
     }
 
     @Test
-    void rejectsNonRequiredSchema() {
-        FileSchema schema = FileSchema.builder("schema")
-                .addColumn("v", PhysicalType.INT32, RepetitionType.OPTIONAL)
-                .build();
-        assertThatThrownBy(() -> ParquetFileWriter.create(new ByteBufferOutputFile(), schema))
-                .isInstanceOf(UnsupportedOperationException.class);
+    void writesAndReadsBackNullableColumn() throws Exception {
+        // Interior and edge nulls, and both signed extremes at present positions.
+        int[] values = { 7, 0, -3, 0, Integer.MIN_VALUE, 0, Integer.MAX_VALUE };
+        boolean[] nulls = { false, true, false, true, false, true, false };
+
+        ByteBufferOutputFile out = new ByteBufferOutputFile();
+        try (ParquetFileWriter writer = ParquetFileWriter.create(out, oneOptionalColumn())) {
+            writer.writeBatch(batch -> batch.ints(0, values, nulls));
+        }
+
+        try (ParquetFileReader reader = ParquetFileReader.open(InputFile.of(ByteBuffer.wrap(out.toByteArray())))) {
+            assertThat(readNullable(reader, 0)).containsExactly(7, null, -3, null, Integer.MIN_VALUE, null, Integer.MAX_VALUE);
+        }
+    }
+
+    @Test
+    void allPresentOptionalColumnReadsBackWithoutNulls() throws Exception {
+        // An OPTIONAL column supplied through the mask-less setter: every row is present,
+        // so the def levels collapse to a single RLE run and the reader reports no nulls.
+        int[] values = { 1, 2, 3, 4, 5 };
+
+        ByteBufferOutputFile out = new ByteBufferOutputFile();
+        try (ParquetFileWriter writer = ParquetFileWriter.create(out, oneOptionalColumn())) {
+            writer.writeBatch(batch -> batch.ints(0, values));
+        }
+
+        try (ParquetFileReader reader = ParquetFileReader.open(InputFile.of(ByteBuffer.wrap(out.toByteArray())));
+                ColumnReader column = reader.columnReader(0)) {
+            assertThat(column.nextBatch()).isTrue();
+            assertThat(column.getLeafValidity().hasNulls()).isFalse();
+            assertThat(Arrays.copyOf(column.getInts(), column.getRecordCount())).containsExactly(values);
+        }
+    }
+
+    @Test
+    void writesAndReadsBackAllNullColumn() throws Exception {
+        boolean[] nulls = { true, true, true, true };
+        int[] values = new int[nulls.length];
+
+        ByteBufferOutputFile out = new ByteBufferOutputFile();
+        try (ParquetFileWriter writer = ParquetFileWriter.create(out, oneOptionalColumn())) {
+            writer.writeBatch(batch -> batch.ints(0, values, nulls));
+        }
+
+        try (ParquetFileReader reader = ParquetFileReader.open(InputFile.of(ByteBuffer.wrap(out.toByteArray())))) {
+            assertThat(reader.getFileMetaData().numRows()).isEqualTo(4);
+            assertThat(readNullable(reader, 0)).containsExactly(null, null, null, null);
+        }
+    }
+
+    @Test
+    void nullsSurvivePageBoundaries() throws Exception {
+        // A tiny page target forces many pages; every third row is null, so nulls and
+        // values straddle page boundaries.
+        int n = 10_000;
+        int[] values = new int[n];
+        boolean[] nulls = new boolean[n];
+        for (int i = 0; i < n; i++) {
+            values[i] = i;
+            nulls[i] = i % 3 == 0;
+        }
+
+        WriterConfig config = WriterConfig.builder().pageTargetBytes(256).build();
+        ByteBufferOutputFile out = new ByteBufferOutputFile();
+        try (ParquetFileWriter writer = ParquetFileWriter.create(out, oneOptionalColumn(), config)) {
+            writer.writeBatch(batch -> batch.ints(0, values, nulls));
+        }
+
+        try (ParquetFileReader reader = ParquetFileReader.open(InputFile.of(ByteBuffer.wrap(out.toByteArray())))) {
+            assertThat(readNullable(reader, 0)).isEqualTo(expectedNullable(values, nulls));
+        }
+    }
+
+    @Test
+    void rewritesNullableColumnFromFixtureByPassingValidityThrough() throws Exception {
+        // Read a PyArrow-produced file whose OPTIONAL INT32 column has interior and trailing
+        // nulls, then write that column back by handing the reader's Validity straight to the
+        // writer — the read-to-write passthrough the Validity seam exists for. Reading the
+        // rewritten file must reproduce the original values and null positions exactly.
+        Path source = Path.of("src/test/resources/nullable_primitives_test.parquet");
+
+        Integer[] original;
+        ByteBufferOutputFile out = new ByteBufferOutputFile();
+        try (ParquetFileReader reader = ParquetFileReader.open(InputFile.of(source))) {
+            int col = reader.getFileSchema().getColumn("nullable_int").columnIndex();
+            assertThat(reader.getFileSchema().getColumn(col).type()).isEqualTo(PhysicalType.INT32);
+            assertThat(reader.getFileSchema().getColumn(col).repetitionType()).isEqualTo(RepetitionType.OPTIONAL);
+
+            original = new Integer[Math.toIntExact(reader.getFileMetaData().numRows())];
+            int pos = 0;
+            try (ParquetFileWriter writer = ParquetFileWriter.create(out, oneOptionalColumn());
+                    ColumnReader column = reader.columnReader(col)) {
+                while (column.nextBatch()) {
+                    int count = column.getRecordCount();
+                    int[] values = Arrays.copyOf(column.getInts(), count);
+                    Validity validity = column.getLeafValidity();
+                    for (int i = 0; i < count; i++) {
+                        original[pos + i] = validity.isNull(i) ? null : values[i];
+                    }
+                    // Hand the reader's Validity straight to the writer, no re-derivation.
+                    writer.writeBatch(batch -> batch.ints(0, values, validity));
+                    pos += count;
+                }
+            }
+        }
+
+        try (ParquetFileReader reader = ParquetFileReader.open(InputFile.of(ByteBuffer.wrap(out.toByteArray())))) {
+            assertThat(readNullable(reader, 0)).containsExactly(original);
+        }
+    }
+
+    @Test
+    void nullsSurviveRowGroupBoundaries() throws Exception {
+        int n = 5_000;
+        int[] values = new int[n];
+        boolean[] nulls = new boolean[n];
+        for (int i = 0; i < n; i++) {
+            values[i] = i * 2;
+            nulls[i] = (i & 1) == 1;
+        }
+
+        WriterConfig config = WriterConfig.builder().rowGroupTargetBytes(4096).build();
+        ByteBufferOutputFile out = new ByteBufferOutputFile();
+        try (ParquetFileWriter writer = ParquetFileWriter.create(out, oneOptionalColumn(), config)) {
+            writer.writeBatch(batch -> batch.ints(0, values, nulls));
+        }
+
+        try (ParquetFileReader reader = ParquetFileReader.open(InputFile.of(ByteBuffer.wrap(out.toByteArray())))) {
+            assertThat(reader.getFileMetaData().rowGroups().size()).isGreaterThan(1);
+            assertThat(readNullable(reader, 0)).isEqualTo(expectedNullable(values, nulls));
+        }
+    }
+
+    @Test
+    void writesNullableColumnViaValidity() throws Exception {
+        // Drive the primary Validity overload directly with a hand-built dense present
+        // bitmap (set-bit = present): rows 0 and 2 present, row 1 null.
+        int[] values = { 10, 20, 30 };
+        Validity nulls = Validity.of(new long[] { 0b101 });
+
+        ByteBufferOutputFile out = new ByteBufferOutputFile();
+        try (ParquetFileWriter writer = ParquetFileWriter.create(out, oneOptionalColumn())) {
+            writer.writeBatch(batch -> batch.ints(0, values, nulls));
+        }
+
+        try (ParquetFileReader reader = ParquetFileReader.open(InputFile.of(ByteBuffer.wrap(out.toByteArray())))) {
+            assertThat(readNullable(reader, 0)).containsExactly(10, null, 30);
+        }
+    }
+
+    @Test
+    void optionalColumnViaNoNullsValidityReadsBackWithoutNulls() throws Exception {
+        int[] values = { 1, 2, 3 };
+
+        ByteBufferOutputFile out = new ByteBufferOutputFile();
+        try (ParquetFileWriter writer = ParquetFileWriter.create(out, oneOptionalColumn())) {
+            writer.writeBatch(batch -> batch.ints(0, values, Validity.NO_NULLS));
+        }
+
+        try (ParquetFileReader reader = ParquetFileReader.open(InputFile.of(ByteBuffer.wrap(out.toByteArray())));
+                ColumnReader column = reader.columnReader(0)) {
+            assertThat(column.nextBatch()).isTrue();
+            assertThat(column.getLeafValidity().hasNulls()).isFalse();
+            assertThat(Arrays.copyOf(column.getInts(), column.getRecordCount())).containsExactly(values);
+        }
+    }
+
+    @Test
+    void rejectsNullMaskOnRequiredColumn() throws Exception {
+        try (ParquetFileWriter writer = ParquetFileWriter.create(new ByteBufferOutputFile(), oneColumn())) {
+            assertThatThrownBy(() -> writer.writeBatch(
+                    batch -> batch.ints(0, new int[] { 1, 2 }, new boolean[] { false, true })))
+                    .isInstanceOf(IllegalArgumentException.class);
+        }
+    }
+
+    @Test
+    void rejectsValidityOnRequiredColumn() throws Exception {
+        try (ParquetFileWriter writer = ParquetFileWriter.create(new ByteBufferOutputFile(), oneColumn())) {
+            assertThatThrownBy(() -> writer.writeBatch(
+                    batch -> batch.ints(0, new int[] { 1, 2 }, Validity.NO_NULLS)))
+                    .isInstanceOf(IllegalArgumentException.class);
+        }
+    }
+
+    @Test
+    void rejectsNullMaskLengthMismatch() throws Exception {
+        try (ParquetFileWriter writer = ParquetFileWriter.create(new ByteBufferOutputFile(), oneOptionalColumn())) {
+            assertThatThrownBy(() -> writer.writeBatch(
+                    batch -> batch.ints(0, new int[] { 1, 2, 3 }, new boolean[] { false, true })))
+                    .isInstanceOf(IllegalArgumentException.class);
+        }
     }
 
     @Test
@@ -339,6 +532,34 @@ class WriterRoundTripTest {
             }
             return result;
         }
+    }
+
+    /// Reads a flat column back into a boxed array, `null` at each null row, so both the
+    /// values and their null positions can be asserted in one comparison.
+    private static Integer[] readNullable(ParquetFileReader reader, int columnIndex) {
+        int rows = Math.toIntExact(reader.getFileMetaData().numRows());
+        Integer[] result = new Integer[rows];
+        try (ColumnReader column = reader.columnReader(columnIndex)) {
+            int pos = 0;
+            while (column.nextBatch()) {
+                int count = column.getRecordCount();
+                int[] batch = column.getInts();
+                Validity validity = column.getLeafValidity();
+                for (int i = 0; i < count; i++) {
+                    result[pos + i] = validity.isNull(i) ? null : batch[i];
+                }
+                pos += count;
+            }
+        }
+        return result;
+    }
+
+    private static Integer[] expectedNullable(int[] values, boolean[] nulls) {
+        Integer[] expected = new Integer[values.length];
+        for (int i = 0; i < values.length; i++) {
+            expected[i] = nulls[i] ? null : values[i];
+        }
+        return expected;
     }
 
     /// An [OutputFile] that throws while writing the second `PAR1` magic — the footer's

--- a/docs/content/concepts/nested-columns.md
+++ b/docs/content/concepts/nested-columns.md
@@ -53,7 +53,7 @@ separately. A flat column reports `getLayerCount() == 0`.
 
 For each layer, two buffers describe the items at that layer:
 
-- `getLayerValidity(k)` — a [Validity](/api/latest/dev/hardwood/reader/Validity.html) indexed by
+- `getLayerValidity(k)` — a [Validity](/api/latest/dev/hardwood/Validity.html) indexed by
   item position; `isNull(i)` / `isNotNull(i)` answer the per-item question, `hasNulls()` is the
   O(1) fast-path gate. Returns the shared `Validity.NO_NULLS` singleton when no item at layer `k`
   is null in this batch.

--- a/docs/content/concepts/reader-models.md
+++ b/docs/content/concepts/reader-models.md
@@ -25,7 +25,7 @@ fits depends on whether your code thinks in *records* or in *columns*.
   `getString("name")`, `getStruct("address")`. You move one row at a time and pull the fields you
   want by name or index.
 - **`ColumnReader`** hands you a column at a time, a batch at a time, as a typed primitive array
-  (`double[]`, `int[]`, …) plus a [`Validity`](/api/latest/dev/hardwood/reader/Validity.html)
+  (`double[]`, `int[]`, …) plus a [`Validity`](/api/latest/dev/hardwood/Validity.html)
   bitmap for nulls. You loop over the array directly.
 
 Both read the same bytes through the same pipeline. The difference is entirely in what they hand

--- a/docs/content/how-to/column-reader.md
+++ b/docs/content/how-to/column-reader.md
@@ -46,7 +46,7 @@ try (ParquetFileReader reader = ParquetFileReader.open(InputFile.of(path))) {
 }
 ```
 
-The [Validity](/api/latest/dev/hardwood/reader/Validity.html) type wraps the underlying null bitmap behind `isNull(i)` / `isNotNull(i)` / `hasNulls()`. When no item in a batch is null, `getLeafValidity()` (and `getLayerValidity(k)`) returns the shared `Validity.NO_NULLS` singleton — `hasNulls()` returns `false` in O(1) and gates the no-per-element-check fast path, no per-batch allocation. Hot inner loops should hoist `hasNulls()` into a local boolean before iterating; see [Hot loops](#hot-loops-hoist-hasnulls-outside-the-loop) for why.
+The [Validity](/api/latest/dev/hardwood/Validity.html) type wraps the underlying null bitmap behind `isNull(i)` / `isNotNull(i)` / `hasNulls()`. When no item in a batch is null, `getLeafValidity()` (and `getLayerValidity(k)`) returns the shared `Validity.NO_NULLS` singleton — `hasNulls()` returns `false` in O(1) and gates the no-per-element-check fast path, no per-batch allocation. Hot inner loops should hoist `hasNulls()` into a local boolean before iterating; see [Hot loops](#hot-loops-hoist-hasnulls-outside-the-loop) for why.
 
 Typed accessors are available for each fixed-width physical type: `getInts()`, `getLongs()`, `getFloats()`, `getDoubles()`, `getBooleans()`. For varlength leaves (`BINARY`, `FIXED_LEN_BYTE_ARRAY`, `INT96`) the primary accessors are `getBinaryValues()` (a `byte[]` buffer) plus `getBinaryOffsets()` (a sentinel-suffixed `int[]` of length `getValueCount() + 1`); the byte slice for value `i` is `[offsets[i], offsets[i+1])`. The convenience accessors `getBinaries()` and `getStrings()` materialise one `byte[]` or `String` per leaf — useful for low-volume / debug paths, so hot loops should read the buffers directly. `getBinaries()` allocates a fresh `byte[]` per value; `getStrings()` likewise allocates per value, except on dictionary-encoded columns, where repeated values reuse a single interned `String` per dictionary entry.
 
@@ -135,7 +135,7 @@ All three navigation methods return `null` when the group isn't of the expected 
 
 `ColumnReader` exposes a nested column's schema chain as a sequence of **layers**, numbered
 `0..getLayerCount() - 1` outermost-to-innermost, with the leaf queried separately. Each layer has a
-[Validity](/api/latest/dev/hardwood/reader/Validity.html) via `getLayerValidity(k)`; `REPEATED`
+[Validity](/api/latest/dev/hardwood/Validity.html) via `getLayerValidity(k)`; `REPEATED`
 layers (lists and maps) additionally have `getLayerOffsets(k)`; and the leaf has its own
 `getLeafValidity()`.
 

--- a/docs/content/reference/packages.md
+++ b/docs/content/reference/packages.md
@@ -15,7 +15,7 @@ Hardwood is organized into public API packages and internal implementation packa
 
 | Package | Visibility | Purpose |
 |---------|-----------|---------|
-| [`dev.hardwood`](/api/latest/dev/hardwood/package-summary.html) | **Public API** | Entry point for creating readers and managing shared resources (thread pool, decompressor pool). |
+| [`dev.hardwood`](/api/latest/dev/hardwood/package-summary.html) | **Public API** | Entry point for creating readers, managing shared resources (thread pool, decompressor pool), and the shared `Validity` null bitmap. |
 | [`dev.hardwood.reader`](/api/latest/dev/hardwood/reader/package-summary.html) | **Public API** | Single-file and multi-file readers for row-oriented and column-oriented access. |
 | [`dev.hardwood.metadata`](/api/latest/dev/hardwood/metadata/package-summary.html) | **Public API** | Parquet file metadata: row groups, column chunks, physical/logical types, and compression codecs. |
 | [`dev.hardwood.schema`](/api/latest/dev/hardwood/schema/package-summary.html) | **Public API** | Schema representation: file schema, column schemas, and column projection. |

--- a/docs/content/tutorial/first-read.md
+++ b/docs/content/tutorial/first-read.md
@@ -153,9 +153,9 @@ typed primitive arrays a batch at a time — no per-row calls. Total the fares:
 
 ```java
 import dev.hardwood.InputFile;
+import dev.hardwood.Validity;
 import dev.hardwood.reader.ColumnReader;
 import dev.hardwood.reader.ParquetFileReader;
-import dev.hardwood.reader.Validity;
 
 import java.nio.file.Path;
 
@@ -181,7 +181,7 @@ try (ParquetFileReader reader =
 ```
 
 That's the columnar path: iterate batches, read the primitive array, and check the
-[`Validity`](/api/latest/dev/hardwood/reader/Validity.html) bitmap for nulls. On analytical work
+[`Validity`](/api/latest/dev/hardwood/Validity.html) bitmap for nulls. On analytical work
 like this it's markedly faster than reading row by row.
 
 ## What you've learned

--- a/parquet-testing-runner/src/test/java/dev/hardwood/testing/Utils.java
+++ b/parquet-testing-runner/src/test/java/dev/hardwood/testing/Utils.java
@@ -38,12 +38,12 @@ import org.apache.parquet.schema.MessageType;
 import org.apache.parquet.schema.MessageTypeParser;
 import org.assertj.core.api.ThrowableAssert;
 
+import dev.hardwood.Validity;
 import dev.hardwood.metadata.LogicalType;
 import dev.hardwood.reader.ColumnReader;
 import dev.hardwood.reader.LayerKind;
 import dev.hardwood.reader.ParquetFileReader;
 import dev.hardwood.reader.RowReader;
-import dev.hardwood.reader.Validity;
 import dev.hardwood.row.PqList;
 import dev.hardwood.row.PqMap;
 import dev.hardwood.row.PqStruct;

--- a/performance-testing/end-to-end/src/test/java/dev/hardwood/perf/FlatPerformanceTest.java
+++ b/performance-testing/end-to-end/src/test/java/dev/hardwood/perf/FlatPerformanceTest.java
@@ -41,12 +41,12 @@ import org.junit.jupiter.api.TestInstance;
 
 import dev.hardwood.Hardwood;
 import dev.hardwood.InputFile;
+import dev.hardwood.Validity;
 import dev.hardwood.metadata.PhysicalType;
 import dev.hardwood.reader.ColumnReader;
 import dev.hardwood.reader.ColumnReaders;
 import dev.hardwood.reader.ParquetFileReader;
 import dev.hardwood.reader.RowReader;
-import dev.hardwood.reader.Validity;
 import dev.hardwood.schema.ColumnProjection;
 import dev.hardwood.schema.SchemaNode;
 

--- a/performance-testing/end-to-end/src/test/java/dev/hardwood/perf/NestedPerformanceTest.java
+++ b/performance-testing/end-to-end/src/test/java/dev/hardwood/perf/NestedPerformanceTest.java
@@ -29,11 +29,11 @@ import org.junit.jupiter.api.TestInstance;
 
 import dev.hardwood.Hardwood;
 import dev.hardwood.InputFile;
+import dev.hardwood.Validity;
 import dev.hardwood.reader.ColumnReader;
 import dev.hardwood.reader.LayerKind;
 import dev.hardwood.reader.ParquetFileReader;
 import dev.hardwood.reader.RowReader;
-import dev.hardwood.reader.Validity;
 import dev.hardwood.row.PqList;
 import dev.hardwood.row.PqMap;
 import dev.hardwood.row.PqStruct;

--- a/performance-testing/end-to-end/src/test/java/dev/hardwood/perf/PageScanPerformanceTest.java
+++ b/performance-testing/end-to-end/src/test/java/dev/hardwood/perf/PageScanPerformanceTest.java
@@ -24,9 +24,9 @@ import org.junit.jupiter.api.TestInstance;
 
 import dev.hardwood.Hardwood;
 import dev.hardwood.InputFile;
+import dev.hardwood.Validity;
 import dev.hardwood.reader.ColumnReader;
 import dev.hardwood.reader.ParquetFileReader;
-import dev.hardwood.reader.Validity;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.withinPercentage;

--- a/performance-testing/micro-benchmarks/src/main/java/dev/hardwood/benchmarks/ValidityIterationBenchmark.java
+++ b/performance-testing/micro-benchmarks/src/main/java/dev/hardwood/benchmarks/ValidityIterationBenchmark.java
@@ -22,7 +22,7 @@ import org.openjdk.jmh.annotations.Setup;
 import org.openjdk.jmh.annotations.State;
 import org.openjdk.jmh.annotations.Warmup;
 
-import dev.hardwood.reader.Validity;
+import dev.hardwood.Validity;
 
 /// Compares two ways of summing a `long[]` column while honoring a
 /// per-item null bitmap:


### PR DESCRIPTION
## Stage 4 — nullable columns (`OPTIONAL INT32`)

Settles the null data model in the flat writer, the last data-model dimension before type breadth (`_designs/WRITER_SUPPORT.md`, stage 4). Targets `main` (stage 3 is merged).

### Commits
1. **Move `Validity` to the neutral `dev.hardwood` package** — pure relocation (interface → `dev.hardwood`, impls → `dev.hardwood.internal`) plus reference updates across reader/tests/benchmarks, so it can be shared read/write vocabulary rather than reader-owned. No behaviour change; compiles standalone.
2. **Stage 4: nullable `OPTIONAL INT32`** — the writer changes, encoders, `Validity.ofNulls`, tests, and docs below.

### Null model
- An `OPTIONAL` column's values carry a **`Validity`**. Because it's an interface, the caller picks the representation via its factory (`NO_NULLS`, `of(long[])` dense present-bitmap, `ofNulls(boolean[])`, and a future sparse form), and the writer lowers any of them identically — `nextNull(from, end)` walks the null positions per page — so a new representation is a drop-in with **no change to the write API**.
- `boolean[] nulls` (true = null, mirroring `Validity.isNull`) is kept as convenience sugar over `Validity.ofNulls`, and is the only null form whose length is validated against the values. The mask-less setter remains the all-present form for both repetitions.
- `Validity` stays `@Experimental`, so the `Validity`-taking `ColumnBatch.ints` overloads are experimental too until the concept is stabilized alongside the zero-copy `ColumnVector` SPI.

### Encoding
- New `RleBitPackingHybridEncoder` (general, widths 0–32; inverse of the decoder) and `LevelEncoder` (def levels, bit-width 1).
- OPTIONAL DataPage V1 body: `[4-byte LE def-level length][RLE def-levels][PLAIN non-null values]`; header `num_values` counts nulls; CRC over the whole body; `ColumnMetaData` encodings `RLE + PLAIN`. An all-present column collapses to a single RLE run, preserving the reader's all-present fast path.

### Validation
- DuckDB differential reads produced **nullable** and **all-null** columns back (independent engine ⇒ spec-correct, not merely self-consistent).
- Read→write **`Validity` passthrough**: a PyArrow fixture's nullable INT32 column is rewritten by handing the reader's `Validity` straight to the writer, then re-read for equality.
- Round-trips via both the `boolean[]` sugar and the `Validity` overload: mixed nulls, all-present fast path, all-null, and nulls crossing page and row-group boundaries.
- Encoder round-trip vs decoder across widths/patterns; `Validity.ofNulls` unit tests; eager-rejection cases.

Docs: `WRITER_SUPPORT.md` null section rewritten around `Validity`; ROADMAP 2.3/3.3 ticked. Full `./mvnw verify` green across all 13 modules.