### PR TITLE
#773 Skip decode setup when pruning leaves zero row groups

### DIFF
--- a/core/src/main/java/dev/hardwood/reader/ColumnReader.java
+++ b/core/src/main/java/dev/hardwood/reader/ColumnReader.java
@@ -140,6 +140,20 @@ public class ColumnReader implements AutoCloseable {
         return new ColumnReader(column, true, layers, nestedBuffer, columnWorker, rowGroupIterator);
     }
 
+    /// A reader that yields no batches, for when row-group pruning has dropped
+    /// every row group so nothing can match. Allocates no batch buffer and
+    /// starts no worker thread — [#nextBatch()] reports exhausted immediately.
+    static ColumnReader exhausted(FileSchema schema, ColumnSchema column) {
+        NestedLevelComputer.Layers layers = NestedLevelComputer.computeLayers(
+                schema.getRootNode(), column.columnIndex());
+        boolean nested = layers.count() > 0 || column.maxRepetitionLevel() > 0;
+        ColumnReader reader = nested
+                ? forNested(column, layers, null, null, null)
+                : forFlat(column, null, null, null);
+        reader.exhausted = true;
+        return reader;
+    }
+
     // ==================== Batch Iteration ====================
 
     /// Advance to the next batch.

--- a/core/src/main/java/dev/hardwood/reader/ColumnReaders.java
+++ b/core/src/main/java/dev/hardwood/reader/ColumnReaders.java
@@ -131,6 +131,27 @@ public class ColumnReaders implements AutoCloseable {
         return new ColumnReaders(readersByName, payloadReaders, coordinator);
     }
 
+    /// Builds a [ColumnReaders] for the case where row-group pruning
+    /// (statistics/bloom) dropped every row group, so no record can match.
+    /// Exposes the `payloadProjected` columns as immediately-exhausted no-op
+    /// readers — no worker threads, no batch buffers, no [SelectionEngine] or
+    /// [FilterCoordinator]. The shared [RowGroupIterator] is owned and closed by
+    /// the [ParquetFileReader]; these readers hold no reference to it. Used by
+    /// [ParquetFileReader#buildColumnReaders] to skip the whole per-column decode
+    /// setup when there is nothing to decode.
+    static ColumnReaders noRows(FileSchema schema, ProjectedSchema payloadProjected) {
+        int payloadCount = payloadProjected.getProjectedColumnCount();
+        Map<String, ColumnReader> readersByName = new LinkedHashMap<>(payloadCount);
+        ColumnReader[] payloadReaders = new ColumnReader[payloadCount];
+        for (int p = 0; p < payloadCount; p++) {
+            ColumnSchema columnSchema = schema.getColumn(payloadProjected.toOriginalIndex(p));
+            ColumnReader reader = ColumnReader.exhausted(schema, columnSchema);
+            payloadReaders[p] = reader;
+            readersByName.put(columnSchema.fieldPath().toString(), reader);
+        }
+        return new ColumnReaders(readersByName, payloadReaders, null);
+    }
+
     /// Get the number of projected columns.
     public int getColumnCount() {
         return readersByIndex.length;

--- a/core/src/main/java/dev/hardwood/reader/ParquetFileReader.java
+++ b/core/src/main/java/dev/hardwood/reader/ParquetFileReader.java
@@ -514,6 +514,11 @@ public class ParquetFileReader implements AutoCloseable {
             iterator.setFirstFile(schema, rowGroups);
             ProjectedSchema projected = iterator.initialize(projection, null);
             rowGroupIterators.add(iterator);
+            // Every row group pruned (e.g. a byte-range row-group filter dropped
+            // them all): nothing to decode.
+            if (iterator.getWorkItems().isEmpty()) {
+                return ColumnReaders.noRows(schema, projected);
+            }
             return new ColumnReaders(context, fixedListFastPathEnabled, iterator, schema, projected,
                     resolveBatchSize(batchSize, projected));
         }
@@ -528,6 +533,14 @@ public class ParquetFileReader implements AutoCloseable {
         ProjectedSchema augProjected = iterator.initialize(augmented, resolved);
         ProjectedSchema payloadProjected = ProjectedSchema.create(schema, projection);
         rowGroupIterators.add(iterator);
+        // Statistics/bloom pruning dropped every row group — no record can match.
+        // Skip building the per-column readers (worker threads + ~batch-sized
+        // buffers) and the selection engine entirely; expose exhausted no-op
+        // readers over the payload columns. The iterator is registered above and
+        // closed by close(), so its file handles/prefetch futures still release.
+        if (iterator.getWorkItems().isEmpty()) {
+            return ColumnReaders.noRows(schema, payloadProjected);
+        }
         // Size against the augmented projection — the predicate columns allocate
         // per-batch arrays too, so they count toward the byte budget.
         return ColumnReaders.filtered(

--- a/core/src/test/java/dev/hardwood/PrunedToEmptyReadTest.java
+++ b/core/src/test/java/dev/hardwood/PrunedToEmptyReadTest.java
@@ -1,0 +1,101 @@
+/*
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Copyright The original authors
+ *
+ *  Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package dev.hardwood;
+
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
+import org.junit.jupiter.api.Test;
+
+import dev.hardwood.reader.ColumnReader;
+import dev.hardwood.reader.ColumnReaders;
+import dev.hardwood.reader.FilterPredicate;
+import dev.hardwood.reader.LayerKind;
+import dev.hardwood.reader.ParquetFileReader;
+import dev.hardwood.reader.RowGroupPredicate;
+import dev.hardwood.schema.ColumnProjection;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/// Exercises the empty-projection short-circuit that
+/// [ParquetFileReader#buildColumnReaders] takes when row-group pruning drops
+/// every row group: it exposes the projected columns as immediately-exhausted
+/// no-op readers ([ColumnReader#exhausted]) instead of building per-column
+/// worker threads, batch buffers, and (on the filtered path) a selection
+/// engine. Both the plain-projection path (dropped by a [RowGroupPredicate])
+/// and the exact-filter path (dropped by statistics) are covered, for flat and
+/// nested columns.
+class PrunedToEmptyReadTest {
+
+    private static final Path INT_FIXTURE = Paths.get("src/test/resources/filter_pushdown_int.parquet");
+    private static final Path LIST_FIXTURE = Paths.get("src/test/resources/filter_pushdown_list.parquet");
+
+    /// A byte range that lies entirely past the end of the file keeps no row
+    /// group under the midpoint rule, so the work list is empty.
+    private static RowGroupPredicate dropAll(Path fixture) {
+        long len = fixture.toFile().length();
+        return RowGroupPredicate.byteRange(len + 1, len + 100);
+    }
+
+    @Test
+    void plainProjectionPrunedToEmptyExposesExhaustedReaders() throws Exception {
+        ColumnProjection projection = ColumnProjection.columns("id", "value", "label");
+        try (ParquetFileReader reader = ParquetFileReader.open(InputFile.of(INT_FIXTURE));
+             ColumnReaders cols = reader.buildColumnReaders(projection)
+                     .filter(dropAll(INT_FIXTURE))
+                     .build()) {
+
+            assertThat(cols.getColumnCount()).isEqualTo(3);
+            assertThat(cols.nextBatch()).isFalse();
+
+            for (String name : new String[] {"id", "value", "label"}) {
+                assertThat(cols.getColumnReader(name).nextBatch()).isFalse();
+            }
+            assertThat(cols.getColumnReader(0).nextBatch()).isFalse();
+        }
+    }
+
+    @Test
+    void filterPredicatePrunedToEmptyExposesExhaustedReaders() throws Exception {
+        // Every `value` is in 1..300, so gt(value, 1000) drops all three row groups
+        // by statistics — the exact-filter path builds no selection engine.
+        try (ParquetFileReader reader = ParquetFileReader.open(InputFile.of(INT_FIXTURE));
+             ColumnReaders cols = reader.buildColumnReaders(ColumnProjection.columns("id", "value"))
+                     .filter(FilterPredicate.gt("value", 1000L))
+                     .build()) {
+
+            assertThat(cols.getColumnCount()).isEqualTo(2);
+            assertThat(cols.nextBatch()).isFalse();
+            assertThat(cols.getColumnReader("id").nextBatch()).isFalse();
+            assertThat(cols.getColumnReader("value").nextBatch()).isFalse();
+        }
+    }
+
+    @Test
+    void prunedNestedReaderPreservesLayerModel() throws Exception {
+        // `scores` is list<int32>: one REPEATED layer. The exhausted reader must
+        // report the same structural metadata a live reader would, since
+        // getLayerCount()/getLayerKind() are documented stable and safe to call
+        // before the first batch.
+        try (ParquetFileReader reader = ParquetFileReader.open(InputFile.of(LIST_FIXTURE));
+             ColumnReaders cols = reader.buildColumnReaders(ColumnProjection.columns("id", "scores.list.element"))
+                     .filter(dropAll(LIST_FIXTURE))
+                     .build()) {
+
+            ColumnReader id = cols.getColumnReader("id");
+            ColumnReader scores = cols.getColumnReader("scores.list.element");
+
+            assertThat(id.getLayerCount()).isEqualTo(0);
+            assertThat(scores.getLayerCount()).isEqualTo(1);
+            assertThat(scores.getLayerKind(0)).isEqualTo(LayerKind.REPEATED);
+
+            assertThat(cols.nextBatch()).isFalse();
+            assertThat(scores.nextBatch()).isFalse();
+        }
+    }
+}


### PR DESCRIPTION
Hello, this PR resolves #773, returning no-op readers, saving allocations, and workers setup overhead if all row groups are filtered out
## Checklist

- [x] Build via `./mvnw clean verify` passes
- [x] The commit message is prefixed with the issue key ("#123 Adding support for...")
- [x] Code changes are covered by tests
- [ ] If this PR adds or changes user-facing behaviour, `docs/` has been updated
