### PR TITLE
#744 Remove the hardwood.simd.disabled system property

### DIFF
--- a/core/src/main/java/dev/hardwood/internal/encoding/simd/VectorSupport.java
+++ b/core/src/main/java/dev/hardwood/internal/encoding/simd/VectorSupport.java
@@ -11,10 +11,8 @@ package dev.hardwood.internal.encoding.simd;
 ///
 /// This is the base implementation for Java 21 that always returns the scalar
 /// fallback. On Java 22+, the multi-release JAR overlay provides the real
-/// implementation with Vector API support.
-///
-/// Use `-Dhardwood.simd.disabled=true` to force scalar operations
-/// even on Java 22+ for debugging or comparison.
+/// implementation with Vector API support, engaged by adding the incubating
+/// Vector API module (`--add-modules jdk.incubator.vector`).
 public final class VectorSupport {
 
     private static final System.Logger LOG = System.getLogger(VectorSupport.class.getName());

--- a/core/src/main/java22/dev/hardwood/internal/encoding/simd/VectorSupport.java
+++ b/core/src/main/java22/dev/hardwood/internal/encoding/simd/VectorSupport.java
@@ -15,8 +15,10 @@ import jdk.incubator.vector.VectorSpecies;
 /// This is the multi-release JAR overlay that provides actual Vector API
 /// detection and SIMD operations when running on Java 22+.
 ///
-/// Use `-Dhardwood.simd.disabled=true` to force scalar operations
-/// for debugging or comparison.
+/// SIMD engages only when the incubating Vector API module is on the module
+/// path (`--add-modules jdk.incubator.vector`); without it, the Vector API
+/// reference fails to link and detection falls back to scalar operations. That
+/// launch flag is therefore the opt-out — omit it to run scalar.
 public final class VectorSupport {
 
     private static final System.Logger LOG = System.getLogger(VectorSupport.class.getName());
@@ -30,32 +32,24 @@ public final class VectorSupport {
         SimdOperations ops = new ScalarOperations();
         String implName = "scalar";
 
-        // Check if SIMD is disabled via system property
-        boolean disabled = Boolean.getBoolean("hardwood.simd.disabled");
+        try {
+            // Verify Vector API is working
+            VectorSpecies<Integer> species = IntVector.SPECIES_PREFERRED;
+            int vectorLength = species.length();
 
-        if (disabled) {
-            LOG.log(System.Logger.Level.INFO, "SIMD support: disabled via system property");
+            if (vectorLength >= 4) {
+                // Vector API is available and has reasonable vector width
+                ops = new VectorOperations();
+                available = true;
+                implName = "simd-" + species.vectorBitSize() + "bit";
+                LOG.log(System.Logger.Level.INFO, "SIMD support: enabled ({0}-bit vectors)", species.vectorBitSize());
+            }
+            else {
+                LOG.log(System.Logger.Level.INFO, "SIMD support: disabled (vector length {0} too small)", vectorLength);
+            }
         }
-        else {
-            try {
-                // Verify Vector API is working
-                VectorSpecies<Integer> species = IntVector.SPECIES_PREFERRED;
-                int vectorLength = species.length();
-
-                if (vectorLength >= 4) {
-                    // Vector API is available and has reasonable vector width
-                    ops = new VectorOperations();
-                    available = true;
-                    implName = "simd-" + species.vectorBitSize() + "bit";
-                    LOG.log(System.Logger.Level.INFO, "SIMD support: enabled ({0}-bit vectors)", species.vectorBitSize());
-                }
-                else {
-                    LOG.log(System.Logger.Level.INFO, "SIMD support: disabled (vector length {0} too small)", vectorLength);
-                }
-            }
-            catch (Throwable t) {
-                LOG.log(System.Logger.Level.INFO, "SIMD support: disabled (Vector API not available: {0})", t.getMessage());
-            }
+        catch (Throwable t) {
+            LOG.log(System.Logger.Level.INFO, "SIMD support: disabled (Vector API not available: {0})", t.getMessage());
         }
 
         AVAILABLE = available;

--- a/docs/content/reference/configuration.md
+++ b/docs/content/reference/configuration.md
@@ -74,11 +74,7 @@ SIMD support: enabled (256-bit vectors)
 
 The vector width depends on your CPU (128-bit for SSE/NEON, 256-bit for AVX2, 512-bit for AVX-512).
 
-To disable SIMD and force scalar operations (for debugging or comparison), set the system property:
-
-```bash
--Dhardwood.simd.disabled=true
-```
+SIMD engages only when the incubator module is added, so to run scalar operations (for debugging or comparison) simply omit the `--add-modules jdk.incubator.vector` argument.
 
 ## JFR (Java Flight Recorder) Events
 
@@ -117,4 +113,3 @@ Events appear under the **Hardwood** category in JDK Mission Control (JMC) or an
 | Property | Default | Description |
 |----------|---------|-------------|
 | `hardwood.uselibdeflate` | `true` | Set to `false` to disable libdeflate for GZIP decompression |
-| `hardwood.simd.disabled` | `false` | Set to `true` to force scalar operations instead of SIMD |


### PR DESCRIPTION
Closes #744.

## Summary

Removes the `hardwood.simd.disabled` system property. It forced scalar decode operations even when the incubating Vector API module was present, but it duplicated an opt-out that already exists: SIMD engages only when `--add-modules jdk.incubator.vector` is on the module path, and `VectorSupport` already falls back to scalar (via its `catch` of the linkage error) when the module is absent. Omitting the launch flag is therefore the way to select scalar, so the property carried no unique capability.

Nothing referenced it — no test, CI job, POM, or benchmark — and there is no scalar-vs-SIMD parity harness that relied on it.

## Changes

- Drop the `Boolean.getBoolean("hardwood.simd.disabled")` read and its branch in the Java 22 multi-release `VectorSupport` overlay; detection now just probes the Vector API and falls back to scalar on any `Throwable`.
- Remove the stale javadoc reference in the base (Java 21) `VectorSupport`.
- Update `docs/content/reference/configuration.md`: replace the `-Dhardwood.simd.disabled=true` guidance with "omit `--add-modules jdk.incubator.vector` to run scalar," and drop the System Properties table row.