### PR TITLE
Faster nested reads: reconstruct on the drain, not the serial consumer

### DIFF
--- a/_designs/NESTED_READ_BENCHMARK.md
+++ b/_designs/NESTED_READ_BENCHMARK.md
@@ -148,15 +148,21 @@ null density `d ∈ {none, sparse, dense}`:
 Same file, three read paths, plus the floor:
 
 - `columnNested` — open a `ColumnReader` on the leaf, and for each batch fold the
-  compacted real-items leaf array (`getFloats()`/`getLongs()`/… over `getValueCount()`).
-  This is the path #750 and #751 accelerate.
+  compacted real-items leaf array (`getFloats()`/`getLongs()`/… over `getValueCount()`)
+  with `getLeafValidity()`. A flat-leaf consumer (values, count, leaf validity — no
+  offsets); the vector/embedding read pattern. This is the path #750 and #751
+  accelerate.
+- `columnNestedStructural` — the same `ColumnReader` path as a list-reconstructing
+  consumer: read `getLayerOffsets()`/`getLayerValidity()` and walk the lists. It reads
+  the per-layer view every batch, so it measures whether that view is built on the
+  drain or lazily on the serial consumer.
 - `rowNested` — open a `RowReader`, materialize the `PqList` per row, and fold its
   numeric elements. The ergonomic all-items path; #751 must not regress it.
 - `flatFloor` — a `ColumnReader` over the flat-twin leaf. The absolute decode floor.
 
-The gap between `columnNested`/`rowNested` and `flatFloor` is the reconstruction cost;
-these three methods let a change move the nested numbers toward the floor while the
-floor itself stays put.
+The gap between the `columnNested*`/`rowNested` paths and `flatFloor` is the
+reconstruction cost; these methods let a change move the nested numbers toward the
+floor while the floor itself stays put.
 
 ### `MixedSchemaReadBenchmark`
 

--- a/_designs/NESTED_READ_BENCHMARK.md
+++ b/_designs/NESTED_READ_BENCHMARK.md
@@ -1,0 +1,212 @@
+# Nested read JMH benchmark
+
+Status: **Implemented**
+
+## Motivation
+
+The general (non-fast-path) nested read path is the slowest part of the reader. For
+a `LIST<float32>` scan with the fixed-size-list fast path disabled it executes on
+the order of 21× the instructions of the equivalent flat read, almost all of it
+per-element bookkeeping around a two-instruction value copy. Three changes target
+this path:
+
+- **#732** — push the flat/nested split down from the reader to the per-column
+  worker, so non-repeated columns in a mixed file read at flat speed instead of
+  being dragged onto the assembly path.
+- **#750** — bulk-copy contiguous present, unmasked runs in `assembleRegularPage`
+  instead of copying one element at a time.
+- **#751** — compute the `RealView` on the parallel drain and drop the per-batch
+  def/rep level materialization on the `ColumnReader` path.
+
+Each of these needs before/after numbers on a workload that isolates the nested
+reconstruction inner loop. No such benchmark exists:
+
+- `NestedPerformanceTest` (end-to-end, Overture Maps places) is a whole-file,
+  wall-clock, cross-engine comparison over a **string-heavy** schema. String decode
+  and I/O dominate its time, drowning the level-scan and assembly signal these three
+  changes move. It measures reader ergonomics, not the reconstruction inner loop.
+- `FixedSizeListDecodeBenchmark` and the standalone `FixedSizeListScanBenchmark`
+  measure only the fixed-width **fast path** (#740) — the path that skips
+  reconstruction — not the general nested path that #732/#750/#751 improve.
+
+This benchmark fills that gap: a JMH benchmark over **numeric** leaves that isolates
+the general nested read path against a flat decode floor, across the dimensions the
+three changes move.
+
+## Goals
+
+- Isolate the general nested assembly and level-scan cost over numeric leaves
+  (int, long, float, double), with no string decode, no compression, no dictionary,
+  and a warm page cache — so the measured time is level handling plus value copy.
+- Measure the same file through both public read paths:
+  - the `ColumnReader` **real-items** path (what #750 and #751 accelerate), and
+  - the `RowReader` **all-items** path (which #751 must not regress and #732
+    touches),
+  against a **flat floor** — the identical leaf values as a plain primitive column.
+- Expose #732's cost directly: scan the scalar columns of a **mixed** scalar+list
+  schema and compare against the same scalars in a purely flat file. The delta is
+  the per-scalar-column tax that today's per-file routing imposes and #732 removes.
+- Cover the shapes whose acceptance criteria demand a no-regression guard:
+  repeated-heavy schemas and a `>1` repetition-layer column (which #751's
+  single-repeated-layer fast path deliberately does not fire on).
+- Fold every contender to a numeric checksum and assert agreement before timing, so
+  a future change that corrupts values fails the run rather than posting a fast wrong
+  number.
+
+## Non-goals
+
+- Cross-engine comparison (parquet-java, Avro, Arrow). That is the job of the
+  publishable standalone suite; this benchmark compares Hardwood to itself and to its
+  own flat floor.
+- Strings/binary leaves, compression, dictionary encoding, and cold-cache/I/O
+  effects. Those are real but orthogonal; including them reintroduces the noise that
+  makes `NestedPerformanceTest` unsuitable for this purpose.
+- Chart generation and publication. This is an in-repo regression/measurement
+  harness under `-Pperformance-test`, not a headline artifact.
+
+## Location
+
+`performance-testing/micro-benchmarks`, in three packages (the existing benchmarks
+such as `FixedSizeListDecodeBenchmark` stay in the root `dev.hardwood.benchmarks`). It
+reuses the module's JMH wiring (annotation processor, `--add-modules
+jdk.incubator.vector`, shade uberjar).
+
+The corpus generators write with parquet-java, so the module gains compile-scope
+`org.apache.parquet:parquet-avro` and `parquet-hadoop` plus the `hadoop-common` and
+`hadoop-mapreduce-client-core` runtime dependencies — the same coordinates the
+`end-to-end` module already declares (parquet 1.17.1, hadoop 3.4.3, versions managed
+in `test-bom`). Only the generators touch these; the benchmark bodies read through
+Hardwood alone.
+
+The two benchmark families live in their own packages, each self-contained with its
+generator and correctness gate, over a small set of shared helpers at the root:
+
+- `dev.hardwood.benchmarks` (shared) — `Elem` (the element-type enum), `NestedReads`
+  (the column/row folds), `BenchmarkWriter` (the parquet-java writer plumbing), and
+  `BenchmarkData` (corpus directory and fixture sizes).
+- `dev.hardwood.benchmarks.nested` (#750, #751) — `NestedListReadBenchmark` (the
+  `LIST<primitive>` path, parameterized by element type and null density),
+  `NestedListFileGenerator`, and `NestedListGate`.
+- `dev.hardwood.benchmarks.mixed` (#732) — `MixedSchemaReadBenchmark` (the mixed
+  scalar+list schema, the struct path, and the no-regression guards: repeated-heavy
+  and the `> 1` repetition-layer depth shapes), `MixedSchemaFileGenerator`, and
+  `MixedSchemaGate`.
+
+## Fixtures
+
+Each family's generator (`NestedListFileGenerator`, `MixedSchemaFileGenerator`) writes
+its fixtures through the shared `BenchmarkWriter`, which wraps parquet-java's
+`AvroParquetWriter` (writer version `PARQUET_2_0` for DataPageV2,
+`CompressionCodecName.UNCOMPRESSED`, dictionary disabled), mirroring the standalone
+suite's `FixedSizeListFileGenerator` and `EventFileGenerator`. Each generator exposes
+idempotent `ensure(dir, …)` methods that its benchmark calls from
+`@Setup(Level.Trial)`, plus a `main` so the corpus can be generated up front; a file
+present and non-empty is left untouched, keyed by the parameters in its name. Files
+land in `performance-testing/test-data-setup/target/benchmark-data/` (the directory
+the existing generators use), overridable with `-Dperf.dataDir`.
+
+All files are DataPageV2, uncompressed, no dictionary. Every file holds the same
+**total leaf-value count** (default 8,000,000, matching the fixed-size-list corpus) so
+ms/op is directly comparable across shapes. Leaf values are deterministic (a
+`java.util.Random` seeded per file).
+
+### `NestedListReadBenchmark` fixtures
+
+For each element type `t ∈ {int64, float64}` (a 4-byte and an 8-byte leaf) and each
+null density `d ∈ {none, sparse, dense}`:
+
+- `list_<t>_<d>.parquet` — `LIST<t>` with variable list length (lengths drawn around a
+  mean so the offset scan sees real variation, not a constant stride the fast path
+  could exploit). At `none` the list and element are required (leaf max def 1, max rep
+  1); at `sparse`/`dense` both are optional, so ~5%/~50% of elements are null with the
+  occasional null/empty list. Nulls and empty lists are what break the contiguous
+  present runs #750 copies in one shot.
+- `list_<t>_<d>_flat.parquet` — the identical leaf stream (same values, same null
+  positions) as a plain `t` column (no list). The decode floor.
+
+### `MixedSchemaReadBenchmark` fixtures
+
+- `mixed.parquet` — 12 non-repeated scalar columns (four int, four long, four double)
+  plus 2 `LIST<double>` columns. The presence of the list columns routes the whole
+  file onto the nested reader today.
+- `flat_scalars.parquet` — the same 12 scalar columns, with **no** list column, so the
+  file is routed onto the flat reader. The floor for the scalar scan.
+- `struct.parquet` — a non-repeated `STRUCT` of primitives (max rep level 0), plus its
+  flat twin `struct_flat.parquet` (the same leaves as top-level scalar columns). Covers
+  the flat-struct path (#475/#497) that #732 subsumes.
+- `repeated_heavy.parquet` — several `LIST<double>` columns and no scalars. The
+  no-regression guard for repetition-heavy schemas.
+- `list_of_list.parquet` — `LIST<LIST<double>>`, leaf max rep level 2, and
+  `list_of_struct.parquet` — `LIST<STRUCT<a: int64, b: float64>>`. These exercise the
+  general path where #751's single-repeated-layer fast path does **not** apply and
+  must be seen not to regress.
+
+## Contenders
+
+### `NestedListReadBenchmark`
+
+Same file, three read paths, plus the floor:
+
+- `columnNested` — open a `ColumnReader` on the leaf, and for each batch fold the
+  compacted real-items leaf array (`getFloats()`/`getLongs()`/… over `getValueCount()`).
+  This is the path #750 and #751 accelerate.
+- `rowNested` — open a `RowReader`, materialize the `PqList` per row, and fold its
+  numeric elements. The ergonomic all-items path; #751 must not regress it.
+- `flatFloor` — a `ColumnReader` over the flat-twin leaf. The absolute decode floor.
+
+The gap between `columnNested`/`rowNested` and `flatFloor` is the reconstruction cost;
+these three methods let a change move the nested numbers toward the floor while the
+floor itself stays put.
+
+### `MixedSchemaReadBenchmark`
+
+- `columnScalarsMixed` — scan the 12 scalar columns out of `mixed.parquet`.
+- `columnScalarsFlat` — scan the same 12 scalar columns out of `flat_scalars.parquet`.
+  The delta between these two is the #732 tax.
+- `columnStruct` / `columnStructFlat` — the struct leaves vs their flat twin.
+- `columnRepeatedHeavy` — scan every list column of `repeated_heavy.parquet` (the
+  no-regression guard).
+- `columnListOfList` / `rowListOfList` and `columnListOfStruct` / `rowListOfStruct` —
+  the `> 1` repetition-layer depth shapes through both read paths.
+
+## Parameters
+
+Kept deliberately small to bound the JMH matrix:
+
+- `NestedListReadBenchmark`: `@Param elem ∈ {int64, float64}` (a 4-byte and an 8-byte
+  leaf; the copy-volume extremes) and `@Param nullDensity ∈ {none, sparse, dense}`.
+- `MixedSchemaReadBenchmark`: no parameters; every shape is a fixed fixture, so the
+  depth guards run as their own methods without a numeric-type sweep multiplying them.
+
+## Measuring a change
+
+A change is measured **branch-vs-main**, which is also #732's stated acceptance
+criterion ("`-Pperformance-test` before/after numbers on fully-flat, mixed-schema,
+and repeated-heavy"):
+
+1. Land this benchmark on `main`.
+2. Run it on `main` to capture the baseline.
+3. Run it on the change branch (`750-...`, `751-...`, `732-...`) and compare ms/op.
+
+The improvement changes are not gated behind `ReaderConfig` options; the benchmark
+carries no on/off toggle machinery, and no config surface is added to the reader for
+the sake of A/B measurement. This keeps the improvements as unconditional code paths
+and the benchmark as a plain scan.
+
+## Harness conventions
+
+Mirror `FixedSizeListDecodeBenchmark`:
+
+- `@BenchmarkMode(AverageTime)`, `@OutputTimeUnit(MILLISECONDS)`, `@State(Benchmark)`.
+- `@Fork(2, jvmArgs = {"-Xms2g", "-Xmx2g", "--add-modules", "jdk.incubator.vector"})`,
+  `@Warmup(3, 1s)`, `@Measurement(5, 1s)`.
+- Data directory via `-Dperf.dataDir` (default the shared `benchmark-data` dir),
+  fixture sizes via `-Dperf.totalValues` / `-Dperf.rows` (`BenchmarkData`); each
+  benchmark's `@Setup` calls the generator's idempotent `ensure(...)` so a fork never
+  measures a missing file.
+- One shared `HardwoodContext` per trial, closed in `@TearDown`.
+- A per-family gate — `NestedListGate` and `MixedSchemaGate`, each a standalone `main`
+  (e.g. `java -cp benchmarks.jar dev.hardwood.benchmarks.nested.NestedListGate`) — that
+  generates its corpus and folds every contender to a numeric checksum, asserting the
+  paths that read the same values agree (within a rounding epsilon across paths) before
+  any timing counts.

--- a/_designs/NESTED_REALVIEW_ON_DRAIN.md
+++ b/_designs/NESTED_REALVIEW_ON_DRAIN.md
@@ -1,0 +1,176 @@
+<!--
+
+     SPDX-License-Identifier: CC-BY-SA-4.0
+
+     Copyright The original authors
+
+     Licensed under the Creative Commons Attribution-ShareAlike 4.0 International License;
+     you may not use this file except in compliance with the License.
+     You may obtain a copy of the License at https://creativecommons.org/licenses/by-sa/4.0/
+
+-->
+# RealView on the drain; drop ColumnReader-path level materialization
+
+Status: **Stage 1 implemented; Stage 2 planned**
+
+Tracking issue: #751
+
+This change lands in two stages. **Stage 1** moves `computeRealView` onto the
+drain while the batch keeps carrying raw def/rep levels — it captures the primary
+win (the critical-path scan runs on idle threads) at low risk, with no dependency
+on #749 and no change to the record-selection path. **Stage 2** drops the raw
+level materialization on the `ColumnReader` path; it depends on #749 and rewrites
+record selection to slice the `RealView`. The stages are split because profiling
+attributes the wall-clock win to the *move*, not the level-drop, so Stage 1
+delivers most of the benefit on its own.
+
+## Problem
+
+On the `ColumnReader` (real-items) nested read path the raw Dremel def/rep level
+arrays are produced on the drain, copied into every batch, re-scanned by
+`NestedLevelComputer.computeRealView` on the **serial consumer thread**, and then
+never read again. The `RealView` scan is the single largest cost on the read's
+critical path.
+
+Profiling `NestedListReadBenchmark` on the N300
+([NESTED_READ_PERFORMANCE_ANALYSIS.md](NESTED_READ_PERFORMANCE_ANALYSIS.md))
+isolates the cause: the eight decode threads sit **96% parked** while the serial
+consumer is the bottleneck, and **~75% of the consumer's on-CPU time is
+`computeRealView`**. The scan runs on the one busy thread while eight idle threads
+wait. Separately, the per-batch def/rep level copy and the drain's all-items index
+(`elementValidity` + `multiLevelOffsets`) are pure waste on this path — the
+`ColumnReader` reads none of them, only the `RealView`.
+
+## Enabling facts
+
+- The `RealView` is a pure function of the batch's def/rep levels, record count,
+  and schema layers — `computeRealView(defLevels, repLevels, valueCount,
+  recordCount, maxDefinitionLevel, layers)`. It produces its own independent
+  arrays (`layerOffsets`, `layerValidity`, `leafValidity`, `realToRawLeaf`), so it
+  can be computed on the drain from the accumulators and outlive them.
+- A `NestedColumnWorker` feeds exactly one reader kind: `ColumnReader` constructs
+  it for the real-items path, `NestedRowReader` for the all-items path. The mode
+  is fixed per worker instance, so the split is a constructor flag, not a
+  per-batch branch.
+- The two reader paths read disjoint batch state:
+  - **`ColumnReader` (real-items):** `RealView` only —
+    `getValueCount`/`getLayerOffsets`/`getLayerValidity`/`getLeafValidity` and the
+    value compaction all route through `ensureRealView()`.
+  - **`RowReader` (all-items):** raw def levels and the all-items index.
+    `NestedBatchIndex.getDefLevel` is consumed by `PqListImpl`, `PqStructImpl`,
+    `PqMapImpl`, `NestedBatchDataView`, and extensively by
+    `VariantShredReassembler`. This path genuinely needs raw levels and is out of
+    scope.
+- With **#749** landed (the public `getDefinitionLevels()` /
+  `getRepetitionLevels()` escape hatches removed), the `ColumnReader` path has
+  *zero* raw-level readers left, so the levels can be dropped outright — no
+  on-demand level synthesis is needed.
+
+## Stage 1 — RealView on the drain (implemented)
+
+### Real-items mode flag
+
+`NestedColumnWorker` takes a `realItemsMode` boolean. `ColumnReader` constructs
+its worker with `true`, `NestedRowReader` with `false`; the convenience
+constructor (tests) defaults to `false`. The flag selects what the drain computes
+at publish time; nothing else in assembly changes.
+
+### NestedBatch carries the RealView
+
+`NestedBatch` gains a `RealView realView` field. On the real-items path the drain
+populates it (`computeIndex` → `buildRealView`); on the all-items path it stays
+`null` and today's fields (`definitionLevels`, `repetitionLevels`,
+`elementValidity`, `multiLevelOffsets`) are populated as they are now.
+
+### Drain publish, real-items mode
+
+In `computeIndex`, when `realItemsMode`:
+
+- Build the `RealView` from the batch's def/rep levels (already set on the batch
+  at this point), and **skip** the all-items index (`computeElementValidity`,
+  `computeLayerOffsets`) — it serves only the `RowReader`, so
+  `batch.elementValidity` / `batch.multiLevelOffsets` stay `null`.
+- Fixed-size-list fast-path batches (`fixedListK > 0`) already omit levels; the
+  drain stamps the arithmetic `RealView` (layer offsets from
+  `fixedListLayerOffsets`, all-present validity, `realToRawLeaf == null`) the
+  consumer used to build in `fixedListRealView`.
+- Raw def/rep levels are **still materialized** on the batch in Stage 1 (dropped
+  in Stage 2). Value compaction stays on the consumer.
+
+### Consumer
+
+`ColumnReader.ensureRealView()` returns `currentNestedBatch.realView` when the
+drain set it, and otherwise falls back to the existing lazy
+`computeRealView` / `fixedListRealView` — the path a batch derived by
+consumer-side record selection still takes, since selection builds its batch
+without a drain view. This keeps the selection path unchanged in Stage 1.
+
+### RowReader path
+
+Unchanged. `realItemsMode == false` keeps materializing def/rep levels and the
+all-items index, so `NestedBatchIndex` and its consumers see exactly today's
+batch.
+
+## Stage 2 — drop ColumnReader-path level materialization (planned)
+
+With **#749** landed (the public `getDefinitionLevels()` / `getRepetitionLevels()`
+escape hatches removed), the real-items path has zero raw-level readers left, so:
+
+- `computeIndex` builds the `RealView` directly from the drain accumulators and
+  leaves `batch.definitionLevels` / `batch.repetitionLevels` **`null`**, dropping
+  the per-batch level `Arrays.copyOf` pair.
+- `applySelection` → `compactNestedBatch` can no longer slice raw levels; it
+  **slices the parent `RealView`** for the kept records. Selection keeps whole
+  top-level records — contiguous real-leaf spans — so `layerOffsets`,
+  `layerValidity`, `leafValidity`, and `realToRawLeaf` are gathered/renumbered
+  directly rather than reconstructed from levels.
+
+## Scope
+
+- **In:** the real-items `ColumnReader` path — RealView on the drain (Stage 1),
+  and dropping the def/rep level copy plus the selection-path RealView slice
+  (Stage 2).
+- **Out:** value compaction stays on the consumer (moving it, and reusing consumer
+  scratch across batches, is the separate buffer-reuse lever). The `RowReader`
+  all-items path is untouched. Bulk-copy assembly (#750) is orthogonal.
+
+## Dependencies
+
+- **#749** (Stage 2 only) — remove the public raw-level escape-hatch accessors.
+  Required before the levels can be dropped: without it the `ColumnReader` path
+  would still have a raw-level reader.
+
+## Benefits
+
+- The dominant critical-path scan moves off the serial consumer onto the ~96%-idle
+  parallel drain threads — a latency win independent of any instruction-count
+  change.
+- The per-batch def/rep level `Arrays.copyOf` pair is eliminated on real-items
+  reads.
+- The drain stops computing the all-items `elementValidity` + `multiLevelOffsets`
+  for `ColumnReader` batches, and the duplicated level scan (drain index vs
+  consumer `RealView`) collapses to one scan.
+
+## Testing
+
+- Differential: `ColumnReader` and `RowReader` folds agree across null densities,
+  masking, multi-level nesting, and the fixed-size-list fast path (the existing
+  nested differential suite).
+- `NestedListReadBenchmark`: `columnNested` improves in wall time; `rowNested` and
+  `flatFloor` do not regress.
+
+## Results (Stage 1)
+
+`NestedListReadBenchmark`, `LIST<float64>`, 8 M leaves, N300, unpinned (the
+cross-core rebalance the change targets is not visible pinned to one core):
+
+| `columnNested` | baseline ms/op | Stage 1 ms/op | Δ |
+|---|--:|--:|--:|
+| none | 197.1 ± 4.1 | 188.4 ± 2.2 | −4.4% |
+| dense | 312.6 ± 14.1 | 271.9 ± 12.2 | −13.0% |
+
+`rowNested` is unchanged (none 147.6 → 147.3, dense 214.8 → 214.1). The win is
+largest on `dense`, where the `RealView` scan does the most validity bookkeeping,
+so moving it off the serial consumer helps most. The residual gap to `rowNested`
+is the consumer-side value compaction and per-batch allocation — the targets of
+the buffer-reuse lever and Stage 2.

--- a/_designs/NESTED_REALVIEW_ON_DRAIN.md
+++ b/_designs/NESTED_REALVIEW_ON_DRAIN.md
@@ -13,17 +13,22 @@
 
 Status: **Implemented**
 
-Tracking issue: #751
+Tracking issues: #751, #766
 
-This change landed in two stages. **Stage 1** moved `computeRealView` onto the
-drain while the batch kept carrying raw def/rep levels — the primary win (the
-critical-path scan runs on idle threads) at low risk, with no dependency on #749
-and no change to the record-selection path. **Stage 2** (this document's end
-state) drops the raw level materialization on the unfiltered `ColumnReader` path,
-which removes per-batch memory traffic on the now-bandwidth-bound drain. It depends
-on #749 (the raw-level escape-hatch accessors removed) and distinguishes the
-filtered from the unfiltered path with a per-worker `IndexMode` — the filtered path
-simply keeps the levels, so record selection is unchanged.
+On the unfiltered `ColumnReader` (real-items) path the drain computes the
+real-items view and drops the raw def/rep level materialization, so the serial
+consumer reads a ready-made view instead of scanning levels on the critical path.
+A per-worker `IndexMode` separates this path from the `RowReader` all-items path
+and the exact-filter path, both of which keep the levels; record selection is
+unchanged. Dropping the raw levels depends on #749 (the escape-hatch accessors
+removed), so no downstream reader needs them.
+
+For an **all-present** batch — one with no null or empty parents — the drain
+builds only a **lean offsets view** (`computeLayerOffsets` alone), skipping the
+per-layer validity and gather-map work of the full `computeRealView` scan. It is
+built unconditionally on the drain, so reconstruction stays off the serial
+consumer for every consumer shape, including a list-reconstructing read that needs
+the offsets.
 
 ## Problem
 
@@ -66,6 +71,11 @@ wait. Separately, the per-batch def/rep level copy and the drain's all-items ind
   `getRepetitionLevels()` escape hatches removed), the `ColumnReader` path has
   *zero* raw-level readers left, so the levels can be dropped outright — no
   on-demand level synthesis is needed.
+- An **all-present** batch (every leaf definition level at max) has no phantom
+  positions, so its real-items `layerOffsets` equal the all-items offsets and
+  every validity is trivially all-present. Its view reduces to the list
+  boundaries, which `computeLayerOffsets` produces without the per-layer
+  presence, leaf-validity, and gather-map work of the full `computeRealView`.
 
 ## End state
 
@@ -78,9 +88,11 @@ changes):
 - **`ALL_ITEMS`** — the `RowReader` path (and the convenience constructor tests
   use). Computes the all-items `elementValidity` + `multiLevelOffsets` index and
   keeps the raw def/rep levels, which `NestedBatchIndex` and its consumers read.
-- **`REAL_VIEW`** — the unfiltered `ColumnReader` path. Builds the `RealView` (and
-  compacted values) on the drain and drops the raw levels and the all-items index;
-  nothing downstream reads them.
+- **`REAL_VIEW`** — the unfiltered `ColumnReader` path. Builds the real-items view
+  on the drain and drops the raw levels and the all-items index; nothing downstream
+  reads them. An all-present batch builds only a **lean offsets view** (see
+  [All-present lean view](#all-present-lean-view)); a batch with phantom positions
+  builds the full `RealView` and compacts its values.
 - **`REAL_VIEW_KEEP_LEVELS`** — the exact-filtered `ColumnReader` path. Keeps the
   raw levels so `applySelection` can slice them per kept record, and skips the
   all-items index; the drain derives no view (the consumer rebuilds it after
@@ -89,7 +101,8 @@ changes):
 ### NestedBatch carries the RealView
 
 `NestedBatch` gains a `RealView realView` field. On the real-items path the drain
-populates it (`computeIndex` → `buildRealView`); on the all-items path it stays
+populates it (`computeIndex` → `buildAllPresentView` for all-present batches,
+`buildRealView` otherwise); on the all-items path it stays
 `null` and today's fields (`definitionLevels`, `repetitionLevels`,
 `elementValidity`, `multiLevelOffsets`) are populated as they are now.
 
@@ -97,21 +110,52 @@ populates it (`computeIndex` → `buildRealView`); on the all-items path it stay
 
 In `computeIndex`:
 
-- **`REAL_VIEW`** builds the `RealView` from the **drain accumulators**
+- **`REAL_VIEW`** derives its view from the **drain accumulators**
   (`nestedDefLevels` / `nestedRepLevels`, still intact for `[0, valueCount)` until
   the counts reset after publish), so `publishCurrentBatch` leaves the batch's
   `definitionLevels` / `repetitionLevels` **`null`** — the per-batch level
   `Arrays.copyOf` pair is dropped. The all-items index is skipped
-  (`elementValidity` / `multiLevelOffsets` stay `null`). Fixed-size-list fast-path
-  batches (`fixedListK > 0`) already omit levels; the drain stamps the arithmetic
-  `RealView` (offsets from `fixedListLayerOffsets`, all-present validity,
-  `realToRawLeaf == null`). Value compaction into `realValues` is also done here
-  (see the value-compaction design); otherwise the raw values pass through.
+  (`elementValidity` / `multiLevelOffsets` stay `null`). What it builds depends on
+  whether the batch has phantom (null/empty parent) positions:
+  - **All-present** (every leaf definition level at max, including the
+    fixed-size-list fast path where `fixedListK > 0`): the drain builds a **lean
+    offsets view** — `layerOffsets` from `computeLayerOffsets` (or
+    `fixedListLayerOffsets` on the fast path), every validity `null`, and
+    `realToRawLeaf == null`. The dense values already are the real-leaf values, so
+    `realValues` is the batch values unchanged.
+  - **Phantom-bearing**: the drain builds the full `RealView` (`computeRealView`)
+    and compacts the leaf values into `realValues` through `realToRawLeaf`
+    (`LeafCompaction`); a batch whose phantom map is the identity passes its values
+    through uncompacted.
 - **`REAL_VIEW_KEEP_LEVELS`** keeps the raw levels (copied as before) and derives
   nothing else — no view, no all-items index. The batch is compacted by
   `applySelection` before the consumer reads it.
 - **`ALL_ITEMS`** keeps the raw levels and computes `elementValidity` +
   `multiLevelOffsets`, as before.
+
+### All-present lean view
+
+An all-present batch has no null or empty parents, so no raw position is a
+phantom: its real-items offsets are identical to the all-items offsets, every
+item at every layer is present, and the leaf values need no gather. The drain
+therefore skips the full `computeRealView` scan — which would build per-layer
+validity bitmaps and a `realToRawLeaf` gather map only to fill them with
+all-present / identity values — and computes the list boundaries alone with
+`computeLayerOffsets`.
+
+The lean view is built unconditionally on the drain, so it serves both
+`ColumnReader` consumer shapes without a consumer-side scan:
+
+- a **flat leaf** read (`getValueCount` plus the typed values — the
+  vector/embedding pattern) ignores the offsets and reads the pass-through values
+  directly; leaf validity is all-present, so `getLeafValidity` returns the
+  no-nulls sentinel;
+- a **list-reconstructing** read (`getLayerOffsets` / `getLayerValidity`) reads the
+  drain-built boundaries and the all-present validities.
+
+Deferring the view to a lazy consumer-side build would put a structural read's
+offset scan back on the serial consumer; building the lean view eagerly avoids
+that while costing a flat leaf read only the cheap boundary scan it discards.
 
 ### Consumer
 
@@ -131,12 +175,13 @@ so `NestedBatchIndex` and its consumers see exactly today's batch.
 
 ## Scope
 
-- **In:** the `ColumnReader` real-items path — `RealView` on the drain, and
-  dropping the def/rep level copy and the all-items index on the unfiltered
-  (`REAL_VIEW`) path.
-- **Out:** value compaction on the drain is a separate change. The `RowReader`
-  all-items path and the exact-filter record-selection logic are untouched.
-  Bulk-copy assembly (#750) is orthogonal.
+- **In:** the `ColumnReader` real-items path — the real-items view on the drain
+  (the lean offsets view for all-present batches, the full `RealView` otherwise),
+  and dropping the def/rep level copy and the all-items index on the unfiltered
+  (`REAL_VIEW`) path. Leaf-value compaction into `realValues` on the phantom-bearing
+  path is tracked as #757 and lands on the same path.
+- **Out:** the `RowReader` all-items path and the exact-filter record-selection
+  logic are untouched. Bulk-copy assembly (#750) is orthogonal.
 
 ## Dependencies
 
@@ -164,31 +209,34 @@ so `NestedBatchIndex` and its consumers see exactly today's batch.
   nested differential suite).
 - `NestedListReadBenchmark`: `columnNested` improves in wall time; `rowNested` and
   `flatFloor` do not regress.
+- `NestedListReadBenchmark.columnNestedStructural` — a list-reconstructing consumer
+  reading `getLayerOffsets` / `getLayerValidity` — folds to the same sum as
+  `columnNested`, `rowNested`, and the flat floor, and reads the drain-built lean
+  view without a consumer-side scan.
 
-## Results (Stage 1)
+## Results
 
-`NestedListReadBenchmark`, `LIST<float64>`, 8 M leaves, N300, unpinned (the
-cross-core rebalance the change targets is not visible pinned to one core):
+The design's benefit was isolated in three parts; the numbers come from different
+measurement points and machines rather than a single main-to-end-state run.
 
-| `columnNested` | baseline ms/op | Stage 1 ms/op | Δ |
+**Reconstruction off the serial consumer** — `NestedListReadBenchmark`,
+`LIST<float64>`, 8 M leaves, N300, unpinned (the cross-core rebalance is not visible
+pinned to one core). Moving the `computeRealView` scan onto the ~96%-idle drain
+threads:
+
+| `columnNested` | before ms/op | after ms/op | Δ |
 |---|--:|--:|--:|
 | none | 197.1 ± 4.1 | 188.4 ± 2.2 | −4.4% |
 | dense | 312.6 ± 14.1 | 271.9 ± 12.2 | −13.0% |
 
 `rowNested` is unchanged (none 147.6 → 147.3, dense 214.8 → 214.1). The win is
-largest on `dense`, where the `RealView` scan does the most validity bookkeeping,
-so moving it off the serial consumer helps most. The residual gap to `rowNested`
-was the consumer-side value compaction and per-batch allocation, addressed by the
-follow-on value-compaction work; Stage 2 (this document's end state) then removed
-the raw-level materialization on top.
+largest on `dense`, where the scan does the most validity bookkeeping.
 
-## Results (Stage 2)
+**Dropping the per-batch level copy** — same benchmark, N300, single-channel, so the
+effect tracks memory bandwidth. Eliminating the def/rep `Arrays.copyOf` pair on the
+unfiltered path:
 
-Dropping the raw-level copy on the unfiltered path removes per-batch drain memory
-traffic, so its effect tracks memory bandwidth. On the single-channel N300 (drain
-bandwidth-bound), isolating Stage 2 against the otherwise-identical prior build:
-
-| benchmark | pre-Stage 2 | Stage 2 | Δ |
+| benchmark | before | after | Δ |
 |---|--:|--:|--:|
 | `columnNested` none | 179.0 | 165.2 | −7.7% |
 | `columnNested` dense | 277.1 | 263.5 | −4.9% |
@@ -196,6 +244,18 @@ bandwidth-bound), isolating Stage 2 against the otherwise-identical prior build:
 | `columnMulti` (8 col) dense | 173.2 | 164.8 | −4.8% |
 
 The win is largest on the wide, all-present case, where the most level bytes are
-dropped (eight columns × two copies × the largest per-batch value counts). On a
-bandwidth-rich machine (Apple Silicon, unified memory) the same A/B is neutral —
-the traffic reduction has no scarce resource to free.
+dropped. On a bandwidth-rich machine (Apple Silicon, unified memory) the same change
+is neutral — the traffic reduction has no scarce resource to free.
+
+**The lean all-present view** — in-container, no perf isolation, directional and
+pending N300 confirmation; `LIST<float64>`, 2 M leaves, `none`. Building only the
+offsets (vs the full `computeRealView`) drops both `ColumnReader` shapes below the
+`rowNested` all-items path:
+
+| benchmark | full drain build | lean view | `rowNested` |
+|---|--:|--:|--:|
+| `columnNested` (flat leaf) | 15.2 | 10.9 | 12.9 |
+| `columnNestedStructural` | 15.4 | 11.4 | 12.9 |
+
+Phantom-bearing (`sparse` / `dense`) batches still build the full `RealView` and
+remain slower than `rowNested`; leaning that path is tracked separately.

--- a/_designs/NESTED_REALVIEW_ON_DRAIN.md
+++ b/_designs/NESTED_REALVIEW_ON_DRAIN.md
@@ -11,18 +11,19 @@
 -->
 # RealView on the drain; drop ColumnReader-path level materialization
 
-Status: **Stage 1 implemented; Stage 2 planned**
+Status: **Implemented**
 
 Tracking issue: #751
 
-This change lands in two stages. **Stage 1** moves `computeRealView` onto the
-drain while the batch keeps carrying raw def/rep levels — it captures the primary
-win (the critical-path scan runs on idle threads) at low risk, with no dependency
-on #749 and no change to the record-selection path. **Stage 2** drops the raw
-level materialization on the `ColumnReader` path; it depends on #749 and rewrites
-record selection to slice the `RealView`. The stages are split because profiling
-attributes the wall-clock win to the *move*, not the level-drop, so Stage 1
-delivers most of the benefit on its own.
+This change landed in two stages. **Stage 1** moved `computeRealView` onto the
+drain while the batch kept carrying raw def/rep levels — the primary win (the
+critical-path scan runs on idle threads) at low risk, with no dependency on #749
+and no change to the record-selection path. **Stage 2** (this document's end
+state) drops the raw level materialization on the unfiltered `ColumnReader` path,
+which removes per-batch memory traffic on the now-bandwidth-bound drain. It depends
+on #749 (the raw-level escape-hatch accessors removed) and distinguishes the
+filtered from the unfiltered path with a per-worker `IndexMode` — the filtered path
+simply keeps the levels, so record selection is unchanged.
 
 ## Problem
 
@@ -66,14 +67,24 @@ wait. Separately, the per-batch def/rep level copy and the drain's all-items ind
   *zero* raw-level readers left, so the levels can be dropped outright — no
   on-demand level synthesis is needed.
 
-## Stage 1 — RealView on the drain (implemented)
+## End state
 
-### Real-items mode flag
+### IndexMode
 
-`NestedColumnWorker` takes a `realItemsMode` boolean. `ColumnReader` constructs
-its worker with `true`, `NestedRowReader` with `false`; the convenience
-constructor (tests) defaults to `false`. The flag selects what the drain computes
-at publish time; nothing else in assembly changes.
+`NestedColumnWorker` takes an `IndexMode`, chosen by the constructing reader, that
+selects what the drain derives per batch at publish time (nothing else in assembly
+changes):
+
+- **`ALL_ITEMS`** — the `RowReader` path (and the convenience constructor tests
+  use). Computes the all-items `elementValidity` + `multiLevelOffsets` index and
+  keeps the raw def/rep levels, which `NestedBatchIndex` and its consumers read.
+- **`REAL_VIEW`** — the unfiltered `ColumnReader` path. Builds the `RealView` (and
+  compacted values) on the drain and drops the raw levels and the all-items index;
+  nothing downstream reads them.
+- **`REAL_VIEW_KEEP_LEVELS`** — the exact-filtered `ColumnReader` path. Keeps the
+  raw levels so `applySelection` can slice them per kept record, and skips the
+  all-items index; the drain derives no view (the consumer rebuilds it after
+  selection).
 
 ### NestedBatch carries the RealView
 
@@ -82,71 +93,66 @@ populates it (`computeIndex` → `buildRealView`); on the all-items path it stay
 `null` and today's fields (`definitionLevels`, `repetitionLevels`,
 `elementValidity`, `multiLevelOffsets`) are populated as they are now.
 
-### Drain publish, real-items mode
+### Drain publish
 
-In `computeIndex`, when `realItemsMode`:
+In `computeIndex`:
 
-- Build the `RealView` from the batch's def/rep levels (already set on the batch
-  at this point), and **skip** the all-items index (`computeElementValidity`,
-  `computeLayerOffsets`) — it serves only the `RowReader`, so
-  `batch.elementValidity` / `batch.multiLevelOffsets` stay `null`.
-- Fixed-size-list fast-path batches (`fixedListK > 0`) already omit levels; the
-  drain stamps the arithmetic `RealView` (layer offsets from
-  `fixedListLayerOffsets`, all-present validity, `realToRawLeaf == null`) the
-  consumer used to build in `fixedListRealView`.
-- Raw def/rep levels are **still materialized** on the batch in Stage 1 (dropped
-  in Stage 2). Value compaction stays on the consumer.
+- **`REAL_VIEW`** builds the `RealView` from the **drain accumulators**
+  (`nestedDefLevels` / `nestedRepLevels`, still intact for `[0, valueCount)` until
+  the counts reset after publish), so `publishCurrentBatch` leaves the batch's
+  `definitionLevels` / `repetitionLevels` **`null`** — the per-batch level
+  `Arrays.copyOf` pair is dropped. The all-items index is skipped
+  (`elementValidity` / `multiLevelOffsets` stay `null`). Fixed-size-list fast-path
+  batches (`fixedListK > 0`) already omit levels; the drain stamps the arithmetic
+  `RealView` (offsets from `fixedListLayerOffsets`, all-present validity,
+  `realToRawLeaf == null`). Value compaction into `realValues` is also done here
+  (see the value-compaction design); otherwise the raw values pass through.
+- **`REAL_VIEW_KEEP_LEVELS`** keeps the raw levels (copied as before) and derives
+  nothing else — no view, no all-items index. The batch is compacted by
+  `applySelection` before the consumer reads it.
+- **`ALL_ITEMS`** keeps the raw levels and computes `elementValidity` +
+  `multiLevelOffsets`, as before.
 
 ### Consumer
 
 `ColumnReader.ensureRealView()` returns `currentNestedBatch.realView` when the
-drain set it, and otherwise falls back to the existing lazy
-`computeRealView` / `fixedListRealView` — the path a batch derived by
-consumer-side record selection still takes, since selection builds its batch
-without a drain view. This keeps the selection path unchanged in Stage 1.
+drain set it (`REAL_VIEW`), and otherwise falls back to the lazy
+`computeRealView` / `fixedListRealView` from the batch's levels — the path taken by
+`REAL_VIEW_KEEP_LEVELS` batches and by the batches `compactNestedBatch` derives
+from them. Because the filtered path keeps its levels, **record selection is
+unchanged**: `compactNestedBatch` slices the raw `(levels, values, recordOffsets)`
+triplet exactly as before, and the consumer rebuilds the view from the sliced
+levels.
 
 ### RowReader path
 
-Unchanged. `realItemsMode == false` keeps materializing def/rep levels and the
-all-items index, so `NestedBatchIndex` and its consumers see exactly today's
-batch.
-
-## Stage 2 — drop ColumnReader-path level materialization (planned)
-
-With **#749** landed (the public `getDefinitionLevels()` / `getRepetitionLevels()`
-escape hatches removed), the real-items path has zero raw-level readers left, so:
-
-- `computeIndex` builds the `RealView` directly from the drain accumulators and
-  leaves `batch.definitionLevels` / `batch.repetitionLevels` **`null`**, dropping
-  the per-batch level `Arrays.copyOf` pair.
-- `applySelection` → `compactNestedBatch` can no longer slice raw levels; it
-  **slices the parent `RealView`** for the kept records. Selection keeps whole
-  top-level records — contiguous real-leaf spans — so `layerOffsets`,
-  `layerValidity`, `leafValidity`, and `realToRawLeaf` are gathered/renumbered
-  directly rather than reconstructed from levels.
+Unchanged. `ALL_ITEMS` keeps materializing def/rep levels and the all-items index,
+so `NestedBatchIndex` and its consumers see exactly today's batch.
 
 ## Scope
 
-- **In:** the real-items `ColumnReader` path — RealView on the drain (Stage 1),
-  and dropping the def/rep level copy plus the selection-path RealView slice
-  (Stage 2).
-- **Out:** value compaction stays on the consumer (moving it, and reusing consumer
-  scratch across batches, is the separate buffer-reuse lever). The `RowReader`
-  all-items path is untouched. Bulk-copy assembly (#750) is orthogonal.
+- **In:** the `ColumnReader` real-items path — `RealView` on the drain, and
+  dropping the def/rep level copy and the all-items index on the unfiltered
+  (`REAL_VIEW`) path.
+- **Out:** value compaction on the drain is a separate change. The `RowReader`
+  all-items path and the exact-filter record-selection logic are untouched.
+  Bulk-copy assembly (#750) is orthogonal.
 
 ## Dependencies
 
-- **#749** (Stage 2 only) — remove the public raw-level escape-hatch accessors.
-  Required before the levels can be dropped: without it the `ColumnReader` path
-  would still have a raw-level reader.
+- **#749** — the public `getDefinitionLevels()` / `getRepetitionLevels()`
+  escape-hatch accessors removed. Required before the levels can be dropped on the
+  `REAL_VIEW` path: without it the `ColumnReader` would still have a raw-level
+  reader.
 
 ## Benefits
 
 - The dominant critical-path scan moves off the serial consumer onto the ~96%-idle
   parallel drain threads — a latency win independent of any instruction-count
   change.
-- The per-batch def/rep level `Arrays.copyOf` pair is eliminated on real-items
-  reads.
+- On the unfiltered path the per-batch def/rep level `Arrays.copyOf` pair is
+  eliminated, cutting drain memory traffic — which matters because the drain is
+  bandwidth-bound once reconstruction has moved onto it.
 - The drain stops computing the all-items `elementValidity` + `multiLevelOffsets`
   for `ColumnReader` batches, and the duplicated level scan (drain index vs
   consumer `RealView`) collapses to one scan.
@@ -172,5 +178,24 @@ cross-core rebalance the change targets is not visible pinned to one core):
 `rowNested` is unchanged (none 147.6 → 147.3, dense 214.8 → 214.1). The win is
 largest on `dense`, where the `RealView` scan does the most validity bookkeeping,
 so moving it off the serial consumer helps most. The residual gap to `rowNested`
-is the consumer-side value compaction and per-batch allocation — the targets of
-the buffer-reuse lever and Stage 2.
+was the consumer-side value compaction and per-batch allocation, addressed by the
+follow-on value-compaction work; Stage 2 (this document's end state) then removed
+the raw-level materialization on top.
+
+## Results (Stage 2)
+
+Dropping the raw-level copy on the unfiltered path removes per-batch drain memory
+traffic, so its effect tracks memory bandwidth. On the single-channel N300 (drain
+bandwidth-bound), isolating Stage 2 against the otherwise-identical prior build:
+
+| benchmark | pre-Stage 2 | Stage 2 | Δ |
+|---|--:|--:|--:|
+| `columnNested` none | 179.0 | 165.2 | −7.7% |
+| `columnNested` dense | 277.1 | 263.5 | −4.9% |
+| `columnMulti` (8 col) none | 129.8 | 113.2 | −12.8% |
+| `columnMulti` (8 col) dense | 173.2 | 164.8 | −4.8% |
+
+The win is largest on the wide, all-present case, where the most level bytes are
+dropped (eight columns × two copies × the largest per-batch value counts). On a
+bandwidth-rich machine (Apple Silicon, unified memory) the same A/B is neutral —
+the traffic reduction has no scarce resource to free.

--- a/core/src/main/java/dev/hardwood/internal/reader/LeafCompaction.java
+++ b/core/src/main/java/dev/hardwood/internal/reader/LeafCompaction.java
@@ -1,0 +1,99 @@
+/*
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Copyright The original authors
+ *
+ *  Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package dev.hardwood.internal.reader;
+
+/// Gathers a nested batch's real-items-only leaf values from its raw
+/// (phantom-including) value array, using a real-leaf → raw-position map. Shared
+/// by the drain — which pre-compacts on the [dev.hardwood.reader.ColumnReader]
+/// path so the scan lands on an idle thread — and the consumer fallback for
+/// batches derived by record selection.
+public final class LeafCompaction {
+
+    private LeafCompaction() {
+    }
+
+    /// Returns a fresh array holding `raw[map[i]]` for each real-leaf index `i`.
+    /// The result is sized to `map.length`; the caller owns it outright.
+    public static Object compact(Object raw, int[] map) {
+        int n = map.length;
+        return switch (raw) {
+            case int[] a -> {
+                int[] out = new int[n];
+                for (int i = 0; i < n; i++) {
+                    out[i] = a[map[i]];
+                }
+                yield out;
+            }
+            case long[] a -> {
+                long[] out = new long[n];
+                for (int i = 0; i < n; i++) {
+                    out[i] = a[map[i]];
+                }
+                yield out;
+            }
+            case float[] a -> {
+                float[] out = new float[n];
+                for (int i = 0; i < n; i++) {
+                    out[i] = a[map[i]];
+                }
+                yield out;
+            }
+            case double[] a -> {
+                double[] out = new double[n];
+                for (int i = 0; i < n; i++) {
+                    out[i] = a[map[i]];
+                }
+                yield out;
+            }
+            case boolean[] a -> {
+                boolean[] out = new boolean[n];
+                for (int i = 0; i < n; i++) {
+                    out[i] = a[map[i]];
+                }
+                yield out;
+            }
+            case BinaryBatchValues bbv -> compactBinary(bbv, map, n);
+            default -> throw new IllegalStateException("Unexpected leaf array type: " + raw.getClass());
+        };
+    }
+
+    /// Compacts a varlength leaf to the records at `map[0..count)`. `map` may be
+    /// an oversized reusable buffer (flat in-place path) or an exact gather index
+    /// (nested path); only its `[0, count)` prefix is read. A dictionary-encoded
+    /// string leaf carries its chunk dictionary and gathered entry indices through,
+    /// so `getStrings()` still reuses the interned instances.
+    public static BinaryBatchValues compactBinary(BinaryBatchValues raw, int[] map, int count) {
+        int totalBytes = 0;
+        int[] outOffsets = new int[count + 1];
+        for (int i = 0; i < count; i++) {
+            int rawIdx = map[i];
+            int len = raw.offsets[rawIdx + 1] - raw.offsets[rawIdx];
+            outOffsets[i] = totalBytes;
+            totalBytes += len;
+        }
+        outOffsets[count] = totalBytes;
+        byte[] outBytes = new byte[totalBytes];
+        boolean interned = raw.dictionary != null;
+        int[] outDictIndices = interned ? new int[count] : null;
+        for (int i = 0; i < count; i++) {
+            int rawIdx = map[i];
+            int rawStart = raw.offsets[rawIdx];
+            int len = raw.offsets[rawIdx + 1] - rawStart;
+            System.arraycopy(raw.bytes, rawStart, outBytes, outOffsets[i], len);
+            if (interned) {
+                outDictIndices[i] = raw.dictIndices[rawIdx];
+            }
+        }
+        BinaryBatchValues out = new BinaryBatchValues(outBytes, outOffsets);
+        if (interned) {
+            out.dictionary = raw.dictionary;
+            out.dictIndices = outDictIndices;
+        }
+        return out;
+    }
+}

--- a/core/src/main/java/dev/hardwood/internal/reader/NestedBatch.java
+++ b/core/src/main/java/dev/hardwood/internal/reader/NestedBatch.java
@@ -61,8 +61,4 @@ public final class NestedBatch {
     /// `null` when no gather is needed (`realView.realToRawLeaf() == null`: the raw
     /// [#values] already pass through) or on paths that compact lazily.
     public Object realValues;
-
-    /// True when the batch has no null/empty parents: the dense value stream is
-    /// already the real-leaf stream and the RealView structure can be deferred.
-    public boolean allPresent;
 }

--- a/core/src/main/java/dev/hardwood/internal/reader/NestedBatch.java
+++ b/core/src/main/java/dev/hardwood/internal/reader/NestedBatch.java
@@ -55,4 +55,10 @@ public final class NestedBatch {
     /// `null` on the all-items path and on batches derived by consumer-side record
     /// selection (for which the consumer builds a view lazily from the sliced levels).
     public NestedLevelComputer.RealView realView;
+
+    /// Real-items-only leaf values, gathered by the drain from [#values] when the
+    /// batch has phantom positions, so the compaction runs off the serial consumer.
+    /// `null` when no gather is needed (`realView.realToRawLeaf() == null`: the raw
+    /// [#values] already pass through) or on paths that compact lazily.
+    public Object realValues;
 }

--- a/core/src/main/java/dev/hardwood/internal/reader/NestedBatch.java
+++ b/core/src/main/java/dev/hardwood/internal/reader/NestedBatch.java
@@ -49,4 +49,10 @@ public final class NestedBatch {
     // batch."
     public long[] elementValidity;
     public int[][] multiLevelOffsets;
+
+    /// Real-items view, computed by the drain on the [dev.hardwood.reader.ColumnReader]
+    /// (real-items) path so the serial consumer reads it without a level scan.
+    /// `null` on the all-items path and on batches derived by consumer-side record
+    /// selection (for which the consumer builds a view lazily from the sliced levels).
+    public NestedLevelComputer.RealView realView;
 }

--- a/core/src/main/java/dev/hardwood/internal/reader/NestedBatch.java
+++ b/core/src/main/java/dev/hardwood/internal/reader/NestedBatch.java
@@ -61,4 +61,8 @@ public final class NestedBatch {
     /// `null` when no gather is needed (`realView.realToRawLeaf() == null`: the raw
     /// [#values] already pass through) or on paths that compact lazily.
     public Object realValues;
+
+    /// True when the batch has no null/empty parents: the dense value stream is
+    /// already the real-leaf stream and the RealView structure can be deferred.
+    public boolean allPresent;
 }

--- a/core/src/main/java/dev/hardwood/internal/reader/NestedColumnWorker.java
+++ b/core/src/main/java/dev/hardwood/internal/reader/NestedColumnWorker.java
@@ -391,12 +391,31 @@ public class NestedColumnWorker extends ColumnWorker<NestedBatch> {
         if (indexMode == IndexMode.REAL_VIEW) {
             // Unfiltered ColumnReader: the consumer reads only the real-items view
             // and values, so build both here on the drain (off the serial consumer)
-            // and skip the all-items index. When the batch has phantom positions the
-            // leaf values are gathered now too; otherwise the raw values pass through.
-            NestedLevelComputer.RealView rv = buildRealView(batch);
-            batch.realView = rv;
-            int[] map = rv.realToRawLeaf();
-            batch.realValues = map != null ? LeafCompaction.compact(batch.values, map) : null;
+            // and skip the all-items index. An all-present batch has no phantom
+            // positions, so its offsets equal the all-items offsets: build just the
+            // lean offsets view (no per-layer validity or gather map) and pass the
+            // dense values through. A batch with phantom positions builds the full
+            // view and gathers the real leaf values. The view is built eagerly on the
+            // drain — not deferred to a lazy ensureRealView() on the consumer — so a
+            // structural read gets its offsets without a consumer-side scan; a flat
+            // leaf read simply ignores them.
+            boolean allPresent = batch.fixedListK > 0 || allDefsMax(batch.valueCount);
+            batch.allPresent = allPresent;
+            if (allPresent) {
+                batch.realValues = batch.values;
+                // With no phantom positions the real-items offsets equal the all-items
+                // offsets, so build just the boundaries (skipping the full projection's
+                // per-layer presence, leaf-validity, and gather-map work). A structural
+                // consumer reads these drain-built offsets without a consumer-side scan;
+                // a flat leaf consumer ignores them.
+                batch.realView = buildAllPresentView(batch);
+            }
+            else {
+                NestedLevelComputer.RealView rv = buildRealView(batch);
+                batch.realView = rv;
+                int[] map = rv.realToRawLeaf();
+                batch.realValues = map != null ? LeafCompaction.compact(batch.values, map) : batch.values;
+            }
             batch.elementValidity = null;
             batch.multiLevelOffsets = null;
             return;
@@ -438,27 +457,43 @@ public class NestedColumnWorker extends ColumnWorker<NestedBatch> {
         }
     }
 
-    /// Real-items view for the batch, built on the drain so the serial consumer
-    /// reads it without a scan. A fixed-width fast-path batch has every element
-    /// present with implicit `k`-multiple boundaries, so its offsets are
-    /// arithmetic and every validity is `null`; the regular path scans the def/rep
-    /// levels. The levels are read from the accumulators ([#nestedDefLevels] /
-    /// [#nestedRepLevels], still intact for `[0, valueCount)` until the counts reset
-    /// after publish) rather than the batch, so the `REAL_VIEW` path can leave the
-    /// batch's level arrays `null`. Mirrors the lazy `ensureRealView` computation
-    /// the consumer used to perform, moved to the parallel drain.
-    private NestedLevelComputer.RealView buildRealView(NestedBatch batch) {
-        if (batch.fixedListK > 0) {
-            int layerCount = layers.count();
-            return new NestedLevelComputer.RealView(
-                    NestedLevelComputer.fixedListLayerOffsets(
-                            batch.fixedListK, batch.recordCount, layers),
-                    new long[layerCount][], null,
-                    Math.multiplyExact(batch.recordCount, batch.fixedListK), null);
+    /// True when every leaf in the batch is present (def at max) — no null/empty
+    /// parents, so a flat consumer needs neither compaction nor per-layer offsets.
+    private boolean allDefsMax(int n) {
+        for (int i = 0; i < n; i++) {
+            if (nestedDefLevels[i] != maxDefinitionLevel) {
+                return false;
+            }
         }
+        return true;
+    }
+
+    /// Full real-items view for a batch with phantom (null/empty parent) positions,
+    /// built on the drain so the serial consumer reads it without a scan. Scans the
+    /// def/rep levels from the accumulators ([#nestedDefLevels] / [#nestedRepLevels],
+    /// still intact for `[0, valueCount)` until the counts reset after publish) rather
+    /// than the batch, so the `REAL_VIEW` path can leave the batch's level arrays
+    /// `null`. An all-present batch takes the cheaper [#buildAllPresentView] instead.
+    private NestedLevelComputer.RealView buildRealView(NestedBatch batch) {
         return NestedLevelComputer.computeRealView(
                 nestedDefLevels, nestedRepLevels,
                 batch.valueCount, batch.recordCount, maxDefinitionLevel, layers);
+    }
+
+    /// Lean real-items view for an all-present batch: only the layer offsets, which
+    /// (absent phantom positions) equal the all-items offsets. Every validity is
+    /// `null` (all present) and `realToRawLeaf` is `null` (the dense values are the
+    /// real-leaf values). Cheaper than [#buildRealView] — no per-layer presence,
+    /// leaf-validity, or gather-map scan — so a flat leaf consumer pays little for it
+    /// while a structural consumer reads the list boundaries off the drain.
+    private NestedLevelComputer.RealView buildAllPresentView(NestedBatch batch) {
+        int layerCount = layers.count();
+        int[][] offsets = batch.fixedListK > 0
+                ? NestedLevelComputer.fixedListLayerOffsets(batch.fixedListK, batch.recordCount, layers)
+                : NestedLevelComputer.computeLayerOffsets(
+                        nestedRepLevels, batch.valueCount, batch.recordCount, layers);
+        return new NestedLevelComputer.RealView(
+                offsets, new long[layerCount][], null, batch.valueCount, null);
     }
 
     // ==================== Nested Helpers ====================

--- a/core/src/main/java/dev/hardwood/internal/reader/NestedColumnWorker.java
+++ b/core/src/main/java/dev/hardwood/internal/reader/NestedColumnWorker.java
@@ -24,6 +24,13 @@ public class NestedColumnWorker extends ColumnWorker<NestedBatch> {
     private final int maxRepetitionLevel;
     private final NestedLevelComputer.Layers layers;
 
+    /// Whether this worker feeds the real-items [dev.hardwood.reader.ColumnReader]
+    /// path. When `true` the drain computes the batch's [NestedLevelComputer.RealView]
+    /// (moving that scan off the serial consumer) and skips the all-items index; when
+    /// `false` it feeds the [NestedRowReader] all-items path and computes the
+    /// element-validity / multi-level-offset index and raw levels as before.
+    private final boolean realItemsMode;
+
     // --- Nested assembly state (drain thread only) ---
     private Object nestedValues;
     private int[] nestedDefLevels;
@@ -61,14 +68,15 @@ public class NestedColumnWorker extends ColumnWorker<NestedBatch> {
     /// @param layers per-layer descriptor (kinds + def thresholds) for the
     ///        column's schema chain, or `null` for non-repeated columns. The
     ///        descriptor drives the layer-indexed `multiLevelOffsets` shape.
-    /// Convenience constructor with the fixed-size-list fast path enabled.
+    /// Convenience constructor feeding the all-items path with the fixed-size-list
+    /// fast path enabled.
     public NestedColumnWorker(PageSource pageSource, BatchExchange<NestedBatch> exchange,
                               ColumnSchema column, int batchCapacity,
                               DecompressorFactory decompressorFactory,
                               Executor decodeExecutor, long maxRows,
                               NestedLevelComputer.Layers layers) {
         this(pageSource, exchange, column, batchCapacity, decompressorFactory,
-             decodeExecutor, maxRows, layers, true);
+             decodeExecutor, maxRows, layers, false, true);
     }
 
     public NestedColumnWorker(PageSource pageSource, BatchExchange<NestedBatch> exchange,
@@ -76,11 +84,13 @@ public class NestedColumnWorker extends ColumnWorker<NestedBatch> {
                               DecompressorFactory decompressorFactory,
                               Executor decodeExecutor, long maxRows,
                               NestedLevelComputer.Layers layers,
+                              boolean realItemsMode,
                               boolean fixedListFastPathEnabled) {
         super(pageSource, exchange, column, batchCapacity, decompressorFactory,
               decodeExecutor, maxRows);
         this.maxRepetitionLevel = column.maxRepetitionLevel();
         this.layers = layers;
+        this.realItemsMode = realItemsMode;
         this.fixedListFastPathEnabled = fixedListFastPathEnabled;
     }
 
@@ -365,6 +375,16 @@ public class NestedColumnWorker extends ColumnWorker<NestedBatch> {
     /// `REPEATED` layer). `multiLevelOffsets[k]` is `null` for `STRUCT`
     /// layers and sentinel-suffixed for `REPEATED` layers.
     private void computeIndex(NestedBatch batch) {
+        if (realItemsMode) {
+            // The ColumnReader reads only the real-items view, so compute it here on
+            // the drain (off the serial consumer) and skip the all-items index.
+            batch.realView = buildRealView(batch);
+            batch.elementValidity = null;
+            batch.multiLevelOffsets = null;
+            return;
+        }
+        batch.realView = null;
+
         if (batch.fixedListK > 0) {
             // All elements present, boundaries at multiples of k: no validity and
             // arithmetic layer offsets, skipping the O(valueCount) level scans.
@@ -387,6 +407,26 @@ public class NestedColumnWorker extends ColumnWorker<NestedBatch> {
         else {
             batch.multiLevelOffsets = null;
         }
+    }
+
+    /// Real-items view for the batch, built on the drain so the serial consumer
+    /// reads it without a scan. A fixed-width fast-path batch has every element
+    /// present with implicit `k`-multiple boundaries, so its offsets are
+    /// arithmetic and every validity is `null`; the regular path scans the batch's
+    /// def/rep levels. Mirrors the lazy `ensureRealView` computation the consumer
+    /// used to perform, moved to the parallel drain.
+    private NestedLevelComputer.RealView buildRealView(NestedBatch batch) {
+        if (batch.fixedListK > 0) {
+            int layerCount = layers.count();
+            return new NestedLevelComputer.RealView(
+                    NestedLevelComputer.fixedListLayerOffsets(
+                            batch.fixedListK, batch.recordCount, layers),
+                    new long[layerCount][], null,
+                    Math.multiplyExact(batch.recordCount, batch.fixedListK), null);
+        }
+        return NestedLevelComputer.computeRealView(
+                batch.definitionLevels, batch.repetitionLevels,
+                batch.valueCount, batch.recordCount, maxDefinitionLevel, layers);
     }
 
     // ==================== Nested Helpers ====================

--- a/core/src/main/java/dev/hardwood/internal/reader/NestedColumnWorker.java
+++ b/core/src/main/java/dev/hardwood/internal/reader/NestedColumnWorker.java
@@ -24,12 +24,23 @@ public class NestedColumnWorker extends ColumnWorker<NestedBatch> {
     private final int maxRepetitionLevel;
     private final NestedLevelComputer.Layers layers;
 
-    /// Whether this worker feeds the real-items [dev.hardwood.reader.ColumnReader]
-    /// path. When `true` the drain computes the batch's [NestedLevelComputer.RealView]
-    /// (moving that scan off the serial consumer) and skips the all-items index; when
-    /// `false` it feeds the [NestedRowReader] all-items path and computes the
-    /// element-validity / multi-level-offset index and raw levels as before.
-    private final boolean realItemsMode;
+    /// Which derived structures the drain computes per batch, selected by the
+    /// constructing reader:
+    ///
+    /// - `ALL_ITEMS` — the [NestedRowReader] path: the all-items element-validity /
+    ///   multi-level-offset index and raw def/rep levels, which
+    ///   [NestedBatchIndex] and its consumers read.
+    /// - `REAL_VIEW` — the unfiltered [dev.hardwood.reader.ColumnReader] path: the
+    ///   real-items [NestedLevelComputer.RealView] (and compacted values), built on
+    ///   the drain from the accumulators so the serial consumer does no scan. The
+    ///   raw levels and the all-items index are dropped — nothing reads them.
+    /// - `REAL_VIEW_KEEP_LEVELS` — the exact-filtered `ColumnReader` path: the raw
+    ///   levels are kept so `applySelection`/`compactNestedBatch` can slice them per
+    ///   kept record, and the consumer rebuilds the view lazily from the compacted
+    ///   levels. The all-items index is still skipped.
+    public enum IndexMode { ALL_ITEMS, REAL_VIEW, REAL_VIEW_KEEP_LEVELS }
+
+    private final IndexMode indexMode;
 
     // --- Nested assembly state (drain thread only) ---
     private Object nestedValues;
@@ -76,7 +87,7 @@ public class NestedColumnWorker extends ColumnWorker<NestedBatch> {
                               Executor decodeExecutor, long maxRows,
                               NestedLevelComputer.Layers layers) {
         this(pageSource, exchange, column, batchCapacity, decompressorFactory,
-             decodeExecutor, maxRows, layers, false, true);
+             decodeExecutor, maxRows, layers, IndexMode.ALL_ITEMS, true);
     }
 
     public NestedColumnWorker(PageSource pageSource, BatchExchange<NestedBatch> exchange,
@@ -84,13 +95,13 @@ public class NestedColumnWorker extends ColumnWorker<NestedBatch> {
                               DecompressorFactory decompressorFactory,
                               Executor decodeExecutor, long maxRows,
                               NestedLevelComputer.Layers layers,
-                              boolean realItemsMode,
+                              IndexMode indexMode,
                               boolean fixedListFastPathEnabled) {
         super(pageSource, exchange, column, batchCapacity, decompressorFactory,
               decodeExecutor, maxRows);
         this.maxRepetitionLevel = column.maxRepetitionLevel();
         this.layers = layers;
-        this.realItemsMode = realItemsMode;
+        this.indexMode = indexMode;
         this.fixedListFastPathEnabled = fixedListFastPathEnabled;
     }
 
@@ -318,8 +329,10 @@ public class NestedColumnWorker extends ColumnWorker<NestedBatch> {
         currentBatch.recordCount = rowsInCurrentBatch;
         currentBatch.valueCount = nestedValueCount;
         currentBatch.fixedListK = batchFixedK;
-        if (batchFixedK > 0) {
-            // Fixed-width batch: boundaries are implicit, levels are omitted.
+        if (batchFixedK > 0 || indexMode == IndexMode.REAL_VIEW) {
+            // Fixed-width batches omit levels (boundaries are implicit); the
+            // unfiltered real-view path derives the view from the accumulators in
+            // computeIndex and drops the raw levels, which nothing downstream reads.
             currentBatch.definitionLevels = null;
             currentBatch.repetitionLevels = null;
         }
@@ -375,11 +388,11 @@ public class NestedColumnWorker extends ColumnWorker<NestedBatch> {
     /// `REPEATED` layer). `multiLevelOffsets[k]` is `null` for `STRUCT`
     /// layers and sentinel-suffixed for `REPEATED` layers.
     private void computeIndex(NestedBatch batch) {
-        if (realItemsMode) {
-            // The ColumnReader reads only the real-items view and values, so build
-            // both here on the drain (off the serial consumer) and skip the
-            // all-items index. When the batch has phantom positions the leaf values
-            // are gathered now too; otherwise the raw values pass through unchanged.
+        if (indexMode == IndexMode.REAL_VIEW) {
+            // Unfiltered ColumnReader: the consumer reads only the real-items view
+            // and values, so build both here on the drain (off the serial consumer)
+            // and skip the all-items index. When the batch has phantom positions the
+            // leaf values are gathered now too; otherwise the raw values pass through.
             NestedLevelComputer.RealView rv = buildRealView(batch);
             batch.realView = rv;
             int[] map = rv.realToRawLeaf();
@@ -390,6 +403,16 @@ public class NestedColumnWorker extends ColumnWorker<NestedBatch> {
         }
         batch.realView = null;
         batch.realValues = null;
+
+        if (indexMode == IndexMode.REAL_VIEW_KEEP_LEVELS) {
+            // Exact-filtered ColumnReader: applySelection compacts the batch from the
+            // raw levels (kept above) before the consumer reads it, then the consumer
+            // rebuilds the view lazily. Nothing is derived on the drain here; the
+            // all-items index the ColumnReader never reads is skipped.
+            batch.elementValidity = null;
+            batch.multiLevelOffsets = null;
+            return;
+        }
 
         if (batch.fixedListK > 0) {
             // All elements present, boundaries at multiples of k: no validity and
@@ -418,9 +441,12 @@ public class NestedColumnWorker extends ColumnWorker<NestedBatch> {
     /// Real-items view for the batch, built on the drain so the serial consumer
     /// reads it without a scan. A fixed-width fast-path batch has every element
     /// present with implicit `k`-multiple boundaries, so its offsets are
-    /// arithmetic and every validity is `null`; the regular path scans the batch's
-    /// def/rep levels. Mirrors the lazy `ensureRealView` computation the consumer
-    /// used to perform, moved to the parallel drain.
+    /// arithmetic and every validity is `null`; the regular path scans the def/rep
+    /// levels. The levels are read from the accumulators ([#nestedDefLevels] /
+    /// [#nestedRepLevels], still intact for `[0, valueCount)` until the counts reset
+    /// after publish) rather than the batch, so the `REAL_VIEW` path can leave the
+    /// batch's level arrays `null`. Mirrors the lazy `ensureRealView` computation
+    /// the consumer used to perform, moved to the parallel drain.
     private NestedLevelComputer.RealView buildRealView(NestedBatch batch) {
         if (batch.fixedListK > 0) {
             int layerCount = layers.count();
@@ -431,7 +457,7 @@ public class NestedColumnWorker extends ColumnWorker<NestedBatch> {
                     Math.multiplyExact(batch.recordCount, batch.fixedListK), null);
         }
         return NestedLevelComputer.computeRealView(
-                batch.definitionLevels, batch.repetitionLevels,
+                nestedDefLevels, nestedRepLevels,
                 batch.valueCount, batch.recordCount, maxDefinitionLevel, layers);
     }
 

--- a/core/src/main/java/dev/hardwood/internal/reader/NestedColumnWorker.java
+++ b/core/src/main/java/dev/hardwood/internal/reader/NestedColumnWorker.java
@@ -21,7 +21,6 @@ import dev.hardwood.schema.ColumnSchema;
 /// levels into [NestedBatch] holders.
 public class NestedColumnWorker extends ColumnWorker<NestedBatch> {
 
-    private final int maxRepetitionLevel;
     private final NestedLevelComputer.Layers layers;
 
     /// Which derived structures the drain computes per batch, selected by the
@@ -99,7 +98,6 @@ public class NestedColumnWorker extends ColumnWorker<NestedBatch> {
                               boolean fixedListFastPathEnabled) {
         super(pageSource, exchange, column, batchCapacity, decompressorFactory,
               decodeExecutor, maxRows);
-        this.maxRepetitionLevel = column.maxRepetitionLevel();
         this.layers = layers;
         this.indexMode = indexMode;
         this.fixedListFastPathEnabled = fixedListFastPathEnabled;
@@ -400,7 +398,6 @@ public class NestedColumnWorker extends ColumnWorker<NestedBatch> {
             // structural read gets its offsets without a consumer-side scan; a flat
             // leaf read simply ignores them.
             boolean allPresent = batch.fixedListK > 0 || allDefsMax(batch.valueCount);
-            batch.allPresent = allPresent;
             if (allPresent) {
                 batch.realValues = batch.values;
                 // With no phantom positions the real-items offsets equal the all-items

--- a/core/src/main/java/dev/hardwood/internal/reader/NestedColumnWorker.java
+++ b/core/src/main/java/dev/hardwood/internal/reader/NestedColumnWorker.java
@@ -376,14 +376,20 @@ public class NestedColumnWorker extends ColumnWorker<NestedBatch> {
     /// layers and sentinel-suffixed for `REPEATED` layers.
     private void computeIndex(NestedBatch batch) {
         if (realItemsMode) {
-            // The ColumnReader reads only the real-items view, so compute it here on
-            // the drain (off the serial consumer) and skip the all-items index.
-            batch.realView = buildRealView(batch);
+            // The ColumnReader reads only the real-items view and values, so build
+            // both here on the drain (off the serial consumer) and skip the
+            // all-items index. When the batch has phantom positions the leaf values
+            // are gathered now too; otherwise the raw values pass through unchanged.
+            NestedLevelComputer.RealView rv = buildRealView(batch);
+            batch.realView = rv;
+            int[] map = rv.realToRawLeaf();
+            batch.realValues = map != null ? LeafCompaction.compact(batch.values, map) : null;
             batch.elementValidity = null;
             batch.multiLevelOffsets = null;
             return;
         }
         batch.realView = null;
+        batch.realValues = null;
 
         if (batch.fixedListK > 0) {
             // All elements present, boundaries at multiples of k: no validity and

--- a/core/src/main/java/dev/hardwood/internal/reader/NestedLevelComputer.java
+++ b/core/src/main/java/dev/hardwood/internal/reader/NestedLevelComputer.java
@@ -371,9 +371,10 @@ public final class NestedLevelComputer {
     /// `realToRawLeaf` maps each real-leaf index to the raw position in the
     /// batch's value array (so `compactInts(rawValues, realToRawLeaf)` etc.
     /// produces real-items-only typed arrays). `null` means the leaf is in
-    /// 1-to-1 correspondence with the raw value stream — i.e. the chain has
-    /// no `REPEATED` layers — and the raw values array can pass through
-    /// without compaction.
+    /// 1-to-1 correspondence with the raw value stream — either the chain has
+    /// no `REPEATED` layers, or this batch has no phantom (null/empty parent)
+    /// positions, so the map would be the identity — and the raw values array
+    /// can pass through without compaction.
     public record RealView(int[][] layerOffsets, long[][] layerValidity,
                            long[] leafValidity, int valueCount,
                            int[] realToRawLeaf) {}
@@ -486,9 +487,14 @@ public final class NestedLevelComputer {
         }
         int realLeafCount = realCount[layerCount];
         int[] trimmedRealToRaw = null;
-        if (realToRaw != null) {
-            trimmedRealToRaw = realLeafCount == realToRaw.length
-                    ? realToRaw : Arrays.copyOf(realToRaw, realLeafCount);
+        // `realToRaw` is sized to `rawValueCount`, so `realLeafCount == rawValueCount`
+        // means every raw position is a real leaf: no phantom (null/empty parent)
+        // positions, and the map is the identity `realToRaw[i] == i`. Leave it null —
+        // the identical pass-through signal a REPEATED-free chain uses — so the
+        // consumer reads the batch's (already per-batch fresh) value array directly
+        // instead of allocating and gathering a compacted copy.
+        if (realToRaw != null && realLeafCount != realToRaw.length) {
+            trimmedRealToRaw = Arrays.copyOf(realToRaw, realLeafCount);
         }
         return new RealView(offsets, layerValidity, leafValidity, realLeafCount,
                 trimmedRealToRaw);

--- a/core/src/main/java/dev/hardwood/internal/reader/NestedRowReader.java
+++ b/core/src/main/java/dev/hardwood/internal/reader/NestedRowReader.java
@@ -132,7 +132,7 @@ public final class NestedRowReader implements RowReader {
             NestedColumnWorker worker = new NestedColumnWorker(
                     pageSource, buffer, columnSchema, batchSize,
                     context.decompressorFactory(), context.executor(), workerMaxRows,
-                    layers, false, fixedListFastPathEnabled);
+                    layers, NestedColumnWorker.IndexMode.ALL_ITEMS, fixedListFastPathEnabled);
 
             buffers[i] = buffer;
             workers[i] = worker;

--- a/core/src/main/java/dev/hardwood/internal/reader/NestedRowReader.java
+++ b/core/src/main/java/dev/hardwood/internal/reader/NestedRowReader.java
@@ -132,7 +132,7 @@ public final class NestedRowReader implements RowReader {
             NestedColumnWorker worker = new NestedColumnWorker(
                     pageSource, buffer, columnSchema, batchSize,
                     context.decompressorFactory(), context.executor(), workerMaxRows,
-                    layers, fixedListFastPathEnabled);
+                    layers, false, fixedListFastPathEnabled);
 
             buffers[i] = buffer;
             workers[i] = worker;

--- a/core/src/main/java/dev/hardwood/reader/ColumnReader.java
+++ b/core/src/main/java/dev/hardwood/reader/ColumnReader.java
@@ -19,6 +19,7 @@ import dev.hardwood.internal.reader.BatchSizing;
 import dev.hardwood.internal.reader.BinaryBatchValues;
 import dev.hardwood.internal.reader.FlatColumnWorker;
 import dev.hardwood.internal.reader.HardwoodContextImpl;
+import dev.hardwood.internal.reader.LeafCompaction;
 import dev.hardwood.internal.reader.NestedBatch;
 import dev.hardwood.internal.reader.NestedColumnWorker;
 import dev.hardwood.internal.reader.NestedLevelComputer;
@@ -621,7 +622,7 @@ public class ColumnReader implements AutoCloseable {
     private static void compactFlatBatchInPlace(BatchExchange.Batch batch, int[] kept, int count) {
         Object values = batch.values;
         if (values instanceof BinaryBatchValues binary) {
-            batch.values = compactBinary(binary, kept, count);
+            batch.values = LeafCompaction.compactBinary(binary, kept, count);
         }
         else {
             compactPrimitiveInPlace(values, kept, count);
@@ -707,7 +708,7 @@ public class ColumnReader implements AutoCloseable {
         out.fixedListK = src.fixedListK;
         out.recordCount = count;
         out.valueCount = total;
-        out.values = compactPrimitive(src.values, keptLeaves);
+        out.values = LeafCompaction.compact(src.values, keptLeaves);
         // A fixed-width batch carries no level arrays; selection keeps whole
         // k-element records, so it stays fixed-width and the real view is rebuilt
         // arithmetically from the new record count.
@@ -775,10 +776,12 @@ public class ColumnReader implements AutoCloseable {
     }
 
     /// Returns the leaf-values backing array sized to [#getValueCount()].
-    /// For flat columns this is the underlying batch array; for nested
-    /// columns it's either pass-through (no compaction needed when the chain
-    /// has no `REPEATED` layers) or a freshly compacted typed array, cached
-    /// per batch.
+    /// For flat columns this is the underlying batch array. For nested columns
+    /// it is, in order: the drain's pre-compacted `realValues` when present;
+    /// otherwise pass-through of the batch values when no compaction is needed
+    /// (no `REPEATED` layer, or an all-present batch with no phantom positions);
+    /// otherwise a freshly compacted typed array (batches derived by record
+    /// selection). Cached per batch.
     private Object realLeafValues() {
         if (!nested) {
             return currentFlatBatch.values;
@@ -786,84 +789,17 @@ public class ColumnReader implements AutoCloseable {
         if (cachedRealValues != null) {
             return cachedRealValues;
         }
-        NestedLevelComputer.RealView rv = ensureRealView();
-        Object raw = currentNestedBatch.values;
-        int[] map = rv.realToRawLeaf();
-        if (map == null) {
-            cachedRealValues = raw;   // pass-through: STRUCT-only chain
+        NestedBatch batch = currentNestedBatch;
+        if (batch.realValues != null) {
+            cachedRealValues = batch.realValues;   // pre-compacted on the drain
         }
         else {
-            cachedRealValues = compactPrimitive(raw, map);
+            int[] map = ensureRealView().realToRawLeaf();
+            cachedRealValues = map == null
+                    ? batch.values                 // pass-through, no compaction
+                    : LeafCompaction.compact(batch.values, map);
         }
         return cachedRealValues;
-    }
-
-    private static Object compactPrimitive(Object raw, int[] map) {
-        int n = map.length;
-        return switch (raw) {
-            case int[] a -> {
-                int[] out = new int[n];
-                for (int i = 0; i < n; i++) out[i] = a[map[i]];
-                yield out;
-            }
-            case long[] a -> {
-                long[] out = new long[n];
-                for (int i = 0; i < n; i++) out[i] = a[map[i]];
-                yield out;
-            }
-            case float[] a -> {
-                float[] out = new float[n];
-                for (int i = 0; i < n; i++) out[i] = a[map[i]];
-                yield out;
-            }
-            case double[] a -> {
-                double[] out = new double[n];
-                for (int i = 0; i < n; i++) out[i] = a[map[i]];
-                yield out;
-            }
-            case boolean[] a -> {
-                boolean[] out = new boolean[n];
-                for (int i = 0; i < n; i++) out[i] = a[map[i]];
-                yield out;
-            }
-            case BinaryBatchValues bbv -> compactBinary(bbv, map, map.length);
-            default -> throw new IllegalStateException("Unexpected leaf array type: " + raw.getClass());
-        };
-    }
-
-    /// Compacts a varlength leaf to the records at `map[0..count)`. `map` may be
-    /// an oversized reusable buffer (flat in-place path) or an exact gather index
-    /// (nested path); only its `[0, count)` prefix is read. A dictionary-encoded
-    /// string leaf carries its chunk dictionary and gathered entry indices through,
-    /// so `getStrings()` still reuses the interned instances.
-    private static BinaryBatchValues compactBinary(BinaryBatchValues raw, int[] map, int count) {
-        int totalBytes = 0;
-        int[] outOffsets = new int[count + 1];
-        for (int i = 0; i < count; i++) {
-            int rawIdx = map[i];
-            int len = raw.offsets[rawIdx + 1] - raw.offsets[rawIdx];
-            outOffsets[i] = totalBytes;
-            totalBytes += len;
-        }
-        outOffsets[count] = totalBytes;
-        byte[] outBytes = new byte[totalBytes];
-        boolean interned = raw.dictionary != null;
-        int[] outDictIndices = interned ? new int[count] : null;
-        for (int i = 0; i < count; i++) {
-            int rawIdx = map[i];
-            int rawStart = raw.offsets[rawIdx];
-            int len = raw.offsets[rawIdx + 1] - rawStart;
-            System.arraycopy(raw.bytes, rawStart, outBytes, outOffsets[i], len);
-            if (interned) {
-                outDictIndices[i] = raw.dictIndices[rawIdx];
-            }
-        }
-        BinaryBatchValues out = new BinaryBatchValues(outBytes, outOffsets);
-        if (interned) {
-            out.dictionary = raw.dictionary;
-            out.dictIndices = outDictIndices;
-        }
-        return out;
     }
 
     private void ensureRealBinary() {

--- a/core/src/main/java/dev/hardwood/reader/ColumnReader.java
+++ b/core/src/main/java/dev/hardwood/reader/ColumnReader.java
@@ -462,54 +462,6 @@ public class ColumnReader implements AutoCloseable {
         return result;
     }
 
-    // ==================== Raw Levels (escape hatch) ====================
-
-    /// Raw definition levels for the current batch. Returns `null` for flat
-    /// columns; their validity is fully captured by [#getLeafValidity()].
-    ///
-    /// When the batch was decoded via the fixed-size-list fast path the level
-    /// arrays are not materialized during decode; this escape hatch synthesizes
-    /// them on demand (every leaf present, so `maxDefinitionLevel`) so callers
-    /// see the same levels the regular path would produce. It is expected to be
-    /// called rarely, so the arrays are rebuilt per call rather than cached.
-    public int[] getDefinitionLevels() {
-        checkBatchAvailable();
-        if (!nested) {
-            return null;
-        }
-        int[] definitionLevels = currentNestedBatch.definitionLevels;
-        if (definitionLevels == null && currentNestedBatch.fixedListK > 0) {
-            definitionLevels = new int[currentNestedBatch.valueCount];
-            Arrays.fill(definitionLevels, column.maxDefinitionLevel());
-        }
-        return definitionLevels;
-    }
-
-    /// Raw repetition levels for the current batch. Returns `null` for columns
-    /// whose `maxRepetitionLevel == 0`.
-    ///
-    /// On a fixed-size-list fast-path batch the levels are synthesized on demand
-    /// (each row is `0` followed by `k - 1` ones), matching the regular path. See
-    /// [#getDefinitionLevels()].
-    public int[] getRepetitionLevels() {
-        checkBatchAvailable();
-        if (!nested) {
-            return null;
-        }
-        if (column.maxRepetitionLevel() == 0) {
-            return null;
-        }
-        int[] repetitionLevels = currentNestedBatch.repetitionLevels;
-        if (repetitionLevels == null && currentNestedBatch.fixedListK > 0) {
-            int k = currentNestedBatch.fixedListK;
-            repetitionLevels = new int[currentNestedBatch.valueCount];
-            for (int i = 0; i < repetitionLevels.length; i++) {
-                repetitionLevels[i] = (i % k == 0) ? 0 : 1;
-            }
-        }
-        return repetitionLevels;
-    }
-
     // ==================== Metadata ====================
 
     public ColumnSchema getColumnSchema() {

--- a/core/src/main/java/dev/hardwood/reader/ColumnReader.java
+++ b/core/src/main/java/dev/hardwood/reader/ColumnReader.java
@@ -842,7 +842,7 @@ public class ColumnReader implements AutoCloseable {
         rowGroupIterator.initialize(projectedSchema, filter);
 
         return createFromIterator(columnSchema, schema, rowGroupIterator, context, fixedListFastPathEnabled,
-                0, rowGroupIterator, resolvedBatchSize);
+                0, rowGroupIterator, resolvedBatchSize, NestedColumnWorker.IndexMode.REAL_VIEW);
     }
 
     /// Creates a ColumnReader from a pre-configured RowGroupIterator.
@@ -858,7 +858,8 @@ public class ColumnReader implements AutoCloseable {
                                            boolean fixedListFastPathEnabled,
                                            int projectedColumnIndex,
                                            RowGroupIterator ownedIterator,
-                                           int batchSize) {
+                                           int batchSize,
+                                           NestedColumnWorker.IndexMode indexMode) {
         NestedLevelComputer.Layers layers = NestedLevelComputer.computeLayers(
                 schema.getRootNode(), columnSchema.columnIndex());
         boolean nested = layers.count() > 0 || columnSchema.maxRepetitionLevel() > 0;
@@ -875,7 +876,7 @@ public class ColumnReader implements AutoCloseable {
             NestedColumnWorker nestedWorker = new NestedColumnWorker(
                     pageSource, nestedBuf, columnSchema, batchSize,
                     context.decompressorFactory(), context.executor(), 0,
-                    layers, true, fixedListFastPathEnabled);
+                    layers, indexMode, fixedListFastPathEnabled);
             nestedWorker.start();
             return ColumnReader.forNested(columnSchema, layers, nestedBuf, nestedWorker, ownedIterator);
         }

--- a/core/src/main/java/dev/hardwood/reader/ColumnReader.java
+++ b/core/src/main/java/dev/hardwood/reader/ColumnReader.java
@@ -738,15 +738,23 @@ public class ColumnReader implements AutoCloseable {
         if (!nested) {
             throw new IllegalStateException(prefix() + "Real view not available for flat columns");
         }
-        currentRealView = currentNestedBatch.fixedListK > 0
-                ? fixedListRealView(currentNestedBatch)
-                : NestedLevelComputer.computeRealView(
-                        currentNestedBatch.definitionLevels,
-                        currentNestedBatch.repetitionLevels,
-                        currentNestedBatch.valueCount,
-                        currentNestedBatch.recordCount,
-                        column.maxDefinitionLevel(),
-                        layers);
+        if (currentNestedBatch.realView != null) {
+            // Computed on the drain (real-items ColumnReader path).
+            currentRealView = currentNestedBatch.realView;
+        }
+        else {
+            // A batch derived by consumer-side record selection carries no drain
+            // view; build it from the sliced levels.
+            currentRealView = currentNestedBatch.fixedListK > 0
+                    ? fixedListRealView(currentNestedBatch)
+                    : NestedLevelComputer.computeRealView(
+                            currentNestedBatch.definitionLevels,
+                            currentNestedBatch.repetitionLevels,
+                            currentNestedBatch.valueCount,
+                            currentNestedBatch.recordCount,
+                            column.maxDefinitionLevel(),
+                            layers);
+        }
         realViewComputed = true;
         return currentRealView;
     }
@@ -979,7 +987,7 @@ public class ColumnReader implements AutoCloseable {
             NestedColumnWorker nestedWorker = new NestedColumnWorker(
                     pageSource, nestedBuf, columnSchema, batchSize,
                     context.decompressorFactory(), context.executor(), 0,
-                    layers, fixedListFastPathEnabled);
+                    layers, true, fixedListFastPathEnabled);
             nestedWorker.start();
             return ColumnReader.forNested(columnSchema, layers, nestedBuf, nestedWorker, ownedIterator);
         }

--- a/core/src/main/java/dev/hardwood/reader/ColumnReaders.java
+++ b/core/src/main/java/dev/hardwood/reader/ColumnReaders.java
@@ -12,6 +12,7 @@ import java.util.Map;
 
 import dev.hardwood.internal.predicate.ResolvedPredicate;
 import dev.hardwood.internal.reader.HardwoodContextImpl;
+import dev.hardwood.internal.reader.NestedColumnWorker;
 import dev.hardwood.internal.reader.RowGroupIterator;
 import dev.hardwood.internal.schema.ProjectedSchema;
 import dev.hardwood.schema.ColumnSchema;
@@ -70,7 +71,8 @@ public class ColumnReaders implements AutoCloseable {
             ColumnSchema columnSchema = schema.getColumn(originalIndex);
 
             ColumnReader reader = ColumnReader.createFromIterator(
-                    columnSchema, schema, rowGroupIterator, context, fixedListFastPathEnabled, i, null, batchSize);
+                    columnSchema, schema, rowGroupIterator, context, fixedListFastPathEnabled, i, null, batchSize,
+                    NestedColumnWorker.IndexMode.REAL_VIEW);
 
             readersByName.put(columnSchema.fieldPath().toString(), reader);
             readersByIndex[i] = reader;
@@ -105,7 +107,8 @@ public class ColumnReaders implements AutoCloseable {
         for (int i = 0; i < augCount; i++) {
             ColumnSchema columnSchema = schema.getColumn(augProjected.toOriginalIndex(i));
             ColumnReader reader = ColumnReader.createFromIterator(
-                    columnSchema, schema, rowGroupIterator, context, fixedListFastPathEnabled, i, null, batchSize);
+                    columnSchema, schema, rowGroupIterator, context, fixedListFastPathEnabled, i, null, batchSize,
+                    NestedColumnWorker.IndexMode.REAL_VIEW_KEEP_LEVELS);
             allReaders[i] = reader;
             byPath.put(columnSchema.fieldPath().toString(), reader);
         }

--- a/core/src/test/java/dev/hardwood/FixedSizeListFastPathReadTest.java
+++ b/core/src/test/java/dev/hardwood/FixedSizeListFastPathReadTest.java
@@ -94,32 +94,6 @@ class FixedSizeListFastPathReadTest {
         }
     }
 
-    /// On a fast-path batch the raw-levels escape hatch synthesizes the levels
-    /// on demand: definition levels are all `maxDef`, repetition levels are the
-    /// `0, 1…1` per-row pattern — the same the regular path would materialize.
-    @Test
-    void escapeHatchSynthesizesLevelsOnFastPath() throws Exception {
-        try (HardwoodContext context = HardwoodContext.create();
-             ParquetFileReader reader =
-                     ParquetFileReader.open(InputFile.of(resource(4, "v2")), context, FAST_PATH_ON);
-             ColumnReader col = reader.columnReader(COLUMN)) {
-            int records = 0;
-            while (col.nextBatch()) {
-                int[] def = col.getDefinitionLevels();
-                int[] rep = col.getRepetitionLevels();
-                int valueCount = col.getValueCount();
-                assertThat(def).as("synthesized def levels").isNotNull();
-                assertThat(rep).as("synthesized rep levels").isNotNull();
-                for (int i = 0; i < valueCount; i++) {
-                    assertThat(def[i]).as("def[%d]", i).isEqualTo(2);
-                    assertThat(rep[i]).as("rep[%d]", i).isEqualTo(i % 4 == 0 ? 0 : 1);
-                }
-                records += col.getRecordCount();
-            }
-            assertThat(records).isEqualTo(300);
-        }
-    }
-
     /// The row-reader path routes fixed-width batches through `NestedBatchIndex` /
     /// `PqList`, which read the (now `null`) level arrays and the arithmetic
     /// offsets. This confirms those consumers tolerate the fixed-width-batch shape.

--- a/performance-testing/micro-benchmarks/pom.xml
+++ b/performance-testing/micro-benchmarks/pom.xml
@@ -44,6 +44,48 @@
       <artifactId>zstd-jni</artifactId>
     </dependency>
 
+    <!-- parquet-java, used only by the benchmark corpus generators to write fixtures -->
+    <dependency>
+      <groupId>org.apache.parquet</groupId>
+      <artifactId>parquet-avro</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.parquet</groupId>
+      <artifactId>parquet-hadoop</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.hadoop</groupId>
+      <artifactId>hadoop-common</artifactId>
+      <version>${hadoop.version}</version>
+      <exclusions>
+        <exclusion>
+          <groupId>org.apache.curator</groupId>
+          <artifactId>*</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.apache.zookeeper</groupId>
+          <artifactId>*</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.apache.kerby</groupId>
+          <artifactId>*</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.eclipse.jetty</groupId>
+          <artifactId>*</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>dnsjava</groupId>
+          <artifactId>*</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.hadoop</groupId>
+      <artifactId>hadoop-mapreduce-client-core</artifactId>
+      <version>${hadoop.version}</version>
+    </dependency>
+
     <!-- JMH -->
     <dependency>
       <groupId>org.openjdk.jmh</groupId>

--- a/performance-testing/micro-benchmarks/src/main/java/dev/hardwood/benchmarks/BenchmarkData.java
+++ b/performance-testing/micro-benchmarks/src/main/java/dev/hardwood/benchmarks/BenchmarkData.java
@@ -1,0 +1,41 @@
+/*
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Copyright The original authors
+ *
+ *  Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package dev.hardwood.benchmarks;
+
+/// Shared benchmark-data configuration for the nested-read benchmarks: the corpus
+/// directory and the fixture sizes, overridable from the command line.
+public final class BenchmarkData {
+
+    /// Leaf-value count per list / repeated / depth fixture, matching the
+    /// fixed-size-list corpus.
+    public static final long DEFAULT_TOTAL_VALUES = 8_000_000L;
+    /// Rows in the mixed / struct fixtures.
+    public static final long DEFAULT_ROWS = 2_000_000L;
+
+    private static final String DEFAULT_DIR =
+            "performance-testing/test-data-setup/target/benchmark-data";
+
+    private BenchmarkData() {
+    }
+
+    /// Corpus directory, `-Dperf.dataDir` or the shared benchmark-data directory.
+    public static String dir() {
+        String dir = System.getProperty("perf.dataDir");
+        return dir == null || dir.isBlank() ? DEFAULT_DIR : dir;
+    }
+
+    /// Leaf-value count per list / repeated / depth fixture, `-Dperf.totalValues`.
+    public static long totalValues() {
+        return Long.getLong("perf.totalValues", DEFAULT_TOTAL_VALUES);
+    }
+
+    /// Row count for the mixed / struct fixtures, `-Dperf.rows`.
+    public static long rows() {
+        return Long.getLong("perf.rows", DEFAULT_ROWS);
+    }
+}

--- a/performance-testing/micro-benchmarks/src/main/java/dev/hardwood/benchmarks/BenchmarkWriter.java
+++ b/performance-testing/micro-benchmarks/src/main/java/dev/hardwood/benchmarks/BenchmarkWriter.java
@@ -1,0 +1,78 @@
+/*
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Copyright The original authors
+ *
+ *  Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package dev.hardwood.benchmarks;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.Random;
+
+import org.apache.avro.Schema;
+import org.apache.avro.generic.GenericRecord;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.parquet.avro.AvroParquetWriter;
+import org.apache.parquet.avro.AvroWriteSupport;
+import org.apache.parquet.column.ParquetProperties.WriterVersion;
+import org.apache.parquet.hadoop.ParquetFileWriter;
+import org.apache.parquet.hadoop.ParquetWriter;
+import org.apache.parquet.hadoop.metadata.CompressionCodecName;
+
+/// Shared parquet-java writer plumbing for the benchmark corpus generators. Every
+/// fixture is written the same way — DataPageV2 (or V1 via `-Dperf.pageVersion=v1`),
+/// uncompressed, dictionary-free, 3-level compliant lists — so a scan measures level
+/// handling and value copy rather than codec or dictionary cost.
+public final class BenchmarkWriter {
+
+    /// Mean list length for the variable-length fixtures.
+    public static final int MEAN_LIST_LEN = 16;
+
+    private BenchmarkWriter() {
+    }
+
+    /// An [AvroParquetWriter] over `path` for `schema`, configured for the benchmark
+    /// corpus. Overwrites any existing file.
+    public static ParquetWriter<GenericRecord> create(Path path, Schema schema) throws IOException {
+        Configuration conf = new Configuration();
+        // 3-level compliant lists (`group list { element }`) so the leaf path is the
+        // standard `field.list.element` the readers resolve.
+        conf.setBoolean(AvroWriteSupport.WRITE_OLD_LIST_STRUCTURE, false);
+        org.apache.hadoop.fs.Path hPath = new org.apache.hadoop.fs.Path(path.toAbsolutePath().toString());
+        return AvroParquetWriter.<GenericRecord>builder(hPath)
+                .withSchema(schema)
+                .withConf(conf)
+                .withWriterVersion(writerVersion())
+                .withCompressionCodec(CompressionCodecName.UNCOMPRESSED)
+                .withDictionaryEncoding(false)
+                .withRowGroupSize(512L * 1024 * 1024)
+                .withWriteMode(ParquetFileWriter.Mode.OVERWRITE)
+                .withPageWriteChecksumEnabled(false)
+                .build();
+    }
+
+    /// A list length drawn around [#MEAN_LIST_LEN], never zero (empty lists are
+    /// introduced only through a null-list path where a fixture wants them).
+    public static int randomLen(Random rng) {
+        return 1 + rng.nextInt(2 * MEAN_LIST_LEN);
+    }
+
+    /// A union `[null, type]` — an optional field. Null comes first so a `null` field
+    /// default validates against the union.
+    public static Schema optional(Schema type) {
+        return Schema.createUnion(List.of(Schema.create(Schema.Type.NULL), type));
+    }
+
+    public static boolean present(Path path) throws IOException {
+        return Files.exists(path) && Files.size(path) > 0;
+    }
+
+    private static WriterVersion writerVersion() {
+        String version = System.getProperty("perf.pageVersion", "v2");
+        return "v1".equalsIgnoreCase(version) ? WriterVersion.PARQUET_1_0 : WriterVersion.PARQUET_2_0;
+    }
+}

--- a/performance-testing/micro-benchmarks/src/main/java/dev/hardwood/benchmarks/Elem.java
+++ b/performance-testing/micro-benchmarks/src/main/java/dev/hardwood/benchmarks/Elem.java
@@ -1,0 +1,26 @@
+/*
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Copyright The original authors
+ *
+ *  Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package dev.hardwood.benchmarks;
+
+/// The primitive leaf type of a list fixture. The filename token keeps distinct
+/// element types from colliding, and the type drives both the Avro schema and the
+/// reader accessor the folds pick.
+public enum Elem {
+    INT64("int64"),
+    FLOAT64("float64");
+
+    private final String token;
+
+    Elem(String token) {
+        this.token = token;
+    }
+
+    public String token() {
+        return token;
+    }
+}

--- a/performance-testing/micro-benchmarks/src/main/java/dev/hardwood/benchmarks/NestedReads.java
+++ b/performance-testing/micro-benchmarks/src/main/java/dev/hardwood/benchmarks/NestedReads.java
@@ -13,6 +13,7 @@ import java.nio.file.Path;
 import dev.hardwood.HardwoodContext;
 import dev.hardwood.InputFile;
 import dev.hardwood.reader.ColumnReader;
+import dev.hardwood.reader.LayerKind;
 import dev.hardwood.reader.ParquetFileReader;
 import dev.hardwood.reader.RowReader;
 import dev.hardwood.reader.Validity;
@@ -122,6 +123,92 @@ public final class NestedReads {
             throws IOException {
         try (ParquetFileReader reader = open(path, context)) {
             return elem == Elem.INT64 ? sumLongColumn(reader, leaf) : sumDoubleColumn(reader, leaf);
+        }
+    }
+
+    // ============== Column (real-items) folds — structural consumer ==============
+    //
+    // Reconstructs the lists per batch via getLayerOffsets/getLayerValidity, the
+    // access pattern a list-shaped consumer (not a flat leaf vector read) uses. It
+    // reads the same leaf stream as foldLong/foldDouble, so the sum agrees, but it
+    // forces the per-layer view every batch — where foldLong/foldDouble touch only
+    // the leaf values, count, and leaf validity. This is the workload that exposes
+    // whether the RealView is built on the drain or lazily on the consumer.
+
+    /// Index of the (single) REPEATED layer — the list boundary. Found by kind so
+    /// the fold is agnostic to whether an optional wrapper adds a STRUCT layer.
+    private static int listLayer(ColumnReader col) {
+        for (int k = col.getLayerCount() - 1; k >= 0; k--) {
+            if (col.getLayerKind(k) == LayerKind.REPEATED) {
+                return k;
+            }
+        }
+        throw new IllegalStateException("no REPEATED layer in column");
+    }
+
+    private static double foldLongStructural(ColumnReader col) {
+        double sum = 0;
+        int layer = -1;
+        while (col.nextBatch()) {
+            if (layer < 0) {
+                layer = listLayer(col);
+            }
+            int[] offsets = col.getLayerOffsets(layer);
+            Validity listValidity = col.getLayerValidity(layer);
+            boolean listHasNulls = listValidity.hasNulls();
+            long[] values = col.getLongs();
+            Validity leafValidity = col.getLeafValidity();
+            boolean leafHasNulls = leafValidity.hasNulls();
+            int lists = offsets.length - 1;
+            for (int l = 0; l < lists; l++) {
+                if (listHasNulls && listValidity.isNull(l)) {
+                    continue;
+                }
+                for (int i = offsets[l]; i < offsets[l + 1]; i++) {
+                    if (!leafHasNulls || leafValidity.isNotNull(i)) {
+                        sum += values[i];
+                    }
+                }
+            }
+        }
+        return sum;
+    }
+
+    private static double foldDoubleStructural(ColumnReader col) {
+        double sum = 0;
+        int layer = -1;
+        while (col.nextBatch()) {
+            if (layer < 0) {
+                layer = listLayer(col);
+            }
+            int[] offsets = col.getLayerOffsets(layer);
+            Validity listValidity = col.getLayerValidity(layer);
+            boolean listHasNulls = listValidity.hasNulls();
+            double[] values = col.getDoubles();
+            Validity leafValidity = col.getLeafValidity();
+            boolean leafHasNulls = leafValidity.hasNulls();
+            int lists = offsets.length - 1;
+            for (int l = 0; l < lists; l++) {
+                if (listHasNulls && listValidity.isNull(l)) {
+                    continue;
+                }
+                for (int i = offsets[l]; i < offsets[l + 1]; i++) {
+                    if (!leafHasNulls || leafValidity.isNotNull(i)) {
+                        sum += values[i];
+                    }
+                }
+            }
+        }
+        return sum;
+    }
+
+    /// Folds a single numeric list leaf through the column reader as a structural
+    /// (list-reconstructing) consumer. Opens and closes its own reader.
+    public static double sumColumnStructural(Path path, String leaf, Elem elem, HardwoodContext context)
+            throws IOException {
+        try (ParquetFileReader reader = open(path, context);
+             ColumnReader col = reader.columnReader(leaf)) {
+            return elem == Elem.INT64 ? foldLongStructural(col) : foldDoubleStructural(col);
         }
     }
 

--- a/performance-testing/micro-benchmarks/src/main/java/dev/hardwood/benchmarks/NestedReads.java
+++ b/performance-testing/micro-benchmarks/src/main/java/dev/hardwood/benchmarks/NestedReads.java
@@ -1,0 +1,286 @@
+/*
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Copyright The original authors
+ *
+ *  Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package dev.hardwood.benchmarks;
+
+import java.io.IOException;
+import java.nio.file.Path;
+
+import dev.hardwood.HardwoodContext;
+import dev.hardwood.InputFile;
+import dev.hardwood.reader.ColumnReader;
+import dev.hardwood.reader.ParquetFileReader;
+import dev.hardwood.reader.RowReader;
+import dev.hardwood.reader.Validity;
+import dev.hardwood.row.PqDoubleList;
+import dev.hardwood.row.PqList;
+import dev.hardwood.row.PqLongList;
+import dev.hardwood.row.PqStruct;
+
+/// Read paths shared by the nested-read benchmarks and their correctness gates. Every
+/// fold reduces a fixture to a single `double` — present numeric leaves summed, longs
+/// and ints widened — so the [ColumnReader] (real-items) path, the [RowReader]
+/// (all-items) path, and the flat floor all produce the same value when they read the
+/// same leaf stream. Null leaves (marked by leaf validity, or by [PqList#isNull]) are
+/// skipped on every path so the sums agree.
+public final class NestedReads {
+
+    private NestedReads() {
+    }
+
+    public static ParquetFileReader open(Path path, HardwoodContext context) throws IOException {
+        return ParquetFileReader.open(InputFile.of(path), context);
+    }
+
+    // ==================== Column (real-items) folds ====================
+
+    private static double foldInt(ColumnReader col) {
+        double sum = 0;
+        while (col.nextBatch()) {
+            int n = col.getValueCount();
+            int[] values = col.getInts();
+            Validity validity = col.getLeafValidity();
+            boolean hasNulls = validity.hasNulls();
+            for (int i = 0; i < n; i++) {
+                if (!hasNulls || validity.isNotNull(i)) {
+                    sum += values[i];
+                }
+            }
+        }
+        return sum;
+    }
+
+    private static double foldLong(ColumnReader col) {
+        double sum = 0;
+        while (col.nextBatch()) {
+            int n = col.getValueCount();
+            long[] values = col.getLongs();
+            Validity validity = col.getLeafValidity();
+            boolean hasNulls = validity.hasNulls();
+            for (int i = 0; i < n; i++) {
+                if (!hasNulls || validity.isNotNull(i)) {
+                    sum += values[i];
+                }
+            }
+        }
+        return sum;
+    }
+
+    private static double foldDouble(ColumnReader col) {
+        double sum = 0;
+        while (col.nextBatch()) {
+            int n = col.getValueCount();
+            double[] values = col.getDoubles();
+            Validity validity = col.getLeafValidity();
+            boolean hasNulls = validity.hasNulls();
+            for (int i = 0; i < n; i++) {
+                if (!hasNulls || validity.isNotNull(i)) {
+                    sum += values[i];
+                }
+            }
+        }
+        return sum;
+    }
+
+    public static double sumIntColumn(ParquetFileReader reader, String leaf) throws IOException {
+        try (ColumnReader col = reader.columnReader(leaf)) {
+            return foldInt(col);
+        }
+    }
+
+    public static double sumLongColumn(ParquetFileReader reader, String leaf) throws IOException {
+        try (ColumnReader col = reader.columnReader(leaf)) {
+            return foldLong(col);
+        }
+    }
+
+    public static double sumLongColumn(ParquetFileReader reader, int columnIndex) throws IOException {
+        try (ColumnReader col = reader.columnReader(columnIndex)) {
+            return foldLong(col);
+        }
+    }
+
+    public static double sumDoubleColumn(ParquetFileReader reader, String leaf) throws IOException {
+        try (ColumnReader col = reader.columnReader(leaf)) {
+            return foldDouble(col);
+        }
+    }
+
+    public static double sumDoubleColumn(ParquetFileReader reader, int columnIndex) throws IOException {
+        try (ColumnReader col = reader.columnReader(columnIndex)) {
+            return foldDouble(col);
+        }
+    }
+
+    /// Folds a single numeric leaf of a standalone file through the column reader,
+    /// selecting the accessor by element type. Opens and closes its own reader.
+    public static double sumColumn(Path path, String leaf, Elem elem, HardwoodContext context)
+            throws IOException {
+        try (ParquetFileReader reader = open(path, context)) {
+            return elem == Elem.INT64 ? sumLongColumn(reader, leaf) : sumDoubleColumn(reader, leaf);
+        }
+    }
+
+    /// Folds several numeric leaves of one file, each through its own
+    /// [ColumnReader], summing all of them on the calling (consumer) thread. The
+    /// per-column workers decode and reconstruct in parallel while this one thread
+    /// folds every column — the shape that exposes consumer-side reconstruction
+    /// cost a single-column scan hides. Serves both the list-leaf columns and their
+    /// flat twin (same call, different leaf names).
+    public static double sumColumns(Path path, String[] leaves, Elem elem, HardwoodContext context)
+            throws IOException {
+        double sum = 0;
+        try (ParquetFileReader reader = open(path, context)) {
+            ColumnReader[] columns = new ColumnReader[leaves.length];
+            try {
+                for (int i = 0; i < leaves.length; i++) {
+                    columns[i] = reader.columnReader(leaves[i]);
+                }
+                for (ColumnReader column : columns) {
+                    sum += elem == Elem.INT64 ? foldLong(column) : foldDouble(column);
+                }
+            }
+            finally {
+                for (ColumnReader column : columns) {
+                    if (column != null) {
+                        column.close();
+                    }
+                }
+            }
+        }
+        return sum;
+    }
+
+    /// Folds several top-level `LIST<primitive>` fields of one file through the row
+    /// reader, materializing each field's [PqList] per row. The all-items twin of
+    /// [#sumColumns] for the multi-column fixture.
+    public static double sumRowsMultiList(Path path, String[] fields, Elem elem, HardwoodContext context)
+            throws IOException {
+        double sum = 0;
+        try (ParquetFileReader reader = open(path, context);
+             RowReader rows = reader.rowReader()) {
+            while (rows.hasNext()) {
+                rows.next();
+                for (String field : fields) {
+                    PqList vec = rows.getList(field);
+                    if (vec == null) {
+                        continue;
+                    }
+                    int size = vec.size();
+                    if (elem == Elem.INT64) {
+                        PqLongList longs = vec.longs();
+                        for (int i = 0; i < size; i++) {
+                            if (!vec.isNull(i)) {
+                                sum += longs.get(i);
+                            }
+                        }
+                    }
+                    else {
+                        PqDoubleList doubles = vec.doubles();
+                        for (int i = 0; i < size; i++) {
+                            if (!vec.isNull(i)) {
+                                sum += doubles.get(i);
+                            }
+                        }
+                    }
+                }
+            }
+        }
+        return sum;
+    }
+
+    // ==================== Row (all-items) folds ====================
+
+    /// Folds the elements of a top-level `LIST<primitive>` through the row reader,
+    /// materializing a [PqList] per row and reading its elements without boxing.
+    public static double sumRowsList(Path path, String field, Elem elem, HardwoodContext context)
+            throws IOException {
+        double sum = 0;
+        try (ParquetFileReader reader = open(path, context);
+             RowReader rows = reader.rowReader()) {
+            while (rows.hasNext()) {
+                rows.next();
+                PqList vec = rows.getList(field);
+                if (vec == null) {
+                    continue;
+                }
+                int size = vec.size();
+                if (elem == Elem.INT64) {
+                    PqLongList longs = vec.longs();
+                    for (int i = 0; i < size; i++) {
+                        if (!vec.isNull(i)) {
+                            sum += longs.get(i);
+                        }
+                    }
+                }
+                else {
+                    PqDoubleList doubles = vec.doubles();
+                    for (int i = 0; i < size; i++) {
+                        if (!vec.isNull(i)) {
+                            sum += doubles.get(i);
+                        }
+                    }
+                }
+            }
+        }
+        return sum;
+    }
+
+    /// Folds a `LIST<LIST<double>>` through the row reader (depth guard).
+    public static double sumRowsListOfList(Path path, String field, HardwoodContext context)
+            throws IOException {
+        double sum = 0;
+        try (ParquetFileReader reader = open(path, context);
+             RowReader rows = reader.rowReader()) {
+            while (rows.hasNext()) {
+                rows.next();
+                PqList outer = rows.getList(field);
+                if (outer == null) {
+                    continue;
+                }
+                for (PqList inner : outer.lists()) {
+                    if (inner == null) {
+                        continue;
+                    }
+                    PqDoubleList doubles = inner.doubles();
+                    int size = inner.size();
+                    for (int i = 0; i < size; i++) {
+                        if (!inner.isNull(i)) {
+                            sum += doubles.get(i);
+                        }
+                    }
+                }
+            }
+        }
+        return sum;
+    }
+
+    /// Folds the `a` (long) and `b` (double) fields of a `LIST<STRUCT>` through the
+    /// row reader (depth guard).
+    public static double sumRowsListOfStruct(Path path, String field, HardwoodContext context)
+            throws IOException {
+        double sum = 0;
+        try (ParquetFileReader reader = open(path, context);
+             RowReader rows = reader.rowReader()) {
+            while (rows.hasNext()) {
+                rows.next();
+                PqList vec = rows.getList(field);
+                if (vec == null) {
+                    continue;
+                }
+                for (PqStruct element : vec.structs()) {
+                    if (element == null) {
+                        continue;
+                    }
+                    sum += element.getLong("a");
+                    sum += element.getDouble("b");
+                }
+            }
+        }
+        return sum;
+    }
+}

--- a/performance-testing/micro-benchmarks/src/main/java/dev/hardwood/benchmarks/mixed/MixedSchemaFileGenerator.java
+++ b/performance-testing/micro-benchmarks/src/main/java/dev/hardwood/benchmarks/mixed/MixedSchemaFileGenerator.java
@@ -1,0 +1,337 @@
+/*
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Copyright The original authors
+ *
+ *  Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package dev.hardwood.benchmarks.mixed;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Random;
+
+import org.apache.avro.Schema;
+import org.apache.avro.SchemaBuilder;
+import org.apache.avro.generic.GenericData;
+import org.apache.avro.generic.GenericRecord;
+import org.apache.parquet.hadoop.ParquetWriter;
+
+import dev.hardwood.benchmarks.BenchmarkData;
+import dev.hardwood.benchmarks.BenchmarkWriter;
+
+/// Generates the fixed-shape numeric corpus for [MixedSchemaReadBenchmark]: the mixed
+/// scalar+list schema and its flat-scalar twin (#732), a non-repeated struct and its
+/// flat twin, a repeated-heavy file, and the two `> 1` repetition-layer depth files.
+/// Each file is skipped when already present.
+public final class MixedSchemaFileGenerator {
+
+    private static final long SCALAR_SEED = 99L;
+    private static final long LIST_SEED = 4242L;
+
+    private MixedSchemaFileGenerator() {
+    }
+
+    // ==================== File name resolution ====================
+
+    public static Path mixedFile(Path dir) {
+        return dir.resolve("mixed.parquet");
+    }
+
+    public static Path flatScalarsFile(Path dir) {
+        return dir.resolve("flat_scalars.parquet");
+    }
+
+    public static Path structFile(Path dir) {
+        return dir.resolve("struct.parquet");
+    }
+
+    public static Path structFlatFile(Path dir) {
+        return dir.resolve("struct_flat.parquet");
+    }
+
+    public static Path repeatedHeavyFile(Path dir) {
+        return dir.resolve("repeated_heavy.parquet");
+    }
+
+    public static Path listOfListFile(Path dir) {
+        return dir.resolve("list_of_list.parquet");
+    }
+
+    public static Path listOfStructFile(Path dir) {
+        return dir.resolve("list_of_struct.parquet");
+    }
+
+    // ==================== Ensure entry points ====================
+
+    public static void ensureMixed(Path dir, long rows) throws IOException {
+        Path mixedPath = mixedFile(dir);
+        Path flatPath = flatScalarsFile(dir);
+        if (BenchmarkWriter.present(mixedPath) && BenchmarkWriter.present(flatPath)) {
+            return;
+        }
+        Files.createDirectories(dir);
+        int rowCount = Math.toIntExact(rows);
+        System.out.printf("Generating mixed / flat-scalar corpus (%,d rows)...%n", rowCount);
+        writeMixed(mixedPath, rowCount, true);
+        writeMixed(flatPath, rowCount, false);
+    }
+
+    public static void ensureStruct(Path dir, long rows) throws IOException {
+        Path structPath = structFile(dir);
+        Path flatPath = structFlatFile(dir);
+        if (BenchmarkWriter.present(structPath) && BenchmarkWriter.present(flatPath)) {
+            return;
+        }
+        Files.createDirectories(dir);
+        int rowCount = Math.toIntExact(rows);
+        System.out.printf("Generating struct / struct-flat corpus (%,d rows)...%n", rowCount);
+        writeStruct(structPath, rowCount, true);
+        writeStruct(flatPath, rowCount, false);
+    }
+
+    public static void ensureRepeatedHeavy(Path dir, long totalValues) throws IOException {
+        Path path = repeatedHeavyFile(dir);
+        if (BenchmarkWriter.present(path)) {
+            return;
+        }
+        Files.createDirectories(dir);
+        System.out.printf("Generating repeated-heavy corpus (%,d leaves x 4 columns)...%n", totalValues);
+        writeRepeatedHeavy(path, Math.toIntExact(totalValues));
+    }
+
+    public static void ensureListOfList(Path dir, long totalValues) throws IOException {
+        Path path = listOfListFile(dir);
+        if (BenchmarkWriter.present(path)) {
+            return;
+        }
+        Files.createDirectories(dir);
+        System.out.printf("Generating list-of-list corpus (%,d leaves)...%n", totalValues);
+        writeListOfList(path, Math.toIntExact(totalValues));
+    }
+
+    public static void ensureListOfStruct(Path dir, long totalValues) throws IOException {
+        Path path = listOfStructFile(dir);
+        if (BenchmarkWriter.present(path)) {
+            return;
+        }
+        Files.createDirectories(dir);
+        System.out.printf("Generating list-of-struct corpus (%,d elements)...%n", totalValues);
+        writeListOfStruct(path, Math.toIntExact(totalValues));
+    }
+
+    /// Generates the full mixed-schema corpus.
+    public static void generateAll(Path dir, long rows, long totalValues) throws IOException {
+        ensureMixed(dir, rows);
+        ensureStruct(dir, rows);
+        ensureRepeatedHeavy(dir, totalValues);
+        ensureListOfList(dir, totalValues);
+        ensureListOfStruct(dir, totalValues);
+    }
+
+    // ==================== Mixed / flat-scalar fixtures ====================
+
+    /// 12 non-repeated scalar columns; when `withLists` is set, two `LIST<double>`
+    /// columns are added, which is what routes the file onto the nested reader. The
+    /// scalar stream is drawn from a fixed seed in a fixed order, so `mixed` and
+    /// `flat_scalars` hold byte-identical scalar values regardless of the lists.
+    private static void writeMixed(Path path, int rows, boolean withLists) throws IOException {
+        Schema schema = mixedSchema(withLists);
+        Random scalarRng = new Random(SCALAR_SEED);
+        Random listRng = new Random(LIST_SEED);
+        try (ParquetWriter<GenericRecord> writer = BenchmarkWriter.create(path, schema)) {
+            for (int r = 0; r < rows; r++) {
+                GenericRecord record = new GenericData.Record(schema);
+                for (int c = 0; c < 4; c++) {
+                    record.put("i" + c, scalarRng.nextInt());
+                }
+                for (int c = 0; c < 4; c++) {
+                    record.put("l" + c, scalarRng.nextLong());
+                }
+                for (int c = 0; c < 4; c++) {
+                    record.put("d" + c, scalarRng.nextGaussian());
+                }
+                if (withLists) {
+                    record.put("vec1", shortDoubleList(listRng));
+                    record.put("vec2", shortDoubleList(listRng));
+                }
+                writer.write(record);
+            }
+        }
+    }
+
+    private static List<Double> shortDoubleList(Random rng) {
+        int len = 1 + rng.nextInt(8);
+        List<Double> list = new ArrayList<>(len);
+        for (int i = 0; i < len; i++) {
+            list.add(rng.nextGaussian());
+        }
+        return list;
+    }
+
+    // ==================== Struct fixtures ====================
+
+    private static void writeStruct(Path path, int rows, boolean nested) throws IOException {
+        Schema schema = nested ? structSchema() : structFlatSchema();
+        Schema inner = nested ? schema.getField("s").schema() : schema;
+        Random rng = new Random(SCALAR_SEED + 1);
+        try (ParquetWriter<GenericRecord> writer = BenchmarkWriter.create(path, schema)) {
+            for (int r = 0; r < rows; r++) {
+                GenericRecord leaves = new GenericData.Record(inner);
+                leaves.put("a", rng.nextLong());
+                leaves.put("b", rng.nextGaussian());
+                leaves.put("c", rng.nextInt());
+                if (nested) {
+                    GenericRecord record = new GenericData.Record(schema);
+                    record.put("s", leaves);
+                    writer.write(record);
+                }
+                else {
+                    writer.write(leaves);
+                }
+            }
+        }
+    }
+
+    // ==================== Repeated-heavy / depth fixtures ====================
+
+    private static void writeRepeatedHeavy(Path path, int totalPerColumn) throws IOException {
+        Schema schema = SchemaBuilder.record("repeated").fields()
+                .name("vec0").type(requiredDoubleArray()).noDefault()
+                .name("vec1").type(requiredDoubleArray()).noDefault()
+                .name("vec2").type(requiredDoubleArray()).noDefault()
+                .name("vec3").type(requiredDoubleArray()).noDefault()
+                .endRecord();
+        Random shapeRng = new Random(LIST_SEED + 11);
+        Random valueRng = new Random(LIST_SEED + 12);
+        // Rows are bounded by the first column reaching the leaf target; every column
+        // uses the same list length per row so the file stays rectangular.
+        try (ParquetWriter<GenericRecord> writer = BenchmarkWriter.create(path, schema)) {
+            int emitted = 0;
+            while (emitted < totalPerColumn) {
+                int len = Math.min(BenchmarkWriter.randomLen(shapeRng), totalPerColumn - emitted);
+                GenericRecord record = new GenericData.Record(schema);
+                for (int c = 0; c < 4; c++) {
+                    List<Double> vec = new ArrayList<>(len);
+                    for (int j = 0; j < len; j++) {
+                        vec.add(valueRng.nextGaussian());
+                    }
+                    record.put("vec" + c, vec);
+                }
+                writer.write(record);
+                emitted += len;
+            }
+        }
+    }
+
+    private static void writeListOfList(Path path, int totalLeaves) throws IOException {
+        Schema doubleArray = requiredDoubleArray();
+        Schema outer = Schema.createArray(doubleArray);
+        Schema schema = SchemaBuilder.record("listOfList").fields()
+                .name("vec").type(outer).noDefault()
+                .endRecord();
+        Random shapeRng = new Random(LIST_SEED + 21);
+        Random valueRng = new Random(LIST_SEED + 22);
+        try (ParquetWriter<GenericRecord> writer = BenchmarkWriter.create(path, schema)) {
+            int emitted = 0;
+            while (emitted < totalLeaves) {
+                int innerLists = 1 + shapeRng.nextInt(4);
+                List<List<Double>> vec = new ArrayList<>(innerLists);
+                for (int il = 0; il < innerLists && emitted < totalLeaves; il++) {
+                    int len = Math.min(1 + shapeRng.nextInt(BenchmarkWriter.MEAN_LIST_LEN), totalLeaves - emitted);
+                    List<Double> inner = new ArrayList<>(len);
+                    for (int j = 0; j < len; j++) {
+                        inner.add(valueRng.nextGaussian());
+                    }
+                    vec.add(inner);
+                    emitted += len;
+                }
+                GenericRecord record = new GenericData.Record(schema);
+                record.put("vec", vec);
+                writer.write(record);
+            }
+        }
+    }
+
+    private static void writeListOfStruct(Path path, int totalElements) throws IOException {
+        Schema element = SchemaBuilder.record("element").fields()
+                .requiredLong("a")
+                .requiredDouble("b")
+                .endRecord();
+        Schema array = Schema.createArray(element);
+        Schema schema = SchemaBuilder.record("listOfStruct").fields()
+                .name("vec").type(array).noDefault()
+                .endRecord();
+        Random shapeRng = new Random(LIST_SEED + 31);
+        Random valueRng = new Random(LIST_SEED + 32);
+        try (ParquetWriter<GenericRecord> writer = BenchmarkWriter.create(path, schema)) {
+            int emitted = 0;
+            while (emitted < totalElements) {
+                int len = Math.min(BenchmarkWriter.randomLen(shapeRng), totalElements - emitted);
+                List<GenericRecord> vec = new ArrayList<>(len);
+                for (int j = 0; j < len; j++) {
+                    GenericRecord e = new GenericData.Record(element);
+                    e.put("a", valueRng.nextLong());
+                    e.put("b", valueRng.nextGaussian());
+                    vec.add(e);
+                    emitted++;
+                }
+                GenericRecord record = new GenericData.Record(schema);
+                record.put("vec", vec);
+                writer.write(record);
+            }
+        }
+    }
+
+    // ==================== Schemas ====================
+
+    private static Schema mixedSchema(boolean withLists) {
+        SchemaBuilder.FieldAssembler<Schema> fields = SchemaBuilder.record("mixed").fields();
+        for (int c = 0; c < 4; c++) {
+            fields = fields.requiredInt("i" + c);
+        }
+        for (int c = 0; c < 4; c++) {
+            fields = fields.requiredLong("l" + c);
+        }
+        for (int c = 0; c < 4; c++) {
+            fields = fields.requiredDouble("d" + c);
+        }
+        if (withLists) {
+            fields = fields.name("vec1").type(requiredDoubleArray()).noDefault();
+            fields = fields.name("vec2").type(requiredDoubleArray()).noDefault();
+        }
+        return fields.endRecord();
+    }
+
+    private static Schema structSchema() {
+        Schema inner = SchemaBuilder.record("s").fields()
+                .requiredLong("a")
+                .requiredDouble("b")
+                .requiredInt("c")
+                .endRecord();
+        return SchemaBuilder.record("structWrapper").fields()
+                .name("s").type(inner).noDefault()
+                .endRecord();
+    }
+
+    private static Schema structFlatSchema() {
+        return SchemaBuilder.record("structFlat").fields()
+                .requiredLong("a")
+                .requiredDouble("b")
+                .requiredInt("c")
+                .endRecord();
+    }
+
+    private static Schema requiredDoubleArray() {
+        return Schema.createArray(Schema.create(Schema.Type.DOUBLE));
+    }
+
+    public static void main(String[] args) throws IOException {
+        Path dir = Path.of(args.length > 0 ? args[0] : BenchmarkData.dir());
+        generateAll(dir, BenchmarkData.rows(), BenchmarkData.totalValues());
+        System.out.println("Mixed-schema corpus ready in " + dir);
+    }
+}

--- a/performance-testing/micro-benchmarks/src/main/java/dev/hardwood/benchmarks/mixed/MixedSchemaGate.java
+++ b/performance-testing/micro-benchmarks/src/main/java/dev/hardwood/benchmarks/mixed/MixedSchemaGate.java
@@ -1,0 +1,116 @@
+/*
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Copyright The original authors
+ *
+ *  Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package dev.hardwood.benchmarks.mixed;
+
+import java.io.IOException;
+import java.nio.file.Path;
+
+import dev.hardwood.HardwoodContext;
+import dev.hardwood.benchmarks.BenchmarkData;
+import dev.hardwood.benchmarks.NestedReads;
+import dev.hardwood.reader.ParquetFileReader;
+
+/// Correctness gate for [MixedSchemaReadBenchmark]. Generates the mixed-schema corpus
+/// and asserts the paths that read the same values agree before any timing is trusted:
+/// the 12 scalar columns fold identically whether or not the file also holds list
+/// columns; the struct leaves match their flat twin; and the depth files agree across
+/// the column and row paths.
+///
+/// Run through the benchmarks uberjar:
+/// ```
+/// java -cp benchmarks.jar dev.hardwood.benchmarks.mixed.MixedSchemaGate [dataDir]
+/// ```
+public final class MixedSchemaGate {
+
+    private static final double EPSILON = 1e-6;
+
+    private MixedSchemaGate() {
+    }
+
+    public static void main(String[] args) throws IOException {
+        Path dir = Path.of(args.length > 0 ? args[0] : BenchmarkData.dir());
+        MixedSchemaFileGenerator.generateAll(dir, BenchmarkData.rows(), BenchmarkData.totalValues());
+
+        System.out.println("Mixed-schema correctness gate:");
+        try (HardwoodContext context = HardwoodContext.create()) {
+            gateMixed(dir, context);
+            gateStruct(dir, context);
+            gateDepth(dir, context);
+        }
+        System.out.println("Gate passed — every path agrees on the values it reads.");
+    }
+
+    /// The 12 scalar columns must fold identically whether or not the file also holds
+    /// list columns.
+    private static void gateMixed(Path dir, HardwoodContext context) throws IOException {
+        double mixed = sumScalars(MixedSchemaFileGenerator.mixedFile(dir), context);
+        double flat = sumScalars(MixedSchemaFileGenerator.flatScalarsFile(dir), context);
+        requireClose("mixed scalars vs flat scalars", mixed, flat);
+        System.out.printf("  OK  mixed scalars sum=%s%n", mixed);
+    }
+
+    private static void gateStruct(Path dir, HardwoodContext context) throws IOException {
+        double nested = sumStruct(MixedSchemaFileGenerator.structFile(dir), "s.a", "s.b", "s.c", context);
+        double flat = sumStruct(MixedSchemaFileGenerator.structFlatFile(dir), "a", "b", "c", context);
+        requireClose("struct vs struct flat", nested, flat);
+        System.out.printf("  OK  struct sum=%s%n", nested);
+    }
+
+    /// The multi-repetition-layer files: the column and row paths must agree.
+    private static void gateDepth(Path dir, HardwoodContext context) throws IOException {
+        Path listOfList = MixedSchemaFileGenerator.listOfListFile(dir);
+        double lolColumn;
+        try (ParquetFileReader reader = NestedReads.open(listOfList, context)) {
+            lolColumn = NestedReads.sumDoubleColumn(reader, 0);
+        }
+        double lolRow = NestedReads.sumRowsListOfList(listOfList, "vec", context);
+        requireClose("list-of-list row vs column", lolRow, lolColumn);
+        System.out.printf("  OK  list-of-list sum=%s%n", lolColumn);
+
+        Path listOfStruct = MixedSchemaFileGenerator.listOfStructFile(dir);
+        double losColumn;
+        try (ParquetFileReader reader = NestedReads.open(listOfStruct, context)) {
+            losColumn = NestedReads.sumLongColumn(reader, 0) + NestedReads.sumDoubleColumn(reader, 1);
+        }
+        double losRow = NestedReads.sumRowsListOfStruct(listOfStruct, "vec", context);
+        requireClose("list-of-struct row vs column", losRow, losColumn);
+        System.out.printf("  OK  list-of-struct sum=%s%n", losColumn);
+    }
+
+    private static double sumScalars(Path path, HardwoodContext context) throws IOException {
+        double sum = 0;
+        try (ParquetFileReader reader = NestedReads.open(path, context)) {
+            for (int c = 0; c < 4; c++) {
+                sum += NestedReads.sumIntColumn(reader, "i" + c);
+            }
+            for (int c = 0; c < 4; c++) {
+                sum += NestedReads.sumLongColumn(reader, "l" + c);
+            }
+            for (int c = 0; c < 4; c++) {
+                sum += NestedReads.sumDoubleColumn(reader, "d" + c);
+            }
+        }
+        return sum;
+    }
+
+    private static double sumStruct(Path path, String a, String b, String c, HardwoodContext context)
+            throws IOException {
+        try (ParquetFileReader reader = NestedReads.open(path, context)) {
+            return NestedReads.sumLongColumn(reader, a)
+                    + NestedReads.sumDoubleColumn(reader, b)
+                    + NestedReads.sumIntColumn(reader, c);
+        }
+    }
+
+    private static void requireClose(String what, double a, double b) {
+        double scale = Math.max(1.0, Math.max(Math.abs(a), Math.abs(b)));
+        if (Math.abs(a - b) > EPSILON * scale) {
+            throw new IllegalStateException("Mismatch (" + what + "): " + a + " vs " + b);
+        }
+    }
+}

--- a/performance-testing/micro-benchmarks/src/main/java/dev/hardwood/benchmarks/mixed/MixedSchemaReadBenchmark.java
+++ b/performance-testing/micro-benchmarks/src/main/java/dev/hardwood/benchmarks/mixed/MixedSchemaReadBenchmark.java
@@ -1,0 +1,179 @@
+/*
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Copyright The original authors
+ *
+ *  Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package dev.hardwood.benchmarks.mixed;
+
+import java.io.IOException;
+import java.nio.file.Path;
+import java.util.concurrent.TimeUnit;
+
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Level;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.TearDown;
+import org.openjdk.jmh.annotations.Warmup;
+
+import dev.hardwood.HardwoodContext;
+import dev.hardwood.benchmarks.BenchmarkData;
+import dev.hardwood.benchmarks.NestedReads;
+import dev.hardwood.reader.ParquetFileReader;
+
+/// Schema-composition effects on the nested read path — the workload behind #732
+/// (per-column-worker routing), plus the shapes whose acceptance criteria demand a
+/// no-regression guard.
+///
+/// - `columnScalarsMixed` vs `columnScalarsFlat` — scan the same 12 non-repeated
+///   scalar columns out of a file that also holds two `LIST` columns
+///   (`mixed.parquet`, routed onto the nested reader today) versus a file with only
+///   the scalars (`flat_scalars.parquet`, routed onto the flat reader). The delta is
+///   the per-scalar-column tax #732 removes.
+/// - `columnStruct` vs `columnStructFlat` — a non-repeated `STRUCT` of primitives
+///   versus the same leaves as top-level columns (the flat-struct path #732 subsumes).
+/// - `columnRepeatedHeavy` — several `LIST` columns and no scalars: the no-regression
+///   guard for repetition-heavy schemas.
+/// - `columnListOfList` / `rowListOfList` / `columnListOfStruct` / `rowListOfStruct` —
+///   columns with more than one repetition layer, where #751's single-repeated-layer
+///   fast path deliberately does not fire; these must not regress.
+///
+/// All leaves are numeric. Fixtures are generated on demand from `@Setup`.
+@BenchmarkMode(Mode.AverageTime)
+@OutputTimeUnit(TimeUnit.MILLISECONDS)
+@State(Scope.Benchmark)
+@Fork(value = 2, jvmArgs = { "-Xms2g", "-Xmx2g", "--add-modules", "jdk.incubator.vector" })
+@Warmup(iterations = 3, time = 1)
+@Measurement(iterations = 5, time = 1)
+public class MixedSchemaReadBenchmark {
+
+    private static final int SCALAR_GROUP = 4;
+
+    private Path mixedPath;
+    private Path flatScalarsPath;
+    private Path structPath;
+    private Path structFlatPath;
+    private Path repeatedHeavyPath;
+    private Path listOfListPath;
+    private Path listOfStructPath;
+    private HardwoodContext context;
+
+    @Setup(Level.Trial)
+    public void setup() throws IOException {
+        Path dir = Path.of(BenchmarkData.dir());
+        long rows = BenchmarkData.rows();
+        long totalValues = BenchmarkData.totalValues();
+        MixedSchemaFileGenerator.ensureMixed(dir, rows);
+        MixedSchemaFileGenerator.ensureStruct(dir, rows);
+        MixedSchemaFileGenerator.ensureRepeatedHeavy(dir, totalValues);
+        MixedSchemaFileGenerator.ensureListOfList(dir, totalValues);
+        MixedSchemaFileGenerator.ensureListOfStruct(dir, totalValues);
+        mixedPath = MixedSchemaFileGenerator.mixedFile(dir);
+        flatScalarsPath = MixedSchemaFileGenerator.flatScalarsFile(dir);
+        structPath = MixedSchemaFileGenerator.structFile(dir);
+        structFlatPath = MixedSchemaFileGenerator.structFlatFile(dir);
+        repeatedHeavyPath = MixedSchemaFileGenerator.repeatedHeavyFile(dir);
+        listOfListPath = MixedSchemaFileGenerator.listOfListFile(dir);
+        listOfStructPath = MixedSchemaFileGenerator.listOfStructFile(dir);
+        context = HardwoodContext.create();
+    }
+
+    @TearDown(Level.Trial)
+    public void tearDown() {
+        context.close();
+    }
+
+    @Benchmark
+    public double columnScalarsMixed() throws IOException {
+        return sumScalars(mixedPath);
+    }
+
+    @Benchmark
+    public double columnScalarsFlat() throws IOException {
+        return sumScalars(flatScalarsPath);
+    }
+
+    @Benchmark
+    public double columnStruct() throws IOException {
+        return sumStruct(structPath, "s.a", "s.b", "s.c");
+    }
+
+    @Benchmark
+    public double columnStructFlat() throws IOException {
+        return sumStruct(structFlatPath, "a", "b", "c");
+    }
+
+    @Benchmark
+    public double columnRepeatedHeavy() throws IOException {
+        double sum = 0;
+        try (ParquetFileReader reader = NestedReads.open(repeatedHeavyPath, context)) {
+            for (int c = 0; c < 4; c++) {
+                sum += NestedReads.sumDoubleColumn(reader, "vec" + c + ".list.element");
+            }
+        }
+        return sum;
+    }
+
+    @Benchmark
+    public double columnListOfList() throws IOException {
+        try (ParquetFileReader reader = NestedReads.open(listOfListPath, context)) {
+            return NestedReads.sumDoubleColumn(reader, 0);
+        }
+    }
+
+    @Benchmark
+    public double rowListOfList() throws IOException {
+        return NestedReads.sumRowsListOfList(listOfListPath, "vec", context);
+    }
+
+    @Benchmark
+    public double columnListOfStruct() throws IOException {
+        double sum = 0;
+        try (ParquetFileReader reader = NestedReads.open(listOfStructPath, context)) {
+            sum += NestedReads.sumLongColumn(reader, 0);
+            sum += NestedReads.sumDoubleColumn(reader, 1);
+        }
+        return sum;
+    }
+
+    @Benchmark
+    public double rowListOfStruct() throws IOException {
+        return NestedReads.sumRowsListOfStruct(listOfStructPath, "vec", context);
+    }
+
+    /// Folds the 12 non-repeated scalar columns (`i0..i3`, `l0..l3`, `d0..d3`) of a
+    /// file, sharing one reader across all of them.
+    private double sumScalars(Path path) throws IOException {
+        double sum = 0;
+        try (ParquetFileReader reader = NestedReads.open(path, context)) {
+            for (int c = 0; c < SCALAR_GROUP; c++) {
+                sum += NestedReads.sumIntColumn(reader, "i" + c);
+            }
+            for (int c = 0; c < SCALAR_GROUP; c++) {
+                sum += NestedReads.sumLongColumn(reader, "l" + c);
+            }
+            for (int c = 0; c < SCALAR_GROUP; c++) {
+                sum += NestedReads.sumDoubleColumn(reader, "d" + c);
+            }
+        }
+        return sum;
+    }
+
+    private double sumStruct(Path path, String a, String b, String c) throws IOException {
+        double sum = 0;
+        try (ParquetFileReader reader = NestedReads.open(path, context)) {
+            sum += NestedReads.sumLongColumn(reader, a);
+            sum += NestedReads.sumDoubleColumn(reader, b);
+            sum += NestedReads.sumIntColumn(reader, c);
+        }
+        return sum;
+    }
+}

--- a/performance-testing/micro-benchmarks/src/main/java/dev/hardwood/benchmarks/nested/NestedListFileGenerator.java
+++ b/performance-testing/micro-benchmarks/src/main/java/dev/hardwood/benchmarks/nested/NestedListFileGenerator.java
@@ -1,0 +1,363 @@
+/*
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Copyright The original authors
+ *
+ *  Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package dev.hardwood.benchmarks.nested;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Random;
+
+import org.apache.avro.Schema;
+import org.apache.avro.SchemaBuilder;
+import org.apache.avro.generic.GenericData;
+import org.apache.avro.generic.GenericRecord;
+import org.apache.parquet.hadoop.ParquetWriter;
+
+import dev.hardwood.benchmarks.BenchmarkData;
+import dev.hardwood.benchmarks.BenchmarkWriter;
+import dev.hardwood.benchmarks.Elem;
+
+/// Generates the `LIST<primitive>` corpus for [NestedListReadBenchmark]: for each
+/// element type and null density, a list file and a flat twin carrying the identical
+/// leaf stream (same values, same null positions) — the decode floor. Files hold a
+/// fixed total leaf count so scan times are comparable across type and density, and
+/// each is skipped when already present.
+public final class NestedListFileGenerator {
+
+    /// Fixed 3-level list leaf path for a `LIST<primitive>` written by parquet-avro
+    /// with the old 2-level structure disabled.
+    public static final String LIST_LEAF = "vec.list.element";
+
+    /// Columns in the multi-column fixture — a record of this many identical
+    /// `LIST<primitive>` fields, folded through one consumer to expose the
+    /// consumer-side reconstruction cost that a single-column scan cannot.
+    public static final int MULTI_COLUMN_COUNT = 8;
+
+    private static final long LIST_SEED = 4242L;
+
+    private NestedListFileGenerator() {
+    }
+
+    /// How many leaves and lists are null in a list fixture.
+    public enum NullDensity {
+        NONE("none", 0.0, 0.0),
+        SPARSE("sparse", 0.05, 0.05),
+        DENSE("dense", 0.50, 0.10);
+
+        private final String token;
+        private final double elementNullProbability;
+        private final double listNullProbability;
+
+        NullDensity(String token, double elementNullProbability, double listNullProbability) {
+            this.token = token;
+            this.elementNullProbability = elementNullProbability;
+            this.listNullProbability = listNullProbability;
+        }
+
+        public String token() {
+            return token;
+        }
+
+        boolean nullable() {
+            return this != NONE;
+        }
+    }
+
+    public static Path listFile(Path dir, Elem elem, NullDensity density) {
+        return dir.resolve("list_" + elem.token() + "_" + density.token() + ".parquet");
+    }
+
+    public static Path listFlatFile(Path dir, Elem elem, NullDensity density) {
+        return dir.resolve("list_" + elem.token() + "_" + density.token() + "_flat.parquet");
+    }
+
+    /// Writes the list fixture and its flat twin for `(elem, density)` if either is
+    /// missing. Both carry the identical leaf stream, so the flat twin is the decode
+    /// floor for the list column.
+    public static void ensureList(Path dir, Elem elem, NullDensity density, long totalValues)
+            throws IOException {
+        Path listPath = listFile(dir, elem, density);
+        Path flatPath = listFlatFile(dir, elem, density);
+        if (BenchmarkWriter.present(listPath) && BenchmarkWriter.present(flatPath)) {
+            return;
+        }
+        Files.createDirectories(dir);
+        int total = Math.toIntExact(totalValues);
+        System.out.printf("Generating list corpus elem=%s density=%s (%,d leaves)...%n",
+                elem.token(), density.token(), total);
+
+        // The full leaf stream, generated once and shared by both files.
+        Random valueRng = new Random(LIST_SEED + elem.ordinal() * 31L + density.ordinal());
+        long[] longs = elem == Elem.INT64 ? new long[total] : null;
+        double[] doubles = elem == Elem.FLOAT64 ? new double[total] : null;
+        boolean[] leafNull = new boolean[total];
+        for (int i = 0; i < total; i++) {
+            leafNull[i] = density.nullable() && valueRng.nextDouble() < density.elementNullProbability;
+            if (elem == Elem.INT64) {
+                longs[i] = valueRng.nextLong();
+            }
+            else {
+                doubles[i] = valueRng.nextGaussian();
+            }
+        }
+
+        writeListFile(listPath, elem, density, longs, doubles, leafNull);
+        writeListFlatFile(flatPath, elem, density, longs, doubles, leafNull);
+    }
+
+    private static void writeListFile(Path path, Elem elem, NullDensity density,
+                                      long[] longs, double[] doubles, boolean[] leafNull)
+            throws IOException {
+        Schema schema = listSchema(elem, density);
+        Random shapeRng = new Random(LIST_SEED + 7);
+        int total = leafNull.length;
+        try (ParquetWriter<GenericRecord> writer = BenchmarkWriter.create(path, schema)) {
+            int idx = 0;
+            while (idx < total) {
+                GenericRecord record = new GenericData.Record(schema);
+                if (density.nullable() && shapeRng.nextDouble() < density.listNullProbability) {
+                    // A null list consumes no leaves (keeps the leaf stream aligned).
+                    record.put("vec", null);
+                    writer.write(record);
+                    continue;
+                }
+                int len = Math.min(BenchmarkWriter.randomLen(shapeRng), total - idx);
+                List<Object> vec = new ArrayList<>(len);
+                for (int j = 0; j < len; j++) {
+                    vec.add(leafNull[idx] ? null : boxed(elem, longs, doubles, idx));
+                    idx++;
+                }
+                record.put("vec", vec);
+                writer.write(record);
+            }
+        }
+    }
+
+    private static void writeListFlatFile(Path path, Elem elem, NullDensity density,
+                                          long[] longs, double[] doubles, boolean[] leafNull)
+            throws IOException {
+        Schema schema = flatValueSchema(elem, density.nullable());
+        int total = leafNull.length;
+        try (ParquetWriter<GenericRecord> writer = BenchmarkWriter.create(path, schema)) {
+            for (int i = 0; i < total; i++) {
+                GenericRecord record = new GenericData.Record(schema);
+                record.put("value", leafNull[i] ? null : boxed(elem, longs, doubles, i));
+                writer.write(record);
+            }
+        }
+    }
+
+    private static Object boxed(Elem elem, long[] longs, double[] doubles, int idx) {
+        return elem == Elem.INT64 ? Long.valueOf(longs[idx]) : Double.valueOf(doubles[idx]);
+    }
+
+    private static Schema listSchema(Elem elem, NullDensity density) {
+        Schema element = primitiveSchema(elem);
+        if (density.nullable()) {
+            element = BenchmarkWriter.optional(element);
+        }
+        Schema array = Schema.createArray(element);
+        SchemaBuilder.FieldAssembler<Schema> fields = SchemaBuilder.record("list").fields();
+        if (density.nullable()) {
+            return fields.name("vec").type(BenchmarkWriter.optional(array)).withDefault(null).endRecord();
+        }
+        return fields.name("vec").type(array).noDefault().endRecord();
+    }
+
+    private static Schema flatValueSchema(Elem elem, boolean nullable) {
+        Schema value = primitiveSchema(elem);
+        SchemaBuilder.FieldAssembler<Schema> fields = SchemaBuilder.record("flat").fields();
+        if (nullable) {
+            return fields.name("value").type(BenchmarkWriter.optional(value)).withDefault(null).endRecord();
+        }
+        return fields.name("value").type(value).noDefault().endRecord();
+    }
+
+    private static Schema primitiveSchema(Elem elem) {
+        return elem == Elem.INT64 ? Schema.create(Schema.Type.LONG) : Schema.create(Schema.Type.DOUBLE);
+    }
+
+    // ==================== Multi-column fixture ====================
+
+    /// The `MULTI_COLUMN_COUNT` list-leaf paths (`vec0.list.element`, …) of the
+    /// multi-column fixture, for the column-reader fold.
+    public static String[] multiListLeaves() {
+        String[] leaves = new String[MULTI_COLUMN_COUNT];
+        for (int c = 0; c < MULTI_COLUMN_COUNT; c++) {
+            leaves[c] = "vec" + c + ".list.element";
+        }
+        return leaves;
+    }
+
+    /// The `MULTI_COLUMN_COUNT` top-level list field names (`vec0`, …), for the
+    /// row-reader fold.
+    public static String[] multiListFields() {
+        String[] fields = new String[MULTI_COLUMN_COUNT];
+        for (int c = 0; c < MULTI_COLUMN_COUNT; c++) {
+            fields[c] = "vec" + c;
+        }
+        return fields;
+    }
+
+    /// The `MULTI_COLUMN_COUNT` flat-twin column names (`c0`, …), the decode floor.
+    public static String[] multiFlatColumns() {
+        String[] columns = new String[MULTI_COLUMN_COUNT];
+        for (int c = 0; c < MULTI_COLUMN_COUNT; c++) {
+            columns[c] = "c" + c;
+        }
+        return columns;
+    }
+
+    public static Path multiListFile(Path dir, Elem elem, NullDensity density) {
+        return dir.resolve("multilist_" + elem.token() + "_" + density.token() + ".parquet");
+    }
+
+    public static Path multiListFlatFile(Path dir, Elem elem, NullDensity density) {
+        return dir.resolve("multilist_" + elem.token() + "_" + density.token() + "_flat.parquet");
+    }
+
+    /// Writes the multi-column fixture and its flat twin for `(elem, density)` if
+    /// either is missing: a record of `MULTI_COLUMN_COUNT` identical
+    /// `LIST<primitive>` columns holding `totalValues` leaves in total (so the
+    /// per-file byte volume matches the single-column fixture), plus a flat twin of
+    /// the same number of primitive columns carrying the identical leaf streams.
+    public static void ensureMultiList(Path dir, Elem elem, NullDensity density, long totalValues)
+            throws IOException {
+        Path listPath = multiListFile(dir, elem, density);
+        Path flatPath = multiListFlatFile(dir, elem, density);
+        if (BenchmarkWriter.present(listPath) && BenchmarkWriter.present(flatPath)) {
+            return;
+        }
+        Files.createDirectories(dir);
+        // Total leaves are split evenly across the columns, which are identical, so
+        // the per-column stream is generated once and written to every column.
+        int perColumn = Math.toIntExact(totalValues / MULTI_COLUMN_COUNT);
+        System.out.printf("Generating multi-column list corpus elem=%s density=%s "
+                        + "(%d cols x %,d leaves)...%n",
+                elem.token(), density.token(), MULTI_COLUMN_COUNT, perColumn);
+
+        Random valueRng = new Random(LIST_SEED + 101 + elem.ordinal() * 31L + density.ordinal());
+        long[] longs = elem == Elem.INT64 ? new long[perColumn] : null;
+        double[] doubles = elem == Elem.FLOAT64 ? new double[perColumn] : null;
+        boolean[] leafNull = new boolean[perColumn];
+        for (int i = 0; i < perColumn; i++) {
+            leafNull[i] = density.nullable() && valueRng.nextDouble() < density.elementNullProbability;
+            if (elem == Elem.INT64) {
+                longs[i] = valueRng.nextLong();
+            }
+            else {
+                doubles[i] = valueRng.nextGaussian();
+            }
+        }
+
+        writeMultiListFile(listPath, elem, density, longs, doubles, leafNull);
+        writeMultiFlatFile(flatPath, elem, density, longs, doubles, leafNull);
+    }
+
+    private static void writeMultiListFile(Path path, Elem elem, NullDensity density,
+                                           long[] longs, double[] doubles, boolean[] leafNull)
+            throws IOException {
+        Schema schema = multiListSchema(elem, density);
+        String[] fields = multiListFields();
+        Random shapeRng = new Random(LIST_SEED + 7);
+        int total = leafNull.length;
+        try (ParquetWriter<GenericRecord> writer = BenchmarkWriter.create(path, schema)) {
+            int idx = 0;
+            while (idx < total) {
+                GenericRecord record = new GenericData.Record(schema);
+                if (density.nullable() && shapeRng.nextDouble() < density.listNullProbability) {
+                    for (String field : fields) {
+                        record.put(field, null);
+                    }
+                    writer.write(record);
+                    continue;
+                }
+                int len = Math.min(BenchmarkWriter.randomLen(shapeRng), total - idx);
+                for (String field : fields) {
+                    List<Object> vec = new ArrayList<>(len);
+                    for (int j = 0; j < len; j++) {
+                        vec.add(leafNull[idx + j] ? null : boxed(elem, longs, doubles, idx + j));
+                    }
+                    record.put(field, vec);
+                }
+                idx += len;
+                writer.write(record);
+            }
+        }
+    }
+
+    private static void writeMultiFlatFile(Path path, Elem elem, NullDensity density,
+                                           long[] longs, double[] doubles, boolean[] leafNull)
+            throws IOException {
+        Schema schema = multiFlatSchema(elem, density.nullable());
+        String[] columns = multiFlatColumns();
+        int total = leafNull.length;
+        try (ParquetWriter<GenericRecord> writer = BenchmarkWriter.create(path, schema)) {
+            for (int i = 0; i < total; i++) {
+                GenericRecord record = new GenericData.Record(schema);
+                Object value = leafNull[i] ? null : boxed(elem, longs, doubles, i);
+                for (String column : columns) {
+                    record.put(column, value);
+                }
+                writer.write(record);
+            }
+        }
+    }
+
+    private static Schema multiListSchema(Elem elem, NullDensity density) {
+        Schema element = primitiveSchema(elem);
+        if (density.nullable()) {
+            element = BenchmarkWriter.optional(element);
+        }
+        Schema array = Schema.createArray(element);
+        Schema fieldType = density.nullable() ? BenchmarkWriter.optional(array) : array;
+        SchemaBuilder.FieldAssembler<Schema> fields = SchemaBuilder.record("multilist").fields();
+        for (int c = 0; c < MULTI_COLUMN_COUNT; c++) {
+            if (density.nullable()) {
+                fields.name("vec" + c).type(fieldType).withDefault(null);
+            }
+            else {
+                fields.name("vec" + c).type(fieldType).noDefault();
+            }
+        }
+        return fields.endRecord();
+    }
+
+    private static Schema multiFlatSchema(Elem elem, boolean nullable) {
+        Schema value = primitiveSchema(elem);
+        Schema fieldType = nullable ? BenchmarkWriter.optional(value) : value;
+        SchemaBuilder.FieldAssembler<Schema> fields = SchemaBuilder.record("multiflat").fields();
+        for (int c = 0; c < MULTI_COLUMN_COUNT; c++) {
+            if (nullable) {
+                fields.name("c" + c).type(fieldType).withDefault(null);
+            }
+            else {
+                fields.name("c" + c).type(fieldType).noDefault();
+            }
+        }
+        return fields.endRecord();
+    }
+
+    /// Generates the list corpus for every element type and null density.
+    public static void generateAll(Path dir, long totalValues) throws IOException {
+        for (Elem elem : Elem.values()) {
+            for (NullDensity density : NullDensity.values()) {
+                ensureList(dir, elem, density, totalValues);
+                ensureMultiList(dir, elem, density, totalValues);
+            }
+        }
+    }
+
+    public static void main(String[] args) throws IOException {
+        Path dir = Path.of(args.length > 0 ? args[0] : BenchmarkData.dir());
+        generateAll(dir, BenchmarkData.totalValues());
+        System.out.println("Nested-list corpus ready in " + dir);
+    }
+}

--- a/performance-testing/micro-benchmarks/src/main/java/dev/hardwood/benchmarks/nested/NestedListGate.java
+++ b/performance-testing/micro-benchmarks/src/main/java/dev/hardwood/benchmarks/nested/NestedListGate.java
@@ -1,0 +1,64 @@
+/*
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Copyright The original authors
+ *
+ *  Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package dev.hardwood.benchmarks.nested;
+
+import java.io.IOException;
+import java.nio.file.Path;
+
+import dev.hardwood.HardwoodContext;
+import dev.hardwood.benchmarks.BenchmarkData;
+import dev.hardwood.benchmarks.Elem;
+import dev.hardwood.benchmarks.NestedReads;
+import dev.hardwood.benchmarks.nested.NestedListFileGenerator.NullDensity;
+
+/// Correctness gate for [NestedListReadBenchmark]. Generates the list corpus and, for
+/// each `(elem, density)`, folds the column real-items path, the row all-items path,
+/// and the flat floor, asserting all three agree before any timing is trusted — they
+/// read the identical leaf stream.
+///
+/// Run through the benchmarks uberjar:
+/// ```
+/// java -cp benchmarks.jar dev.hardwood.benchmarks.nested.NestedListGate [dataDir]
+/// ```
+public final class NestedListGate {
+
+    private static final double EPSILON = 1e-6;
+
+    private NestedListGate() {
+    }
+
+    public static void main(String[] args) throws IOException {
+        Path dir = Path.of(args.length > 0 ? args[0] : BenchmarkData.dir());
+        NestedListFileGenerator.generateAll(dir, BenchmarkData.totalValues());
+
+        System.out.println("Nested-list correctness gate:");
+        try (HardwoodContext context = HardwoodContext.create()) {
+            for (Elem elem : Elem.values()) {
+                for (NullDensity density : NullDensity.values()) {
+                    Path listPath = NestedListFileGenerator.listFile(dir, elem, density);
+                    Path flatPath = NestedListFileGenerator.listFlatFile(dir, elem, density);
+                    double column = NestedReads.sumColumn(listPath, NestedListFileGenerator.LIST_LEAF, elem, context);
+                    double row = NestedReads.sumRowsList(listPath, "vec", elem, context);
+                    double flat = NestedReads.sumColumn(flatPath, "value", elem, context);
+                    requireClose("list " + elem + "/" + density + " column vs flat floor", column, flat);
+                    requireClose("list " + elem + "/" + density + " row vs column", row, column);
+                    System.out.printf("  OK  list elem=%-8s density=%-7s sum=%s%n",
+                            elem.token(), density.token(), column);
+                }
+            }
+        }
+        System.out.println("Gate passed — every path agrees on the values it reads.");
+    }
+
+    private static void requireClose(String what, double a, double b) {
+        double scale = Math.max(1.0, Math.max(Math.abs(a), Math.abs(b)));
+        if (Math.abs(a - b) > EPSILON * scale) {
+            throw new IllegalStateException("Mismatch (" + what + "): " + a + " vs " + b);
+        }
+    }
+}

--- a/performance-testing/micro-benchmarks/src/main/java/dev/hardwood/benchmarks/nested/NestedListGate.java
+++ b/performance-testing/micro-benchmarks/src/main/java/dev/hardwood/benchmarks/nested/NestedListGate.java
@@ -43,9 +43,11 @@ public final class NestedListGate {
                     Path listPath = NestedListFileGenerator.listFile(dir, elem, density);
                     Path flatPath = NestedListFileGenerator.listFlatFile(dir, elem, density);
                     double column = NestedReads.sumColumn(listPath, NestedListFileGenerator.LIST_LEAF, elem, context);
+                    double structural = NestedReads.sumColumnStructural(listPath, NestedListFileGenerator.LIST_LEAF, elem, context);
                     double row = NestedReads.sumRowsList(listPath, "vec", elem, context);
                     double flat = NestedReads.sumColumn(flatPath, "value", elem, context);
                     requireClose("list " + elem + "/" + density + " column vs flat floor", column, flat);
+                    requireClose("list " + elem + "/" + density + " structural vs column", structural, column);
                     requireClose("list " + elem + "/" + density + " row vs column", row, column);
                     System.out.printf("  OK  list elem=%-8s density=%-7s sum=%s%n",
                             elem.token(), density.token(), column);

--- a/performance-testing/micro-benchmarks/src/main/java/dev/hardwood/benchmarks/nested/NestedListReadBenchmark.java
+++ b/performance-testing/micro-benchmarks/src/main/java/dev/hardwood/benchmarks/nested/NestedListReadBenchmark.java
@@ -1,0 +1,109 @@
+/*
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Copyright The original authors
+ *
+ *  Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package dev.hardwood.benchmarks.nested;
+
+import java.io.IOException;
+import java.nio.file.Path;
+import java.util.concurrent.TimeUnit;
+
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Level;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.TearDown;
+import org.openjdk.jmh.annotations.Warmup;
+
+import dev.hardwood.HardwoodContext;
+import dev.hardwood.benchmarks.BenchmarkData;
+import dev.hardwood.benchmarks.Elem;
+import dev.hardwood.benchmarks.NestedReads;
+import dev.hardwood.benchmarks.nested.NestedListFileGenerator.NullDensity;
+
+/// The general nested read path over a top-level `LIST<primitive>`, isolated against a
+/// flat decode floor. This is the workload the reconstruction improvements (#750
+/// bulk-copy of present runs, #751 `RealView` on the drain) target, kept numeric so
+/// the measured time is level handling and value copy rather than string decode.
+///
+/// - `columnNested` — the [dev.hardwood.reader.ColumnReader] real-items path: pull
+///   each batch's compacted leaf array and fold it. This is what #750/#751 accelerate.
+/// - `rowNested` — the [dev.hardwood.reader.RowReader] all-items path: materialize the
+///   `PqList` per row and fold its elements. #751 must not regress this path.
+/// - `flatFloor` — the identical leaf stream as a plain primitive column read through
+///   the column reader: the fastest these bytes move with no list structure.
+///
+/// The gap between `columnNested`/`rowNested` and `flatFloor` is the reconstruction
+/// cost; an improvement moves the nested numbers toward the floor while the floor
+/// itself stays put. `nullDensity` sweeps the run structure the bulk copy depends on
+/// — nulls and null/empty lists break the contiguous present runs #750 copies in one
+/// shot. Element type spans a 4-byte and an 8-byte leaf.
+///
+/// Generate the corpus first (also done on demand from `@Setup`):
+/// ```
+/// java ... dev.hardwood.benchmarks.nested.NestedListFileGenerator <dataDir>
+/// ```
+@BenchmarkMode(Mode.AverageTime)
+@OutputTimeUnit(TimeUnit.MILLISECONDS)
+@State(Scope.Benchmark)
+@Fork(value = 2, jvmArgs = { "-Xms2g", "-Xmx2g", "--add-modules", "jdk.incubator.vector" })
+@Warmup(iterations = 3, time = 1)
+@Measurement(iterations = 5, time = 1)
+public class NestedListReadBenchmark {
+
+    private static final String LIST_FIELD = "vec";
+    private static final String FLAT_COLUMN = "value";
+
+    @Param({ "int64", "float64" })
+    private String elem;
+
+    @Param({ "none", "sparse", "dense" })
+    private String nullDensity;
+
+    private Elem elemKind;
+    private Path listPath;
+    private Path flatPath;
+    private HardwoodContext context;
+
+    @Setup(Level.Trial)
+    public void setup() throws IOException {
+        elemKind = Elem.valueOf(elem.toUpperCase());
+        NullDensity density = NullDensity.valueOf(nullDensity.toUpperCase());
+        Path dir = Path.of(BenchmarkData.dir());
+        long totalValues = BenchmarkData.totalValues();
+        NestedListFileGenerator.ensureList(dir, elemKind, density, totalValues);
+        listPath = NestedListFileGenerator.listFile(dir, elemKind, density);
+        flatPath = NestedListFileGenerator.listFlatFile(dir, elemKind, density);
+        context = HardwoodContext.create();
+    }
+
+    @TearDown(Level.Trial)
+    public void tearDown() {
+        context.close();
+    }
+
+    @Benchmark
+    public double columnNested() throws IOException {
+        return NestedReads.sumColumn(listPath, NestedListFileGenerator.LIST_LEAF, elemKind, context);
+    }
+
+    @Benchmark
+    public double rowNested() throws IOException {
+        return NestedReads.sumRowsList(listPath, LIST_FIELD, elemKind, context);
+    }
+
+    @Benchmark
+    public double flatFloor() throws IOException {
+        return NestedReads.sumColumn(flatPath, FLAT_COLUMN, elemKind, context);
+    }
+}

--- a/performance-testing/micro-benchmarks/src/main/java/dev/hardwood/benchmarks/nested/NestedListReadBenchmark.java
+++ b/performance-testing/micro-benchmarks/src/main/java/dev/hardwood/benchmarks/nested/NestedListReadBenchmark.java
@@ -36,8 +36,13 @@ import dev.hardwood.benchmarks.nested.NestedListFileGenerator.NullDensity;
 /// bulk-copy of present runs, #751 `RealView` on the drain) target, kept numeric so
 /// the measured time is level handling and value copy rather than string decode.
 ///
-/// - `columnNested` — the [dev.hardwood.reader.ColumnReader] real-items path: pull
-///   each batch's compacted leaf array and fold it. This is what #750/#751 accelerate.
+/// - `columnNested` — the [dev.hardwood.reader.ColumnReader] real-items path as a
+///   flat leaf consumer: pull each batch's compacted leaf array, count, and leaf
+///   validity and fold it. This is what #750/#751 accelerate.
+/// - `columnNestedStructural` — the same real-items path as a list-reconstructing
+///   consumer: read `getLayerOffsets`/`getLayerValidity` and walk the lists. It
+///   forces the per-layer view every batch, so it measures whether that view is
+///   built on the drain or lazily on the serial consumer.
 /// - `rowNested` — the [dev.hardwood.reader.RowReader] all-items path: materialize the
 ///   `PqList` per row and fold its elements. #751 must not regress this path.
 /// - `flatFloor` — the identical leaf stream as a plain primitive column read through
@@ -95,6 +100,11 @@ public class NestedListReadBenchmark {
     @Benchmark
     public double columnNested() throws IOException {
         return NestedReads.sumColumn(listPath, NestedListFileGenerator.LIST_LEAF, elemKind, context);
+    }
+
+    @Benchmark
+    public double columnNestedStructural() throws IOException {
+        return NestedReads.sumColumnStructural(listPath, NestedListFileGenerator.LIST_LEAF, elemKind, context);
     }
 
     @Benchmark

--- a/performance-testing/micro-benchmarks/src/main/java/dev/hardwood/benchmarks/nested/NestedMultiListReadBenchmark.java
+++ b/performance-testing/micro-benchmarks/src/main/java/dev/hardwood/benchmarks/nested/NestedMultiListReadBenchmark.java
@@ -1,0 +1,107 @@
+/*
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Copyright The original authors
+ *
+ *  Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package dev.hardwood.benchmarks.nested;
+
+import java.io.IOException;
+import java.nio.file.Path;
+import java.util.concurrent.TimeUnit;
+
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Level;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.TearDown;
+import org.openjdk.jmh.annotations.Warmup;
+
+import dev.hardwood.HardwoodContext;
+import dev.hardwood.benchmarks.BenchmarkData;
+import dev.hardwood.benchmarks.Elem;
+import dev.hardwood.benchmarks.NestedReads;
+import dev.hardwood.benchmarks.nested.NestedListFileGenerator.NullDensity;
+
+/// The general nested read path over **many** top-level `LIST<primitive>` columns
+/// folded through one consumer thread, against the same flat decode floor. The
+/// single-column [NestedListReadBenchmark] hides consumer-side reconstruction cost
+/// once it is moved onto the per-column drains, because one consumer folding one
+/// column is rarely the bottleneck; this fans the fold across
+/// [NestedListFileGenerator#MULTI_COLUMN_COUNT] columns so the shared consumer does
+/// that many columns' work while the drains reconstruct in parallel.
+///
+/// - `columnMulti` — one [dev.hardwood.reader.ColumnReader] per column, all folded
+///   on the calling thread.
+/// - `rowMulti` — the [dev.hardwood.reader.RowReader] all-items path over every list
+///   field per row.
+/// - `flatMultiFloor` — the identical leaf streams as plain primitive columns: the
+///   fastest these bytes move with no list structure.
+///
+/// The fixture holds the same total leaf count as the single-column one, split
+/// evenly across the columns, so per-file byte volume is comparable.
+@BenchmarkMode(Mode.AverageTime)
+@OutputTimeUnit(TimeUnit.MILLISECONDS)
+@State(Scope.Benchmark)
+@Fork(value = 2, jvmArgs = { "-Xms2g", "-Xmx2g", "--add-modules", "jdk.incubator.vector" })
+@Warmup(iterations = 3, time = 1)
+@Measurement(iterations = 5, time = 1)
+public class NestedMultiListReadBenchmark {
+
+    @Param({ "int64", "float64" })
+    private String elem;
+
+    @Param({ "none", "sparse", "dense" })
+    private String nullDensity;
+
+    private Elem elemKind;
+    private Path listPath;
+    private Path flatPath;
+    private String[] listLeaves;
+    private String[] listFields;
+    private String[] flatColumns;
+    private HardwoodContext context;
+
+    @Setup(Level.Trial)
+    public void setup() throws IOException {
+        elemKind = Elem.valueOf(elem.toUpperCase());
+        NullDensity density = NullDensity.valueOf(nullDensity.toUpperCase());
+        Path dir = Path.of(BenchmarkData.dir());
+        long totalValues = BenchmarkData.totalValues();
+        NestedListFileGenerator.ensureMultiList(dir, elemKind, density, totalValues);
+        listPath = NestedListFileGenerator.multiListFile(dir, elemKind, density);
+        flatPath = NestedListFileGenerator.multiListFlatFile(dir, elemKind, density);
+        listLeaves = NestedListFileGenerator.multiListLeaves();
+        listFields = NestedListFileGenerator.multiListFields();
+        flatColumns = NestedListFileGenerator.multiFlatColumns();
+        context = HardwoodContext.create();
+    }
+
+    @TearDown(Level.Trial)
+    public void tearDown() {
+        context.close();
+    }
+
+    @Benchmark
+    public double columnMulti() throws IOException {
+        return NestedReads.sumColumns(listPath, listLeaves, elemKind, context);
+    }
+
+    @Benchmark
+    public double rowMulti() throws IOException {
+        return NestedReads.sumRowsMultiList(listPath, listFields, elemKind, context);
+    }
+
+    @Benchmark
+    public double flatMultiFloor() throws IOException {
+        return NestedReads.sumColumns(flatPath, flatColumns, elemKind, context);
+    }
+}


### PR DESCRIPTION
## Summary

Reading a nested column (`LIST`/`MAP`/struct) through `ColumnReader` reconstructs
the real-items view — level scan, per-layer offsets/validity, and value compaction —
on the **serial consumer thread**, while the parallel per-column decode/drain
threads sit mostly idle. Profiling a `LIST<float64>` scan showed the decode threads
~96% parked and the consumer's on-CPU time dominated by that reconstruction.

This PR moves the reconstruction onto the drain threads and removes redundant work,
so the consumer does little beyond handing back already-built arrays. Nested
`ColumnReader` reads get **~19–24% faster single-column and ~55–59% faster
across a wide (8-column) projection**, with the row-reader and flat-read paths
unchanged.

Closes #749, #751, #756, #757, #754.

## What changed

**#751 — Compute the `RealView` on the drain.** A `NestedColumnWorker` now takes an
`IndexMode` chosen by the constructing reader:
- `REAL_VIEW` (unfiltered `ColumnReader`) builds the real-items view on the drain
  from the level accumulators and **drops the raw def/rep levels and the all-items
  index** — nothing downstream reads them. This eliminates a full level scan on the
  serial consumer *and* two `Arrays.copyOf(valueCount)` per batch of level
  materialisation, cutting per-batch allocation and memory traffic.
- `REAL_VIEW_KEEP_LEVELS` (exact-filtered `ColumnReader`) keeps the raw levels so
  `applySelection` slices them per kept record, unchanged.
- `ALL_ITEMS` (`RowReader`) is untouched — `NestedBatchIndex` still reads raw levels.

**#756 — Skip compaction when there are no phantom positions.** `computeRealView`
returns a `null` gather map when every raw slot is a real leaf (the all-present
case), so the consumer passes the batch's own value array through instead of
allocating and gathering a compacted copy. The array is already fresh per batch, so
the ownership contract holds.

**#757 — Compact leaf values on the drain.** When a gather *is* needed (null/empty
parents), it runs on the drain into `NestedBatch.realValues` rather than on the
serial consumer. Shared gather logic is extracted to `LeafCompaction`.

**#749 — Remove the raw-level escape-hatch accessors.** `ColumnReader.getDefinitionLevels()`
/ `getRepetitionLevels()` are removed. They had no callers, returned `null` for flat
columns, and were the last raw-level readers on the unfiltered path — blocking the
level-drop above. **API note:** breaking removal on the `@Experimental` batch API.

**#754 — Benchmark suite.** JMH benchmarks isolating the nested reconstruction inner
loop against a flat decode floor: `NestedListReadBenchmark` (single `LIST<primitive>`),
`NestedMultiListReadBenchmark` (wide projection of such columns), and
`MixedSchemaReadBenchmark`, plus shared fixtures and correctness gates.

## Performance

`LIST<float64>`, 8M leaves, JMH avgt (2 forks × 5 iters, mean ± 99.9% CI).
Before = base + benchmark; after = this PR. Hardware: MacBook Pro M3 Max.

| Benchmark | density | before (ms) | after (ms) | change |
|---|---|--:|--:|--:|
| `columnNested` (1 column) | none | 65.9 | 53.4 | **−19%** (1.24×) |
| `columnNested` (1 column) | dense | 151.3 | 115.1 | **−24%** (1.32×) |
| `columnMulti` (8 columns) | none | 36.3 | 16.1 | **−55%** (2.25×) |
| `columnMulti` (8 columns) | dense | 97.6 | 40.2 | **−59%** (2.43×) |

Controls unchanged (≤2.4%, within noise): `rowNested` 44.9→45.6 / 96.3→97.5,
`rowMulti` 29.1→29.5 / 47.8→47.6, `flatFloor` 7.4→7.5 / 36.9→36.8, `flatMultiFloor`
9.0→9.0 / 27.9→28.6.

In the wide case the columnar path flips from **slower** than the row reader
(`columnMulti` 36.3 vs `rowMulti` 29.1) to **~1.8× faster** (16.1 vs 29.5), reaching
1.8× the flat decode floor (down from 4.0×). Reproduced with the same direction on a
second, different-architecture machine (Intel N300, x86 single memory channel:
−19% single / −38% multi), so the win is not hardware-specific.

## Design

See `_designs/NESTED_REALVIEW_ON_DRAIN.md` for the `IndexMode` model, the drain vs
consumer split, and the filtered/unfiltered distinction.

## Notes / follow-ups

- The per-column-worker routing for mixed flat+nested files (#732) remains future
  work; this PR converges the real-items reconstruction it would build on.
