### PR TITLE
#750 Bulk-copy present runs in the regular nested assembly path

### DIFF
--- a/_designs/NESTED_REGULAR_PATH_RUN_COPY.md
+++ b/_designs/NESTED_REGULAR_PATH_RUN_COPY.md
@@ -1,0 +1,84 @@
+<!--
+
+     SPDX-License-Identifier: CC-BY-SA-4.0
+
+     Copyright The original authors
+
+     Licensed under the Creative Commons Attribution-ShareAlike 4.0 International License;
+     you may not use this file except in compliance with the License.
+     You may obtain a copy of the License at https://creativecommons.org/licenses/by-sa/4.0/
+
+-->
+# Bulk run copy for the regular nested assembly path
+
+Status: **Planned**
+
+Tracking issue: #750
+
+## Problem
+
+`NestedColumnWorker.assembleRegularPage` materializes a page one value at a time.
+For every non-masked position it calls `copyOneValue`, writes a definition level
+and a repetition level, and checks accumulator capacity. Profiling a
+`LIST<float32>` scan (fast path disabled) shows this per-element sequence — not
+the value copy itself — dominates: ~1.26 B instructions/op versus ~60 M for a
+flat read of the same values (21×), at IPC 1.58 (compute-bound, not memory). The
+per-value machinery is a capacity check, two bounds-checked level `iastore`s, and
+a `checkcast` of the value array, around a two-instruction copy.
+
+## Enabling invariant
+
+A decoded page is **level-aligned**: `values()`, `definitionLevels()`, and
+`repetitionLevels()` all have `size()` entries, one per level-stream position.
+Present values are scattered into `values()` at their level position; null
+positions carry a placeholder (`0` / `null` ref). `assembleRegularPage` copies
+every non-masked position 1:1 into the batch (nulls included, as placeholder
+slots — their null-ness is carried by the definition levels), advancing
+`nestedValueCount` once per position.
+
+Therefore, over a contiguous span of kept positions, the batch's values and its
+definition and repetition levels are each a **contiguous slice** of the page's
+corresponding array. The span can be filled with three `System.arraycopy`s
+instead of a per-element loop.
+
+## End state
+
+`assembleRegularPage` processes each page as a sequence of **runs** — maximal
+spans of consecutive kept (non-masked) positions that also fit within the current
+batch and `maxRows` budget. For each run:
+
+- **Values** — bulk-copied via `copyValueRun` (the same primitive the fixed-size
+  fast path uses; primitive types only). Byte-array-backed types
+  (`BYTE_ARRAY`, `FIXED_LEN_BYTE_ARRAY`, `INT96`) keep the per-element
+  `copyOneValue`, since their batch representation is not a flat array.
+- **Levels** — the run's definition and repetition levels are a slice of the
+  page's level arrays: `System.arraycopy` when the page carries them, or
+  `Arrays.fill` with `maxDefinitionLevel` / `0` for the all-present case where a
+  level array is `null`.
+- **Record offsets** — a run spans one or more whole top-level records. Record
+  starts (`repLevel == 0`) are visited to record `nestedRecordOffsets`; this is a
+  per-record step, not per-value.
+- **Capacity** — one `ensureNestedCapacity` for the whole run.
+
+Run boundaries are cut at: a masked-out record (the run resumes at the next kept
+record), the batch-capacity limit (publish, then continue), the `maxRows` limit,
+and page end. Record-boundary detection, masking, batch publishing, and the
+first-record-of-stream handling are unchanged in behavior — only the inner
+value/level writes move from per-element to per-run.
+
+The change is transparent: identical `NestedBatch` output (values, levels, record
+offsets, validity) for all inputs — nulls, masking, multi-level nesting, and
+mixed pages. Arbitrary nesting depth is preserved because the deeper structure is
+reconstructed downstream from the faithfully copied levels; `assembleRegularPage`
+only interprets `repLevel == 0` for top-level record offsets.
+
+## Scope
+
+- Primitive element columns get the run copy; byte-array columns are unchanged.
+- This is the general-path analogue of the fixed-size-list fast path
+  ([FIXED_SIZE_LIST_FASTPATH.md](FIXED_SIZE_LIST_FASTPATH.md)) and shares its
+  `copyValueRun` primitive. It applies whenever a run is all-present and unmasked,
+  which is the common case even for variable-length lists.
+- Measurement note: this lands as the baseline the fixed-size-list fast path is
+  measured against, so the fast path's reported speedup is not inflated by an
+  unoptimized per-element reconstruction base.

--- a/core/src/main/java/dev/hardwood/internal/reader/NestedColumnWorker.java
+++ b/core/src/main/java/dev/hardwood/internal/reader/NestedColumnWorker.java
@@ -87,6 +87,17 @@ public class NestedColumnWorker extends ColumnWorker<NestedBatch> {
         int intervalCursor = 0;
         int recordIndex = -1;
 
+        // The page's values and level arrays are level-aligned (one slot per
+        // position, nulls carried as placeholders), and every kept position maps
+        // 1:1 to a batch slot. So a maximal span of consecutive kept positions is
+        // a contiguous slice in both the page and the batch: its values and levels
+        // are filled with bulk copies when the span closes ([#flushRun]) rather
+        // than element by element. Only record-boundary bookkeeping, masking, and
+        // batch splitting stay per-position; a span closes at a masked gap, a batch
+        // publish, the maxRows cut, or page end.
+        int runStart = -1;
+        int runBaseCount = 0;
+
         for (int i = 0; i < pageSize; i++) {
             int repLevel = pageRepLevels != null ? pageRepLevels[i] : 0;
             boolean atRecordStart = repLevel == 0;
@@ -103,6 +114,12 @@ public class NestedColumnWorker extends ColumnWorker<NestedBatch> {
 
             if (!maskAll && (intervalCursor >= intervalCount
                     || recordIndex < mask.start(intervalCursor))) {
+                // Masked-out position: close the open run before the gap.
+                if (runStart >= 0) {
+                    flushRun(page, pageDefLevels, pageRepLevels,
+                            runStart, runBaseCount, nestedValueCount - runBaseCount);
+                    runStart = -1;
+                }
                 continue;
             }
 
@@ -111,8 +128,14 @@ public class NestedColumnWorker extends ColumnWorker<NestedBatch> {
             // we also start record 0. Masked-out records are already filtered by the
             // `continue` above, so they never reach this branch.
             if (atRecordStart && (nestedValueCount > 0 || rowsInCurrentBatch > 0)) {
-                // Previous record is complete — check if batch is full
+                // Previous record is complete — check if batch is full. Publishing
+                // reads the accumulators, so the open run must be flushed first.
                 if (rowsInCurrentBatch >= batchCapacity) {
+                    if (runStart >= 0) {
+                        flushRun(page, pageDefLevels, pageRepLevels,
+                                runStart, runBaseCount, nestedValueCount - runBaseCount);
+                        runStart = -1;
+                    }
                     publishCurrentBatch();
                     if (done) {
                         return;
@@ -121,6 +144,11 @@ public class NestedColumnWorker extends ColumnWorker<NestedBatch> {
 
                 // Check maxRows after publishing
                 if (maxRows > 0 && totalRowsAssembled >= maxRows) {
+                    if (runStart >= 0) {
+                        flushRun(page, pageDefLevels, pageRepLevels,
+                                runStart, runBaseCount, nestedValueCount - runBaseCount);
+                        runStart = -1;
+                    }
                     if (rowsInCurrentBatch > 0) {
                         publishCurrentBatch();
                     }
@@ -145,20 +173,88 @@ public class NestedColumnWorker extends ColumnWorker<NestedBatch> {
                 totalRowsAssembled++;
             }
 
-            // Ensure capacity for the new value
-            if (nestedValueCount >= nestedDefLevels.length) {
-                int newCapacity = nestedDefLevels.length * 2;
-                nestedValues = growValues(nestedValues, newCapacity);
-                nestedDefLevels = Arrays.copyOf(nestedDefLevels, newCapacity);
-                nestedRepLevels = Arrays.copyOf(nestedRepLevels, newCapacity);
+            // Extend the open run to cover this position; its value and levels are
+            // written in bulk when the run closes.
+            if (runStart < 0) {
+                runStart = i;
+                runBaseCount = nestedValueCount;
             }
-
-            // Copy value and levels
-            nestedDefLevels[nestedValueCount] = pageDefLevels != null
-                    ? pageDefLevels[i] : maxDefinitionLevel;
-            nestedRepLevels[nestedValueCount] = repLevel;
-            copyOneValue(page, i, nestedValues, nestedValueCount);
             nestedValueCount++;
+        }
+
+        if (runStart >= 0) {
+            flushRun(page, pageDefLevels, pageRepLevels,
+                    runStart, runBaseCount, nestedValueCount - runBaseCount);
+        }
+    }
+
+    /// Fills the batch slots `[destStart, destStart + len)` for a run of `len`
+    /// consecutive kept page positions starting at `srcStart`. Values are
+    /// bulk-copied with [#copyValueRun] for primitive element types (byte-array
+    /// types keep the per-element append, since their batch representation is not a
+    /// flat array), and the definition and repetition levels are a contiguous slice
+    /// of the page's level arrays — an `System.arraycopy` when present, or a fill
+    /// with `maxDefinitionLevel` / `0` for the all-present case where a page level
+    /// array is `null`. The result is identical to writing each position
+    /// individually; only the per-element capacity check, bounds-checked level
+    /// stores, and value-array type check are hoisted out of the inner loop.
+    private void flushRun(Page page, int[] pageDefLevels, int[] pageRepLevels,
+                          int srcStart, int destStart, int len) {
+        if (len == 0) {
+            return;
+        }
+        ensureNestedCapacity(destStart + len);
+        if (page instanceof Page.ByteArrayPage) {
+            for (int j = 0; j < len; j++) {
+                copyOneValue(page, srcStart + j, nestedValues, destStart + j);
+            }
+        }
+        else {
+            copyValueRun(page, srcStart, destStart, len);
+        }
+        if (pageDefLevels != null) {
+            System.arraycopy(pageDefLevels, srcStart, nestedDefLevels, destStart, len);
+        }
+        else {
+            Arrays.fill(nestedDefLevels, destStart, destStart + len, maxDefinitionLevel);
+        }
+        if (pageRepLevels != null) {
+            System.arraycopy(pageRepLevels, srcStart, nestedRepLevels, destStart, len);
+        }
+        else {
+            Arrays.fill(nestedRepLevels, destStart, destStart + len, 0);
+        }
+    }
+
+    /// Grows the value and level accumulators to hold at least `needed` slots,
+    /// preserving the existing contents. The three arrays share `nestedDefLevels`
+    /// as the capacity marker.
+    private void ensureNestedCapacity(int needed) {
+        if (needed <= nestedDefLevels.length) {
+            return;
+        }
+        int newCapacity = nestedDefLevels.length * 2;
+        if (newCapacity < needed) {
+            newCapacity = needed;
+        }
+        nestedValues = growValues(nestedValues, newCapacity);
+        nestedDefLevels = Arrays.copyOf(nestedDefLevels, newCapacity);
+        nestedRepLevels = Arrays.copyOf(nestedRepLevels, newCapacity);
+    }
+
+    /// Copies `count` consecutive values from `page` starting at `srcStart` into
+    /// the value accumulator at `destStart`. Primitive pages bulk-copy; the caller
+    /// ([#flushRun]) routes byte-array pages to the per-element append instead, so
+    /// a byte-array page never reaches here.
+    private void copyValueRun(Page page, int srcStart, int destStart, int count) {
+        switch (page) {
+            case Page.IntPage p -> System.arraycopy(p.values(), srcStart, (int[]) nestedValues, destStart, count);
+            case Page.LongPage p -> System.arraycopy(p.values(), srcStart, (long[]) nestedValues, destStart, count);
+            case Page.FloatPage p -> System.arraycopy(p.values(), srcStart, (float[]) nestedValues, destStart, count);
+            case Page.DoublePage p -> System.arraycopy(p.values(), srcStart, (double[]) nestedValues, destStart, count);
+            case Page.BooleanPage p -> System.arraycopy(p.values(), srcStart, (boolean[]) nestedValues, destStart, count);
+            case Page.ByteArrayPage p -> throw new IllegalStateException(
+                    "byte-array run must use the per-element copy path, not copyValueRun");
         }
     }
 

--- a/core/src/test/java/dev/hardwood/NestedRegularBatchInvarianceTest.java
+++ b/core/src/test/java/dev/hardwood/NestedRegularBatchInvarianceTest.java
@@ -1,0 +1,71 @@
+/*
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Copyright The original authors
+ *
+ *  Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package dev.hardwood;
+
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+
+import dev.hardwood.reader.ColumnReader;
+import dev.hardwood.reader.ParquetFileReader;
+import dev.hardwood.reader.Validity;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/// The regular nested assembly path (`NestedColumnWorker.assembleRegularPage`)
+/// fills each batch by bulk-copying runs of consecutive kept positions. A run is
+/// cut wherever a batch boundary falls mid-page, so the reconstructed records must
+/// not depend on the batch size. Reading a nullable list column with a tiny batch
+/// (splitting almost every page) and with a batch large enough to hold the whole
+/// column must yield identical records — the direct regression guard that
+/// splitting a run across a publish preserves values, list boundaries, and nulls.
+class NestedRegularBatchInvarianceTest {
+
+    private static final Path FILE =
+            Paths.get("src/test/resources/batch_array_identity_test.parquet");
+    private static final String COLUMN = "nums.list.element";
+
+    @Test
+    void regularNestedReadIsBatchSizeInvariant() throws Exception {
+        List<int[]> small = readIntLists(2);
+        List<int[]> large = readIntLists(4096);
+
+        assertThat(small).as("record count (small vs large batch)").hasSameSizeAs(large);
+        for (int r = 0; r < small.size(); r++) {
+            assertThat(small.get(r)).as("record %d (batchSize 2 vs 4096)", r).isEqualTo(large.get(r));
+        }
+    }
+
+    /// Reads every list record as an `int[]` (or `null` for a null list),
+    /// flattened across batches, at the given batch size.
+    private static List<int[]> readIntLists(int batchSize) throws Exception {
+        List<int[]> records = new ArrayList<>();
+        try (ParquetFileReader reader = ParquetFileReader.open(InputFile.of(FILE));
+             ColumnReader col = reader.buildColumnReader(COLUMN).batchSize(batchSize).build()) {
+            while (col.nextBatch()) {
+                int recordCount = col.getRecordCount();
+                int[] offsets = col.getLayerOffsets(0);
+                Validity validity = col.getLayerValidity(0);
+                int[] values = col.getInts();
+                for (int r = 0; r < recordCount; r++) {
+                    if (validity.hasNulls() && validity.isNull(r)) {
+                        records.add(null);
+                        continue;
+                    }
+                    int[] list = new int[offsets[r + 1] - offsets[r]];
+                    System.arraycopy(values, offsets[r], list, 0, list.length);
+                    records.add(list);
+                }
+            }
+        }
+        return records;
+    }
+}


### PR DESCRIPTION
Closes #750.

## What

`NestedColumnWorker.assembleRegularPage` materialized each page one value at a time — per position a `copyOneValue` type-switch, two bounds-checked level stores, and a capacity check. This replaces the inner loop with run-based bulk copies.

A decoded page is **level-aligned**: its values and level arrays each hold one slot per position (nulls carried as placeholders), and every kept position maps 1:1 to a batch slot. So a maximal span of consecutive kept positions is a contiguous slice in both the page and the batch. The loop now accumulates such runs and, when one closes (at a masked gap, a batch publish, the `maxRows` cut, or page end), fills the values with a bulk `copyValueRun` and the def/rep levels with `System.arraycopy` — hoisting the capacity check, level bounds checks, and value type-check out of the inner loop. Byte-array element types keep the per-element append.

## Why

Profiling a `LIST<float32>` scan (N300, k=768) attributed the cost to the per-element machinery, not the value copy: **~1.26 B instructions/op vs ~60 M for a flat read** of the same values, at IPC 1.58 (compute-bound, not memory). This closes a chunk of that gap.

## Correctness

Output is **byte-identical** for every input (levels copied verbatim, values via the same primitive), so the existing differential / null / masking / multi-level suites carry it — full core suite green (1548). Adds `NestedRegularBatchInvarianceTest`, which pins that a run split across a batch-publish boundary reconstructs identically at `batchSize=2` vs a whole-column batch.

## Context

First of the regular-path ("baseline") optimizations landing on `main` ahead of the fixed-size-list fast path (#741), so the fast path is measured against an optimized reconstruction base rather than a per-element one. Introduces the shared `copyValueRun` primitive the fast path also uses. Design: `_designs/NESTED_REGULAR_PATH_RUN_COPY.md`. Follow-ups: #749 (drop raw-level accessors), #751 (move `computeRealView` to the drain).