### PR TITLE
#781 Trim ColumnReader typed accessors to getValueCount()

### DIFF
--- a/core/src/main/java/dev/hardwood/internal/reader/FlatRowReader.java
+++ b/core/src/main/java/dev/hardwood/internal/reader/FlatRowReader.java
@@ -358,6 +358,14 @@ public final class FlatRowReader implements RowReader {
             matchedRowsYielded++;
         }
         else {
+            // Fail early on an unguarded next() past the batch: without this bound
+            // rowIndex would walk into the capacity tail, where an all-present
+            // column's ALL_PRESENT sentinel lets the accessor return phantom/stale
+            // leaf values instead of throwing. After any hasNext() == true this
+            // check never trips (a freshly loaded batch resets rowIndex to -1).
+            if (rowIndex + 1 >= batchSize) {
+                throw new NoSuchElementException("No row available. Call hasNext() first.");
+            }
             rowIndex++;
         }
     }

--- a/core/src/main/java/dev/hardwood/internal/reader/NestedRowReader.java
+++ b/core/src/main/java/dev/hardwood/internal/reader/NestedRowReader.java
@@ -14,6 +14,7 @@ import java.time.LocalDateTime;
 import java.time.LocalTime;
 import java.util.Arrays;
 import java.util.List;
+import java.util.NoSuchElementException;
 import java.util.UUID;
 
 import dev.hardwood.internal.predicate.RecordFilterCompiler;
@@ -209,6 +210,13 @@ public final class NestedRowReader implements RowReader {
 
     @Override
     public void next() {
+        // Fail early on an unguarded next() past the batch rather than letting
+        // rowIndex point into the capacity tail and expose phantom/stale rows.
+        // After any hasNext() == true this check never trips (a freshly loaded
+        // batch resets rowIndex to -1).
+        if (rowIndex + 1 >= batchSize) {
+            throw new NoSuchElementException("No row available. Call hasNext() first.");
+        }
         rowIndex++;
         dataView.setRowIndex(rowIndex);
     }

--- a/core/src/main/java/dev/hardwood/reader/ColumnReader.java
+++ b/core/src/main/java/dev/hardwood/reader/ColumnReader.java
@@ -750,23 +750,50 @@ public class ColumnReader implements AutoCloseable {
     /// otherwise a freshly compacted typed array (batches derived by record
     /// selection). Cached per batch.
     private Object realLeafValues() {
-        if (!nested) {
-            return currentFlatBatch.values;
-        }
         if (cachedRealValues != null) {
             return cachedRealValues;
         }
+        cachedRealValues = trimToValueCount(rawLeafValues());
+        return cachedRealValues;
+    }
+
+    /// The untrimmed leaf-values backing store. For flat columns this is the
+    /// underlying batch array. For nested columns it is, in order: the drain's
+    /// pre-compacted `realValues` when present; otherwise pass-through of the
+    /// batch values when no compaction is needed (no `REPEATED` layer, or an
+    /// all-present batch with no phantom positions); otherwise a freshly
+    /// compacted typed array (batches derived by record selection).
+
+    private Object rawLeafValues() {
+        if (!nested) {
+            return currentFlatBatch.values;
+        }
         NestedBatch batch = currentNestedBatch;
         if (batch.realValues != null) {
-            cachedRealValues = batch.realValues;   // pre-compacted on the drain
+            return batch.realValues;               // pre-compacted on the drain
         }
-        else {
-            int[] map = ensureRealView().realToRawLeaf();
-            cachedRealValues = map == null
-                    ? batch.values                 // pass-through, no compaction
-                    : LeafCompaction.compact(batch.values, map);
-        }
-        return cachedRealValues;
+        int[] map = ensureRealView().realToRawLeaf();
+        return map == null
+                ? batch.values                     // pass-through, no compaction
+                : LeafCompaction.compact(batch.values, map);
+    }
+
+    /// Trims a primitive leaf array to exactly [#getValueCount()] entries so the
+    /// capacity tail — stale or zero-filled values past the batch's real leaf
+    /// count — is never exposed through the typed accessors. Already-exact arrays
+    /// and non-array payloads ([BinaryBatchValues], whose offsets are trimmed on
+    /// their own path) pass through untouched, so only the final short batch of a
+    /// column ever pays a copy.
+    private Object trimToValueCount(Object values) {
+        int n = getValueCount();
+        return switch (values) {
+            case int[] a -> a.length == n ? a : Arrays.copyOf(a, n);
+            case long[] a -> a.length == n ? a : Arrays.copyOf(a, n);
+            case float[] a -> a.length == n ? a : Arrays.copyOf(a, n);
+            case double[] a -> a.length == n ? a : Arrays.copyOf(a, n);
+            case boolean[] a -> a.length == n ? a : Arrays.copyOf(a, n);
+            default -> values;
+        };
     }
 
     private void ensureRealBinary() {

--- a/core/src/test/java/dev/hardwood/ColumnReadersTest.java
+++ b/core/src/test/java/dev/hardwood/ColumnReadersTest.java
@@ -317,6 +317,42 @@ class ColumnReadersTest {
     }
 
     @Test
+    void testTypedArraysAreSizedToRecordCount() throws Exception {
+        Path filePath = Paths.get("src/test/resources/primitive_types_test.parquet");
+
+        try (Hardwood hardwood = Hardwood.create();
+             ParquetFileReader parquet = hardwood.openAll(InputFile.ofPaths(List.of(filePath)));
+             ColumnReaders columns = parquet.columnReaders(ColumnProjection.columns(
+                     "int_col", "long_col", "float_col", "double_col", "bool_col", "string_col"))) {
+
+            ColumnReader intReader = columns.getColumnReader("int_col");
+            ColumnReader longReader = columns.getColumnReader("long_col");
+            ColumnReader floatReader = columns.getColumnReader("float_col");
+            ColumnReader doubleReader = columns.getColumnReader("double_col");
+            ColumnReader boolReader = columns.getColumnReader("bool_col");
+            ColumnReader stringReader = columns.getColumnReader("string_col");
+
+            assertThat(intReader.nextBatch() & longReader.nextBatch()
+                    & floatReader.nextBatch() & doubleReader.nextBatch()
+                    & boolReader.nextBatch() & stringReader.nextBatch()).isTrue();
+
+            int count = intReader.getRecordCount();
+            assertThat(count).isEqualTo(3);
+
+            assertThat(intReader.getInts()).hasSize(count);
+            assertThat(longReader.getLongs()).hasSize(count);
+            assertThat(floatReader.getFloats()).hasSize(count);
+            assertThat(doubleReader.getDoubles()).hasSize(count);
+            assertThat(boolReader.getBooleans()).hasSize(count);
+
+            assertThat(stringReader.getBinaries().length).isEqualTo(count);
+
+            assertThat(intReader.getInts()).containsExactly(1, 2, 3);
+            assertThat(doubleReader.getDoubles()).containsExactly(10.5, 20.5, 30.5);
+        }
+    }
+
+    @Test
     void testNullsAcrossFileBoundary() throws Exception {
         Path filePath = Paths.get("src/test/resources/plain_uncompressed_with_nulls.parquet");
         List<Path> files = List.of(filePath, filePath);

--- a/core/src/test/java/dev/hardwood/PqRowApiTest.java
+++ b/core/src/test/java/dev/hardwood/PqRowApiTest.java
@@ -15,6 +15,7 @@ import java.time.LocalDate;
 import java.time.LocalTime;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.NoSuchElementException;
 import java.util.UUID;
 
 import org.junit.jupiter.api.Test;
@@ -64,6 +65,45 @@ public class PqRowApiTest {
             assertThat(rowReader.getLong("value")).isEqualTo(300L);
 
             assertThat(rowReader.hasNext()).isFalse();
+        }
+    }
+
+    @Test
+    void unguardedNextPastEndThrowsInsteadOfReturningPhantomData() throws Exception {
+        Path parquetFile = Paths.get("src/test/resources/plain_uncompressed.parquet");
+
+        try (ParquetFileReader fileReader = ParquetFileReader.open(InputFile.of(parquetFile));
+             RowReader rowReader = fileReader.rowReader()) {
+
+            // Drain all real rows through the documented hasNext()/next() loop.
+            while (rowReader.hasNext()) {
+                rowReader.next();
+            }
+
+            // A further next() with no hasNext() guard used to walk rowIndex into
+            // the capacity tail, where an all-present column's validity sentinel
+            // let getLong() return a phantom/stale value with no exception. It must
+            // now fail early instead (#781).
+            assertThatThrownBy(rowReader::next)
+                    .isInstanceOf(NoSuchElementException.class)
+                    .hasMessageContaining("Call hasNext() first");
+        }
+    }
+
+    @Test
+    void unguardedNextPastEndThrowsForNestedReader() throws Exception {
+        Path parquetFile = Paths.get("src/test/resources/nested_struct_test.parquet");
+
+        try (ParquetFileReader fileReader = ParquetFileReader.open(InputFile.of(parquetFile));
+             RowReader rowReader = fileReader.rowReader()) {
+
+            while (rowReader.hasNext()) {
+                rowReader.next();
+            }
+
+            assertThatThrownBy(rowReader::next)
+                    .isInstanceOf(NoSuchElementException.class)
+                    .hasMessageContaining("Call hasNext() first");
         }
     }
 


### PR DESCRIPTION
In a playground I was looping on getDoubles().length where i noticed it has more data than expected
This PR trims it if the length doesn't match the count (so only last batch pays the cost)

## Checklist

- [x] Build via `./mvnw clean verify` passes
- [x] The commit message is prefixed with the issue key 
- [x] Code changes are covered by tests
- [ ] If this PR adds or changes user-facing behaviour, `docs/` has been updated
