### PR TITLE
#766 Remove obsolete deferral framing from the lean-view path

### DIFF
--- a/_designs/NESTED_REALVIEW_ON_DRAIN.md
+++ b/_designs/NESTED_REALVIEW_ON_DRAIN.md
@@ -153,9 +153,9 @@ The lean view is built unconditionally on the drain, so it serves both
 - a **list-reconstructing** read (`getLayerOffsets` / `getLayerValidity`) reads the
   drain-built boundaries and the all-present validities.
 
-Deferring the view to a lazy consumer-side build would put a structural read's
-offset scan back on the serial consumer; building the lean view eagerly avoids
-that while costing a flat leaf read only the cheap boundary scan it discards.
+Building the lean view eagerly on the drain keeps a structural read's offset scan
+off the serial consumer, while costing a flat leaf read only the cheap boundary
+scan it discards.
 
 ### Consumer
 

--- a/core/src/main/java/dev/hardwood/internal/reader/NestedColumnWorker.java
+++ b/core/src/main/java/dev/hardwood/internal/reader/NestedColumnWorker.java
@@ -393,10 +393,10 @@ public class NestedColumnWorker extends ColumnWorker<NestedBatch> {
             // positions, so its offsets equal the all-items offsets: build just the
             // lean offsets view (no per-layer validity or gather map) and pass the
             // dense values through. A batch with phantom positions builds the full
-            // view and gathers the real leaf values. The view is built eagerly on the
-            // drain — not deferred to a lazy ensureRealView() on the consumer — so a
-            // structural read gets its offsets without a consumer-side scan; a flat
-            // leaf read simply ignores them.
+            // view and gathers the real leaf values. Building the view eagerly on the
+            // drain keeps reconstruction off the serial consumer for both shapes: a
+            // structural read gets its offsets without a consumer-side scan, and a
+            // flat leaf read simply ignores them.
             boolean allPresent = batch.fixedListK > 0 || allDefsMax(batch.valueCount);
             if (allPresent) {
                 batch.realValues = batch.values;


### PR DESCRIPTION
Post-merge cleanup of #760 (#766). The shipped implementation builds a **lean offsets view eagerly on the drain** for all-present nested batches; the deferral approach #766 originally proposed (`realView = null` + lazy consumer-side `ensureRealView()`) was never shipped. A few descriptions still carried that obsolete framing:

- `NestedColumnWorker.computeIndex` comment — dropped the "not deferred to a lazy `ensureRealView()`" contrast; states the eager-build rationale directly.
- `_designs/NESTED_REALVIEW_ON_DRAIN.md` — removed the rejected-alternative sentence ("Deferring the view … would put a structural read's offset scan back on the serial consumer"), per the project convention that design docs describe the end state, not alternatives that were considered and rejected.

No behavior change — comment and doc text only. (The dead `NestedBatch.allPresent` field flagged in the same re-review was already removed by `13fc7e95`; the issue #766 title/body were updated and the issue closed separately.)