### PR TITLE
#9 Write support stage 10: page compression with size accounting

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -191,7 +191,7 @@ For field-level `parquet.thrift` metadata coverage (which spec fields are read/p
 - [x] Automatic row group flushing
 - [x] Dictionary page writing
 - [x] Data page encoding and writing
-- [ ] Page compression
+- [x] Page compression
 - [x] Footer writing
 - [x] File finalization
 

--- a/_designs/WRITER_DICTIONARY.md
+++ b/_designs/WRITER_DICTIONARY.md
@@ -154,6 +154,15 @@ Dictionary encoding is **on by default** for every `INT32` column and can be dis
 writer through `WriterConfig.enableDictionary(false)`, in which case every chunk is `PLAIN`
 from the start with no dictionary page — the stage 1–8 behaviour.
 
+The mid-chunk fallback described here is the stage-9 mechanism: the encoding is chosen
+value-by-value from a byte-limit heuristic, so a chunk can carry an `RLE_DICTIONARY` prefix
+followed by `PLAIN` pages. Stage 16 ([WRITER_SUPPORT.md](WRITER_SUPPORT.md)) replaces the
+heuristic with a row-group-global decision taken once the group is buffered — each chunk is
+encoded `RLE_DICTIONARY` or `PLAIN` as a whole from its true cardinality, so no chunk mixes
+encodings and no dictionary page is written for a chunk that ends up `PLAIN`. The
+per-page-encoding invariant above still holds; it is simply no longer exercised within a
+single chunk.
+
 ## `ColumnMetaData` wiring
 
 `ColumnMetaDataWriter` gains two things:

--- a/_designs/WRITER_SUPPORT.md
+++ b/_designs/WRITER_SUPPORT.md
@@ -248,7 +248,9 @@ The writer auto-selects sensible per-column encodings and exposes overrides thro
   optional and deferred to a later breadth increment.
 - **Compression**: `UNCOMPRESSED` first, then `SNAPPY` / `ZSTD` / `GZIP` / `LZ4` —
   the existing codec libraries are bidirectional, so the encode side reuses them.
-  Default codec is `ZSTD`.
+  The default codec is `ZSTD` when the zstd-jni library is on the classpath and
+  `UNCOMPRESSED` otherwise, so a caller who did not ask to compress is not forced to
+  carry the optional dependency; selecting a codec explicitly still requires its library.
 
 `WriterConfig` knobs: row-group size, page size, dictionary page-size limit, codec,
 and the written `created_by` string.
@@ -329,7 +331,7 @@ API), *Optimization*, *Spike* (design-only), or *Docs* (user-facing documentatio
 | 7 | **List shredding** (`INT32` leaves): `REPEATED` fields — repetition levels via `LevelEncoder`, offset-driven nested input. | Dimension | The repetition-level data model is settled | 3.3 (rep levels), 6.3 | [x] |
 | 8 | **Map shredding** (`INT32` leaves): key/value repeated group, reusing the list machinery. | Dimension | The full nested shape (structs, lists, maps) is settled | 6.3 | [x] |
 | 9 | Dictionary encoding (`INT32`): dictionary page + `RLE_DICTIONARY` indices + plain fallback, exercised on nullable and nested columns so the level + dictionary-index page layout is proven together. Settled in `_designs/WRITER_DICTIONARY.md`. | Dimension | Dictionary column-chunk layout proven, incl. nulls and nesting | 2.2 | [x] |
-| 10 | Compression on the write path (`INT32`, one codec). | Dimension | Compress step + compressed/uncompressed size accounting proven | 6.2 (page compression) | [ ] |
+| 10 | Compression on the write path (`INT32`, one codec). | Dimension | Compress step + compressed/uncompressed size accounting proven | 6.2 (page compression) | [x] |
 | 11 | Column statistics (`INT32`: `min`/`max`/`null_count`, `ColumnOrder`-correct) accumulated during encode. | Dimension | Produced files support pushdown | 9.1 (stats) | [ ] |
 | 12 | All primitive physical types (incl. `FIXED_LEN_BYTE_ARRAY` type length and `BYTE_ARRAY` min/max truncation), each inheriting paging, nulls, nesting, dictionary, compression and stats. Variable-width values end the constant-bytes-per-row assumption, so the row-group flush moves from the fixed rows-per-group proxy (`rowGroupTargetBytes / (columnCount × 4)`) to tracking the actual buffered uncompressed bytes. | Breadth | Write any column type, flat or nested | 2.1, 9.1 (truncation) | [ ] |
 | 13 | Logical-type annotations: `LogicalTypeWriter` serializes the `LogicalType` union and legacy `converted_type`/`scale`/`precision`; `FileSchema.Builder` logical-type overload. Both annotations are emitted together for every type with a legacy equivalent (STRING, DATE, DECIMAL, the INT/UINT widths, TIME/TIMESTAMP millis+micros, ENUM, JSON, BSON, `LIST`, `MAP`), the union taking read precedence and the `converted_type` kept for pre-union readers; only types without a legacy equivalent (UUID, FLOAT16, NANOS units, VARIANT, GEOMETRY/GEOGRAPHY) are union-only. This makes stage 13 additive to the `converted_type`-only annotations stages 6–8 already write. | Breadth | Columns read back with their logical type (STRING, DATE, TIMESTAMP, DECIMAL, …) | 6.4 (annotation) | [ ] |

--- a/_designs/WRITER_SUPPORT.md
+++ b/_designs/WRITER_SUPPORT.md
@@ -39,8 +39,9 @@ is serialized onto the schema and converted at the API boundary.
 
 Sequenced as later work, each its own design: DataPage V2, the Avro write API, the
 optional index structures (OffsetIndex, ColumnIndex, Bloom filters), the optional delta
-and byte-stream-split encoders, a CLI write/convert command, and the S3 `OutputFile`
-backend. Sorting-column metadata and custom record materializers are non-goals.
+and byte-stream-split encoders, and a CLI write/convert command. The S3 `OutputFile`
+backend is planned as increment 19 below. Sorting-column metadata and custom record
+materializers are non-goals.
 
 ## Write model
 
@@ -170,8 +171,13 @@ public interface OutputFile extends Closeable {
   write never leaves a truncated file presented as valid.
 - **In-memory backend** (`internal.writer.ByteBufferOutputFile`): a growable buffer,
   the write-side counterpart to `ByteBufferInputFile`, used for tests and round-trips.
-- **S3 backend** (later): sequential writes buffer to the multipart part size and
-  upload parts; `close()` completes the multipart upload.
+- **S3 backend** (`internal.writer.S3OutputFile`, increment 19): sequential writes buffer
+  to the multipart part size and upload parts; `close()` completes the multipart upload.
+  In-flight bytes are bounded to the part size times a small concurrency multiple, so a
+  fast producer cannot outrun the uploads; `CreateMultipartUpload` is deferred until the
+  first part flushes, with a single `PutObject` for an output that never exceeds one part.
+  It reuses the read-side S3 / SigV4 stack (`_designs/S3_OBJECT_STORAGE.md`,
+  `_designs/S3_ZERO_SDK.md`).
 
 A file is valid only after `close()` returns successfully. A writer abandoned before
 `close()` produces no footer and therefore no readable file.
@@ -242,10 +248,14 @@ The writer auto-selects sensible per-column encodings and exposes overrides thro
 
 - **Levels**: definition and repetition levels are RLE/bit-packed via `LevelEncoder`
   (flat schemas have no repetition levels; nested columns add a repetition-level stream).
-- **Values**: `PLAIN` is the correctness baseline. `RLE_DICTIONARY` with plain
-  fallback (on dictionary-size overflow) is the default for eligible columns, matching
-  the reader's dictionary fast paths. The delta and byte-stream-split encodings are
-  optional and deferred to a later breadth increment.
+- **Values**: `PLAIN` is the correctness baseline. `RLE_DICTIONARY` is the default for
+  eligible columns, matching the reader's dictionary fast paths; a column chunk that is
+  not dictionary-friendly is written `PLAIN` instead. The dictionary-vs-`PLAIN` choice is
+  made per column chunk from its cardinality — incrementally with a mid-chunk `PLAIN`
+  fallback on dictionary-size overflow initially (stage 9), then as a row-group-global
+  decision taken once the group is buffered (stage 16), so no chunk mixes encodings. The
+  delta and byte-stream-split encodings are optional and deferred to a later breadth
+  increment.
 - **Compression**: `UNCOMPRESSED` first, then `SNAPPY` / `ZSTD` / `GZIP` / `LZ4` —
   the existing codec libraries are bidirectional, so the encode side reuses them.
   The default codec is `ZSTD` when the zstd-jni library is on the classpath and
@@ -337,27 +347,30 @@ API), *Optimization*, *Spike* (design-only), or *Docs* (user-facing documentatio
 | 13 | Logical-type annotations: `LogicalTypeWriter` serializes the `LogicalType` union and legacy `converted_type`/`scale`/`precision`; `FileSchema.Builder` logical-type overload. Both annotations are emitted together for every type with a legacy equivalent (STRING, DATE, DECIMAL, the INT/UINT widths, TIME/TIMESTAMP millis+micros, ENUM, JSON, BSON, `LIST`, `MAP`), the union taking read precedence and the `converted_type` kept for pre-union readers; only types without a legacy equivalent (UUID, FLOAT16, NANOS units, VARIANT, GEOMETRY/GEOGRAPHY) are union-only. This makes stage 13 additive to the `converted_type`-only annotations stages 6–8 already write. | Breadth | Columns read back with their logical type (STRING, DATE, TIMESTAMP, DECIMAL, …) | 6.4 (annotation) | [ ] |
 | 14 | Remaining codecs + optional delta and byte-stream-split encoders. | Breadth | Full codec / encoding choice | 2.4, 2.5 | [ ] |
 | 15 | Parallel column encoding + row-group pipelining. | Optimization | Write throughput | — | [ ] |
-| 16 | Row-oriented `ParquetWriter` ergonomic layer on the columnar core, including nested record materialization and logical-type value conversion (inverse of `LogicalTypeConverter`). | Layer | Mainstream-friendly API | 6.1 (`ParquetWriter`), 6.4 (value conversion) | [ ] |
-| 17 | User-facing documentation under `docs/content/` for the writer public API (`OutputFile`, `ParquetFileWriter`, `FileSchema.Builder`): a `how-to` guide and a `reference` page, covering the settled surface including nesting and the row-oriented layer. | Docs | Documented, stable public API | — | [ ] |
+| 16 | **Row-group-global dictionary selection**: replace the per-column-chunk optimistic build with mid-chunk `PLAIN` fallback (stage 9) with a choice made once the row group is fully buffered — each column chunk is encoded `RLE_DICTIONARY` or `PLAIN` as a whole from its true cardinality, so no chunk mixes encodings and no dictionary page is written for a chunk that ends up `PLAIN`. Trades a second encode pass and higher peak buffer occupancy for the optimal per-chunk choice; the payoff scales with the variable-width types from stage 12, where indices are far smaller than the values and the dictionary byte-limit is a poor proxy for whether encoding pays. With the whole group buffered the choice follows from the exact cardinality — and, where the byte-limit proxy is weakest, a direct comparison of the two encodings' sizes — so no predictive threshold is needed; the stage-9 streaming abort heuristic does not apply here. | Optimization | Optimal, uniform per-chunk encoding choice | 2.2 | [ ] |
+| 17 | Row-oriented `ParquetWriter` ergonomic layer on the columnar core, including nested record materialization and logical-type value conversion (inverse of `LogicalTypeConverter`). | Layer | Mainstream-friendly API | 6.1 (`ParquetWriter`), 6.4 (value conversion) | [ ] |
+| 18 | User-facing documentation under `docs/content/` for the writer public API (`OutputFile`, `ParquetFileWriter`, `FileSchema.Builder`): a `how-to` guide and a `reference` page, covering the settled surface including nesting and the row-oriented layer. | Docs | Documented, stable public API | — | [ ] |
+| 19 | S3 `OutputFile` backend: sequential multipart upload — buffer to the part size, upload parts, complete on `close()`. In-flight bytes bounded to the part size times a small concurrency multiple; lazy `CreateMultipartUpload` deferred to the first part flush, with a single `PutObject` fallback for a sub-part output. Reuses the read-side S3 / SigV4 stack. | Layer | Write directly to object storage | — | [ ] |
 
 Increments 1–4 settle the flat dimensions on `INT32`; 5–8 settle the nested shape —
 design, then struct / list / map shredding — on `INT32`; 9–11 finish the remaining
-dimensions (dictionary, compression, statistics) on the now flat-and-nested shape; 12–16
-are breadth and layers that build on the settled shape; 17 documents the finished public
-surface. Together they constitute the write-support milestone (#9). Sequenced as later
-work, each its own design and sequence: DataPage V2, the optional index structures and
-Bloom filters, the Avro write adapter, a CLI write/convert command, and the S3
-`OutputFile` backend.
+dimensions (dictionary, compression, statistics) on the now flat-and-nested shape; 12–14
+are breadth on the settled shape, 15–16 are internal encoding optimizations, and 17 is the
+row-oriented layer; 18 documents the finished public surface. Together, increments 1–18
+constitute the write-support milestone (#9); increment 19 adds the S3 `OutputFile` backend
+on the settled surface. Sequenced as later work, each its own design and sequence: DataPage
+V2, the optional index structures and Bloom filters, the Avro write adapter, and a CLI
+write/convert command.
 
 ## User documentation
 
 User-facing documentation under `docs/content/` is delivered as the closing increment
-of the milestone (stage 17), once the full public surface — including nesting and the
+of the milestone (stage 18), once the full public surface — including nesting and the
 row-oriented layer — is settled. Documenting the provisional `INT32`-only surface earlier
 would be throwaway, so deferring is a recorded, intentional exception to the CLAUDE.md
 rule that a new public API ships with a docs update — not an oversight. The public surface
 (`OutputFile`, `ParquetFileWriter`, `FileSchema.Builder`) gets its `how-to`/`reference`
-pages at stage 17.
+pages at stage 18.
 
 ## Roadmap reconciliation
 

--- a/core/src/main/java/dev/hardwood/internal/compression/CodecLibraries.java
+++ b/core/src/main/java/dev/hardwood/internal/compression/CodecLibraries.java
@@ -1,0 +1,50 @@
+/*
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Copyright The original authors
+ *
+ *  Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package dev.hardwood.internal.compression;
+
+/// Probes for the optional per-codec libraries (zstd-jni, snappy-java, lz4-java, …) on the
+/// classpath. These are optional dependencies, so both the read and write paths must confirm
+/// a codec's library is present before handing work to it, and fail with an actionable message
+/// naming the missing dependency when it is not.
+public final class CodecLibraries {
+
+    private CodecLibraries() {
+    }
+
+    /// Whether `className` is loadable from this class's loader. The class is probed for
+    /// presence only, not initialized, so probing a native-backed codec never triggers its
+    /// native load.
+    ///
+    /// @param className the fully qualified class to probe for
+    /// @return `true` when the class is on the classpath
+    public static boolean isPresent(String className) {
+        try {
+            Class.forName(className, false, CodecLibraries.class.getClassLoader());
+            return true;
+        }
+        catch (ClassNotFoundException e) {
+            return false;
+        }
+    }
+
+    /// Ensures the library class backing a codec is on the classpath, throwing an
+    /// [UnsupportedOperationException] that names the dependency to add otherwise.
+    ///
+    /// @param className the library class that must be loadable
+    /// @param codecName the codec's name, for the error message
+    /// @param dependency the Maven coordinates to add when the library is missing
+    /// @param action `read` or `write`, naming the path that needs the library
+    /// @throws UnsupportedOperationException if the library is not on the classpath
+    public static void require(String className, String codecName, String dependency, String action) {
+        if (!isPresent(className)) {
+            throw new UnsupportedOperationException(
+                    "Cannot " + action + " " + codecName + "-compressed Parquet file: required library not found. " +
+                            "Add the following dependency to your project: " + dependency);
+        }
+    }
+}

--- a/core/src/main/java/dev/hardwood/internal/compression/Compressor.java
+++ b/core/src/main/java/dev/hardwood/internal/compression/Compressor.java
@@ -1,0 +1,30 @@
+/*
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Copyright The original authors
+ *
+ *  Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package dev.hardwood.internal.compression;
+
+import java.io.IOException;
+
+/// Compresses a page body on the write path, the inverse of [Decompressor].
+///
+/// A page's body — level streams and values — is compressed as one unit before its
+/// header is framed, so the header can record both the uncompressed and compressed sizes.
+public interface Compressor {
+
+    /// Compress `length` bytes of `data` starting at `offset`, returning a newly allocated
+    /// array sized exactly to the compressed output.
+    ///
+    /// @param data the buffer holding the bytes to compress
+    /// @param offset the first byte to compress
+    /// @param length the number of bytes to compress
+    /// @return the compressed bytes, in an array whose length is the compressed size
+    /// @throws IOException if compression fails
+    byte[] compress(byte[] data, int offset, int length) throws IOException;
+
+    /// The name of this compressor.
+    String getName();
+}

--- a/core/src/main/java/dev/hardwood/internal/compression/CompressorFactory.java
+++ b/core/src/main/java/dev/hardwood/internal/compression/CompressorFactory.java
@@ -1,0 +1,46 @@
+/*
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Copyright The original authors
+ *
+ *  Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package dev.hardwood.internal.compression;
+
+import dev.hardwood.metadata.CompressionCodec;
+
+/// Factory for [Compressor] instances, the write-side counterpart to [DecompressorFactory].
+///
+/// The write path currently supports `UNCOMPRESSED` and `ZSTD`; the remaining codecs are
+/// rejected until later increments add their encode side.
+public class CompressorFactory {
+
+    /// Get a compressor for the given compression codec.
+    ///
+    /// @param codec the compression codec
+    /// @return the appropriate compressor
+    /// @throws UnsupportedOperationException if the codec cannot yet be written, or the required
+    ///         library is missing
+    public Compressor getCompressor(CompressionCodec codec) {
+        return switch (codec) {
+            case UNCOMPRESSED -> new UncompressedCompressor();
+            case ZSTD -> {
+                checkClassAvailable("com.github.luben.zstd.Zstd", "ZSTD", "com.github.luben:zstd-jni");
+                yield new ZstdCompressor();
+            }
+            default -> throw new UnsupportedOperationException(
+                    "Writing " + codec + "-compressed pages is not yet supported");
+        };
+    }
+
+    private static void checkClassAvailable(String className, String codecName, String dependency) {
+        try {
+            Class.forName(className);
+        }
+        catch (ClassNotFoundException e) {
+            throw new UnsupportedOperationException(
+                    "Cannot write " + codecName + "-compressed Parquet file: required library not found. " +
+                            "Add the following dependency to your project: " + dependency);
+        }
+    }
+}

--- a/core/src/main/java/dev/hardwood/internal/compression/CompressorFactory.java
+++ b/core/src/main/java/dev/hardwood/internal/compression/CompressorFactory.java
@@ -25,22 +25,11 @@ public class CompressorFactory {
         return switch (codec) {
             case UNCOMPRESSED -> new UncompressedCompressor();
             case ZSTD -> {
-                checkClassAvailable("com.github.luben.zstd.Zstd", "ZSTD", "com.github.luben:zstd-jni");
+                CodecLibraries.require("com.github.luben.zstd.Zstd", "ZSTD", "com.github.luben:zstd-jni", "write");
                 yield new ZstdCompressor();
             }
             default -> throw new UnsupportedOperationException(
                     "Writing " + codec + "-compressed pages is not yet supported");
         };
-    }
-
-    private static void checkClassAvailable(String className, String codecName, String dependency) {
-        try {
-            Class.forName(className);
-        }
-        catch (ClassNotFoundException e) {
-            throw new UnsupportedOperationException(
-                    "Cannot write " + codecName + "-compressed Parquet file: required library not found. " +
-                            "Add the following dependency to your project: " + dependency);
-        }
     }
 }

--- a/core/src/main/java/dev/hardwood/internal/compression/DecompressorFactory.java
+++ b/core/src/main/java/dev/hardwood/internal/compression/DecompressorFactory.java
@@ -49,48 +49,37 @@ public class DecompressorFactory {
                 yield new GzipDecompressor();
             }
             case SNAPPY -> {
-                checkClassAvailable("org.xerial.snappy.Snappy",
+                CodecLibraries.require("org.xerial.snappy.Snappy",
                         "SNAPPY",
-                        "org.xerial.snappy:snappy-java");
+                        "org.xerial.snappy:snappy-java", "read");
                 yield new SnappyDecompressor();
             }
             case ZSTD -> {
-                checkClassAvailable("com.github.luben.zstd.Zstd",
+                CodecLibraries.require("com.github.luben.zstd.Zstd",
                         "ZSTD",
-                        "com.github.luben:zstd-jni");
+                        "com.github.luben:zstd-jni", "read");
                 yield new ZstdDecompressor();
             }
             case LZ4 -> {
-                checkClassAvailable("net.jpountz.lz4.LZ4Factory",
+                CodecLibraries.require("net.jpountz.lz4.LZ4Factory",
                         "LZ4",
-                        "at.yawk.lz4:lz4-java");
+                        "at.yawk.lz4:lz4-java", "read");
                 yield new Lz4Decompressor();
             }
             case LZ4_RAW -> {
-                checkClassAvailable("net.jpountz.lz4.LZ4Factory",
+                CodecLibraries.require("net.jpountz.lz4.LZ4Factory",
                         "LZ4_RAW",
-                        "at.yawk.lz4:lz4-java");
+                        "at.yawk.lz4:lz4-java", "read");
                 yield new Lz4RawDecompressor();
             }
             case BROTLI -> {
-                checkClassAvailable("com.aayushatharva.brotli4j.Brotli4jLoader",
+                CodecLibraries.require("com.aayushatharva.brotli4j.Brotli4jLoader",
                         "BROTLI",
-                        "com.aayushatharva.brotli4j:brotli4j");
+                        "com.aayushatharva.brotli4j:brotli4j", "read");
                 yield new BrotliDecompressor();
             }
             case LZO -> throw new UnsupportedOperationException("LZO compression is not supported");
         };
-    }
-
-    private static void checkClassAvailable(String className, String codecName, String dependency) {
-        try {
-            Class.forName(className);
-        }
-        catch (ClassNotFoundException e) {
-            throw new UnsupportedOperationException(
-                    "Cannot read " + codecName + "-compressed Parquet file: required library not found. " +
-                            "Add the following dependency to your project: " + dependency);
-        }
     }
 
     private static void logGzipDecompressor(String name) {

--- a/core/src/main/java/dev/hardwood/internal/compression/UncompressedCompressor.java
+++ b/core/src/main/java/dev/hardwood/internal/compression/UncompressedCompressor.java
@@ -1,0 +1,25 @@
+/*
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Copyright The original authors
+ *
+ *  Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package dev.hardwood.internal.compression;
+
+import java.util.Arrays;
+
+/// Pass-through [Compressor] for the `UNCOMPRESSED` codec: it copies the requested slice out
+/// so the compressed and uncompressed forms are the same bytes.
+public class UncompressedCompressor implements Compressor {
+
+    @Override
+    public byte[] compress(byte[] data, int offset, int length) {
+        return Arrays.copyOfRange(data, offset, offset + length);
+    }
+
+    @Override
+    public String getName() {
+        return "UNCOMPRESSED";
+    }
+}

--- a/core/src/main/java/dev/hardwood/internal/compression/ZstdCompressor.java
+++ b/core/src/main/java/dev/hardwood/internal/compression/ZstdCompressor.java
@@ -1,0 +1,35 @@
+/*
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Copyright The original authors
+ *
+ *  Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package dev.hardwood.internal.compression;
+
+import java.io.IOException;
+import java.util.Arrays;
+
+import com.github.luben.zstd.Zstd;
+
+/// [Compressor] for the ZSTD codec, the inverse of [ZstdDecompressor]. Compresses at zstd's
+/// default level, the same trade-off point the reference implementations write.
+public class ZstdCompressor implements Compressor {
+
+    private final int level = Zstd.defaultCompressionLevel();
+
+    @Override
+    public byte[] compress(byte[] data, int offset, int length) throws IOException {
+        byte[] output = new byte[Math.toIntExact(Zstd.compressBound(length))];
+        long written = Zstd.compressByteArray(output, 0, output.length, data, offset, length, level);
+        if (Zstd.isError(written)) {
+            throw new IOException("ZSTD compression failed: " + Zstd.getErrorName(written));
+        }
+        return Arrays.copyOf(output, Math.toIntExact(written));
+    }
+
+    @Override
+    public String getName() {
+        return "ZSTD";
+    }
+}

--- a/core/src/main/java/dev/hardwood/internal/writer/ColumnChunkBuffer.java
+++ b/core/src/main/java/dev/hardwood/internal/writer/ColumnChunkBuffer.java
@@ -9,6 +9,7 @@ package dev.hardwood.internal.writer;
 
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
+import java.io.UncheckedIOException;
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
 import java.util.ArrayList;
@@ -17,6 +18,7 @@ import java.util.Map;
 import java.util.zip.CRC32;
 
 import dev.hardwood.OutputFile;
+import dev.hardwood.internal.compression.Compressor;
 import dev.hardwood.internal.encoding.DictionaryEncoder;
 import dev.hardwood.internal.encoding.LevelEncoder;
 import dev.hardwood.internal.encoding.PlainEncoder;
@@ -30,7 +32,7 @@ import dev.hardwood.metadata.PhysicalType;
 import dev.hardwood.schema.ColumnSchema;
 
 /// Accumulates one `INT32` column's level entries for the current row group, packing them
-/// into uncompressed data pages of at most the page capacity. The [RecordShredder] streams a
+/// into data pages of at most the page capacity. The [RecordShredder] streams a
 /// record range's entries into this buffer through [#accept] (as a [RecordShredder.LevelSink]);
 /// a page is sealed each time the pending buffer fills — even part-way through a record — and
 /// the tail is sealed at flush. The encoded pages are held until the row group is flushed,
@@ -39,7 +41,11 @@ import dev.hardwood.schema.ColumnSchema;
 /// A page body is `[rep levels?][def levels?][value section]`, each level stream prefixed by
 /// its 4-byte little-endian length. When dictionary encoding is enabled the value section is
 /// `[1-byte index bit width][RLE/bit-packed indices]` (`RLE_DICTIONARY`); otherwise, and after
-/// a fallback, it is `[PLAIN present values]`.
+/// a fallback, it is `[PLAIN present values]`. The assembled body (levels and values together)
+/// is compressed with the chunk's [Compressor] before framing, and the page header records
+/// both the uncompressed and the stored compressed size; the dictionary page body is
+/// compressed the same way. The CRC-32 is taken over the stored bytes, matching what the
+/// reader validates.
 ///
 /// Dictionary encoding is column-chunk scoped: present values are interned in first-seen order
 /// through a [DictionaryEncoder], and each page's indices reference the dictionary page written
@@ -55,10 +61,15 @@ final class ColumnChunkBuffer implements RecordShredder.LevelSink {
     private final int[] pendingRep;
     private final int[] pendingDef;
     private final int[] pendingValues; // indices while dictionary-encoding, raw values once plain
-    private final ByteArrayOutputStream pages = new ByteArrayOutputStream();
+    private final ByteArrayOutputStream pages = new ByteArrayOutputStream(); // stored (compressed) data pages
     private int pendingCount;      // level entries buffered for the current page
     private int pendingValueCount; // present values buffered for the current page
     private long numValues;        // total level entries across sealed pages
+    private long dataPagesUncompressedSize; // sum of header + uncompressed body across data pages
+    private long dictionaryPageUncompressedSize; // header + uncompressed body of the dictionary page
+
+    private final Compressor compressor;
+    private final CompressionCodec codec;
 
     private final DictionaryEncoder dictionary; // null when dictionary encoding is disabled
     private final int dictionaryLimitBytes;
@@ -69,8 +80,11 @@ final class ColumnChunkBuffer implements RecordShredder.LevelSink {
     /// @param maxRepLevel the column's maximum repetition level (0 selects no rep stream)
     /// @param enableDictionary whether to dictionary-encode this chunk (with `PLAIN` fallback)
     /// @param dictionaryLimitBytes the dictionary size past which the chunk falls back to `PLAIN`
+    /// @param compressor compresses each page body before framing
+    /// @param codec the codec `compressor` applies, recorded in the chunk metadata
     ColumnChunkBuffer(int pageValues, int maxDefLevel, int maxRepLevel,
-                      boolean enableDictionary, int dictionaryLimitBytes) {
+                      boolean enableDictionary, int dictionaryLimitBytes,
+                      Compressor compressor, CompressionCodec codec) {
         this.maxDefLevel = maxDefLevel;
         this.maxRepLevel = maxRepLevel;
         this.pendingValues = new int[pageValues];
@@ -79,6 +93,8 @@ final class ColumnChunkBuffer implements RecordShredder.LevelSink {
         this.dictionary = enableDictionary ? new DictionaryEncoder() : null;
         this.dictionaryLimitBytes = dictionaryLimitBytes;
         this.dictionaryActive = enableDictionary;
+        this.compressor = compressor;
+        this.codec = codec;
     }
 
     /// Shreds records `[fromRecord, fromRecord + count)` of this column straight into the
@@ -125,25 +141,30 @@ final class ColumnChunkBuffer implements RecordShredder.LevelSink {
         boolean hasDictionary = dictionary != null && dictionary.size() > 0;
         long dataPageOffset = chunkStartOffset;
         Long dictionaryPageOffset = null;
-        long dictionaryPageSize = 0;
+        long dictionaryCompressedSize = 0;
+        long dictionaryUncompressedSize = 0;
         if (hasDictionary) {
             byte[] dictionaryPage = buildDictionaryPage();
             dictionaryPageOffset = chunkStartOffset;
             dataPageOffset = chunkStartOffset + dictionaryPage.length;
-            dictionaryPageSize = dictionaryPage.length;
+            dictionaryCompressedSize = dictionaryPage.length;
+            dictionaryUncompressedSize = dictionaryPageUncompressedSize;
             out.write(ByteBuffer.wrap(dictionaryPage));
         }
-        long totalSize = dictionaryPageSize + pages.size();
+        // Page headers are stored uncompressed either way; only the bodies differ, so the
+        // compressed total is what was actually written and the uncompressed total restores
+        // each body to its pre-compression size.
+        long totalCompressed = dictionaryCompressedSize + pages.size();
+        long totalUncompressed = dictionaryUncompressedSize + dataPagesUncompressedSize;
         out.write(ByteBuffer.wrap(pages.toByteArray()));
-        // Pages are stored uncompressed, so compressed and uncompressed sizes are equal.
         return new ColumnMetaData(
                 PhysicalType.INT32,
                 encodings(hasDictionary),
                 column.fieldPath(),
-                CompressionCodec.UNCOMPRESSED,
+                codec,
                 numValues,
-                totalSize,
-                totalSize,
+                totalUncompressed,
+                totalCompressed,
                 Map.of(),
                 dataPageOffset,
                 dictionaryPageOffset,
@@ -167,16 +188,19 @@ final class ColumnChunkBuffer implements RecordShredder.LevelSink {
         }
         boolean dictionaryPage = dictionaryActive && dictionary != null && dictionary.size() > 0;
         byte[] body = buildBody(dictionaryPage);
-        // CRC-32 over the page body as stored on disk (uncompressed here), matching what the
-        // reader validates.
+        byte[] stored = compress(body);
+        // CRC-32 over the page body as stored on disk (compressed), matching what the reader
+        // validates.
         CRC32 crc = new CRC32();
-        crc.update(body);
+        crc.update(stored);
         ThriftCompactWriter header = new ThriftCompactWriter();
         Encoding valuesEncoding = dictionaryPage ? Encoding.RLE_DICTIONARY : Encoding.PLAIN;
-        PageHeaderWriter.writeDataPageV1(header, pendingCount, body.length, body.length,
+        PageHeaderWriter.writeDataPageV1(header, pendingCount, body.length, stored.length,
                 (int) crc.getValue(), valuesEncoding);
-        pages.writeBytes(header.toByteArray());
-        pages.writeBytes(body);
+        byte[] headerBytes = header.toByteArray();
+        pages.writeBytes(headerBytes);
+        pages.writeBytes(stored);
+        dataPagesUncompressedSize += headerBytes.length + body.length;
         numValues += pendingCount;
         pendingCount = 0;
         pendingValueCount = 0;
@@ -209,18 +233,34 @@ final class ColumnChunkBuffer implements RecordShredder.LevelSink {
     }
 
     /// Builds the dictionary page: a `DICTIONARY_PAGE` header over the distinct values,
-    /// `PLAIN`-encoded in index order.
+    /// `PLAIN`-encoded in index order and compressed with the chunk's codec. Records the
+    /// page's uncompressed size (header plus uncompressed body) for the chunk metadata.
     private byte[] buildDictionaryPage() {
         byte[] body = PlainEncoder.encodeInts(dictionary.values(), 0, dictionary.size());
+        byte[] stored = compress(body);
         CRC32 crc = new CRC32();
-        crc.update(body);
+        crc.update(stored);
         ThriftCompactWriter header = new ThriftCompactWriter();
-        PageHeaderWriter.writeDictionaryPageV1(header, dictionary.size(), body.length, body.length,
+        PageHeaderWriter.writeDictionaryPageV1(header, dictionary.size(), body.length, stored.length,
                 (int) crc.getValue(), Encoding.PLAIN);
+        byte[] headerBytes = header.toByteArray();
+        dictionaryPageUncompressedSize = headerBytes.length + body.length;
         ByteArrayOutputStream page = new ByteArrayOutputStream();
-        page.writeBytes(header.toByteArray());
-        page.writeBytes(body);
+        page.writeBytes(headerBytes);
+        page.writeBytes(stored);
         return page.toByteArray();
+    }
+
+    /// Compresses a page body with the chunk's codec. Compressing an in-memory buffer that
+    /// fails is unrecoverable, so a codec error surfaces as an unchecked exception rather than
+    /// forcing a checked-exception path through the [RecordShredder.LevelSink] callback.
+    private byte[] compress(byte[] body) {
+        try {
+            return compressor.compress(body, 0, body.length);
+        }
+        catch (IOException e) {
+            throw new UncheckedIOException("Failed to " + codec + "-compress a page body", e);
+        }
     }
 
     /// The deduplicated set of encodings the chunk actually uses: `RLE` for the level streams

--- a/core/src/main/java/dev/hardwood/internal/writer/RowGroupBuffer.java
+++ b/core/src/main/java/dev/hardwood/internal/writer/RowGroupBuffer.java
@@ -12,8 +12,10 @@ import java.util.ArrayList;
 import java.util.List;
 
 import dev.hardwood.OutputFile;
+import dev.hardwood.internal.compression.Compressor;
 import dev.hardwood.metadata.ColumnChunk;
 import dev.hardwood.metadata.ColumnMetaData;
+import dev.hardwood.metadata.CompressionCodec;
 import dev.hardwood.metadata.RowGroup;
 import dev.hardwood.schema.FileSchema;
 
@@ -30,13 +32,16 @@ public final class RowGroupBuffer {
     /// @param pageValues maximum number of level triples per data page
     /// @param enableDictionary whether columns are dictionary-encoded (with `PLAIN` fallback)
     /// @param dictionaryLimitBytes the dictionary size past which a chunk falls back to `PLAIN`
-    public RowGroupBuffer(FileSchema schema, int pageValues, boolean enableDictionary, int dictionaryLimitBytes) {
+    /// @param compressor compresses each page body before it is buffered
+    /// @param codec the codec `compressor` applies, recorded in each chunk's metadata
+    public RowGroupBuffer(FileSchema schema, int pageValues, boolean enableDictionary, int dictionaryLimitBytes,
+                          Compressor compressor, CompressionCodec codec) {
         this.schema = schema;
         this.columns = new ColumnChunkBuffer[schema.getColumnCount()];
         for (int c = 0; c < columns.length; c++) {
             columns[c] = new ColumnChunkBuffer(pageValues,
                     schema.getColumn(c).maxDefinitionLevel(), schema.getColumn(c).maxRepetitionLevel(),
-                    enableDictionary, dictionaryLimitBytes);
+                    enableDictionary, dictionaryLimitBytes, compressor, codec);
         }
     }
 

--- a/core/src/main/java/dev/hardwood/writer/ParquetFileWriter.java
+++ b/core/src/main/java/dev/hardwood/writer/ParquetFileWriter.java
@@ -18,6 +18,8 @@ import java.util.Map;
 import java.util.function.Consumer;
 
 import dev.hardwood.OutputFile;
+import dev.hardwood.internal.compression.Compressor;
+import dev.hardwood.internal.compression.CompressorFactory;
 import dev.hardwood.internal.encoding.LevelEncoder;
 import dev.hardwood.internal.thrift.FileMetaDataWriter;
 import dev.hardwood.internal.thrift.ThriftCompactWriter;
@@ -35,13 +37,14 @@ import dev.hardwood.schema.FileSchema;
 /// This increment writes `INT32` columns — flat `REQUIRED` / `OPTIONAL`, nested inside
 /// `REQUIRED` / `OPTIONAL` `struct` groups, and inside `LIST`s and `MAP`s (including lists
 /// of lists, lists of structs, and maps of any in-scope value). Data is supplied as
-/// [ColumnBatch] slices; the writer packs each column into size-bounded, uncompressed data
-/// pages — a levelled column's pages carrying an RLE definition-level stream ahead of the
-/// values — and flushes a row group once its buffered data reaches the configured target, so
-/// peak memory is bounded regardless of how much is written. Columns are dictionary-encoded
-/// by default (a dictionary page plus `RLE_DICTIONARY` index pages), falling back to `PLAIN`
-/// when the dictionary grows past the configured limit; both are configurable through
-/// [WriterConfig]. The row groups and footer are finalized on [#close()].
+/// [ColumnBatch] slices; the writer packs each column into size-bounded data pages — a
+/// levelled column's pages carrying an RLE definition-level stream ahead of the values — and
+/// flushes a row group once its buffered data reaches the configured target, so peak memory is
+/// bounded regardless of how much is written. Columns are dictionary-encoded by default (a
+/// dictionary page plus `RLE_DICTIONARY` index pages), falling back to `PLAIN` when the
+/// dictionary grows past the configured limit. Each page body is compressed with the
+/// configured codec (`ZSTD` by default, or `UNCOMPRESSED`). All of these are configurable
+/// through [WriterConfig]. The row groups and footer are finalized on [#close()].
 ///
 /// The file is produced front to back and is valid only after `close()` returns.
 public final class ParquetFileWriter implements Closeable {
@@ -55,24 +58,27 @@ public final class ParquetFileWriter implements Closeable {
     private final int pageValues;
     private final int maxRowsPerGroup;
     private final RecordShredder shredder;
+    private final Compressor compressor;
     private final List<RowGroup> rowGroups = new ArrayList<>();
 
     private RowGroupBuffer current;
     private long numRows;
     private boolean closed;
 
-    private ParquetFileWriter(OutputFile out, FileSchema schema, WriterConfig config) {
+    private ParquetFileWriter(OutputFile out, FileSchema schema, WriterConfig config, Compressor compressor) {
         this.out = out;
         this.schema = schema;
         this.config = config;
         this.pageValues = pageRowCapacity(config.pageTargetBytes(), schema);
         this.maxRowsPerGroup = maxRowsPerGroup(config.rowGroupTargetBytes(), schema);
         this.shredder = new RecordShredder(schema, pageValues);
+        this.compressor = compressor;
         this.current = newRowGroupBuffer();
     }
 
     private RowGroupBuffer newRowGroupBuffer() {
-        return new RowGroupBuffer(schema, pageValues, config.enableDictionary(), config.dictionaryPageLimitBytes());
+        return new RowGroupBuffer(schema, pageValues, config.enableDictionary(), config.dictionaryPageLimitBytes(),
+                compressor, config.codec());
     }
 
     /// Opens a writer with the default [WriterConfig].
@@ -93,7 +99,8 @@ public final class ParquetFileWriter implements Closeable {
     /// @param config the writer configuration
     /// @return an open writer
     /// @throws IOException if the destination cannot be opened
-    /// @throws UnsupportedOperationException if the schema has a non-`INT32` column
+    /// @throws UnsupportedOperationException if the schema has a non-`INT32` column, or the
+    ///         configured codec cannot be written
     public static ParquetFileWriter create(OutputFile out, FileSchema schema, WriterConfig config)
             throws IOException {
         for (int c = 0; c < schema.getColumnCount(); c++) {
@@ -103,9 +110,12 @@ public final class ParquetFileWriter implements Closeable {
                         "Only INT32 columns are supported; column " + column.name() + " is " + column.type());
             }
         }
+        // Resolve the codec before touching the output, so an unsupported codec or a missing
+        // codec library fails before any bytes are written rather than leaving a partial file.
+        Compressor compressor = new CompressorFactory().getCompressor(config.codec());
         out.create();
         out.write(ByteBuffer.wrap(MAGIC));
-        return new ParquetFileWriter(out, schema, config);
+        return new ParquetFileWriter(out, schema, config, compressor);
     }
 
     /// Writes one aligned batch of column values, flushing row groups as the buffered

--- a/core/src/main/java/dev/hardwood/writer/WriterConfig.java
+++ b/core/src/main/java/dev/hardwood/writer/WriterConfig.java
@@ -7,6 +7,8 @@
  */
 package dev.hardwood.writer;
 
+import dev.hardwood.metadata.CompressionCodec;
+
 /// Tuning knobs for [ParquetFileWriter].
 ///
 /// The two size targets bound the writer's output granularity and peak memory:
@@ -32,11 +34,18 @@ public final class WriterConfig {
     /// chunk falls back to `PLAIN`.
     public static final int DEFAULT_DICTIONARY_PAGE_LIMIT_BYTES = 1 << 20;
 
+    /// Default page compression codec: `ZSTD` when the zstd-jni library is on the classpath,
+    /// otherwise `UNCOMPRESSED`. Choosing a codec explicitly through [Builder#codec] still
+    /// requires that codec's library and fails at writer creation when it is missing; this
+    /// default only avoids imposing the ZSTD dependency on callers who did not ask to compress.
+    public static final CompressionCodec DEFAULT_CODEC = defaultCodec();
+
     private final int pageTargetBytes;
     private final long rowGroupTargetBytes;
     private final String createdBy;
     private final boolean enableDictionary;
     private final int dictionaryPageLimitBytes;
+    private final CompressionCodec codec;
 
     private WriterConfig(Builder builder) {
         this.pageTargetBytes = builder.pageTargetBytes;
@@ -44,6 +53,7 @@ public final class WriterConfig {
         this.createdBy = builder.createdBy;
         this.enableDictionary = builder.enableDictionary;
         this.dictionaryPageLimitBytes = builder.dictionaryPageLimitBytes;
+        this.codec = builder.codec;
     }
 
     /// The default configuration.
@@ -81,6 +91,23 @@ public final class WriterConfig {
         return dictionaryPageLimitBytes;
     }
 
+    /// The codec each page body is compressed with.
+    public CompressionCodec codec() {
+        return codec;
+    }
+
+    /// `ZSTD` when its library is loadable, otherwise `UNCOMPRESSED`. The class is only probed
+    /// for presence, not initialized, so picking the default never triggers the native load.
+    private static CompressionCodec defaultCodec() {
+        try {
+            Class.forName("com.github.luben.zstd.Zstd", false, WriterConfig.class.getClassLoader());
+            return CompressionCodec.ZSTD;
+        }
+        catch (ClassNotFoundException e) {
+            return CompressionCodec.UNCOMPRESSED;
+        }
+    }
+
     /// Builder for [WriterConfig].
     public static final class Builder {
 
@@ -89,6 +116,7 @@ public final class WriterConfig {
         private String createdBy = DEFAULT_CREATED_BY;
         private boolean enableDictionary = true;
         private int dictionaryPageLimitBytes = DEFAULT_DICTIONARY_PAGE_LIMIT_BYTES;
+        private CompressionCodec codec = DEFAULT_CODEC;
 
         private Builder() {
         }
@@ -137,6 +165,17 @@ public final class WriterConfig {
                         + Integer.BYTES + " but was " + dictionaryPageLimitBytes);
             }
             this.dictionaryPageLimitBytes = dictionaryPageLimitBytes;
+            return this;
+        }
+
+        /// Sets the codec each page body is compressed with; must be non-null. Only
+        /// `UNCOMPRESSED` and `ZSTD` are currently supported on the write path, and a
+        /// non-`UNCOMPRESSED` codec requires its library on the classpath.
+        public Builder codec(CompressionCodec codec) {
+            if (codec == null) {
+                throw new IllegalArgumentException("codec must not be null");
+            }
+            this.codec = codec;
             return this;
         }
 

--- a/core/src/main/java/dev/hardwood/writer/WriterConfig.java
+++ b/core/src/main/java/dev/hardwood/writer/WriterConfig.java
@@ -7,6 +7,7 @@
  */
 package dev.hardwood.writer;
 
+import dev.hardwood.internal.compression.CodecLibraries;
 import dev.hardwood.metadata.CompressionCodec;
 
 /// Tuning knobs for [ParquetFileWriter].
@@ -99,13 +100,9 @@ public final class WriterConfig {
     /// `ZSTD` when its library is loadable, otherwise `UNCOMPRESSED`. The class is only probed
     /// for presence, not initialized, so picking the default never triggers the native load.
     private static CompressionCodec defaultCodec() {
-        try {
-            Class.forName("com.github.luben.zstd.Zstd", false, WriterConfig.class.getClassLoader());
-            return CompressionCodec.ZSTD;
-        }
-        catch (ClassNotFoundException e) {
-            return CompressionCodec.UNCOMPRESSED;
-        }
+        return CodecLibraries.isPresent("com.github.luben.zstd.Zstd")
+                ? CompressionCodec.ZSTD
+                : CompressionCodec.UNCOMPRESSED;
     }
 
     /// Builder for [WriterConfig].

--- a/core/src/test/java/dev/hardwood/writer/WriterConfigTest.java
+++ b/core/src/test/java/dev/hardwood/writer/WriterConfigTest.java
@@ -9,6 +9,8 @@ package dev.hardwood.writer;
 
 import org.junit.jupiter.api.Test;
 
+import dev.hardwood.metadata.CompressionCodec;
+
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
@@ -22,6 +24,22 @@ class WriterConfigTest {
         assertThat(config.pageTargetBytes()).isEqualTo(WriterConfig.DEFAULT_PAGE_TARGET_BYTES);
         assertThat(config.rowGroupTargetBytes()).isEqualTo(WriterConfig.DEFAULT_ROW_GROUP_TARGET_BYTES);
         assertThat(config.createdBy()).isEqualTo(WriterConfig.DEFAULT_CREATED_BY);
+        assertThat(config.codec()).isEqualTo(WriterConfig.DEFAULT_CODEC);
+        // zstd-jni is on the build classpath, so the classpath-conditional default resolves to
+        // ZSTD here; it degrades to UNCOMPRESSED only when the library is absent.
+        assertThat(WriterConfig.DEFAULT_CODEC).isEqualTo(CompressionCodec.ZSTD);
+    }
+
+    @Test
+    void codecOverrideIsRetained() {
+        assertThat(WriterConfig.builder().codec(CompressionCodec.UNCOMPRESSED).build().codec())
+                .isEqualTo(CompressionCodec.UNCOMPRESSED);
+    }
+
+    @Test
+    void rejectsNullCodec() {
+        assertThatThrownBy(() -> WriterConfig.builder().codec(null))
+                .isInstanceOf(IllegalArgumentException.class);
     }
 
     @Test

--- a/core/src/test/java/dev/hardwood/writer/WriterDifferentialTest.java
+++ b/core/src/test/java/dev/hardwood/writer/WriterDifferentialTest.java
@@ -448,6 +448,47 @@ class WriterDifferentialTest {
     }
 
     @Test
+    void duckDbReadsZstdCompressedColumn(@TempDir Path dir) throws Exception {
+        // ZSTD is the default codec, so this file's pages are compressed. DuckDB shares no code
+        // with hardwood's compressor, so its agreement proves the compressed bytes are
+        // spec-correct. Dictionary is disabled to force compressible PLAIN page bodies.
+        int n = 20_000;
+        int[] v = new int[n];
+        int[] r = new int[n];
+        for (int i = 0; i < n; i++) {
+            v[i] = i % 100;
+            r[i] = i;
+        }
+
+        FileSchema schema = FileSchema.builder("schema")
+                .addColumn("r", PhysicalType.INT32, RepetitionType.REQUIRED)
+                .addColumn("v", PhysicalType.INT32, RepetitionType.REQUIRED)
+                .build();
+        WriterConfig config = WriterConfig.builder().enableDictionary(false).build();
+        Path file = dir.resolve("zstd.parquet");
+        try (ParquetFileWriter writer = ParquetFileWriter.create(OutputFile.of(file), schema, config)) {
+            writer.writeBatch(batch -> batch.ints(0, r).ints(1, v));
+        }
+
+        try (Connection conn = DriverManager.getConnection("jdbc:duckdb:");
+                Statement stmt = conn.createStatement();
+                ResultSet rs = stmt.executeQuery(
+                        "SELECT count(*) AS n, sum(v) AS s, max(v) AS mx FROM read_parquet('"
+                                + file.toAbsolutePath() + "')")) {
+            rs.next();
+            long sum = 0;
+            long max = 0;
+            for (int value : v) {
+                sum += value;
+                max = Math.max(max, value);
+            }
+            assertThat(rs.getLong("n")).isEqualTo(n);
+            assertThat(rs.getLong("s")).isEqualTo(sum);
+            assertThat(rs.getLong("mx")).isEqualTo(max);
+        }
+    }
+
+    @Test
     void duckDbReadsMultipleRowGroups(@TempDir Path dir) throws Exception {
         int n = 5_000;
         int[] v = new int[n];

--- a/core/src/test/java/dev/hardwood/writer/WriterRoundTripTest.java
+++ b/core/src/test/java/dev/hardwood/writer/WriterRoundTripTest.java
@@ -29,6 +29,7 @@ import dev.hardwood.internal.thrift.PageHeaderReader;
 import dev.hardwood.internal.thrift.ThriftCompactReader;
 import dev.hardwood.internal.writer.ByteBufferOutputFile;
 import dev.hardwood.metadata.ColumnMetaData;
+import dev.hardwood.metadata.CompressionCodec;
 import dev.hardwood.metadata.Encoding;
 import dev.hardwood.metadata.PhysicalType;
 import dev.hardwood.metadata.RepetitionType;
@@ -779,6 +780,107 @@ class WriterRoundTripTest {
                 assertThat(readMapOfInts(kr, vr)).containsExactly(
                         mapOf(1, 5, 2, null), Map.of(), null, mapOf(3, 5, 4, 9));
             }
+        }
+    }
+
+    @Test
+    void compressesPagesWithZstdByDefault() throws Exception {
+        // The default codec is ZSTD, so a file written with no override records ZSTD and reads
+        // back through the reader's ZSTD path.
+        int[] values = new int[1_000];
+        int[] palette = { 3, 3, 7, 3, 9 };
+        for (int i = 0; i < values.length; i++) {
+            values[i] = palette[i % palette.length];
+        }
+
+        ByteBufferOutputFile out = new ByteBufferOutputFile();
+        try (ParquetFileWriter writer = ParquetFileWriter.create(out, oneColumn())) {
+            writer.writeBatch(batch -> batch.ints(0, values));
+        }
+
+        try (ParquetFileReader reader = ParquetFileReader.open(InputFile.of(ByteBuffer.wrap(out.toByteArray())))) {
+            assertThat(columnMeta(reader, 0).codec()).isEqualTo(CompressionCodec.ZSTD);
+            assertThat(Arrays.equals(readInts(reader, 0), values)).isTrue();
+        }
+    }
+
+    @Test
+    void zstdShrinksACompressiblePageAndAccountsForBothSizes() throws Exception {
+        // A large single-valued PLAIN column (dictionary disabled) has a highly compressible
+        // body, so ZSTD stores far fewer bytes than it holds — proving the compress step ran
+        // and that the compressed and uncompressed sizes are tracked independently, at both the
+        // chunk-metadata and the page-header level.
+        int n = 10_000;
+        int[] values = new int[n];
+        Arrays.fill(values, 42);
+
+        WriterConfig config = WriterConfig.builder().enableDictionary(false).build();
+        ByteBufferOutputFile out = new ByteBufferOutputFile();
+        try (ParquetFileWriter writer = ParquetFileWriter.create(out, oneColumn(), config)) {
+            writer.writeBatch(batch -> batch.ints(0, values));
+        }
+        byte[] bytes = out.toByteArray();
+
+        try (ParquetFileReader reader = ParquetFileReader.open(InputFile.of(ByteBuffer.wrap(bytes)))) {
+            ColumnMetaData meta = columnMeta(reader, 0);
+            assertThat(meta.codec()).isEqualTo(CompressionCodec.ZSTD);
+            assertThat(meta.totalCompressedSize()).isLessThan(meta.totalUncompressedSize());
+
+            int offset = Math.toIntExact(meta.dataPageOffset());
+            ThriftCompactReader thrift = new ThriftCompactReader(ByteBuffer.wrap(bytes), offset);
+            PageHeader header = PageHeaderReader.read(thrift);
+            assertThat(header.compressedPageSize()).isLessThan(header.uncompressedPageSize());
+            // The CRC covers the stored (compressed) bytes.
+            int bodyStart = offset + thrift.getBytesRead();
+            CRC32 crc = new CRC32();
+            crc.update(bytes, bodyStart, header.compressedPageSize());
+            assertThat(header.crc().intValue()).isEqualTo((int) crc.getValue());
+
+            assertThat(Arrays.equals(readInts(reader, 0), values)).isTrue();
+        }
+    }
+
+    @Test
+    void uncompressedCodecStoresBodiesVerbatim() throws Exception {
+        // With the UNCOMPRESSED codec the stored bytes are the body bytes, so the chunk's
+        // compressed and uncompressed sizes are equal.
+        int[] values = { 1, 2, 3, 4, 5 };
+
+        WriterConfig config = WriterConfig.builder().codec(CompressionCodec.UNCOMPRESSED).build();
+        ByteBufferOutputFile out = new ByteBufferOutputFile();
+        try (ParquetFileWriter writer = ParquetFileWriter.create(out, oneColumn(), config)) {
+            writer.writeBatch(batch -> batch.ints(0, values));
+        }
+
+        try (ParquetFileReader reader = ParquetFileReader.open(InputFile.of(ByteBuffer.wrap(out.toByteArray())))) {
+            ColumnMetaData meta = columnMeta(reader, 0);
+            assertThat(meta.codec()).isEqualTo(CompressionCodec.UNCOMPRESSED);
+            assertThat(meta.totalCompressedSize()).isEqualTo(meta.totalUncompressedSize());
+            assertThat(readInts(reader, 0)).containsExactly(values);
+        }
+    }
+
+    @Test
+    void compressionComposesWithNullsAcrossPages() throws Exception {
+        // ZSTD compression under a tiny page target: many compressed pages, each carrying a
+        // def-level stream and PLAIN values, must all decompress and reassemble the nulls.
+        int n = 4_000;
+        int[] values = new int[n];
+        boolean[] nulls = new boolean[n];
+        for (int i = 0; i < n; i++) {
+            values[i] = i;
+            nulls[i] = i % 4 == 0;
+        }
+
+        WriterConfig config = WriterConfig.builder().pageTargetBytes(256).build();
+        ByteBufferOutputFile out = new ByteBufferOutputFile();
+        try (ParquetFileWriter writer = ParquetFileWriter.create(out, oneOptionalColumn(), config)) {
+            writer.writeBatch(batch -> batch.ints(0, values, nulls));
+        }
+
+        try (ParquetFileReader reader = ParquetFileReader.open(InputFile.of(ByteBuffer.wrap(out.toByteArray())))) {
+            assertThat(columnMeta(reader, 0).codec()).isEqualTo(CompressionCodec.ZSTD);
+            assertThat(readNullable(reader, 0)).isEqualTo(expectedNullable(values, nulls));
         }
     }
 


### PR DESCRIPTION
Stage 10 of the writer milestone (#9): **compression on the write path**, per the delivery plan in `_designs/WRITER_SUPPORT.md`.

## What changed

Data pages were written uncompressed, so produced files never exercised the reader's decompression paths and carried no evidence that compressed and uncompressed sizes are tracked as distinct quantities.

- New `Compressor` / `CompressorFactory` in `internal.compression` — the write-side inverse of the existing `Decompressor` / `DecompressorFactory` (`UncompressedCompressor`, `ZstdCompressor`).
- `ColumnChunkBuffer` compresses each data- and dictionary-page body before framing, recording the uncompressed body size and the stored compressed size **independently** in both the page header and the column-chunk metadata. The CRC now covers the stored (compressed) bytes.
- `WriterConfig` gains a `codec` knob. Its default is **ZSTD when zstd-jni is on the classpath, UNCOMPRESSED otherwise**, so a caller who did not ask to compress is not forced to carry the optional dependency — while an *explicit* codec choice whose library is absent still fails loudly at writer creation rather than silently downgrading.
- The codec is resolved before the output is opened, so an unsupported codec fails before any bytes are written rather than leaving a partial file.

Only `UNCOMPRESSED` and `ZSTD` are supported on the write path for now; the remaining codecs are rejected until their encode side lands (later breadth increment).

## Validation

- **Round-trip** tests: ZSTD default reads back; a compressible page shrinks with both sizes tracked at chunk + page-header level; `UNCOMPRESSED` stores bodies verbatim with equal sizes; compression composes with nulls across pages.
- **DuckDB differential**: an independent engine reads a ZSTD-compressed hardwood-written file, proving the bytes are spec-correct.
- Full `core` suite green: **1700 tests, 0 failures**, all style / error-prone gates passing.

Docs for the writer public API remain deferred to stage 17 (recorded exception in the design doc). Roadmap box 6.2 (page compression) ticked.