### PR TITLE
Fan-out-aware batch sizing + bulk-copy all-present nested assembly (#748, #786)

### DIFF
--- a/_designs/COLUMN_READER_ADAPTIVE_BATCH_SIZING.md
+++ b/_designs/COLUMN_READER_ADAPTIVE_BATCH_SIZING.md
@@ -17,27 +17,32 @@ Status: **Completed**
 
 The reader has two batch-sizing regimes that must agree but did not:
 
-- The `RowReader` path (`FlatRowReader` / `NestedRowReader`) sizes each batch by a **byte budget**: `BatchSizing.computeOptimalBatchSize` targets ~6 MB across all projected columns and clamps the resulting row count to `[16 384, 524 288]`, so the per-batch column arrays stay within L2 cache regardless of column width or projection breadth.
+- The `RowReader` path (`FlatRowReader` / `NestedRowReader`) sizes each batch by a **byte budget**: `BatchSizing.computeOptimalBatchSize` targets ~6 MB across all projected columns and caps the resulting row count at `524 288` (`BatchSizing.MAX_BATCH`), so the per-batch column arrays stay within L2 cache regardless of column width or projection breadth.
 - The `ColumnReader` / `ColumnReaders` builders used a fixed **record count** default of `262 144` rows.
 
 Because the `ColumnReader` default was a fixed row count, the real per-batch footprint floated with the data: ~1 MB for a single `INT32`, ~2 MB for a single `INT64`/`DOUBLE`, tens of MB for a `BYTE_ARRAY` column once payload and `String` objects are counted, and ~210 MB for a 100-column `INT64` projection (each reader allocating its own `262 144`-row arrays). The batch arrays are freshly allocated per batch (no scratch reuse) and `BatchExchange` prefetch adds a queue-depth multiplier on top, so an oversized default translates directly into allocation and GC churn.
 
+The byte budget itself assumed **one value per row per column**. A repeated (list) column expands each row into many leaf values, so its per-batch value array — and the two `int` level arrays its nested worker holds alongside — are the list's *fan-out* times larger than a row-count budget predicts. A wide `LIST<float32>` (768-element vectors) whose row count fits under the clamp drained the entire column into a single ~512 MB batch: far past the L2 target, memory-bound to both assemble and scan, and at higher fan-out an outright heap exhaustion. So even once both regimes were byte-budgeted, a fan-out-blind estimate still oversized repeated columns and left the regimes disagreeing for them.
+
 ## End state
 
-The default batch size for the column path is **byte-budgeted**, routed through the same `BatchSizing.computeOptimalBatchSize` the row path uses. The two regimes now produce identical batch sizes for the same projection.
+The default batch size for the column path is **byte-budgeted**, routed through the same `BatchSizing.computeOptimalBatchSize` the row path uses, and the budget is scaled by each column's **list fan-out**. The two regimes produce identical batch sizes for the same projection.
 
+- The per-row cost of a column is its value width times its average leaf-values-per-row (fan-out), plus the def/rep level bytes a repeated column's nested worker allocates per value (two `int`s). A flat column's fan-out is `1` and it carries no per-value level arrays, so the budget collapses to the plain value width.
+- The row-count floor is removed. Because the value count per batch is now roughly constant across fan-out (`≈ budget / value-bytes`), a high-fan-out column's small row count still carries a full batch of work, so no floor is needed to amortise per-batch overhead. `BatchSizing.MAX_BATCH` (`524 288`) remains the only clamp.
 - `ColumnReaderBuilder.batchSize(int)` and `ColumnReadersBuilder.batchSize(int)` remain the explicit override and are honored verbatim. The positivity check is unchanged.
-- When the caller does not set `batchSize`, the builder leaves it unset and the size is resolved at `build()` time from the projection's column widths.
+- When the caller does not set `batchSize`, the builder leaves it unset and the size is resolved at `build()` time from the projection's column widths and fan-out.
 - The width used is that of **every column the batch decodes**: the full projection on the plain path, and the predicate-augmented projection on the exact-filtering path (the predicate columns allocate arrays too, so they count toward the budget).
-- The public `ColumnReader.DEFAULT_BATCH_SIZE` constant is removed: there is no longer a single fixed default to name. `BatchSizing.MAX_BATCH` (`524 288`) remains the upper clamp.
+- The public `ColumnReader.DEFAULT_BATCH_SIZE` constant is removed: there is no longer a single fixed default to name.
 
 This is a no-op for callers that already pass an explicit `batchSize`. Callers relying on the default get smaller, width-aware batches and lower peak allocation, especially on wide and variable-width projections.
 
 ## Mechanics
 
-`batchSize` carries a sentinel of `0` ("unset") from the builders down to the bridge methods on `ParquetFileReader`. `resolveBatchSize(requested, projectedSchema)` returns `requested` when positive and `BatchSizing.computeOptimalBatchSize(projectedSchema)` otherwise. Resolution happens at the single point where the full `ProjectedSchema` is known:
+`batchSize` carries a sentinel of `0` ("unset") from the builders down to the bridge methods on `ParquetFileReader`. `resolveBatchSize(requested, projectedSchema, rowGroups)` returns `requested` when positive and otherwise `BatchSizing.computeOptimalBatchSize(projectedSchema, BatchSizing.valuesPerRow(projectedSchema, rowGroups))`. `valuesPerRow` derives each projected column's fan-out from the row-group metadata — its total leaf value count (`Σ chunk.numValues`) over the total row count (`Σ rowGroup.numRows`) — so the estimate needs both the projection *and* the file's row groups. Resolution happens where both are known:
 
-- `ParquetFileReader.buildColumnReaders` — resolves against the plain projection (unfiltered) or the augmented projection (filtered) before constructing `ColumnReaders`.
-- `ColumnReader.create` — the single-column, unfiltered entry point builds its own one-column `ProjectedSchema` and resolves against it.
+- `ParquetFileReader.buildColumnReaders` — resolves against the plain projection (unfiltered) or the augmented projection (filtered), with the file's row groups, before constructing `ColumnReaders`.
+- `ColumnReader.create` — the single-column, unfiltered entry point builds its own one-column `ProjectedSchema` and resolves against it and its row groups.
+- `NestedRowReader.create` — the nested row-materialisation path, sized from the same metadata (threaded from `createRowReader`) so it agrees with the column path for repeated projections. `FlatRowReader` needs no fan-out — a flat schema is one value per row — and is unchanged.
 
 All downstream consumers (`ColumnReaders`, `ColumnReader.createFromIterator`, the workers, `BatchExchange.allocateArray`) continue to receive a concrete, already-resolved positive batch size.

--- a/_designs/FIXED_SIZE_LIST_FASTPATH.md
+++ b/_designs/FIXED_SIZE_LIST_FASTPATH.md
@@ -199,8 +199,8 @@ marker (`0` for a regular page/batch). All types live in
   slices levels pre-decompression; V1 reads them from the decompressed body —
   the only difference between the two seams.
 - **Assembly** — `NestedColumnWorker.assembleFixedWidthPage` bulk-copies each
-  record's values and sets record offsets arithmetically, skipping the
-  per-element level copy. A published batch stays homogeneous — wholly
+  contiguous run of kept records in one `copyValueRun` and sets record offsets
+  arithmetically, skipping the per-element level copy. A published batch stays homogeneous — wholly
   fixed-width (levels omitted) or wholly regular — but batch boundaries must fall
   at the same rows across every column, which holds only at batch-capacity and
   file boundaries. The assembler therefore never cuts a batch at a page boundary:
@@ -268,8 +268,8 @@ Findings:
   across the whole *k* sweep, at **3.2–4.2×** over the naive `LIST` decode. The
   naive path is 5.2–8.1× slower than the flat floor; the fast path lands at
   ~1.6–2.1× of it.
-- The residual over the flat floor is **value decode plus per-record assembly**,
-  not level handling — the honest ceiling. A native fixed-size-list type would
+- The residual over the flat floor is **value decode plus the value copy into the
+  batch**, not level handling — the honest ceiling. A native fixed-size-list type would
   need to justify itself on that residual, not on the reconstruction cost this
   fast path already removes.
 - The SWAR tiled compare makes small-*k* detection negligible (0.31 ms,

--- a/_designs/FIXED_SIZE_LIST_FASTPATH.md
+++ b/_designs/FIXED_SIZE_LIST_FASTPATH.md
@@ -225,6 +225,18 @@ marker (`0` for a regular page/batch). All types live in
   value array alone rather than tripling it with two same-length `int` level
   arrays, which matters most for large *k*, where a batch holds *k* values per
   row.
+- **Batch value hand-off** — on the fast path the value accumulator is sized to
+  exactly `batchCapacity · k` at the start of a fresh fixed-width batch
+  (`prepareFixedWidthValues`), so a full batch fills it precisely. At publish such a
+  batch hands that array straight to the `NestedBatch` and starts the next batch on a
+  fresh array, rather than copying the values out of the reused accumulator
+  (`trimValues`). This leaves the fast path with the single value copy the flat path
+  also makes — page → batch — instead of the two the accumulator model otherwise
+  incurs (page → accumulator → trimmed copy); the flat floor never makes that second
+  copy, so eliminating it removes the corresponding streaming pass over the value
+  array (the dominant residual cost on memory-bandwidth-bound hosts). A partial batch
+  (file tail or `maxRows` cutoff) and any batch that fell back to the regular
+  representation have a value count below the pinned capacity and still trim.
 - **Column reader** — `ColumnReader.ensureRealView` builds the real-items view
   directly for a fixed-width batch (arithmetic offsets, null validity, identity
   pass-through of the dense values) instead of scanning levels;
@@ -268,10 +280,13 @@ Findings:
   across the whole *k* sweep, at **3.2–4.2×** over the naive `LIST` decode. The
   naive path is 5.2–8.1× slower than the flat floor; the fast path lands at
   ~1.6–2.1× of it.
-- The residual over the flat floor is **value decode plus the value copy into the
-  batch**, not level handling — the honest ceiling. A native fixed-size-list type would
-  need to justify itself on that residual, not on the reconstruction cost this
-  fast path already removes.
+- The residual over the flat floor is **value decode, the single page → batch value
+  copy the flat path also makes, and the level scan plus arithmetic index build** —
+  not level materialisation, the honest ceiling. (The value array is handed off at
+  publish rather than copied a second time, so the fast path makes no more value
+  copies than the flat floor; see the *Batch value hand-off* implementation note.) A
+  native fixed-size-list type would need to justify itself on that residual, not on
+  the reconstruction cost this fast path already removes.
 - The SWAR tiled compare makes small-*k* detection negligible (0.31 ms,
   ~2% of the fast path; without it the scalar bit walk was ~5 ms, ~39% at k=4).
   It does not move the recovered fraction: in the full read, detection overlaps

--- a/_designs/NESTED_ALL_PRESENT_PAGE_BULK_COPY.md
+++ b/_designs/NESTED_ALL_PRESENT_PAGE_BULK_COPY.md
@@ -1,0 +1,158 @@
+# Design: bulk-copy whole all-present pages in regular nested assembly
+
+**Status: Completed.** Tracking issue: #786. Potential follow-up: #750.
+
+## Goal
+
+Give `NestedColumnWorker.assembleRegularPage` a whole-page fast path: when an
+entire page is proven all-present and is read unmasked, gather its leaf values
+into the batch with one `System.arraycopy` and produce whatever the batch's index
+mode requires directly, instead of walking the page one element at a time. Any
+page that is not wholly present, or is read under a record mask, falls back
+unchanged to the existing per-element path.
+
+The optimisation is keyed on **presence, not shape**, so it is not specific to
+lists: it applies to any column the regular nested assembly path serves — lists
+(fixed or variable length), maps, structs — and, until #732 moves non-repeated
+columns to direct addressing, the flat columns of a mixed dataset that are
+currently routed through the nested worker. It produces byte-for-byte the same
+batch output and requires no format or writer change.
+
+## Background & motivation
+
+Parquet stores only present values, densely. When an entire page is all-present
+its leaf values are one contiguous block, 1:1 with page positions; the repetition
+levels group them into records but do not move them. Value contiguity is a
+property of presence, not of the column being a fixed-width list.
+
+The regular assembly path does not exploit this. For every leaf it runs a
+per-element sequence — two capacity checks (`ensureLevelCapacity` +
+`ensureValueCapacity`), a bounds-checked `iastore` for each of the definition and
+repetition level, a `checkcast` of the destination array, and `copyOneValue` —
+around a value copy that is itself two instructions. On an all-present scan this
+path executes on the order of 20× the instructions of the equivalent flat read,
+and the value copy is the cheap part; the cost is the per-element bookkeeping. The
+flat reader already avoids it (`FlatColumnWorker` copies a whole page range in one
+`arraycopy`), as does the fixed-size-list fast path per fixed-width page.
+
+## Whole page, not sub-page runs
+
+The unit of this optimisation is the **whole page**, decided by a single O(1)
+check, not maximal present runs discovered inside a page.
+
+A page is taken on the fast path when both hold:
+
+- **All-present**: the definition-level stream is a single RLE run of
+  `maxDefinitionLevel` covering all `numValues` — the same O(1) header inspection
+  (`isSingleRleRunOf`) the flat reader and the fixed-size-list detector already
+  use. It reads one varint and one value byte; it does **not** scan the levels.
+- **Unmasked**: the read mask selects the whole page (`mask.isAll()`), so the
+  page's values are one contiguous, record-aligned span with no gaps.
+
+If either fails — any null or empty entry anywhere on the page, or a record mask
+that fragments it — the page is handled entirely by the existing per-element path.
+
+Sub-page present-run copying (scanning the definition levels for runs broken by
+nulls or mask gaps, and bulk-copying each run) is deliberately **not** part of
+this design: the per-run detection is O(numValues) and the run-boundary
+bookkeeping offsets the bulk-copy saving, so it does not pay off. The whole-page
+gate is O(1) and adds nothing to the fallback path, which is what makes the win
+free to attempt: a page either qualifies wholesale or is untouched. Generalising
+to sub-page present runs is a potential follow-up, tracked in #750.
+
+## Design
+
+When a page qualifies, `assembleRegularPage` resolves the page value type once and
+processes the page in record-aligned chunks rather than per element.
+
+**Values (all index modes).** Bulk-copy the chunk with one `System.arraycopy` from
+the page value array into the batch accumulator, into a destination array whose
+type was resolved once for the page (no per-element `checkcast` or `switch
+(page)`), growing the accumulator once per chunk.
+
+**Structure — as cheaply as the index mode allows.** The all-present shape makes
+every mode's per-batch output trivial to produce, so none of it is done per
+element:
+
+- `REAL_VIEW` (the unfiltered `ColumnReader` path, which since #751 derives
+  offsets + validity on the drain and drops raw levels): build that view directly
+  — record offsets from a repetition-level boundary scan, validity all-true — and
+  do **not** materialise raw def/rep level arrays. This is the same output the
+  fixed-size-list fast path already produces via its all-present view.
+- `REAL_VIEW_KEEP_LEVELS` (exact-filter) and `ALL_ITEMS`: these consumers read the
+  raw level arrays, so fill them for the chunk in one pass — definition levels are
+  the constant `maxDefinitionLevel` (bulk fill), repetition levels are
+  `arraycopy`-ed from the page — instead of the per-element bounds-checked
+  `iastore`s.
+
+Record boundaries are identical to the per-element path in every mode, so
+cross-column batch alignment is preserved.
+
+### Record-aligned cuts
+
+A nested batch must cut at a **record** boundary, and records have variable
+length, so a qualifying page may span more records than fit in the open batch. The
+page is copied in batch-capacity-aligned chunks: copy up to the record boundary
+that fills the batch, publish, then continue into the next batch. The
+repetition-level boundary scan supplies the cut points, so they are known without
+touching values.
+
+## Scope
+
+**In scope:** the unfiltered regular `assembleRegularPage` path for any wholly
+present page the nested worker handles — lists (fixed or variable length), maps,
+structs, and (until #732) non-repeated columns routed through the nested worker.
+Transparent: identical batch output and public behaviour.
+
+**Out of scope:**
+
+- **Partially-null or masked pages.** Any page with an interior null/empty, or read
+  under a record mask, uses the existing per-element path unchanged. Sub-page run
+  copying is explicitly excluded (see above; follow-up #750).
+
+**Builds on (already implemented):**
+
+- **#751 — level materialisation dropped on the drain** ([NESTED_REALVIEW_ON_DRAIN.md]).
+  The `REAL_VIEW` mode this exploits — deriving offsets + validity without raw
+  levels — exists because of #751; this design makes producing that view for an
+  all-present page cheaper (direct, not per-element).
+- **#741 — fixed-size-list fast path** ([FIXED_SIZE_LIST_FASTPATH.md]). The
+  fixed-`k` present-page case, which additionally uses arithmetic `(rows × k)`
+  offsets and skips the repetition scan. It is the shape-specific specialisation of
+  this general all-present path.
+
+## Relationship to the fixed-size-list fast path
+
+The fixed-size-list fast path (#741) already ships. It is the fixed-`k`
+specialisation of this optimisation: a wholly present page whose records all have
+the same length, so its offsets are arithmetic and its repetition scan can be
+skipped. This design generalises the same idea — bulk value copy for an
+all-present page — to any record shape, and the two share one bulk-copy primitive
+(the fixed-list path's per-record `copyValueRun` is refactored onto it).
+
+The fast path currently reports its speedup against the regular per-element path as
+baseline. Because that baseline copies element by element, the reported
+fast-vs-baseline ratio overstates the win; bulk-copying whole all-present pages in
+the regular path makes the baseline honest, after which the fast path's remaining
+advantage is only the arithmetic offsets and the skipped repetition scan.
+
+## Correctness
+
+Validated against the differential oracle (DuckDB) and the nested reader tests,
+which must stay green across: all-present columns, columns with interior nulls and
+empty lists, null and empty top-level records, filtered scans with interval masks
+(and the exact-filter `REAL_VIEW_KEEP_LEVELS` path), batch boundaries that fall
+inside a qualifying page, and dictionary / byte-array / FLBA leaves. The whole-page
+path and the per-element fallback must produce identical batches; the same
+all-present page forced through the per-element path folds to the same values,
+offsets, validity, and levels.
+
+## Performance
+
+Bulk-copying whole all-present pages removes most of the regular nested path's
+per-element instruction overhead, moving a fast-path-off all-present scan
+materially toward the flat-column floor. The fixed-`k` fast path, rebuilt on the
+shared span-copy primitive, is unchanged or faster — and copying record runs in
+one span rather than per record is the dominant win at small `k`, where the
+per-record `arraycopy` calls previously dominated. The per-element fallback for
+null-bearing or masked pages is not regressed.

--- a/core/src/main/java/dev/hardwood/internal/reader/BatchSizing.java
+++ b/core/src/main/java/dev/hardwood/internal/reader/BatchSizing.java
@@ -7,7 +7,12 @@
  */
 package dev.hardwood.internal.reader;
 
+import java.util.List;
+
 import dev.hardwood.internal.schema.ProjectedSchema;
+import dev.hardwood.metadata.ColumnChunk;
+import dev.hardwood.metadata.FieldPath;
+import dev.hardwood.metadata.RowGroup;
 import dev.hardwood.schema.ColumnSchema;
 
 /// Computes optimal batch sizes for column data assembly.
@@ -23,30 +28,96 @@ public final class BatchSizing {
 
     /// Computes a batch size that keeps all column arrays for one batch within the L2 cache.
     ///
-    /// Each batch allocates one primitive array per projected column. The total memory for a
-    /// batch is approximately `batchSize * sum(bytesPerColumn)`. This method sizes the batch
-    /// so that total stays under the target (6 MB), clamped to [`16 384`, [#MAX_BATCH]]
-    /// rows.
-    ///
-    /// For example, 3 projected DOUBLE columns (8 bytes each = 24 bytes/row) yields
-    /// `6 MB / 24 = 262 144` rows per batch.
+    /// Equivalent to [#computeOptimalBatchSize(ProjectedSchema, double[])] with no
+    /// fan-out information — every column is assumed to hold one value per row.
     public static int computeOptimalBatchSize(ProjectedSchema projectedSchema) {
-        // Initially target 6 MB (fits comfortably in L2 cache)
+        return computeOptimalBatchSize(projectedSchema, null);
+    }
+
+    /// Computes a batch size that keeps all column arrays for one batch within the L2 cache.
+    ///
+    /// Each batch allocates one value array per projected column, sized to the batch's
+    /// **value** count. For a flat column that equals the row count, but for a repeated
+    /// (list) column each row expands to several leaf values, so the value array is
+    /// `valuesPerRow` times larger than the row count. `valuesPerRow[i]` is the average
+    /// leaf values per top-level row for projected column `i` (its list fan-out); a `null`
+    /// array, a short array, or a non-positive entry falls back to `1.0` (one value per
+    /// row). Sizing by rows alone — ignoring fan-out — makes a wide list column's value
+    /// array many times larger than the intended budget, so the batch no longer fits in
+    /// cache and both assembly and the consumer run memory-bound.
+    ///
+    /// The batch is sized so the total value memory stays under the target (6 MB), clamped
+    /// to at least one row and at most [#MAX_BATCH]. No larger row floor is applied: because
+    /// the value count per batch is `rows * fan-out ~= budget / valueBytes`, the work per
+    /// batch is roughly constant regardless of fan-out, so a high-fan-out column's small row
+    /// count still carries a full batch of values to amortise per-batch overhead.
+    ///
+    /// For example, 3 projected DOUBLE columns (8 bytes each, one value per row = 24
+    /// bytes/row) yields `6 MB / 24 = 262 144` rows; a single `LIST<float32>` of 768-wide
+    /// vectors (`768 * 4 = 3072` bytes/row) yields `6 MB / 3072 = 2048` rows.
+    public static int computeOptimalBatchSize(ProjectedSchema projectedSchema, double[] valuesPerRow) {
+        // Target 6 MB of value memory per batch (fits comfortably in L2 cache).
         long targetBytes = 6L * 1024 * 1024;
-        int minBatch = 16384;
         int maxBatch = MAX_BATCH;
 
-        int bytesPerRow = 0;
+        double bytesPerRow = 0;
         for (int i = 0; i < projectedSchema.getProjectedColumnCount(); i++) {
-            bytesPerRow += columnByteWidth(projectedSchema.getProjectedColumn(i));
+            ColumnSchema column = projectedSchema.getProjectedColumn(i);
+            double fanout = valuesPerRow != null && i < valuesPerRow.length && valuesPerRow[i] > 0
+                    ? valuesPerRow[i]
+                    : 1.0;
+            bytesPerRow += fanout * (columnByteWidth(column) + levelBytesPerValue(column));
         }
 
-        if (bytesPerRow == 0) {
+        if (bytesPerRow <= 0) {
             bytesPerRow = 8;
         }
 
-        int batchSize = (int) (targetBytes / bytesPerRow);
-        return Math.max(minBatch, Math.min(maxBatch, batchSize));
+        return (int) Math.min(maxBatch, Math.max(1, (long) (targetBytes / bytesPerRow)));
+    }
+
+    /// Computes each projected column's average list fan-out — leaf values per
+    /// top-level row — from row-group metadata, for
+    /// [#computeOptimalBatchSize(ProjectedSchema, double[])]. A column's fan-out is
+    /// its total leaf value count across `rowGroups` divided by the total row count.
+    /// Returns `null` when there are no rows (the caller then assumes one value per
+    /// row). A flat column's fan-out is `1`; a `LIST<float32>` of 768-wide vectors is
+    /// `768`.
+    public static double[] valuesPerRow(ProjectedSchema projectedSchema, List<RowGroup> rowGroups) {
+        long totalRows = 0;
+        for (RowGroup rowGroup : rowGroups) {
+            totalRows += rowGroup.numRows();
+        }
+        if (totalRows == 0) {
+            return null;
+        }
+        int columnCount = projectedSchema.getProjectedColumnCount();
+        double[] valuesPerRow = new double[columnCount];
+        for (int i = 0; i < columnCount; i++) {
+            FieldPath path = projectedSchema.getProjectedColumn(i).fieldPath();
+            long values = 0;
+            for (RowGroup rowGroup : rowGroups) {
+                for (ColumnChunk chunk : rowGroup.columns()) {
+                    if (chunk.metaData().pathInSchema().equals(path)) {
+                        values += chunk.metaData().numValues();
+                        break;
+                    }
+                }
+            }
+            valuesPerRow[i] = (double) values / totalRows;
+        }
+        return valuesPerRow;
+    }
+
+    /// Bytes of repetition/definition level storage a repeated column's nested
+    /// worker holds per leaf value — one `int` definition level plus one `int`
+    /// repetition level. A repeated column drains through [NestedColumnWorker],
+    /// which accumulates both `int[]` level arrays alongside the value array, so
+    /// they count toward the batch's cache footprint. Non-repeated columns carry no
+    /// per-value level arrays (nullability rides a packed validity bitmap), so they
+    /// contribute `0`.
+    private static int levelBytesPerValue(ColumnSchema column) {
+        return column.maxRepetitionLevel() > 0 ? 2 * Integer.BYTES : 0;
     }
 
     /// Returns the estimated byte width of a single value for the given column's physical type.

--- a/core/src/main/java/dev/hardwood/internal/reader/NestedBatch.java
+++ b/core/src/main/java/dev/hardwood/internal/reader/NestedBatch.java
@@ -44,6 +44,12 @@ public final class NestedBatch {
     /// multiples of this value.
     public int fixedListK;
 
+    /// True when every leaf in this batch is present (no null or empty parents) —
+    /// set by the assembler when every contributing page was gated all-present, so
+    /// the drain can skip the `O(valueCount)` definition-level scan that would
+    /// otherwise re-derive the same fact.
+    public boolean allPresent;
+
     // Pre-computed index (computed by drain before publish). Validity bit set
     // iff present. Null means "all items at that layer are present in this
     // batch."

--- a/core/src/main/java/dev/hardwood/internal/reader/NestedColumnWorker.java
+++ b/core/src/main/java/dev/hardwood/internal/reader/NestedColumnWorker.java
@@ -178,54 +178,60 @@ public class NestedColumnWorker extends ColumnWorker<NestedBatch> {
         nestedFirstValueSeen = true;
         int pageRecords = page.size() / k;
         boolean maskAll = mask.isAll();
-        int intervalCount = maskAll ? 0 : mask.intervalCount();
-        int intervalCursor = 0;
-
-        for (int r = 0; r < pageRecords; r++) {
-            if (!maskAll) {
-                while (intervalCursor < intervalCount && r >= mask.end(intervalCursor)) {
-                    intervalCursor++;
+        // Kept record ranges are contiguous k-runs, so each range is copied in
+        // batch-capacity-sized chunks with one arraycopy per chunk rather than one
+        // per record. Unmasked = the whole page; masked = each interval (page-local
+        // record indices), clamped to the page.
+        int rangeCount = maskAll ? 1 : mask.intervalCount();
+        for (int rangeIdx = 0; rangeIdx < rangeCount; rangeIdx++) {
+            int r = maskAll ? 0 : Math.max(0, mask.start(rangeIdx));
+            int rangeEnd = maskAll ? pageRecords : Math.min(pageRecords, mask.end(rangeIdx));
+            while (r < rangeEnd) {
+                if (rowsInCurrentBatch >= batchCapacity) {
+                    publishCurrentBatch();
+                    if (done) {
+                        return;
+                    }
                 }
-                if (intervalCursor >= intervalCount || r < mask.start(intervalCursor)) {
-                    continue;
-                }
-            }
-
-            if (rowsInCurrentBatch >= batchCapacity) {
-                publishCurrentBatch();
-                if (done) {
+                if (maxRows > 0 && totalRowsAssembled >= maxRows) {
+                    if (rowsInCurrentBatch > 0) {
+                        publishCurrentBatch();
+                    }
+                    finishDrain();
                     return;
                 }
-            }
-            if (maxRows > 0 && totalRowsAssembled >= maxRows) {
-                if (rowsInCurrentBatch > 0) {
-                    publishCurrentBatch();
-                }
-                finishDrain();
-                return;
-            }
 
-            if (asRegularBatch) {
-                ensureNestedCapacity(nestedValueCount + k);
-            }
-            else {
-                ensureValueCapacity(nestedValueCount + k);
-            }
-            nestedRecordOffsets[rowsInCurrentBatch] = nestedValueCount;
-            int destStart = nestedValueCount;
-            copyValueRun(page, r * k, destStart, k);
-            if (asRegularBatch) {
-                for (int j = 0; j < k; j++) {
-                    nestedDefLevels[destStart + j] = maxDefinitionLevel;
-                    nestedRepLevels[destStart + j] = (j == 0) ? 0 : 1;
+                int records = Math.min(rangeEnd - r, batchCapacity - rowsInCurrentBatch);
+                if (maxRows > 0) {
+                    records = (int) Math.min(records, maxRows - totalRowsAssembled);
                 }
+                int span = records * k;
+                int destStart = nestedValueCount;
+                if (asRegularBatch) {
+                    ensureNestedCapacity(nestedValueCount + span);
+                }
+                else {
+                    ensureValueCapacity(nestedValueCount + span);
+                }
+                copyValueRun(page, r * k, destStart, span);
+                for (int j = 0; j < records; j++) {
+                    nestedRecordOffsets[rowsInCurrentBatch + j] = destStart + j * k;
+                }
+                if (asRegularBatch) {
+                    Arrays.fill(nestedDefLevels, destStart, destStart + span, maxDefinitionLevel);
+                    Arrays.fill(nestedRepLevels, destStart, destStart + span, 1);
+                    for (int j = 0; j < records; j++) {
+                        nestedRepLevels[destStart + j * k] = 0;
+                    }
+                }
+                else {
+                    batchFixedK = k;
+                }
+                nestedValueCount += span;
+                rowsInCurrentBatch += records;
+                totalRowsAssembled += records;
+                r += records;
             }
-            else {
-                batchFixedK = k;
-            }
-            nestedValueCount += k;
-            rowsInCurrentBatch++;
-            totalRowsAssembled++;
         }
     }
 
@@ -242,6 +248,16 @@ public class NestedColumnWorker extends ColumnWorker<NestedBatch> {
                         "Invalid column chunk for '" + column.name()
                         + "': first repetition level must be 0 but was " + pageRepLevels[0]);
             }
+        }
+
+        // Whole-page all-present fast path: every leaf is present (PageDecoder's
+        // O(1) def-gate), so on an unmasked page the values are one contiguous,
+        // record-aligned run that can be bulk-copied instead of walked per element.
+        // Byte-array leaves stay on the per-element path — their values are appended
+        // into a shared buffer, not arraycopy-able.
+        if (page.allPresent() && mask.isAll() && !(page instanceof Page.ByteArrayPage)) {
+            assembleAllPresentPage(page, pageRepLevels);
+            return;
         }
 
         boolean maskAll = mask.isAll();
@@ -317,6 +333,89 @@ public class NestedColumnWorker extends ColumnWorker<NestedBatch> {
             copyOneValue(page, i, nestedValues, nestedValueCount);
             nestedValueCount++;
         }
+    }
+
+    /// Whole-page assembly for an all-present, unmasked page. Every leaf is present
+    /// ([Page#allPresent]), so the page's values are 1:1 with positions and
+    /// contiguous. The record and batch-capacity bookkeeping mirrors
+    /// [#assembleRegularPage] — a record opens at each `repLevel == 0`, a full batch
+    /// is published at the next record boundary — but the per-element value copy and
+    /// level stores are deferred and flushed as bulk operations once per batch (see
+    /// [#flushRun]). Records may span pages, so the batch is left open at page end
+    /// for the next page to continue.
+    private void assembleAllPresentPage(Page page, int[] pageRepLevels) {
+        int pageSize = page.size();
+        if (pageSize == 0) {
+            return;
+        }
+        // The current batch's pending run of not-yet-flushed values: page positions
+        // [runStartPage, i), written at batch value index starting at runStartDest.
+        int runStartPage = 0;
+        int runStartDest = nestedValueCount;
+
+        for (int i = 0; i < pageSize; i++) {
+            if (pageRepLevels != null && pageRepLevels[i] != 0) {
+                continue; // continuation of the open record, not a boundary
+            }
+            int batchValueIndex = runStartDest + (i - runStartPage);
+            if (batchValueIndex > 0 || rowsInCurrentBatch > 0) {
+                // A record just closed; open the next, publishing first if the batch
+                // is full (records are never split across batches).
+                if (rowsInCurrentBatch >= batchCapacity) {
+                    flushRun(page, pageRepLevels, runStartPage, i, runStartDest);
+                    publishCurrentBatch();
+                    if (done) {
+                        return;
+                    }
+                    runStartPage = i;
+                    runStartDest = 0;
+                }
+                if (maxRows > 0 && totalRowsAssembled >= maxRows) {
+                    flushRun(page, pageRepLevels, runStartPage, i, runStartDest);
+                    if (rowsInCurrentBatch > 0) {
+                        publishCurrentBatch();
+                    }
+                    finishDrain();
+                    return;
+                }
+                if (nestedRecordOffsets.length <= rowsInCurrentBatch) {
+                    nestedRecordOffsets = Arrays.copyOf(nestedRecordOffsets,
+                            nestedRecordOffsets.length * 2);
+                }
+                nestedRecordOffsets[rowsInCurrentBatch] = runStartDest + (i - runStartPage);
+                rowsInCurrentBatch++;
+                totalRowsAssembled++;
+            }
+            else {
+                // First kept value of the stream — open record 0.
+                nestedRecordOffsets[0] = 0;
+                rowsInCurrentBatch = 1;
+                totalRowsAssembled++;
+            }
+        }
+        flushRun(page, pageRepLevels, runStartPage, pageSize, runStartDest);
+    }
+
+    /// Flushes the pending run of an all-present page — page positions
+    /// `[fromPage, toPage)` written at batch value index `destStart` — as three bulk
+    /// operations: the values via [#copyValueRun], the constant definition levels via
+    /// `Arrays.fill`, and the repetition levels via `System.arraycopy` (all `0` when
+    /// the column is not repeated). Advances [#nestedValueCount] past the run.
+    private void flushRun(Page page, int[] pageRepLevels, int fromPage, int toPage, int destStart) {
+        int span = toPage - fromPage;
+        if (span <= 0) {
+            return;
+        }
+        ensureNestedCapacity(destStart + span);
+        copyValueRun(page, fromPage, destStart, span);
+        Arrays.fill(nestedDefLevels, destStart, destStart + span, maxDefinitionLevel);
+        if (pageRepLevels != null) {
+            System.arraycopy(pageRepLevels, fromPage, nestedRepLevels, destStart, span);
+        }
+        else {
+            Arrays.fill(nestedRepLevels, destStart, destStart + span, 0);
+        }
+        nestedValueCount = destStart + span;
     }
 
     @Override

--- a/core/src/main/java/dev/hardwood/internal/reader/NestedColumnWorker.java
+++ b/core/src/main/java/dev/hardwood/internal/reader/NestedColumnWorker.java
@@ -55,6 +55,12 @@ public class NestedColumnWorker extends ColumnWorker<NestedBatch> {
     /// capacity, since a fixed-width batch publishes with `null` levels. The
     /// level arrays are grown to match only when a batch falls back to the
     /// regular representation ([#materializeFixedWidthBatchLevels]).
+    ///
+    /// On the fast path this is additionally pinned to exactly `batchCapacity * k`
+    /// at a fresh batch's start ([#prepareFixedWidthValues]), so a full fixed-width
+    /// batch fills the array precisely — the condition
+    /// `nestedValueCount == nestedValuesCapacity` that lets [#publishCurrentBatch]
+    /// hand the array straight to the batch instead of trimming a copy out of it.
     private int nestedValuesCapacity;
 
     /// Whether we have seen the first value in the nested stream.
@@ -187,6 +193,13 @@ public class NestedColumnWorker extends ColumnWorker<NestedBatch> {
     /// [#publishCurrentBatch] (at batch capacity) resets it for the next batch.
     private void assembleFixedWidthPage(Page page, PageRowMask mask, int k, boolean asRegularBatch) {
         nestedFirstValueSeen = true;
+        // On a fresh fast-path batch, size the value accumulator to exactly
+        // batchCapacity * k so a full batch fills it precisely and publish can hand
+        // the array straight to the batch (no trim copy). A continuation page (batch
+        // already partly filled) leaves the sizing from the batch's start untouched.
+        if (!asRegularBatch && nestedValueCount == 0) {
+            prepareFixedWidthValues(k);
+        }
         int pageRecords = page.size() / k;
         boolean maskAll = mask.isAll();
         // Kept record ranges are contiguous k-runs, so each range is copied in
@@ -450,7 +463,18 @@ public class NestedColumnWorker extends ColumnWorker<NestedBatch> {
             currentBatch.repetitionLevels = Arrays.copyOf(nestedRepLevels, nestedValueCount);
         }
         currentBatch.recordOffsets = Arrays.copyOf(nestedRecordOffsets, rowsInCurrentBatch);
-        currentBatch.values = trimValues(nestedValues, nestedValueCount);
+        if (batchFixedK > 0 && nestedValueCount == nestedValuesCapacity) {
+            // Pure fixed-width full batch: the accumulator was pre-sized to exactly
+            // batchCapacity * k (prepareFixedWidthValues), so it is already the batch's
+            // final values array — hand it off without the trim copy and start the next
+            // batch on a fresh array of the same size. A partial fixed-width batch (file
+            // tail or maxRows cutoff) has fewer values than capacity and still trims.
+            currentBatch.values = nestedValues;
+            nestedValues = BatchExchange.allocateArray(column, nestedValuesCapacity);
+        }
+        else {
+            currentBatch.values = trimValues(nestedValues, nestedValueCount);
+        }
         currentBatch.fileName = currentBatchFileName;
 
         // Compute index structures before publishing so the consumer thread
@@ -652,6 +676,23 @@ public class NestedColumnWorker extends ColumnWorker<NestedBatch> {
     private void ensureNestedCapacity(int needed) {
         ensureLevelCapacity(needed);
         ensureValueCapacity(needed);
+    }
+
+    /// Sizes the value accumulator to exactly `batchCapacity * k` at the start of a
+    /// fresh fixed-width batch. A full fixed-width batch is then exactly
+    /// `batchCapacity` records (`batchCapacity * k` values) and fills the array to
+    /// its capacity, so [#publishCurrentBatch] can hand the array to the batch
+    /// directly rather than trimming a copy out of a reused accumulator — the
+    /// single-copy behaviour the flat path already has. Reallocates only when the
+    /// capacity does not already match (the first fixed-width batch, or a change in
+    /// `k`); a same-`k` steady state reuses the array freshly allocated at the
+    /// previous handoff.
+    private void prepareFixedWidthValues(int k) {
+        int cap = Math.multiplyExact(batchCapacity, k);
+        if (nestedValuesCapacity != cap) {
+            nestedValues = BatchExchange.allocateArray(column, cap);
+            nestedValuesCapacity = cap;
+        }
     }
 
     /// Ensures the value accumulator holds at least `needed` slots, growing it

--- a/core/src/main/java/dev/hardwood/internal/reader/NestedColumnWorker.java
+++ b/core/src/main/java/dev/hardwood/internal/reader/NestedColumnWorker.java
@@ -66,6 +66,13 @@ public class NestedColumnWorker extends ColumnWorker<NestedBatch> {
     /// between the fast and regular paths (or between different `k`).
     private int batchFixedK;
 
+    /// Whether every page that has contributed to the batch currently being
+    /// assembled was gated all-present. When true at publish, the drain skips the
+    /// `allDefsMax` re-scan. Reset to the in-flight page's status after each publish
+    /// (a page may span batches), and AND-ed with each page's [Page#allPresent].
+    private boolean currentBatchAllPresent = true;
+    private boolean currentPageAllPresent = true;
+
     /// Creates a new nested column worker.
     ///
     /// @param pageSource yields [PageInfo] objects for this column
@@ -111,10 +118,14 @@ public class NestedColumnWorker extends ColumnWorker<NestedBatch> {
         nestedDefLevels = new int[initialCapacity];
         nestedRepLevels = new int[initialCapacity];
         nestedRecordOffsets = new int[batchCapacity];
+        currentBatchAllPresent = true;
+        currentPageAllPresent = true;
     }
 
     @Override
     void assemblePage(Page page, PageRowMask mask) {
+        currentPageAllPresent = page.allPresent();
+        currentBatchAllPresent &= currentPageAllPresent;
         int k = page.fixedListK();
         boolean pageFixedWidth = k > 0;
         // A published batch must stay homogeneous — wholly fixed-width (levels
@@ -426,6 +437,7 @@ public class NestedColumnWorker extends ColumnWorker<NestedBatch> {
         currentBatch.recordCount = rowsInCurrentBatch;
         currentBatch.valueCount = nestedValueCount;
         currentBatch.fixedListK = batchFixedK;
+        currentBatch.allPresent = currentBatchAllPresent;
         if (batchFixedK > 0 || indexMode == IndexMode.REAL_VIEW) {
             // Fixed-width batches omit levels (boundaries are implicit); the
             // unfiltered real-view path derives the view from the accumulators in
@@ -468,6 +480,9 @@ public class NestedColumnWorker extends ColumnWorker<NestedBatch> {
         rowsInCurrentBatch = 0;
         nestedValueCount = 0;
         batchFixedK = 0;
+        // A page can span batches, so the next batch inherits the in-flight page's
+        // presence; later pages AND into it (see assemblePage).
+        currentBatchAllPresent = currentPageAllPresent;
         // The accumulator is reused for the next batch; clear its dictionary
         // slot so dictIndex state is rebuilt from scratch (the dictIndices array
         // is retained and overwritten in place).
@@ -496,7 +511,8 @@ public class NestedColumnWorker extends ColumnWorker<NestedBatch> {
             // drain keeps reconstruction off the serial consumer for both shapes: a
             // structural read gets its offsets without a consumer-side scan, and a
             // flat leaf read simply ignores them.
-            boolean allPresent = batch.fixedListK > 0 || allDefsMax(batch.valueCount);
+            boolean allPresent = batch.fixedListK > 0 || batch.allPresent
+                    || allDefsMax(batch.valueCount);
             if (allPresent) {
                 batch.realValues = batch.values;
                 // With no phantom positions the real-items offsets equal the all-items

--- a/core/src/main/java/dev/hardwood/internal/reader/NestedRowReader.java
+++ b/core/src/main/java/dev/hardwood/internal/reader/NestedRowReader.java
@@ -22,6 +22,7 @@ import dev.hardwood.internal.predicate.ResolvedPredicate;
 import dev.hardwood.internal.predicate.RowMatcher;
 import dev.hardwood.internal.schema.ProjectedSchema;
 import dev.hardwood.metadata.FieldPath;
+import dev.hardwood.metadata.RowGroup;
 import dev.hardwood.reader.RowReader;
 import dev.hardwood.row.PqInterval;
 import dev.hardwood.row.PqList;
@@ -99,6 +100,7 @@ public final class NestedRowReader implements RowReader {
     /// @param maxRows maximum rows (0 = unlimited). Without a filter this caps scanned
     ///                rows at the [ColumnWorker] drain. With a filter it caps *matching*
     ///                rows (SQL LIMIT), enforced over matches by the FilteredRowReader wrapper.
+    /// @param rowGroups first-file row groups, for fan-out-aware batch sizing
     /// @return a [NestedRowReader] or [FilteredRowReader]
     public static RowReader create(RowGroupIterator rowGroupIterator,
                             FileSchema schema,
@@ -106,8 +108,10 @@ public final class NestedRowReader implements RowReader {
                             HardwoodContextImpl context,
                             boolean fixedListFastPathEnabled,
                             ResolvedPredicate filter,
-                            long maxRows) {
-        int batchSize = BatchSizing.computeOptimalBatchSize(projectedSchema);
+                            long maxRows,
+                            List<RowGroup> rowGroups) {
+        int batchSize = BatchSizing.computeOptimalBatchSize(projectedSchema,
+                BatchSizing.valuesPerRow(projectedSchema, rowGroups));
         int projectedColumnCount = projectedSchema.getProjectedColumnCount();
         // With a row-level filter, `maxRows` caps *matching* rows (SQL LIMIT), so the
         // workers scan unbounded, and the FilteredRowReader wrapper enforces the cap.

--- a/core/src/main/java/dev/hardwood/internal/reader/Page.java
+++ b/core/src/main/java/dev/hardwood/internal/reader/Page.java
@@ -37,12 +37,20 @@ public sealed interface Page {
     /// [FixedSizeListDetector].
     int fixedListK();
 
+    /// True when every leaf on this page is present — no null or empty parents.
+    /// Represented as a `null` definition-level array (the reader's all-present
+    /// convention, produced by [PageDecoder]'s O(1) def-gate for both flat and
+    /// nested columns), so callers test presence without inspecting per-value
+    /// levels. A repetition-level array is still present for nested columns.
+    default boolean allPresent() {
+        return definitionLevels() == null;
+    }
+
     default boolean isNull(int index) {
-        int[] defLevels = definitionLevels();
-        if (defLevels == null) {
+        if (allPresent()) {
             return false;
         }
-        return defLevels[index] < maxDefinitionLevel();
+        return definitionLevels()[index] < maxDefinitionLevel();
     }
 
     /// Returns a copy of `page` marked as a fixed-width fixed-size-list page with

--- a/core/src/main/java/dev/hardwood/internal/reader/PageDecoder.java
+++ b/core/src/main/java/dev/hardwood/internal/reader/PageDecoder.java
@@ -168,15 +168,17 @@ public class PageDecoder {
     /// and represent "all present" as a `null` level array — the same
     /// representation used for required columns throughout the reader.
     ///
-    /// Restricted to flat columns; nested record assembly consumes the def-level
-    /// array directly and stays on the materializing path.
+    /// Applies to flat and nested columns alike: nested assembly treats a `null`
+    /// definition-level array as all-present (every leaf at `maxDef`) and takes a
+    /// whole-page bulk-copy path; the repetition levels are still materialised, so
+    /// record boundaries are preserved.
     private int[] decodeDefinitionLevels(byte[] levelData, int offset, int length, int numValues) {
         int maxDef = column.maxDefinitionLevel();
         int bitWidth = getBitWidth(maxDef);
         RleBitPackingHybridDecoder decoder = new RleBitPackingHybridDecoder(levelData, offset, length, bitWidth);
         // The probe loads the first run; if it is not the all-present fast path,
         // readInts below resumes from that same loaded run on the same instance.
-        if (column.maxRepetitionLevel() == 0 && decoder.isSingleRleRunOf(maxDef, numValues)) {
+        if (decoder.isSingleRleRunOf(maxDef, numValues)) {
             return null;
         }
         int[] levels = new int[numValues];

--- a/core/src/main/java/dev/hardwood/reader/ColumnReader.java
+++ b/core/src/main/java/dev/hardwood/reader/ColumnReader.java
@@ -876,7 +876,8 @@ public class ColumnReader implements AutoCloseable {
 
         int resolvedBatchSize = batchSize > 0
                 ? batchSize
-                : BatchSizing.computeOptimalBatchSize(projectedSchema);
+                : BatchSizing.computeOptimalBatchSize(projectedSchema,
+                        BatchSizing.valuesPerRow(projectedSchema, rowGroups));
 
         RowGroupIterator rowGroupIterator = new RowGroupIterator(
                 List.of(inputFile), context, 0);

--- a/core/src/main/java/dev/hardwood/reader/ParquetFileReader.java
+++ b/core/src/main/java/dev/hardwood/reader/ParquetFileReader.java
@@ -388,7 +388,7 @@ public class ParquetFileReader implements AutoCloseable {
             iterator.setTailSkip(skip);
         }
 
-        RowReader reader = createRowReader(iterator, schema, projectedSchema, context, null, 0);
+        RowReader reader = createRowReader(iterator, schema, projectedSchema, context, null, 0, subset);
 
         if (!fastSkip) {
             // Fallback: at least one projected column closes the per-page
@@ -431,7 +431,8 @@ public class ParquetFileReader implements AutoCloseable {
         // discard a no-op — for non-skip reads and for the filtered (logical) skip path.
         long firstRowGroupSkip = iterator.firstRowGroupSkip();
         long readerMaxRows = maxRows == 0 ? 0 : Math.addExact(maxRows, firstRowGroupSkip);
-        RowReader reader = createRowReader(iterator, schema, projectedSchema, context, resolved, readerMaxRows);
+        RowReader reader = createRowReader(iterator, schema, projectedSchema, context, resolved, readerMaxRows,
+                firstFileRowGroups);
         return discardLeadingRows(reader, firstRowGroupSkip);
     }
 
@@ -447,17 +448,19 @@ public class ParquetFileReader implements AutoCloseable {
     /// @param context hardwood context
     /// @param filter resolved predicate, or `null` for no filtering
     /// @param maxRows maximum rows (0 = unlimited)
+    /// @param rowGroups first-file row groups, for fan-out-aware batch sizing (nested path)
     private RowReader createRowReader (RowGroupIterator rowGroupIterator,
                             FileSchema schema,
                             ProjectedSchema projectedSchema,
                             HardwoodContextImpl context,
                             ResolvedPredicate filter,
-                            long maxRows) {
+                            long maxRows,
+                            List<RowGroup> rowGroups) {
         if (schema.isFlatSchema()) {
             return FlatRowReader.create(rowGroupIterator, schema, projectedSchema, context, filter, maxRows);
         }
         else {
-            return NestedRowReader.create(rowGroupIterator, schema, projectedSchema, context, fixedListFastPathEnabled, filter, maxRows);
+            return NestedRowReader.create(rowGroupIterator, schema, projectedSchema, context, fixedListFastPathEnabled, filter, maxRows, rowGroups);
         }
     }
 
@@ -520,7 +523,7 @@ public class ParquetFileReader implements AutoCloseable {
                 return ColumnReaders.noRows(schema, projected);
             }
             return new ColumnReaders(context, fixedListFastPathEnabled, iterator, schema, projected,
-                    resolveBatchSize(batchSize, projected));
+                    resolveBatchSize(batchSize, projected, rowGroups));
         }
 
         // Exact filtering (#624): decode the payload columns *and* the predicate
@@ -545,16 +548,20 @@ public class ParquetFileReader implements AutoCloseable {
         // per-batch arrays too, so they count toward the byte budget.
         return ColumnReaders.filtered(
                 context, fixedListFastPathEnabled, iterator, schema, augProjected, payloadProjected, resolved,
-                resolveBatchSize(batchSize, augProjected));
+                resolveBatchSize(batchSize, augProjected, rowGroups));
     }
 
     /// Resolves a requested batch size to a concrete record count. A positive
     /// `requested` (set explicitly via the builders' `batchSize(int)`) is used
     /// verbatim; the [#AUTO_BATCH_SIZE] sentinel is turned into a byte-budgeted
-    /// size derived from the projected column widths, the same logic the
-    /// `RowReader` path uses, so both regimes agree.
-    private static int resolveBatchSize(int requested, ProjectedSchema projected) {
-        return requested > 0 ? requested : BatchSizing.computeOptimalBatchSize(projected);
+    /// size derived from the projected column widths scaled by their list fan-out
+    /// (from `rowGroups` metadata), the same logic the `RowReader` path uses, so
+    /// both regimes agree.
+    private static int resolveBatchSize(int requested, ProjectedSchema projected, List<RowGroup> rowGroups) {
+        return requested > 0
+                ? requested
+                : BatchSizing.computeOptimalBatchSize(projected,
+                        BatchSizing.valuesPerRow(projected, rowGroups));
     }
 
     /// Builds the union of `projection` and the predicate's leaf columns so the

--- a/core/src/test/java/dev/hardwood/FixedSizeListFastPathReadTest.java
+++ b/core/src/test/java/dev/hardwood/FixedSizeListFastPathReadTest.java
@@ -163,6 +163,77 @@ class FixedSizeListFastPathReadTest {
         }
     }
 
+    /// The fast-path value hand-off across many full batches. A purely fixed-width
+    /// file (k=8, 128 rows, no nulls) read with `batchSize = 10` fills twelve
+    /// complete 10-row batches — each handed straight to the published batch by
+    /// [prepareFixedWidthValues]/publishCurrentBatch instead of trimmed out of the
+    /// accumulator — then a final 8-row partial batch (128 % 10 != 0), which is below
+    /// the pinned capacity and still trims. Default (large) batch sizes never fill a
+    /// small fixture to capacity, so this is the only place the hand-off runs.
+    ///
+    /// Two things are asserted. First, values stay correct across every hand-off
+    /// boundary (vs. the reconstruction path and the generator formula). Second — the
+    /// invariant the hand-off trades `trimValues` for — a handed-off array is never
+    /// aliased into the reused accumulator: each batch's array is retained alongside a
+    /// snapshot and, after the whole file is drained (the producer assembles later
+    /// batches ahead of the consumer), must be unchanged. Aliasing would make the
+    /// drain overwrite an earlier batch's values while it is still live.
+    @Test
+    void fixedWidthValueHandoffAcrossFullBatches() throws Exception {
+        int k = 8;
+        int batchSize = 10;
+        Path file = resource(k, "v2");
+
+        List<float[]> retained = new ArrayList<>();
+        List<float[]> snapshots = new ArrayList<>();
+        List<float[]> viaFast = new ArrayList<>();
+        try (HardwoodContext context = HardwoodContext.create();
+             ParquetFileReader reader = ParquetFileReader.open(InputFile.of(file), context, FAST_PATH_ON);
+             ColumnReader col = reader.buildColumnReader(COLUMN).batchSize(batchSize).build()) {
+            while (col.nextBatch()) {
+                int recordCount = col.getRecordCount();
+                int[] offsets = col.getLayerOffsets(0);
+                float[] values = col.getFloats();
+                retained.add(values);
+                snapshots.add(values.clone());
+                for (int r = 0; r < recordCount; r++) {
+                    float[] vec = new float[offsets[r + 1] - offsets[r]];
+                    System.arraycopy(values, offsets[r], vec, 0, vec.length);
+                    viaFast.add(vec);
+                }
+            }
+        }
+
+        // The hand-off boundary was actually crossed (more than one batch) with a
+        // partial tail — otherwise the coverage below would be vacuous.
+        assertThat(retained.size()).as("batch count (full hand-offs + partial tail)").isGreaterThan(1);
+        assertThat(viaFast).hasSize(128);
+
+        // Aliasing tripwire: no later batch's assembly clobbered an earlier handed-off
+        // array while it was still live.
+        for (int b = 0; b < retained.size(); b++) {
+            assertThat(retained.get(b)).as("batch %d values stable after later batches drained", b)
+                    .containsExactly(snapshots.get(b));
+        }
+
+        // Cross-check the reconstruction path and the deterministic generator formula.
+        List<float[]> viaRegular;
+        try (HardwoodContext context = HardwoodContext.create()) {
+            viaRegular = readMixedRecords(file, COLUMN, batchSize, context,
+                    ReaderConfig.builder().option("hardwood.fixed-list-fast-path", "false").build());
+        }
+        assertThat(viaFast).as("fast vs reconstruction record count").hasSameSizeAs(viaRegular);
+        for (int r = 0; r < viaFast.size(); r++) {
+            assertThat(viaFast.get(r)).as("record %d fast vs reconstruction", r)
+                    .containsExactly(viaRegular.get(r));
+            float[] expected = new float[k];
+            for (int i = 0; i < k; i++) {
+                expected[i] = (r * k + i) * 1.5f + 0.25f;
+            }
+            assertThat(viaFast.get(r)).as("record %d generator formula", r).containsExactly(expected);
+        }
+    }
+
     /// Reads a nullable fixed-size-list column record by record, returning `null`
     /// for a null row and the element slice otherwise, flattened across batches.
     private static List<float[]> readMixedRecords(Path file, String column, int batchSize,

--- a/core/src/test/java/dev/hardwood/WideListBatchBoundTest.java
+++ b/core/src/test/java/dev/hardwood/WideListBatchBoundTest.java
@@ -1,0 +1,91 @@
+/*
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Copyright The original authors
+ *
+ *  Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package dev.hardwood;
+
+import java.nio.ByteBuffer;
+
+import org.junit.jupiter.api.Test;
+
+import dev.hardwood.internal.writer.ByteBufferOutputFile;
+import dev.hardwood.metadata.PhysicalType;
+import dev.hardwood.metadata.RepetitionType;
+import dev.hardwood.reader.ColumnReader;
+import dev.hardwood.reader.ParquetFileReader;
+import dev.hardwood.schema.FileSchema;
+import dev.hardwood.writer.ParquetFileWriter;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/// Regression test for #748. A wide repeated column expands each row into many
+/// leaf values, so a value array sized by row count alone is the list's fan-out
+/// times larger than the byte budget. When the row count fits under
+/// `BatchSizing.MAX_BATCH`, the fan-out-blind sizing drained the whole column
+/// into a single batch — value and level arrays scaled by the fan-out — which is
+/// memory-bound to assemble and scan and, at higher fan-out, exhausted the heap.
+///
+/// Fan-out-aware sizing must bound each batch by value memory, so a wide list is
+/// split across several batches rather than materialised in one.
+class WideListBatchBoundTest {
+
+    private static final int K = 512;      // leaf values per row (list fan-out)
+    private static final int ROWS = 4000;  // < MAX_BATCH rows, but ROWS * K = 2.05M values >> the byte budget
+    private static final String LEAF = "v.list.element";
+
+    @Test
+    void wideListIsNotDrainedIntoOneOversizedBatch() throws Exception {
+        byte[] file = writeFixedWidthListOfInts();
+
+        long totalValues = 0;
+        long maxBatchValues = 0;
+        int batches = 0;
+        try (ParquetFileReader reader =
+                        ParquetFileReader.open(InputFile.of(ByteBuffer.wrap(file)));
+                // Default (auto) batch size — the path #748 fixed.
+                ColumnReader col = reader.columnReader(LEAF)) {
+            while (col.nextBatch()) {
+                batches++;
+                int values = col.getValueCount();
+                totalValues += values;
+                maxBatchValues = Math.max(maxBatchValues, values);
+            }
+        }
+
+        // Every value is read back...
+        assertThat(totalValues).isEqualTo((long) ROWS * K);
+        // ...but the column is split by value budget, not handed over in one batch
+        // whose value array is the fan-out times the intended footprint.
+        assertThat(batches).isGreaterThan(1);
+        assertThat(maxBatchValues).isLessThan((long) ROWS * K);
+    }
+
+    /// A `REQUIRED list<REQUIRED int32>` of exactly `K` present elements per row,
+    /// written as one row group.
+    private static byte[] writeFixedWidthListOfInts() throws Exception {
+        FileSchema schema = FileSchema.builder("schema")
+                .list("v", RepetitionType.REQUIRED,
+                        el -> el.primitive(PhysicalType.INT32, RepetitionType.REQUIRED))
+                .build();
+
+        int[] offsets = new int[ROWS + 1];
+        for (int i = 0; i <= ROWS; i++) {
+            offsets[i] = i * K;
+        }
+        int[] elements = new int[ROWS * K];
+        for (int i = 0; i < elements.length; i++) {
+            elements[i] = i;
+        }
+
+        ByteBufferOutputFile out = new ByteBufferOutputFile();
+        try (ParquetFileWriter writer = ParquetFileWriter.create(out, schema)) {
+            writer.writeBatch(batch -> batch
+                    .list("v", offsets)
+                    .ints(LEAF, elements));
+        }
+        return out.toByteArray();
+    }
+}

--- a/core/src/test/java/dev/hardwood/internal/reader/BatchSizingTest.java
+++ b/core/src/test/java/dev/hardwood/internal/reader/BatchSizingTest.java
@@ -20,8 +20,9 @@ import dev.hardwood.schema.FileSchema;
 import static org.assertj.core.api.Assertions.assertThat;
 
 /// Verifies the byte-budgeted batch sizing the column- and row-reader paths
-/// share: the size depends on the projected columns' physical widths and is
-/// clamped to `[16 384, MAX_BATCH]`, rather than being a fixed record count.
+/// share: the size depends on the projected columns' physical widths scaled by
+/// their list fan-out, clamped to at most `MAX_BATCH`, rather than being a fixed
+/// record count.
 class BatchSizingTest {
 
     /// `int_col` (INT32), `long_col` (INT64), `float_col` (FLOAT),
@@ -63,6 +64,28 @@ class BatchSizingTest {
             int expected = (int) (TARGET_BYTES / 32);
             assertThat(sizeFor(reader, "long_col", "double_col", "string_col")).isEqualTo(expected);
             assertThat(expected).isBetween(16_384, BatchSizing.MAX_BATCH);
+        }
+    }
+
+    @Test
+    void fanoutScalesTheByteBudgetByValuesPerRow() throws Exception {
+        try (ParquetFileReader reader = ParquetFileReader.open(InputFile.of(PRIMITIVES))) {
+            FileSchema schema = reader.getFileSchema();
+            ProjectedSchema projected =
+                    ProjectedSchema.create(schema, ColumnProjection.columns("float_col"));
+
+            // Fan-out 1 (a flat float column): 4 bytes/row budgets far above the clamp.
+            assertThat(BatchSizing.computeOptimalBatchSize(projected, new double[] { 1.0 }))
+                    .isEqualTo(BatchSizing.MAX_BATCH);
+
+            // Fan-out 768 (a 768-wide LIST<float32>): each row is 768 * 4 = 3072 bytes,
+            // so the batch follows the byte budget down to 2 048 rows — far below the
+            // 16 384 rows a fan-out-blind sizing would have forced, which would have made
+            // the value array ~768x the L2 target.
+            assertThat(BatchSizing.computeOptimalBatchSize(projected, new double[] { 768.0 }))
+                    .isEqualTo((int) (TARGET_BYTES / (768 * 4)))
+                    .isEqualTo(2048)
+                    .isLessThan(16_384);
         }
     }
 


### PR DESCRIPTION
Two related improvements to the nested / fixed-size-list read path, landing together (the second builds on the first).

## #786 — bulk-copy all-present nested values

The regular nested assembly path materialized leaf values one element at a time, spending most of its instructions on per-element bookkeeping (capacity checks, bounds-checked level stores, a destination checkcast) around a two-instruction value copy. When a page is proven all-present by `PageDecoder`'s O(1) def-gate — now applied to nested columns, not only flat — its leaves are one contiguous, record-aligned block, now gathered in bulk: values, the constant definition levels, and the repetition levels once per batch. Byte-array leaves and masked or null-bearing pages keep the per-element path.

The fixed-size-list fast path, which previously copied one *k*-value record at a time (an `arraycopy` per record — crippling at small *k*), is rebuilt on the same span-copy primitive: one `copyValueRun` per contiguous run of kept records. Both paths now gather values the same way.

## #748 — fan-out-aware batch sizing

`BatchSizing` budgeted a batch by row count times a per-row byte estimate that assumed **one value per row**. A repeated column expands each row into many leaf values, so a wide `LIST<float32>` (768-element vectors) produced a value array ~768× the intended 6 MB L2 budget — a ~512 MB batch whenever the whole column fits under `MAX_BATCH` rows, memory-bound to assemble and to scan, and an outright OOME at higher fan-out.

The budget now folds in each column's average list fan-out (from column-chunk metadata) plus the per-value level bytes a repeated column's nested worker allocates, and the row floor is dropped. Every auto-sizing site — the single-column `ColumnReader`, the multi-column / filtered `ColumnReaders`, and `NestedRowReader` — routes through the same computation, so both reader regimes produce identical batch sizes for a projection (`FlatRowReader` is one value per row and unchanged).

## Results

Intel N300, **all 8 cores**, warm cache, `LIST<float32>` 768-element vectors, 128M values/file. Throughput in M float32 values/s (higher is better):

| contender | before (main) | after (this PR) |
|---|---:|---:|
| columnFast | 209 | **357** |
| columnBaseline | 90 | 202 |
| rowFast | 207 | **349** |
| rowBaseline | 72 | 147 |
| flat-column floor | 592 | 576 |

Every reader roughly doubles, and the fixed-size-list fast path moves from **2.8× below** the flat-column decode floor to **~1.6×**.

### Headline — reading 768-wide vectors (k=768, 128M values)

| before (main) | after (this PR) |
|:---:|:---:|
| ![headline before](https://raw.githubusercontent.com/hardwood-hq/hardwood/pr789-charts/pr789-headline-before.png) | ![headline after](https://raw.githubusercontent.com/hardwood-hq/hardwood/pr789-charts/pr789-headline-after.png) |

### Speedup over record-reconstruction across k (8M values)

| before (main) | after (this PR) |
|:---:|:---:|
| ![sweep before](https://raw.githubusercontent.com/hardwood-hq/hardwood/pr789-charts/pr789-sweep-before.png) | ![sweep after](https://raw.githubusercontent.com/hardwood-hq/hardwood/pr789-charts/pr789-sweep-after.png) |

The fast-path-over-baseline **ratio** shrinks at large *k* after the PR (column 2.4× → 1.8×) — this is not a regression: #786 makes the reconstruction *baseline* itself much faster, so the fast path's relative lead narrows even as absolute times fall for both. The visible sweep win is at small *k*, where the per-run copy lifts the column fast path from **0.9× (slower than the baseline) → 1.1×**.

### Balanced machine — AWS m7i.2xlarge, all cores (k=768, 128M values)

The N300 above has a single memory channel, so an all-core scan is bandwidth-bound and the fast path — which moves more memory — can't reach the floor there (its all-core ~1.6× gap is in fact *worse* than single-core's ~1.07×, as 8 cores saturate the one channel). On a balanced multi-channel host that ceiling lifts and the fast path reaches the flat-column decode floor:

![headline aws](https://raw.githubusercontent.com/hardwood-hq/hardwood/pr789-charts/pr789-headline-aws.png)

Column fast **866** vs. floor **879** M values/s — **1.4% off**, 1.9× over baseline; row fast **860** (4.2× over baseline), also at the floor.

## Validation

- Full `core` suite green (**1698** tests), including a new OOM regression test (`WideListBatchBoundTest`) — verified **red without** the fan-out fix (the column drains into one batch) and **green with** it.
- Differential (DuckDB oracle) and nested suites green.

## Notes

- Charts live on the `pr789-charts` assets branch (kept out of this PR's diff; safe to delete after merge).
- Design docs: `NESTED_ALL_PRESENT_PAGE_BULK_COPY.md` (new), `COLUMN_READER_ADAPTIVE_BATCH_SIZING.md` (extended for fan-out), `FIXED_SIZE_LIST_FASTPATH.md` (assembly description).
- Follow-up: sub-page present-run copying (#750).

Closes #786
Closes #748


