### PR TITLE
#713 Guard Variant object/array/metadata offset arithmetic against 32-bit overflow

### DIFF
--- a/core/src/main/java/dev/hardwood/internal/variant/VariantBinary.java
+++ b/core/src/main/java/dev/hardwood/internal/variant/VariantBinary.java
@@ -107,6 +107,30 @@ public final class VariantBinary {
         return result;
     }
 
+    /// Validates that a Variant object/array/metadata header fits inside a buffer
+    /// of `bufferLength` bytes. `headerEnd` is the exclusive end offset of the
+    /// header's id and offset tables — the caller computes it in `long` from the
+    /// **unsigned** element or dictionary `count`, so a hostile count cannot wrap
+    /// the 32-bit product into an in-bounds-looking offset that later slips past
+    /// the per-access bounds checks. Returns `headerEnd` narrowed to `int` once it
+    /// is known to fit.
+    ///
+    /// @param region human-readable name of the count, used in the error message
+    /// @param count declared element/dictionary count (interpreted as unsigned 32-bit)
+    /// @param headerEnd exclusive end offset of the id/offset tables, computed in `long`
+    /// @param bufferLength length of the enclosing buffer
+    /// @return `headerEnd` as an `int`
+    /// @throws IllegalArgumentException if the header does not fit the buffer
+    static int checkHeaderFits(String region, int count, long headerEnd, int bufferLength) {
+        if (headerEnd > bufferLength) {
+            throw new IllegalArgumentException(
+                    "Variant " + region + " count " + Integer.toUnsignedString(count)
+                            + " does not fit in a buffer of " + bufferLength
+                            + " bytes (header tables alone require " + headerEnd + " bytes)");
+        }
+        return Math.toIntExact(headerEnd);
+    }
+
     /// Map a Variant value-header byte to its [VariantType]. Returns `null` for
     /// unrecognized primitive type tags so callers can fail-early with context.
     public static VariantType typeOf(byte header) {

--- a/core/src/main/java/dev/hardwood/internal/variant/VariantMetadata.java
+++ b/core/src/main/java/dev/hardwood/internal/variant/VariantMetadata.java
@@ -54,11 +54,12 @@ public final class VariantMetadata {
                     "Variant metadata dictionary_size is not a valid unsigned int: " + dictionarySize);
         }
         this.offsetsStart = headerEnd + offsetSize;
-        int offsetsLen = (dictionarySize + 1) * offsetSize;
-        if (buf.length < offsetsStart + offsetsLen) {
-            throw new IllegalArgumentException("Variant metadata buffer truncated before offset table");
-        }
-        this.stringsStart = offsetsStart + offsetsLen;
+        // Widen the offset-table arithmetic to long: a hostile dictionary_size
+        // would otherwise overflow the 32-bit product and wrap the offset-table
+        // extent to an in-bounds-looking value that bypasses this truncation check.
+        long stringsSectionStart = offsetsStart + ((long) dictionarySize + 1L) * offsetSize;
+        this.stringsStart = VariantBinary.checkHeaderFits(
+                "metadata dictionary", dictionarySize, stringsSectionStart, buf.length);
         int totalStringBytes = readOffset(dictionarySize);
         if (buf.length < stringsStart + totalStringBytes) {
             throw new IllegalArgumentException("Variant metadata buffer truncated before end of strings section");

--- a/core/src/main/java/dev/hardwood/internal/variant/VariantValueDecoder.java
+++ b/core/src/main/java/dev/hardwood/internal/variant/VariantValueDecoder.java
@@ -250,15 +250,18 @@ public final class VariantValueDecoder {
         int idSize = ((valueHeader >>> VariantBinary.OBJECT_FIELD_ID_SIZE_SHIFT) & VariantBinary.OBJECT_FIELD_ID_SIZE_MASK) + 1;
         boolean isLarge = (valueHeader & VariantBinary.OBJECT_IS_LARGE_MASK) != 0;
         int numSize = isLarge ? 4 : 1;
-        int pos = offset + 1;
-        int numElements = VariantBinary.readUnsignedLE(buf, pos, numSize);
-        pos += numSize;
-        int idsStart = pos;
-        pos += numElements * idSize;
-        int offsetsStart = pos;
-        pos += (numElements + 1) * offsetSize;
-        int valuesStart = pos;
-        return new ObjectLayout(numElements, idSize, offsetSize, idsStart, offsetsStart, valuesStart);
+        int numElements = VariantBinary.readUnsignedLE(buf, offset + 1, numSize);
+        int idsStart = offset + 1 + numSize;
+        // Widen the id/offset-table arithmetic to long over the *unsigned* count:
+        // a hostile numElements would otherwise overflow the 32-bit product and
+        // wrap valuesStart to an in-bounds-looking offset that slips past the
+        // value accessors' bounds checks.
+        long elements = Integer.toUnsignedLong(numElements);
+        long offsetsStart = idsStart + elements * idSize;
+        long valuesStart = offsetsStart + (elements + 1L) * offsetSize;
+        int valuesStartInt = VariantBinary.checkHeaderFits("object element", numElements, valuesStart, buf.length);
+        return new ObjectLayout(numElements, idSize, offsetSize,
+                idsStart, Math.toIntExact(offsetsStart), valuesStartInt);
     }
 
     public static ArrayLayout parseArray(byte[] buf, int offset) {
@@ -271,13 +274,14 @@ public final class VariantValueDecoder {
         int offsetSize = (valueHeader & VariantBinary.ARRAY_FIELD_OFFSET_SIZE_MASK) + 1;
         boolean isLarge = (valueHeader & VariantBinary.ARRAY_IS_LARGE_MASK) != 0;
         int numSize = isLarge ? 4 : 1;
-        int pos = offset + 1;
-        int numElements = VariantBinary.readUnsignedLE(buf, pos, numSize);
-        pos += numSize;
-        int offsetsStart = pos;
-        pos += (numElements + 1) * offsetSize;
-        int valuesStart = pos;
-        return new ArrayLayout(numElements, offsetSize, offsetsStart, valuesStart);
+        int numElements = VariantBinary.readUnsignedLE(buf, offset + 1, numSize);
+        int offsetsStart = offset + 1 + numSize;
+        // Widen the offset-table arithmetic to long over the *unsigned* count so a
+        // hostile numElements cannot overflow the 32-bit product and wrap
+        // valuesStart into an in-bounds-looking offset.
+        long valuesStart = offsetsStart + (Integer.toUnsignedLong(numElements) + 1L) * offsetSize;
+        int valuesStartInt = VariantBinary.checkHeaderFits("array element", numElements, valuesStart, buf.length);
+        return new ArrayLayout(numElements, offsetSize, offsetsStart, valuesStartInt);
     }
 
     /// Returns the byte length of the Variant value whose header byte lives at

--- a/core/src/test/java/dev/hardwood/internal/variant/VariantMetadataTest.java
+++ b/core/src/test/java/dev/hardwood/internal/variant/VariantMetadataTest.java
@@ -70,6 +70,17 @@ class VariantMetadataTest {
     }
 
     @Test
+    void dictionarySizeOffsetOverflowRejected() {
+        // Header 0xC1: version=1, offset_size=4. Count 0x33333333 clears the
+        // negative-size guard but overflows (dictionary_size + 1) * offset_size.
+        byte[] bytes = { (byte) 0xC1, 0x33, 0x33, 0x33, 0x33 };
+        assertThatThrownBy(() -> new VariantMetadata(bytes))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("metadata dictionary")
+                .hasMessageContaining("858993459");
+    }
+
+    @Test
     void truncatedBufferRejected() {
         byte[] bytes = { 0x01 }; // header only, no dictionary size bytes
         assertThatThrownBy(() -> new VariantMetadata(bytes))

--- a/core/src/test/java/dev/hardwood/internal/variant/VariantValueDecoderTest.java
+++ b/core/src/test/java/dev/hardwood/internal/variant/VariantValueDecoderTest.java
@@ -14,17 +14,20 @@ import java.time.Instant;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
+import java.util.Arrays;
 import java.util.Base64;
 import java.util.UUID;
 
 import org.junit.jupiter.api.Test;
 
+import dev.hardwood.internal.variant.VariantValueDecoder.ArrayLayout;
 import dev.hardwood.row.PqVariant;
 import dev.hardwood.row.PqVariantArray;
 import dev.hardwood.row.PqVariantObject;
 import dev.hardwood.row.VariantType;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 /// Verifies the Variant binary decoder against the canonical primitive/object/array
 /// fixtures from [`apache/parquet-testing/variant/`](https://github.com/apache/parquet-testing/tree/master/variant).
@@ -303,5 +306,49 @@ class VariantValueDecoderTest {
         assertThat(names.get(0).asString()).isEqualTo("Apple");
         assertThat(names.get(1).asString()).isEqualTo("Ray");
         assertThat(names.get(2).isNull()).isTrue();
+    }
+
+    @Test
+    void objectElementCountOverflowRejected() {
+        // OBJECT header 0x7E: offset_size=id_size=4, is_large (4-byte count). Count
+        // 0x33333333 overflows the 32-bit id/offset-table arithmetic.
+        byte[] buf = { 0x7E, 0x33, 0x33, 0x33, 0x33 };
+        assertThatThrownBy(() -> VariantValueDecoder.parseObject(buf, 0))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("object element")
+                .hasMessageContaining("858993459")
+                .hasMessageContaining(String.valueOf(buf.length));
+    }
+
+    @Test
+    void arrayElementCountOverflowRejected() {
+        // ARRAY header 0x1F: offset_size=4, is_large (4-byte count). Count 0x33333333
+        // overflows the 32-bit offset-table arithmetic.
+        byte[] buf = { 0x1F, 0x33, 0x33, 0x33, 0x33 };
+        assertThatThrownBy(() -> VariantValueDecoder.parseArray(buf, 0))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("array element")
+                .hasMessageContaining("858993459")
+                .hasMessageContaining(String.valueOf(buf.length));
+    }
+
+    @Test
+    void largeButValidArrayStillDecodes() {
+        // A large but in-bounds count must still decode; the guard rejects only
+        // counts too big to fit, not the 4-byte (is_large) count encoding.
+        int n = 300;
+        byte[][] elements = new byte[n][];
+        for (int i = 0; i < n; i++) {
+            byte[] element = new byte[2];
+            VariantValueEncoder.writeInt8(element, 0, i & 0x7F);
+            elements[i] = element;
+        }
+        byte[] scratch = new byte[4096];
+        int end = VariantValueEncoder.writeArray(scratch, 0, elements);
+        byte[] value = Arrays.copyOf(scratch, end);
+
+        ArrayLayout layout = VariantValueDecoder.parseArray(value, 0);
+        assertThat(layout.numElements()).isEqualTo(n);
+        assertThat(layout.valuesStart()).isLessThanOrEqualTo(value.length);
     }
 }


### PR DESCRIPTION
## Description
This pull request addresses #713, which observed that the Variant decoder sizes its object / array / metadata header tables with unguarded 32-bit arithmetic. `VariantValueDecoder.parseObject` / `parseArray` and the `VariantMetadata` constructor compute the id-array and offset-table extents from a file-controlled element / dictionary count (`numElements * idSize`, `(numElements + 1) * offsetSize`, `(dictionarySize + 1) * offsetSize`) in plain `int`. A hostile count such as `0x33333333` overflows the product and wraps the values-section offset to a small or negative value that looks in-bounds, so the subsequent per-access bounds checks read from an arbitrary buffer location instead of rejecting the input. Today Hardwood only avoids this by accident (an unrelated field-id-range check happens to trip first) so the vulnerability the upstream `int_overflow_in_bounds_check` fixture targets is genuinely unguarded.

The change is internal to the variant decoder: the public `PqVariant` surface is unchanged, and well-formed files decode exactly as before.

## Key Changes
- **Widened the header arithmetic to `long` over the unsigned count**
    - `parseObject` / `parseArray` compute the id-array and offset-table extents in `long` via `Integer.toUnsignedLong(numElements)`, and `VariantMetadata` widens `(dictionary_size + 1) * offset_size` the same way, so a hostile count can no longer wrap the product into an in-bounds-looking offset.
- **Consolidated the fit check into one shared helper**
    - A single package-private `VariantBinary.checkHeaderFits(region, count, headerEnd, bufferLength)` validates the `long` extent against the buffer length, returns it narrowed via `Math.toIntExact`, and throws a descriptive `IllegalArgumentException` naming the count and the buffer size when the header cannot fit. Both the decoder and the metadata constructor route through it, replacing the ad-hoc truncation check.
    - Downstream per-element arithmetic (`i * offsetSize`, `numElements * offsetSize`, …) is deliberately left as `int`: it only ever runs on a layout that has already cleared the fit check, where the product is provably bounded by the buffer length and cannot overflow.
    - The pre-existing negative-`dictionary_size` guard in `VariantMetadata` is retained ahead of the helper, so that path keeps its existing message.

## Verification and Testing
Coverage drives the real decode entry points with crafted headers rather than mocks, and each test was confirmed to fail before the guard was added:
- `VariantValueDecoderTest` - `objectElementCountOverflowRejected` / `arrayElementCountOverflowRejected` feed a `0x33333333` count through `parseObject` / `parseArray` and assert an `IllegalArgumentException` naming the count and buffer size. Pre-fix, both methods returned a wrapped, in-bounds-looking layout with no exception at all. `largeButValidArrayStillDecodes` builds a genuine 300-element array via `VariantValueEncoder.writeArray` and asserts it still decodes, so the guard rejects only counts too large to fit — not the `is_large` 4-byte-count encoding itself.
- `VariantMetadataTest` - `dictionarySizeOffsetOverflowRejected` drives the same overflow through the metadata constructor; pre-fix it threw an incidental `ArrayIndexOutOfBoundsException` from a wrapped negative offset reaching into the buffer, exactly the bounds-check bypass the issue describes.
- Full `core` module green via `./mvnw -pl core -am verify`: `Tests run: 1551` (unit) + `14` (integration), `Failures: 0, Errors: 0`, including the Error Prone `NoVar` / `NoLegacyJavadoc` gates.

The guarded methods run once per object / array / metadata parse (not per value), and on the success path the fit check is a single comparison plus `Math.toIntExact` (the message is constructed only on the throw path) so there is no measurable decode-path cost.

## Checklist
- [x] Build via `./mvnw clean verify` passes
- [x] The commit message is prefixed with the issue key
- [x] Code changes are covered by tests
- [x] If this PR adds or changes user-facing behavior, `docs/` has been updated _(internal decoder hardening; no public API or user-facing change)_