### PR TITLE
#778 Fix ColumnWorker test instrumentation race

### DIFF
--- a/core/src/test/java/dev/hardwood/internal/reader/ColumnWorkerTest.java
+++ b/core/src/test/java/dev/hardwood/internal/reader/ColumnWorkerTest.java
@@ -382,6 +382,12 @@ class ColumnWorkerTest {
             assertThat(worker.drainThread.isAlive())
                     .as("drain thread must have exited")
                     .isFalse();
+
+            long deadline = System.nanoTime() + TimeUnit.SECONDS.toNanos(5);
+            while (decodesFinished.get() != decodesEntered.get()
+                    && System.nanoTime() < deadline) {
+                Thread.sleep(10);
+            }
             assertThat(decodesFinished.get())
                     .as("every submitted decode task should have finished")
                     .isEqualTo(decodesEntered.get());


### PR DESCRIPTION
## Summary

Wait briefly for the executor-wrapper instrumentation counter to catch up before comparing it with the submitted decode count. `worker.close()` correctly waits for the decode command, but the test wrapper increments its counter immediately after that command returns, leaving a small assertion race.

No product code is changed.

## Validation

- `./mvnw process-sources -DskipTests -pl :hardwood-core`
- Targeted test repeated 50 times: 50/50 passed
- `./mvnw verify -pl :hardwood-core` — 1,665 unit tests and 14 integration tests passed
- `git diff --check`

The repository-wide `./mvnw clean verify` was not run because this runner cannot access its Docker daemon; the affected core module's complete `verify` lifecycle passed.

## Checklist

- [ ] Build via `./mvnw clean verify` passes (full multi-module build not run; see validation above)
- [x] The commit message is prefixed with the issue key ("#123 Adding support for...")
- [x] Code changes are covered by tests
- [x] If this PR adds or changes user-facing behaviour, `docs/` has been updated (not applicable; test-only change)

Fixes #778
