### PR TITLE
#710 Thread a nesting-depth cap through Variant value navigation

### DIFF
--- a/core/src/main/java/dev/hardwood/internal/variant/PqVariantArrayImpl.java
+++ b/core/src/main/java/dev/hardwood/internal/variant/PqVariantArrayImpl.java
@@ -18,11 +18,13 @@ final class PqVariantArrayImpl implements PqVariantArray {
     private final VariantMetadata metadata;
     private final byte[] valueBuf;
     private final ArrayLayout layout;
+    private final int depth;
 
-    PqVariantArrayImpl(VariantMetadata metadata, byte[] valueBuf, int arrayHeaderOffset) {
+    PqVariantArrayImpl(VariantMetadata metadata, byte[] valueBuf, int arrayHeaderOffset, int depth) {
         this.metadata = metadata;
         this.valueBuf = valueBuf;
         this.layout = VariantValueDecoder.parseArray(valueBuf, arrayHeaderOffset);
+        this.depth = depth;
     }
 
     @Override
@@ -36,6 +38,6 @@ final class PqVariantArrayImpl implements PqVariantArray {
             throw new IndexOutOfBoundsException("Index " + index + " out of bounds for size " + layout.numElements());
         }
         int off = VariantValueDecoder.arrayElementOffset(valueBuf, layout, index);
-        return new PqVariantImpl(metadata, valueBuf, off);
+        return new PqVariantImpl(metadata, valueBuf, off, VariantValueDecoder.descend(depth));
     }
 }

--- a/core/src/main/java/dev/hardwood/internal/variant/PqVariantImpl.java
+++ b/core/src/main/java/dev/hardwood/internal/variant/PqVariantImpl.java
@@ -29,6 +29,7 @@ public final class PqVariantImpl implements PqVariant {
     private final VariantMetadata metadata;
     private final byte[] valueBuf;
     private final int valueOffset;
+    private final int depth;
 
     /// Construct a top-level Variant from raw `metadata` and `value` bytes. The
     /// value header starts at `valueBuf[0]`.
@@ -37,9 +38,17 @@ public final class PqVariantImpl implements PqVariant {
     }
 
     public PqVariantImpl(VariantMetadata metadata, byte[] valueBuf, int valueOffset) {
+        this(metadata, valueBuf, valueOffset, 0);
+    }
+
+    /// Construct a Variant nested at `depth` in its enclosing value tree. Child
+    /// flyweights carry the depth so navigation can be capped, see
+    /// [VariantValueDecoder#descend(int)].
+    PqVariantImpl(VariantMetadata metadata, byte[] valueBuf, int valueOffset, int depth) {
         this.metadata = metadata;
         this.valueBuf = valueBuf;
         this.valueOffset = valueOffset;
+        this.depth = depth;
     }
 
     VariantMetadata metadataView() {
@@ -180,7 +189,7 @@ public final class PqVariantImpl implements PqVariant {
         if (VariantBinary.basicType(valueBuf[valueOffset]) != VariantBinary.BASIC_TYPE_OBJECT) {
             throw VariantErrors.expected(VariantType.OBJECT, type());
         }
-        return new PqVariantObjectImpl(metadata, valueBuf, valueOffset);
+        return new PqVariantObjectImpl(metadata, valueBuf, valueOffset, depth);
     }
 
     @Override
@@ -188,6 +197,6 @@ public final class PqVariantImpl implements PqVariant {
         if (VariantBinary.basicType(valueBuf[valueOffset]) != VariantBinary.BASIC_TYPE_ARRAY) {
             throw VariantErrors.expected(VariantType.ARRAY, type());
         }
-        return new PqVariantArrayImpl(metadata, valueBuf, valueOffset);
+        return new PqVariantArrayImpl(metadata, valueBuf, valueOffset, depth);
     }
 }

--- a/core/src/main/java/dev/hardwood/internal/variant/PqVariantObjectImpl.java
+++ b/core/src/main/java/dev/hardwood/internal/variant/PqVariantObjectImpl.java
@@ -32,11 +32,13 @@ final class PqVariantObjectImpl implements PqVariantObject {
     private final VariantMetadata metadata;
     private final byte[] valueBuf;
     private final ObjectLayout layout;
+    private final int depth;
 
-    PqVariantObjectImpl(VariantMetadata metadata, byte[] valueBuf, int objectHeaderOffset) {
+    PqVariantObjectImpl(VariantMetadata metadata, byte[] valueBuf, int objectHeaderOffset, int depth) {
         this.metadata = metadata;
         this.valueBuf = valueBuf;
         this.layout = VariantValueDecoder.parseObject(valueBuf, objectHeaderOffset);
+        this.depth = depth;
     }
 
     /// Locate the child-array index for the given field name, or -1 if absent.
@@ -75,7 +77,7 @@ final class PqVariantObjectImpl implements PqVariantObject {
     }
 
     private PqVariant wrap(int valueOffset) {
-        return new PqVariantImpl(metadata, valueBuf, valueOffset);
+        return new PqVariantImpl(metadata, valueBuf, valueOffset, VariantValueDecoder.descend(depth));
     }
 
     // ==================== Metadata ====================
@@ -227,7 +229,7 @@ final class PqVariantObjectImpl implements PqVariantObject {
         if (t != VariantType.OBJECT) {
             throw VariantErrors.expected(VariantType.OBJECT, t);
         }
-        return new PqVariantObjectImpl(metadata, valueBuf, off);
+        return new PqVariantObjectImpl(metadata, valueBuf, off, VariantValueDecoder.descend(depth));
     }
 
     @Override
@@ -240,7 +242,7 @@ final class PqVariantObjectImpl implements PqVariantObject {
         if (t != VariantType.ARRAY) {
             throw VariantErrors.expected(VariantType.ARRAY, t);
         }
-        return new PqVariantArrayImpl(metadata, valueBuf, off);
+        return new PqVariantArrayImpl(metadata, valueBuf, off, VariantValueDecoder.descend(depth));
     }
 
     @Override

--- a/core/src/main/java/dev/hardwood/internal/variant/VariantValueDecoder.java
+++ b/core/src/main/java/dev/hardwood/internal/variant/VariantValueDecoder.java
@@ -27,6 +27,23 @@ public final class VariantValueDecoder {
 
     private VariantValueDecoder() {}
 
+    // ==================== Nesting-depth guard ====================
+
+    /// Maximum object/array nesting depth of a Variant value; deeper navigation is
+    /// rejected to prevent stack-exhausting recursion. Matches the parquet-java convention.
+    static final int MAX_NESTING_DEPTH = 500;
+
+    /// Returns `parentDepth + 1`, rejecting it if it would exceed [#MAX_NESTING_DEPTH].
+    /// Called wherever navigation descends into an object field or array element.
+    static int descend(int parentDepth) {
+        int childDepth = parentDepth + 1;
+        if (childDepth > MAX_NESTING_DEPTH) {
+            throw new IllegalArgumentException(
+                    "Variant value nesting exceeds the maximum depth of " + MAX_NESTING_DEPTH);
+        }
+        return childDepth;
+    }
+
     // ==================== Type introspection ====================
 
     /// Returns the [VariantType] of the value starting at `buf[offset]`.

--- a/core/src/test/java/dev/hardwood/internal/variant/PqVariantInvalidInputTest.java
+++ b/core/src/test/java/dev/hardwood/internal/variant/PqVariantInvalidInputTest.java
@@ -9,12 +9,14 @@ package dev.hardwood.internal.variant;
 
 import java.io.IOException;
 import java.io.InputStream;
+import java.util.Arrays;
 
 import org.junit.jupiter.api.Test;
 
 import dev.hardwood.row.PqVariant;
 import dev.hardwood.row.PqVariantArray;
 import dev.hardwood.row.PqVariantObject;
+import dev.hardwood.row.VariantType;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -28,6 +30,13 @@ class PqVariantInvalidInputTest {
     /// Minimal valid metadata (version 1, empty dictionary) for pairing with
     /// hand-built malformed value buffers.
     private static final byte[] EMPTY_METADATA = { 0x01, 0x00, 0x00 };
+
+    /// Metadata with a single-entry dictionary `["a"]` (version 1, offset_size 1),
+    /// for pairing with hand-built nested-object value buffers keyed on `"a"`.
+    private static final byte[] SINGLE_FIELD_METADATA = { 0x01, 0x01, 0x00, 0x01, 0x61 };
+
+    /// A leaf INT8 value (`42`) to sit at the bottom of a nesting chain.
+    private static final byte[] LEAF_INT8 = { 0x0C, 42 };
 
     @Test
     void objectGetOnMissingFieldThrows() throws IOException {
@@ -166,6 +175,119 @@ class PqVariantInvalidInputTest {
         assertThatThrownBy(() -> new PqVariantImpl(EMPTY_METADATA, value).value())
                 .isInstanceOf(IllegalArgumentException.class)
                 .hasMessageContaining("primitive value");
+    }
+
+    @Test
+    void deeplyNestedArrayRejected() {
+        // Arrays nested far past the limit must fail fast when navigated, rather
+        // than being descended into unbounded recursion.
+        PqVariant root = new PqVariantImpl(EMPTY_METADATA, nestInArrays(VariantValueDecoder.MAX_NESTING_DEPTH + 100));
+        assertThatThrownBy(() -> descendArrayToLeaf(root))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("nesting")
+                .hasMessageContaining(String.valueOf(VariantValueDecoder.MAX_NESTING_DEPTH));
+    }
+
+    @Test
+    void arrayNestedAtLimitNavigatesFully() {
+        // Exactly at the limit: the whole chain navigates and the leaf reads back.
+        PqVariant root = new PqVariantImpl(EMPTY_METADATA, nestInArrays(VariantValueDecoder.MAX_NESTING_DEPTH));
+        assertThat(descendArrayToLeaf(root).asInt()).isEqualTo(42);
+    }
+
+    @Test
+    void arrayNestedOnePastLimitRejected() {
+        // One level beyond the limit is the boundary that must be rejected.
+        PqVariant root = new PqVariantImpl(EMPTY_METADATA, nestInArrays(VariantValueDecoder.MAX_NESTING_DEPTH + 1));
+        assertThatThrownBy(() -> descendArrayToLeaf(root))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("nesting");
+    }
+
+    @Test
+    void deeplyNestedObjectRejected() {
+        // The object descent path (getObject) is guarded the same way as arrays.
+        int levels = VariantValueDecoder.MAX_NESTING_DEPTH + 100;
+        PqVariant root = new PqVariantImpl(SINGLE_FIELD_METADATA, nestInObjects(levels));
+        assertThatThrownBy(() -> descendObject(root.asObject(), levels))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("nesting")
+                .hasMessageContaining(String.valueOf(VariantValueDecoder.MAX_NESTING_DEPTH));
+    }
+
+    @Test
+    void objectNestedAtLimitNavigatesFully() {
+        // Object path navigates to exactly the limit: getObject to the innermost
+        // level, then getVariant reads the leaf at the 500th (allowed) descent.
+        PqVariantObject object = new PqVariantImpl(SINGLE_FIELD_METADATA,
+                nestInObjects(VariantValueDecoder.MAX_NESTING_DEPTH)).asObject();
+        for (int i = 1; i < VariantValueDecoder.MAX_NESTING_DEPTH; i++) {
+            object = object.getObject("a");
+        }
+        assertThat(object.getVariant("a").asInt()).isEqualTo(42);
+    }
+
+    @Test
+    void arrayIterationNestingRejected() {
+        // for-each iteration descends through the guarded get(int), so deep nesting
+        // is rejected on the iteration path too.
+        PqVariant root = new PqVariantImpl(EMPTY_METADATA, nestInArrays(VariantValueDecoder.MAX_NESTING_DEPTH + 100));
+        assertThatThrownBy(() -> descendArrayByIteration(root))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("nesting");
+    }
+
+    /// Descend through array-of-array values via [PqVariantArray#get(int)] until a
+    /// non-array leaf is reached, returning it.
+    private static PqVariant descendArrayToLeaf(PqVariant value) {
+        PqVariant current = value;
+        while (current.type() == VariantType.ARRAY) {
+            current = current.asArray().get(0);
+        }
+        return current;
+    }
+
+    /// Descend through array-of-array values via for-each iteration, which routes
+    /// through [PqVariantArray#get(int)].
+    private static void descendArrayByIteration(PqVariant value) {
+        PqVariant current = value;
+        while (current.type() == VariantType.ARRAY) {
+            for (PqVariant element : current.asArray()) {
+                current = element;
+                break;
+            }
+        }
+    }
+
+    /// Descend `levels` deep through object-in-object values via
+    /// [PqVariantObject#getObject(String)] on field `"a"`.
+    private static void descendObject(PqVariantObject object, int levels) {
+        PqVariantObject current = object;
+        for (int i = 0; i < levels; i++) {
+            current = current.getObject("a");
+        }
+    }
+
+    /// Wrap [#LEAF_INT8] in `levels` single-element arrays, innermost first.
+    private static byte[] nestInArrays(int levels) {
+        byte[] current = LEAF_INT8;
+        for (int i = 0; i < levels; i++) {
+            byte[] buf = new byte[current.length + 16];
+            int end = VariantValueEncoder.writeArray(buf, 0, new byte[][] { current });
+            current = Arrays.copyOf(buf, end);
+        }
+        return current;
+    }
+
+    /// Wrap [#LEAF_INT8] in `levels` single-field objects keyed on `"a"` (id 0).
+    private static byte[] nestInObjects(int levels) {
+        byte[] current = LEAF_INT8;
+        for (int i = 0; i < levels; i++) {
+            byte[] buf = new byte[current.length + 16];
+            int end = VariantValueEncoder.writeObject(buf, 0, new int[] { 0 }, new byte[][] { current }, 0);
+            current = Arrays.copyOf(buf, end);
+        }
+        return current;
     }
 
     private static PqVariant load(String caseName) throws IOException {


### PR DESCRIPTION
## Description
This pull request addresses #710, which observed that Hardwood's Variant decoder had no recursion-depth guard: a Variant value nesting objects or arrays arbitrarily deep could be navigated without bound, letting a consumer that walks the value tree recurse until the stack is exhausted — a denial-of-service on hostile input. parquet-java and Spark both cap Variant nesting depth (~500 levels); this brings Hardwood in line, and closes the last parquet-testing#113 malformed-variant fixture (`over_deep_nested_children.parquet`) that Hardwood did not previously reject.

The change is internal to the Variant read path; the public `PqVariant` / `PqVariantObject` / `PqVariantArray` surface is unchanged, and well-formed values navigate exactly as before.

## Key Changes
- **Depth carried on the flyweights, checked at every descent**
    - `PqVariantImpl`, `PqVariantObjectImpl`, and `PqVariantArrayImpl` each carry a `depth`, and a single `VariantValueDecoder.descend(parentDepth)` returns `parentDepth + 1` after checking it against `MAX_NESTING_DEPTH`, throwing a descriptive `IllegalArgumentException` otherwise. It is called at every child-producing site — object field access (`getVariant` / `getValue` / `getObject` / `getArray`) and array element access (`get`) — so object, array, and mixed nesting are counted through one funnel. `asObject` / `asArray` are same-value views and pass the depth through unchanged.
- **One source of truth for the limit**
    - `MAX_NESTING_DEPTH = 500`, a single named constant matching the parquet-java / Spark convention; the exception message names the limit.

## Verification and Testing
Coverage drives the real public navigation API with values built in-memory via the existing `VariantValueEncoder` — no fixture dependency:
- `PqVariantInvalidInputTest` — `deeplyNestedArrayRejected` / `deeplyNestedObjectRejected` cover the array (`get`) and object (`getObject`) descent paths; `arrayNestedAtLimitNavigatesFully` / `arrayNestedOnePastLimitRejected` / `objectNestedAtLimitNavigatesFully` pin the boundary on both paths (exactly 500 levels navigates and reads the leaf back, 501 rejected); and `arrayIterationNestingRejected` confirms the `Iterable` for-each route, which goes through the guarded `get(int)`. Each rejection case was confirmed to fail before the guard — deep values were previously walked to the bottom (silent accept on arrays, a late `VariantTypeException` on objects).
- Full `core` module green via `./mvnw -pl core -am verify`: `Tests run: 1618` (unit) + `14` (integration), `Failures: 0, Errors: 0`, including the Error Prone `NoVar` / `NoLegacyJavadoc` gates.

The guard adds one comparison per navigation step and no allocation on the success path, so there is no measurable navigation cost.

## Checklist
- [x] Build via `./mvnw clean verify` passes
- [x] The commit message is prefixed with the issue key
- [x] Code changes are covered by tests
- [x] If this PR adds or changes user-facing behavior, `docs/` has been updated _(internal decoder hardening; no public API or user-facing change)_
