### PR TITLE
#714 Bounds-check Variant value lengths and extents

### DIFF
--- a/core/src/main/java/dev/hardwood/internal/variant/VariantBinary.java
+++ b/core/src/main/java/dev/hardwood/internal/variant/VariantBinary.java
@@ -107,28 +107,27 @@ public final class VariantBinary {
         return result;
     }
 
-    /// Validates that a Variant object/array/metadata header fits inside a buffer
-    /// of `bufferLength` bytes. `headerEnd` is the exclusive end offset of the
-    /// header's id and offset tables — the caller computes it in `long` from the
-    /// **unsigned** element or dictionary `count`, so a hostile count cannot wrap
-    /// the 32-bit product into an in-bounds-looking offset that later slips past
-    /// the per-access bounds checks. Returns `headerEnd` narrowed to `int` once it
-    /// is known to fit.
+    /// Validates that `end`, an exclusive buffer offset derived from an untrusted
+    /// count or length, lies within `bufferLength`, returning it narrowed to `int`.
+    /// The caller computes `end` in `long` from the **unsigned** value, so a hostile
+    /// count/length cannot wrap the 32-bit arithmetic into an in-bounds-looking
+    /// offset that later slips past the per-access bounds checks. Used for
+    /// object/array/metadata header tables and for string/binary payload lengths alike.
     ///
-    /// @param region human-readable name of the count, used in the error message
-    /// @param count declared element/dictionary count (interpreted as unsigned 32-bit)
-    /// @param headerEnd exclusive end offset of the id/offset tables, computed in `long`
+    /// @param region human-readable name of the count/length, used in the error message
+    /// @param declared declared count or length (interpreted as unsigned 32-bit)
+    /// @param end exclusive end offset computed in `long` from `declared`
     /// @param bufferLength length of the enclosing buffer
-    /// @return `headerEnd` as an `int`
-    /// @throws IllegalArgumentException if the header does not fit the buffer
-    static int checkHeaderFits(String region, int count, long headerEnd, int bufferLength) {
-        if (headerEnd > bufferLength) {
+    /// @return `end` as an `int`
+    /// @throws IllegalArgumentException if `end` exceeds `bufferLength`
+    static int checkFits(String region, int declared, long end, int bufferLength) {
+        if (end > bufferLength) {
             throw new IllegalArgumentException(
-                    "Variant " + region + " count " + Integer.toUnsignedString(count)
-                            + " does not fit in a buffer of " + bufferLength
-                            + " bytes (header tables alone require " + headerEnd + " bytes)");
+                    "Variant " + region + " (" + Integer.toUnsignedString(declared)
+                            + ") does not fit within its " + bufferLength
+                            + "-byte buffer (needs " + end + " bytes)");
         }
-        return Math.toIntExact(headerEnd);
+        return Math.toIntExact(end);
     }
 
     /// Map a Variant value-header byte to its [VariantType]. Returns `null` for

--- a/core/src/main/java/dev/hardwood/internal/variant/VariantMetadata.java
+++ b/core/src/main/java/dev/hardwood/internal/variant/VariantMetadata.java
@@ -58,7 +58,7 @@ public final class VariantMetadata {
         // would otherwise overflow the 32-bit product and wrap the offset-table
         // extent to an in-bounds-looking value that bypasses this truncation check.
         long stringsSectionStart = offsetsStart + ((long) dictionarySize + 1L) * offsetSize;
-        this.stringsStart = VariantBinary.checkHeaderFits(
+        this.stringsStart = VariantBinary.checkFits(
                 "metadata dictionary", dictionarySize, stringsSectionStart, buf.length);
         int totalStringBytes = readOffset(dictionarySize);
         if (buf.length < stringsStart + totalStringBytes) {

--- a/core/src/main/java/dev/hardwood/internal/variant/VariantValueDecoder.java
+++ b/core/src/main/java/dev/hardwood/internal/variant/VariantValueDecoder.java
@@ -296,21 +296,18 @@ public final class VariantValueDecoder {
         }
         if (basic == VariantBinary.BASIC_TYPE_PRIMITIVE) {
             int tag = header >>> VariantBinary.VALUE_HEADER_SHIFT;
-            return 1 + primitivePayloadLength(buf, offset, tag);
+            int length = 1 + primitivePayloadLength(buf, offset, tag);
+            VariantBinary.checkFits("primitive value", length, (long) offset + length, buf.length);
+            return length;
         }
         if (basic == VariantBinary.BASIC_TYPE_OBJECT) {
             ObjectLayout layout = parseObject(buf, offset);
-            int lastOff = VariantBinary.readUnsignedLE(buf,
-                    layout.offsetsStart() + layout.numElements() * layout.offsetSize(),
-                    layout.offsetSize());
-            return layout.valuesStart() - offset + lastOff;
+            return objectOrArrayValueLength(buf, offset, layout.valuesStart(),
+                    layout.offsetsStart() + layout.numElements() * layout.offsetSize(), layout.offsetSize());
         }
-        // ARRAY
         ArrayLayout layout = parseArray(buf, offset);
-        int lastOff = VariantBinary.readUnsignedLE(buf,
-                layout.offsetsStart() + layout.numElements() * layout.offsetSize(),
-                layout.offsetSize());
-        return layout.valuesStart() - offset + lastOff;
+        return objectOrArrayValueLength(buf, offset, layout.valuesStart(),
+                layout.offsetsStart() + layout.numElements() * layout.offsetSize(), layout.offsetSize());
     }
 
     private static int primitivePayloadLength(byte[] buf, int offset, int tag) {
@@ -349,6 +346,14 @@ public final class VariantValueDecoder {
         VariantBinary.checkFits("string/binary length", declaredLength,
                 (long) offset + 5 + Integer.toUnsignedLong(declaredLength), buf.length);
         return declaredLength;
+    }
+
+    /// Byte length of an OBJECT/ARRAY value, with the offset-table's final offset
+    /// validated against the buffer.
+    private static int objectOrArrayValueLength(byte[] buf, int offset, int valuesStart, int lastOffsetPos, int offsetSize) {
+        int lastOff = VariantBinary.readUnsignedLE(buf, lastOffsetPos, offsetSize);
+        long end = (long) valuesStart + Integer.toUnsignedLong(lastOff);
+        return VariantBinary.checkFits("object/array value", lastOff, end, buf.length) - offset;
     }
 
     /// Reads the field id stored at index `i` in an object's id array.

--- a/core/src/main/java/dev/hardwood/internal/variant/VariantValueDecoder.java
+++ b/core/src/main/java/dev/hardwood/internal/variant/VariantValueDecoder.java
@@ -102,8 +102,7 @@ public final class VariantValueDecoder {
         if (basic == VariantBinary.BASIC_TYPE_PRIMITIVE) {
             int tag = VariantBinary.valueHeader(buf[offset]);
             if (tag == VariantBinary.PRIM_STRING) {
-                int length = readIntLE(buf, offset + 1, 4);
-                checkBounds(buf, offset + 5, length);
+                int length = stringPayloadLength(buf, offset);
                 return new String(buf, offset + 5, length, StandardCharsets.UTF_8);
             }
         }
@@ -115,8 +114,7 @@ public final class VariantValueDecoder {
         if (t != VariantType.BINARY) {
             throw VariantErrors.expected(VariantType.BINARY, t);
         }
-        int length = readIntLE(buf, offset + 1, 4);
-        checkBounds(buf, offset + 5, length);
+        int length = stringPayloadLength(buf, offset);
         byte[] out = new byte[length];
         System.arraycopy(buf, offset + 5, out, 0, length);
         return out;
@@ -259,7 +257,7 @@ public final class VariantValueDecoder {
         long elements = Integer.toUnsignedLong(numElements);
         long offsetsStart = idsStart + elements * idSize;
         long valuesStart = offsetsStart + (elements + 1L) * offsetSize;
-        int valuesStartInt = VariantBinary.checkHeaderFits("object element", numElements, valuesStart, buf.length);
+        int valuesStartInt = VariantBinary.checkFits("object element", numElements, valuesStart, buf.length);
         return new ObjectLayout(numElements, idSize, offsetSize,
                 idsStart, Math.toIntExact(offsetsStart), valuesStartInt);
     }
@@ -280,7 +278,7 @@ public final class VariantValueDecoder {
         // hostile numElements cannot overflow the 32-bit product and wrap
         // valuesStart into an in-bounds-looking offset.
         long valuesStart = offsetsStart + (Integer.toUnsignedLong(numElements) + 1L) * offsetSize;
-        int valuesStartInt = VariantBinary.checkHeaderFits("array element", numElements, valuesStart, buf.length);
+        int valuesStartInt = VariantBinary.checkFits("array element", numElements, valuesStart, buf.length);
         return new ArrayLayout(numElements, offsetSize, offsetsStart, valuesStartInt);
     }
 
@@ -293,6 +291,7 @@ public final class VariantValueDecoder {
         int basic = header & VariantBinary.BASIC_TYPE_MASK;
         if (basic == VariantBinary.BASIC_TYPE_SHORT_STRING) {
             int length = header >>> VariantBinary.VALUE_HEADER_SHIFT;
+            VariantBinary.checkFits("short string length", length, (long) offset + 1 + length, buf.length);
             return 1 + length;
         }
         if (basic == VariantBinary.BASIC_TYPE_PRIMITIVE) {
@@ -336,10 +335,20 @@ public final class VariantValueDecoder {
             case VariantBinary.PRIM_DECIMAL16 -> 1 + 16; // scale byte + 128-bit
             case VariantBinary.PRIM_UUID -> 16;
             case VariantBinary.PRIM_STRING,
-                 VariantBinary.PRIM_BINARY -> 4 + readIntLE(buf, offset + 1, 4);
+                 VariantBinary.PRIM_BINARY -> 4 + stringPayloadLength(buf, offset);
             default -> throw new IllegalArgumentException(
                     "Unknown Variant primitive tag " + tag + " at offset " + offset);
         };
+    }
+
+    /// Reads and validates the 4-byte length prefix of a long string/binary
+    /// primitive at `buf[offset]`, rejecting a truncated field or out-of-buffer length.
+    private static int stringPayloadLength(byte[] buf, int offset) {
+        checkBounds(buf, offset + 1, 4);
+        int declaredLength = readIntLE(buf, offset + 1, 4);
+        VariantBinary.checkFits("string/binary length", declaredLength,
+                (long) offset + 5 + Integer.toUnsignedLong(declaredLength), buf.length);
+        return declaredLength;
     }
 
     /// Reads the field id stored at index `i` in an object's id array.

--- a/core/src/test/java/dev/hardwood/internal/variant/PqVariantInvalidInputTest.java
+++ b/core/src/test/java/dev/hardwood/internal/variant/PqVariantInvalidInputTest.java
@@ -16,6 +16,7 @@ import dev.hardwood.row.PqVariant;
 import dev.hardwood.row.PqVariantArray;
 import dev.hardwood.row.PqVariantObject;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 /// Pins the fail-early error paths on the Variant read surface. Each accessor
@@ -23,6 +24,10 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 /// assertion here so silent-regression to wrong-but-plausible output is
 /// caught immediately.
 class PqVariantInvalidInputTest {
+
+    /// Minimal valid metadata (version 1, empty dictionary) for pairing with
+    /// hand-built malformed value buffers.
+    private static final byte[] EMPTY_METADATA = { 0x01, 0x00, 0x00 };
 
     @Test
     void objectGetOnMissingFieldThrows() throws IOException {
@@ -78,6 +83,51 @@ class PqVariantInvalidInputTest {
         assertThatThrownBy(() -> new VariantMetadata(bytes))
                 .isInstanceOf(IllegalArgumentException.class)
                 .hasMessageContaining("Unsupported Variant metadata version");
+    }
+
+    @Test
+    void oversizedPrimitiveLengthRejected() {
+        // PRIM_BINARY (0x3C), 4-byte length 0x7FFFFFFF — runs far past the buffer.
+        byte[] value = { 0x3C, (byte) 0xFF, (byte) 0xFF, (byte) 0xFF, 0x7F };
+        assertThatThrownBy(() -> new PqVariantImpl(EMPTY_METADATA, value).value())
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("string/binary length");
+    }
+
+    @Test
+    void shortStringLengthExceedsBufferRejected() {
+        // SHORT_STRING (0x29) declaring length 10 with no payload bytes present.
+        byte[] value = { 0x29 };
+        assertThatThrownBy(() -> new PqVariantImpl(EMPTY_METADATA, value).value())
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("short string length");
+    }
+
+    @Test
+    void truncatedPrimitiveSizeRejected() {
+        // PRIM_STRING (0x40) whose 4-byte length prefix is truncated to 2 bytes.
+        byte[] value = { 0x40, 0x05, 0x00 };
+        assertThatThrownBy(() -> new PqVariantImpl(EMPTY_METADATA, value).value())
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("truncated");
+    }
+
+    @Test
+    void binaryAccessorOversizedLengthRejected() {
+        // asBinary: 0x80000000 reads back negative and slipped past the old check.
+        byte[] value = { 0x3C, 0x00, 0x00, 0x00, (byte) 0x80 };
+        assertThatThrownBy(() -> new PqVariantImpl(EMPTY_METADATA, value).asBinary())
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("string/binary length");
+    }
+
+    @Test
+    void validPrimitiveStringDecodes() {
+        // The guard rejects only out-of-range lengths — a well-formed string reads.
+        byte[] value = { 0x40, 0x03, 0x00, 0x00, 0x00, 'a', 'b', 'c' };
+        PqVariant v = new PqVariantImpl(EMPTY_METADATA, value);
+        assertThat(v.asString()).isEqualTo("abc");
+        assertThat(v.value()).isEqualTo(value);
     }
 
     private static PqVariant load(String caseName) throws IOException {

--- a/core/src/test/java/dev/hardwood/internal/variant/PqVariantInvalidInputTest.java
+++ b/core/src/test/java/dev/hardwood/internal/variant/PqVariantInvalidInputTest.java
@@ -130,6 +130,34 @@ class PqVariantInvalidInputTest {
         assertThat(v.value()).isEqualTo(value);
     }
 
+    @Test
+    void stringAccessorOversizedLengthRejected() {
+        // asString: PRIM_STRING (0x40) with a 0x7FFFFFFF length prefix.
+        byte[] value = { 0x40, (byte) 0xFF, (byte) 0xFF, (byte) 0xFF, 0x7F };
+        assertThatThrownBy(() -> new PqVariantImpl(EMPTY_METADATA, value).asString())
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("string/binary length");
+    }
+
+    @Test
+    void objectValueExtentRejected() {
+        // Empty OBJECT (0x0E) whose sole offset-table entry claims a 0x7FFFFFFF-byte
+        // values section — value() would size a copy far past the buffer.
+        byte[] value = { 0x0E, 0x00, (byte) 0xFF, (byte) 0xFF, (byte) 0xFF, 0x7F };
+        assertThatThrownBy(() -> new PqVariantImpl(EMPTY_METADATA, value).value())
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("object/array value");
+    }
+
+    @Test
+    void fixedWidthPrimitiveTruncationRejected() {
+        // PRIM_INT64 (0x18) header claiming an 8-byte payload with only 2 bytes present.
+        byte[] value = { 0x18, 0x01, 0x02 };
+        assertThatThrownBy(() -> new PqVariantImpl(EMPTY_METADATA, value).value())
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("primitive value");
+    }
+
     private static PqVariant load(String caseName) throws IOException {
         byte[] metadata = readResource("/variant/" + caseName + ".metadata");
         byte[] value = readResource("/variant/" + caseName + ".value");

--- a/core/src/test/java/dev/hardwood/internal/variant/PqVariantInvalidInputTest.java
+++ b/core/src/test/java/dev/hardwood/internal/variant/PqVariantInvalidInputTest.java
@@ -150,6 +150,16 @@ class PqVariantInvalidInputTest {
     }
 
     @Test
+    void arrayValueExtentRejected() {
+        // Empty ARRAY (0x0F) whose sole offset-table entry claims a 0x7FFFFFFF-byte
+        // values section — exercises the array branch of the extent guard.
+        byte[] value = { 0x0F, 0x00, (byte) 0xFF, (byte) 0xFF, (byte) 0xFF, 0x7F };
+        assertThatThrownBy(() -> new PqVariantImpl(EMPTY_METADATA, value).value())
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("object/array value");
+    }
+
+    @Test
     void fixedWidthPrimitiveTruncationRejected() {
         // PRIM_INT64 (0x18) header claiming an 8-byte payload with only 2 bytes present.
         byte[] value = { 0x18, 0x01, 0x02 };


### PR DESCRIPTION
## Description
This pull request addresses #714, which observed that the Variant value decoder sizes string, binary, and short-string payloads and, through `value()`, whole object / array and fixed-width values from lengths and offsets read straight out of the value buffer without validating them. A hostile or truncated length drove `PqVariantImpl.value()` / `asBinary` / `asString` into an out-of-range (`~1 GiB` or negative) `new byte[...]` or an out-of-bounds read rather than a clean rejection.

The work is two commits: the first guards the primitive / short-string length prefixes (the issue's three fixtures); the second closes the same failure on the `value()` path for object / array containers and truncated fixed-width primitives, surfaced during review. The change is internal to the decoder (the public `PqVariant` surface is unchanged) and well-formed files decode exactly as before.

## Key Changes
- **Generalized the #713 fit-check helper**
    - `VariantBinary.checkHeaderFits` → `checkFits(region, declared, end, bufferLength)`. It already validated a `long`-computed end offset against the buffer for object / array / metadata header tables; it now backs payload-length and value-extent checks too, so there is one validated-extent primitive rather than a parallel helper.
- **Guarded the string / binary and short-string length reads** 
    - A single `VariantValueDecoder.stringPayloadLength` reads the 4-byte length prefix, confirms the prefix is present, and validates the payload fits via unsigned `long` arithmetic; `asString`, `asBinary`, and `primitivePayloadLength` all route through it. `valueLength` gains the analogous short-string check.
- **Guarded the object / array and fixed-width value extents** 
    - `valueLength`'s object / array branches validate the offset table's trailing offset against the buffer (`objectOrArrayValueLength`), and the primitive branch validates the full fixed-width value extent so `value()` on any malformed value throws a descriptive `IllegalArgumentException` instead of over-allocating or reading out of bounds.

## Verification and Testing
Coverage drives the real decode / accessor entry points with crafted headers rather than mocks, and every guard test was confirmed to fail before its guard was added:
- `PqVariantInvalidInputTest` - `oversizedPrimitiveLengthRejected`, `shortStringLengthExceedsBufferRejected`, `truncatedPrimitiveSizeRejected`, `binaryAccessorOversizedLengthRejected`, `stringAccessorOversizedLengthRejected`, `objectValueExtentRejected`, `fixedWidthPrimitiveTruncationRejected`, plus a positive `validPrimitiveStringDecodes`. Pre-fix these produced the exact incidental failures the issue names - `NegativeArraySizeException: -2147483644` / `-2147483643` and `ArrayIndexOutOfBoundsException` on the truncated / short-string paths and now all reject with a descriptive `IllegalArgumentException`.
- #713's overflow tests still pin the object / array / metadata header checks against the renamed `checkFits`.
- Full `core` module green via `./mvnw -pl core -am verify`: `Tests run: 1606` (unit) + `14` (integration), `Failures: 0, Errors: 0`, including the Error Prone `NoVar` / `NoLegacyJavadoc` gates.

The guards run once per value decode (not per byte), and only on the already-allocating `value()` / `asString` / `asBinary` accessors, the typed numeric accessors (e.g. `asInt`, `asLong`, `asDouble`), don't touch these paths. On the success path each guard is a comparison plus `Math.toIntExact`, with the message built only on the throw path, so there is no measurable decode-path cost and no benchmark is warranted for this change.

## Checklist
- [x] Build via `./mvnw clean verify` passes
- [x] The commit message is prefixed with the issue key
- [x] Code changes are covered by tests
- [x] If this PR adds or changes user-facing behavior, `docs/` has been updated _(internal decoder hardening; no public API or user-facing change)_