### PR TITLE
#739 Verify unknown logical types fall back to the physical type

### DIFF
--- a/core/src/test/java/dev/hardwood/internal/thrift/LogicalTypeReaderTest.java
+++ b/core/src/test/java/dev/hardwood/internal/thrift/LogicalTypeReaderTest.java
@@ -1,0 +1,68 @@
+/*
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Copyright The original authors
+ *
+ *  Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package dev.hardwood.internal.thrift;
+
+import java.nio.ByteBuffer;
+
+import org.junit.jupiter.api.Test;
+
+import dev.hardwood.internal.thrift.ThriftCompactConstants.FieldType;
+import dev.hardwood.metadata.LogicalType;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/// Unit tests for [LogicalTypeReader], focused on a logical-type union member
+/// the reader does not recognize. A future or bespoke logical type must decode
+/// to a null [LogicalType] rather than failing the read, so the column's
+/// physical type is what gets exposed.
+class LogicalTypeReaderTest {
+
+    @Test
+    void unknownUnionMemberDecodesToNull() throws Exception {
+        ThriftCompactWriter writer = new ThriftCompactWriter();
+        // Unrecognized field id 19 carrying an empty marker struct, the shape
+        // most known logical types take.
+        writer.writeFieldBegin(19, FieldType.STRUCT);
+        writer.writeFieldStop(); // empty member struct
+        writer.writeFieldStop(); // union STOP
+
+        assertThat(read(writer)).isNull();
+    }
+
+    @Test
+    void unknownParameterizedUnionMemberSkippedCleanly() throws Exception {
+        ThriftCompactWriter writer = new ThriftCompactWriter();
+        // Unknown member (field id 20) whose struct carries a parameter, the
+        // shape a future parameterized logical type would take. The reader must
+        // skip the whole nested struct without desyncing the surrounding parse.
+        writer.writeFieldBegin(20, FieldType.STRUCT);
+        short savedMember = writer.pushFieldIdContext();
+        writer.writeFieldBegin(1, FieldType.I32);
+        writer.writeI32(42);
+        writer.writeFieldStop(); // member struct STOP
+        writer.popFieldIdContext(savedMember);
+        writer.writeFieldStop(); // union STOP
+
+        // A sentinel field after the union proves the reader stopped exactly at
+        // the union STOP: a skip that over- or under-ran would not read it back.
+        writer.pushFieldIdContext(); // sentinel is relative to a fresh struct
+        writer.writeFieldBegin(1, FieldType.I32);
+        writer.writeI32(7);
+
+        ThriftCompactReader reader = new ThriftCompactReader(ByteBuffer.wrap(writer.toByteArray()));
+        assertThat(LogicalTypeReader.read(reader)).isNull();
+
+        ThriftCompactReader.FieldHeader sentinel = reader.readFieldHeader();
+        assertThat(sentinel.fieldId()).isEqualTo((short) 1);
+        assertThat(reader.readI32()).isEqualTo(7);
+    }
+
+    private static LogicalType read(ThriftCompactWriter writer) throws Exception {
+        return LogicalTypeReader.read(new ThriftCompactReader(ByteBuffer.wrap(writer.toByteArray())));
+    }
+}

--- a/core/src/test/java/dev/hardwood/internal/thrift/SchemaElementReaderTest.java
+++ b/core/src/test/java/dev/hardwood/internal/thrift/SchemaElementReaderTest.java
@@ -1,0 +1,56 @@
+/*
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Copyright The original authors
+ *
+ *  Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package dev.hardwood.internal.thrift;
+
+import java.nio.ByteBuffer;
+
+import org.junit.jupiter.api.Test;
+
+import dev.hardwood.internal.thrift.ThriftCompactConstants.FieldType;
+import dev.hardwood.metadata.PhysicalType;
+import dev.hardwood.metadata.SchemaElement;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/// Unit tests for [SchemaElementReader]. A SchemaElement annotated with a
+/// logical type the reader does not recognize must still parse, exposing its
+/// physical type with a null logical type.
+class SchemaElementReaderTest {
+
+    @Test
+    void unknownLogicalTypeExposesPhysicalType() throws Exception {
+        ThriftCompactWriter writer = new ThriftCompactWriter();
+        // field 1: type = INT32 (Thrift physical-type enum value 1)
+        writer.writeFieldBegin(1, FieldType.I32);
+        writer.writeI32(1);
+        // field 4: name
+        writer.writeFieldBegin(4, FieldType.BINARY);
+        writer.writeString("col");
+        // field 10: logicalType, an unrecognized parameterized union member.
+        // Nesting mirrors the reader's field-id context handling so the delta
+        // encoding matches: SchemaElement -> union -> member struct.
+        writer.writeFieldBegin(10, FieldType.STRUCT);
+        short savedUnion = writer.pushFieldIdContext();
+        writer.writeFieldBegin(20, FieldType.STRUCT);
+        short savedMember = writer.pushFieldIdContext();
+        writer.writeFieldBegin(1, FieldType.I32);
+        writer.writeI32(99);
+        writer.writeFieldStop(); // member struct STOP
+        writer.popFieldIdContext(savedMember);
+        writer.writeFieldStop(); // union STOP
+        writer.popFieldIdContext(savedUnion);
+        writer.writeFieldStop(); // SchemaElement STOP
+
+        SchemaElement element = SchemaElementReader.read(
+                new ThriftCompactReader(ByteBuffer.wrap(writer.toByteArray())));
+
+        assertThat(element.type()).isEqualTo(PhysicalType.INT32);
+        assertThat(element.logicalType()).isNull();
+        assertThat(element.name()).isEqualTo("col");
+    }
+}

--- a/docs/content/concepts/compatibility-philosophy.md
+++ b/docs/content/concepts/compatibility-philosophy.md
@@ -28,8 +28,11 @@ Two goals are in tension, and Hardwood resolves them on different axes:
   years — parquet-mr, Arrow, Spark, Hive, PyArrow — using legacy encodings, deprecated types,
   and annotations that newer specs dropped. Hardwood reads these transparently: most legacy
   list-encoding variants, INT96 timestamps, the legacy `converted_type` annotations that
-  predate the modern logical-type union, `NULL`-typed columns, FLOAT16. On the *input* side,
-  Hardwood is liberal — if parquet-java can read it, Hardwood aims to.
+  predate the modern logical-type union, `NULL`-typed columns, FLOAT16. The tolerance also
+  extends *forward*: a logical-type annotation newer than Hardwood recognizes is ignored rather
+  than rejected, and the column's physical type is exposed, so a file written by a tool that
+  has adopted a future logical type still reads. On the *input* side, Hardwood is liberal — if
+  parquet-java can read it, Hardwood aims to.
 - **Don't silently produce wrong results.** On the *semantic* side, where a behavior is a matter
   of correctness rather than file compatibility, Hardwood chooses the well-defined answer even
   when that diverges from parquet-java's historical behavior. This follows the project's

--- a/parquet-testing-runner/src/test/java/dev/hardwood/testing/UnknownLogicalTypeReadTest.java
+++ b/parquet-testing-runner/src/test/java/dev/hardwood/testing/UnknownLogicalTypeReadTest.java
@@ -1,0 +1,81 @@
+/*
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Copyright The original authors
+ *
+ *  Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package dev.hardwood.testing;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+
+import dev.hardwood.InputFile;
+import dev.hardwood.metadata.LogicalType;
+import dev.hardwood.metadata.PhysicalType;
+import dev.hardwood.reader.ParquetFileReader;
+import dev.hardwood.reader.RowReader;
+import dev.hardwood.schema.FileSchema;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/// End-to-end coverage for an unrecognized logical type, reading the canonical
+/// `unknown-logical-type.parquet` fixture from apache/parquet-testing. A column annotated with a
+/// logical type Hardwood does not recognize must still open, expose its BYTE_ARRAY physical type
+/// with a null logical annotation, and read its raw values back, while a recognized annotation on
+/// a sibling column is unaffected. Thrift-level decoding of the unknown union member is covered by
+/// `LogicalTypeReaderTest` / `SchemaElementReaderTest` in the core module.
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+class UnknownLogicalTypeReadTest {
+
+    private static final String KNOWN_COLUMN = "column with known type";
+    private static final String UNKNOWN_COLUMN = "column with unknown type";
+
+    private final List<String> knownValues = new ArrayList<>();
+    private final List<byte[]> unknownValues = new ArrayList<>();
+
+    @BeforeAll
+    void readAllRows() throws IOException {
+        Path file = ParquetTestingRepoCloner.getTestFile("data/unknown-logical-type.parquet");
+        try (ParquetFileReader reader = ParquetFileReader.open(InputFile.of(file));
+             RowReader rowReader = reader.rowReader()) {
+
+            FileSchema schema = reader.getFileSchema();
+            // The unrecognized annotation is dropped: the physical type surfaces, logical type is null.
+            assertThat(schema.getColumn(UNKNOWN_COLUMN).type()).isEqualTo(PhysicalType.BYTE_ARRAY);
+            assertThat(schema.getColumn(UNKNOWN_COLUMN).logicalType()).isNull();
+            // A recognized annotation on a sibling column is unaffected.
+            assertThat(schema.getColumn(KNOWN_COLUMN).type()).isEqualTo(PhysicalType.BYTE_ARRAY);
+            assertThat(schema.getColumn(KNOWN_COLUMN).logicalType())
+                    .isInstanceOf(LogicalType.StringType.class);
+
+            while (rowReader.hasNext()) {
+                rowReader.next();
+                knownValues.add(rowReader.getString(KNOWN_COLUMN));
+                unknownValues.add(rowReader.getBinary(UNKNOWN_COLUMN));
+            }
+        }
+    }
+
+    @Test
+    void knownColumnDecodesAsString() {
+        assertThat(knownValues)
+                .containsExactly("known string 1", "known string 2", "known string 3");
+    }
+
+    @Test
+    void unknownColumnExposesRawPhysicalBytes() {
+        List<String> asText = unknownValues.stream()
+                .map(bytes -> new String(bytes, StandardCharsets.UTF_8))
+                .toList();
+        assertThat(asText)
+                .containsExactly("unknown string 1", "unknown string 2", "unknown string 3");
+    }
+}


### PR DESCRIPTION
## Description
Closes #739. A Parquet file written against a newer spec revision may annotate a column with a logical type this reader predates. Per [this Parquet dev discussion](https://lists.apache.org/thread/flfzz94ftdrdop9d5b0o1hkqkprzj3l5), the agreed forward-compatibility contract is that a reader meeting a logical type it doesn't know should treat the annotation as absent, keep the physical schema, and still read the column, rather than failing footer conversion.

Hardwood already behaves this way, so this is a verification rather than a fix: it pins the contract with tests and documents it. No decoder change was required.

## Key Changes
- **Thrift-decode contract (core)**
    - `LogicalTypeReaderTest` — an unrecognized union member decodes to a null annotation; a *parameterized* unknown member is skipped without desyncing the surrounding parse (a sentinel field after the union is read back to prove exact consumption).
    - `SchemaElementReaderTest` — a `SchemaElement` carrying an unknown logical type still exposes its physical type with a null logical type.
- **End-to-end against the canonical fixture (parquet-testing-runner)**
    - `UnknownLogicalTypeReadTest` reads `unknown-logical-type.parquet` from apache/parquet-testing, asserting the unknown-type column exposes `BYTE_ARRAY` with a null logical type and reads its raw values, while the sibling `STRING` column is unaffected. This fixture was previously unverified against Hardwood: the comparison suite skips it because the parquet-java reference reader cannot open it.
- **Forward-compatibility note** added to `concepts/compatibility-philosophy.md`, alongside the existing legacy-annotation discussion.

## Verification and Testing
- `core`: `Tests run: 1615, Failures: 0, Errors: 0`, including the Error Prone `NoVar` / `NoLegacyJavadoc` gates.
- `parquet-testing-runner`: `UnknownLogicalTypeReadTest` green.
- Decode tests confirmed non-vacuous by mutation: forcing the unknown-type arm to throw fails all three; removing its `skipField` fails the sentinel test. Both mutations reverted.

## Follow-ups (out of scope; to track separately)
- Column statistics should not be trusted for pushdown on columns with an unrecognized logical type (requires distinguishing "unknown" from "absent" annotation) — #XXX.
- Reject unknown VARIANT spec versions (`variant(2)`, parquet-testing#113) — #XXX.

## Checklist
- [x] Build via `./mvnw clean verify` passes
- [x] The commit message is prefixed with the issue key
- [x] Code changes are covered by tests
- [x] If this PR adds or changes user-facing behavior, `docs/` has been updated