### PR TITLE
#767 Add zero-decode Parquet merge command

### DIFF
--- a/_designs/PARQUET_FILE_STITCHING.md
+++ b/_designs/PARQUET_FILE_STITCHING.md
@@ -1,0 +1,51 @@
+# Parquet File Stitching
+
+**Status: completed**
+
+## Purpose
+
+The `hardwood merge` command combines same-schema Parquet files without decoding,
+re-encoding, or recompressing their pages. Each input row group remains unchanged.
+
+## File assembly
+
+For every input, the stitcher copies the complete file body between the leading
+`PAR1` magic and the footer. Copying the whole body preserves column chunks, page
+indexes, bloom filters, padding, and their relative layout. One relocation delta,
+the destination body offset minus the source body offset, is applied to every
+absolute offset from that input's footer.
+
+The output consists of one leading magic, the copied input bodies in argument
+order, and a newly serialized footer. Its row-group list is the concatenation of
+the input row-group lists and its row count is their checked sum.
+
+## Validation
+
+All inputs are opened and validated before the output is created. Inputs must have
+identical schema elements and column orders. File-level key/value metadata must be
+identical because choosing one input's conflicting value would silently change the
+meaning of another input. Encrypted files are rejected by the existing metadata
+reader.
+
+Offsets and row counts use checked arithmetic. A failure discards the temporary
+output through `OutputFile`, so a partial Parquet file is never published.
+
+## Metadata
+
+The rebuilt footer preserves file and column key/value metadata, statistics,
+column orders, page-index locations, and bloom-filter locations. Page encodings
+and compression codecs may differ between row groups because Parquet describes
+them per column chunk.
+
+`ColumnChunk.file_offset` is written as zero. That field is deprecated and zero is
+the specified value when column metadata exists only in the footer. Row-group
+`file_offset`, when present, is relocated with the rest of the body pointers.
+
+The output `created_by` value identifies Hardwood's stitcher. Source `created_by`
+values are descriptive rather than semantic and are not combined.
+
+## Scope
+
+The first command accepts local input and output paths. It does not repack row
+groups: changing row-group boundaries requires interpreting page-level records and
+is incompatible with byte-for-byte page reuse.

--- a/cli/src/main/java/dev/hardwood/cli/command/HardwoodCommand.java
+++ b/cli/src/main/java/dev/hardwood/cli/command/HardwoodCommand.java
@@ -21,6 +21,7 @@ import picocli.CommandLine.IVersionProvider;
         InfoCommand.class,
         SchemaCommand.class,
         ConvertCommand.class,
+        MergeCommand.class,
         FooterCommand.class,
         InspectCommand.class,
         PrintCommand.class,

--- a/cli/src/main/java/dev/hardwood/cli/command/MergeCommand.java
+++ b/cli/src/main/java/dev/hardwood/cli/command/MergeCommand.java
@@ -1,0 +1,60 @@
+/*
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Copyright The original authors
+ *
+ *  Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package dev.hardwood.cli.command;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.concurrent.Callable;
+
+import dev.hardwood.InputFile;
+import dev.hardwood.OutputFile;
+import dev.hardwood.internal.writer.ParquetFileStitcher;
+import picocli.CommandLine;
+import picocli.CommandLine.Model.CommandSpec;
+import picocli.CommandLine.Spec;
+
+@CommandLine.Command(name = "merge",
+        description = "Merge same-schema Parquet files without re-encoding their pages.")
+public final class MergeCommand implements Callable<Integer> {
+    @CommandLine.Mixin HelpMixin help;
+    @Spec CommandSpec spec;
+
+    @CommandLine.Option(names = {"-o", "--output"}, required = true, paramLabel = "FILE",
+            description = "Output Parquet file.")
+    Path output;
+
+    @CommandLine.Parameters(arity = "1..*", paramLabel = "INPUT",
+            description = "Input Parquet files in output row order.")
+    List<Path> inputs;
+
+    @Override
+    public Integer call() {
+        try {
+            Path normalizedOutput = output.toAbsolutePath().normalize();
+            for (Path input : inputs) {
+                Path normalizedInput = input.toAbsolutePath().normalize();
+                if (normalizedInput.equals(normalizedOutput)
+                        || (Files.exists(input) && Files.exists(output) && Files.isSameFile(input, output))) {
+                    throw new IllegalArgumentException("Output must not also be an input: " + input);
+                }
+            }
+            ParquetFileStitcher.stitch(InputFile.ofPaths(inputs), OutputFile.of(output));
+            return CommandLine.ExitCode.OK;
+        }
+        catch (IllegalArgumentException | UnsupportedOperationException e) {
+            spec.commandLine().getErr().println(e.getMessage());
+            return CommandLine.ExitCode.USAGE;
+        }
+        catch (IOException e) {
+            spec.commandLine().getErr().println("Error merging files: " + e.getMessage());
+            return CommandLine.ExitCode.SOFTWARE;
+        }
+    }
+}

--- a/cli/src/test/java/dev/hardwood/cli/command/MergeCommandTest.java
+++ b/cli/src/test/java/dev/hardwood/cli/command/MergeCommandTest.java
@@ -1,0 +1,63 @@
+/*
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Copyright The original authors
+ *
+ *  Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package dev.hardwood.cli.command;
+
+import java.nio.file.Path;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import dev.hardwood.InputFile;
+import dev.hardwood.OutputFile;
+import dev.hardwood.metadata.PhysicalType;
+import dev.hardwood.metadata.RepetitionType;
+import dev.hardwood.reader.ParquetFileReader;
+import dev.hardwood.schema.FileSchema;
+import dev.hardwood.writer.ParquetFileWriter;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class MergeCommandTest {
+    @Test
+    void mergesLocalFiles(@TempDir Path directory) throws Exception {
+        Path first = directory.resolve("first.parquet");
+        Path second = directory.resolve("second.parquet");
+        Path output = directory.resolve("merged.parquet");
+        write(first, 1, 2);
+        write(second, 3, 4, 5);
+
+        Cli.Result result = Cli.launch("merge", "--output", output.toString(),
+                first.toString(), second.toString());
+
+        assertThat(result.exitCode()).isZero();
+        try (ParquetFileReader reader = ParquetFileReader.open(InputFile.of(output))) {
+            assertThat(reader.getFileMetaData().numRows()).isEqualTo(5);
+            assertThat(reader.getFileMetaData().rowGroups()).hasSize(2);
+        }
+    }
+
+    @Test
+    void rejectsOutputUsedAsInput(@TempDir Path directory) throws Exception {
+        Path file = directory.resolve("input.parquet");
+        write(file, 1);
+
+        Cli.Result result = Cli.launch("merge", "-o", file.toString(), file.toString());
+
+        assertThat(result.exitCode()).isNotZero();
+        assertThat(result.errorOutput()).contains("Output must not also be an input");
+    }
+
+    private static void write(Path path, int... values) throws Exception {
+        FileSchema schema = FileSchema.builder("schema")
+                .addColumn("id", PhysicalType.INT32, RepetitionType.REQUIRED)
+                .build();
+        try (ParquetFileWriter writer = ParquetFileWriter.create(OutputFile.of(path), schema)) {
+            writer.writeBatch(batch -> batch.ints(0, values));
+        }
+    }
+}

--- a/core/src/main/java/dev/hardwood/internal/thrift/ColumnChunkWriter.java
+++ b/core/src/main/java/dev/hardwood/internal/thrift/ColumnChunkWriter.java
@@ -19,11 +19,28 @@ public class ColumnChunkWriter {
             // 2: file_offset (required). For a single-page chunk with no dictionary
             // this is the offset of the data page, matching data_page_offset.
             writer.writeFieldBegin(2, ThriftCompactConstants.FieldType.I64);
-            writer.writeI64(chunk.metaData().dataPageOffset());
+            writer.writeI64(0);
 
             // 3: meta_data
             writer.writeFieldBegin(3, ThriftCompactConstants.FieldType.STRUCT);
             ColumnMetaDataWriter.write(writer, chunk.metaData());
+
+            if (chunk.offsetIndexOffset() != null) {
+                writer.writeFieldBegin(4, ThriftCompactConstants.FieldType.I64);
+                writer.writeI64(chunk.offsetIndexOffset());
+            }
+            if (chunk.offsetIndexLength() != null) {
+                writer.writeFieldBegin(5, ThriftCompactConstants.FieldType.I32);
+                writer.writeI32(chunk.offsetIndexLength());
+            }
+            if (chunk.columnIndexOffset() != null) {
+                writer.writeFieldBegin(6, ThriftCompactConstants.FieldType.I64);
+                writer.writeI64(chunk.columnIndexOffset());
+            }
+            if (chunk.columnIndexLength() != null) {
+                writer.writeFieldBegin(7, ThriftCompactConstants.FieldType.I32);
+                writer.writeI32(chunk.columnIndexLength());
+            }
 
             writer.writeFieldStop();
         }

--- a/core/src/main/java/dev/hardwood/internal/thrift/ColumnMetaDataReader.java
+++ b/core/src/main/java/dev/hardwood/internal/thrift/ColumnMetaDataReader.java
@@ -44,6 +44,7 @@ public class ColumnMetaDataReader {
         long totalCompressedSize = 0;
         Map<String, String> keyValueMetadata = Collections.emptyMap();
         long dataPageOffset = 0;
+        Long indexPageOffset = null;
         Long dictionaryPageOffset = null;
         Statistics statistics = null;
         GeospatialStatistics geospatialStatistics = null;
@@ -135,8 +136,13 @@ public class ColumnMetaDataReader {
                         reader.skipField(header.type());
                     }
                     break;
-                case 10: // index_page_offset (optional) - skipped for now
-                    reader.skipField(header.type());
+                case 10: // index_page_offset
+                    if (header.type() == 0x06) {
+                        indexPageOffset = reader.readI64();
+                    }
+                    else {
+                        reader.skipField(header.type());
+                    }
                     break;
                 case 11: // dictionary_page_offset (optional)
                     if (header.type() == 0x06) {
@@ -186,6 +192,7 @@ public class ColumnMetaDataReader {
 
         return new ColumnMetaData(type, encodings, new FieldPath(List.copyOf(pathInSchema)), codec,
                 numValues, totalUncompressedSize, totalCompressedSize, keyValueMetadata, dataPageOffset,
-                dictionaryPageOffset, statistics, geospatialStatistics, bloomFilterOffset, bloomFilterLength);
+                indexPageOffset, dictionaryPageOffset, statistics, geospatialStatistics,
+                bloomFilterOffset, bloomFilterLength);
     }
 }

--- a/core/src/main/java/dev/hardwood/internal/thrift/ColumnMetaDataWriter.java
+++ b/core/src/main/java/dev/hardwood/internal/thrift/ColumnMetaDataWriter.java
@@ -53,14 +53,41 @@ public class ColumnMetaDataWriter {
             writer.writeFieldBegin(7, ThriftCompactConstants.FieldType.I64);
             writer.writeI64(metaData.totalCompressedSize());
 
+            if (!metaData.keyValueMetadata().isEmpty()) {
+                writer.writeFieldBegin(8, ThriftCompactConstants.FieldType.LIST);
+                KeyValueMetadataWriter.write(writer, metaData.keyValueMetadata());
+            }
+
             // 9: data_page_offset
             writer.writeFieldBegin(9, ThriftCompactConstants.FieldType.I64);
             writer.writeI64(metaData.dataPageOffset());
+
+            if (metaData.indexPageOffset() != null) {
+                writer.writeFieldBegin(10, ThriftCompactConstants.FieldType.I64);
+                writer.writeI64(metaData.indexPageOffset());
+            }
 
             // 11: dictionary_page_offset (present only for a dictionary-encoded chunk)
             if (metaData.dictionaryPageOffset() != null) {
                 writer.writeFieldBegin(11, ThriftCompactConstants.FieldType.I64);
                 writer.writeI64(metaData.dictionaryPageOffset());
+            }
+
+            if (metaData.statistics() != null) {
+                writer.writeFieldBegin(12, ThriftCompactConstants.FieldType.STRUCT);
+                StatisticsWriter.write(writer, metaData.statistics());
+            }
+
+            if (metaData.bloomFilterOffset() != null) {
+                writer.writeFieldBegin(14, ThriftCompactConstants.FieldType.I64);
+                writer.writeI64(metaData.bloomFilterOffset());
+            }
+            if (metaData.bloomFilterLength() != null) {
+                writer.writeFieldBegin(15, ThriftCompactConstants.FieldType.I32);
+                writer.writeI32(metaData.bloomFilterLength());
+            }
+            if (metaData.geospatialStatistics() != null) {
+                throw new UnsupportedOperationException("Cannot serialize geospatial statistics");
             }
 
             writer.writeFieldStop();

--- a/core/src/main/java/dev/hardwood/internal/thrift/FileMetaDataWriter.java
+++ b/core/src/main/java/dev/hardwood/internal/thrift/FileMetaDataWriter.java
@@ -40,10 +40,32 @@ public class FileMetaDataWriter {
             RowGroupWriter.write(writer, rowGroup);
         }
 
+        if (!metaData.keyValueMetadata().isEmpty()) {
+            writer.writeFieldBegin(5, ThriftCompactConstants.FieldType.LIST);
+            KeyValueMetadataWriter.write(writer, metaData.keyValueMetadata());
+        }
+
         // 6: created_by (optional)
         if (metaData.createdBy() != null) {
             writer.writeFieldBegin(6, ThriftCompactConstants.FieldType.BINARY);
             writer.writeString(metaData.createdBy());
+        }
+
+        if (!metaData.columnOrders().isEmpty()) {
+            writer.writeFieldBegin(7, ThriftCompactConstants.FieldType.LIST);
+            writer.writeListBegin(metaData.columnOrders().size(), ThriftCompactConstants.ElementType.STRUCT);
+            for (dev.hardwood.metadata.ColumnOrder order : metaData.columnOrders()) {
+                if (order != dev.hardwood.metadata.ColumnOrder.TYPE_DEFINED_ORDER) {
+                    throw new UnsupportedOperationException("Cannot serialize column order: " + order);
+                }
+                short saved = writer.pushFieldIdContext();
+                writer.writeFieldBegin(1, ThriftCompactConstants.FieldType.STRUCT);
+                short union = writer.pushFieldIdContext();
+                writer.writeFieldStop();
+                writer.popFieldIdContext(union);
+                writer.writeFieldStop();
+                writer.popFieldIdContext(saved);
+            }
         }
 
         writer.writeFieldStop();

--- a/core/src/main/java/dev/hardwood/internal/thrift/KeyValueMetadataWriter.java
+++ b/core/src/main/java/dev/hardwood/internal/thrift/KeyValueMetadataWriter.java
@@ -1,0 +1,29 @@
+/*
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Copyright The original authors
+ *
+ *  Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package dev.hardwood.internal.thrift;
+
+import java.util.Map;
+
+final class KeyValueMetadataWriter {
+    private KeyValueMetadataWriter() {}
+
+    static void write(ThriftCompactWriter writer, Map<String, String> metadata) {
+        writer.writeListBegin(metadata.size(), ThriftCompactConstants.ElementType.STRUCT);
+        for (Map.Entry<String, String> entry : metadata.entrySet()) {
+            short saved = writer.pushFieldIdContext();
+            writer.writeFieldBegin(1, ThriftCompactConstants.FieldType.BINARY);
+            writer.writeString(entry.getKey());
+            if (entry.getValue() != null) {
+                writer.writeFieldBegin(2, ThriftCompactConstants.FieldType.BINARY);
+                writer.writeString(entry.getValue());
+            }
+            writer.writeFieldStop();
+            writer.popFieldIdContext(saved);
+        }
+    }
+}

--- a/core/src/main/java/dev/hardwood/internal/thrift/RowGroupReader.java
+++ b/core/src/main/java/dev/hardwood/internal/thrift/RowGroupReader.java
@@ -31,6 +31,9 @@ public class RowGroupReader {
         List<ColumnChunk> columns = new ArrayList<>();
         long totalByteSize = 0;
         long numRows = 0;
+        Long fileOffset = null;
+        Long totalCompressedSize = null;
+        Short ordinal = null;
 
         while (true) {
             ThriftCompactReader.FieldHeader header = reader.readFieldHeader();
@@ -66,12 +69,36 @@ public class RowGroupReader {
                         reader.skipField(header.type());
                     }
                     break;
+                case 5: // file_offset
+                    if (header.type() == 0x06) {
+                        fileOffset = reader.readI64();
+                    }
+                    else {
+                        reader.skipField(header.type());
+                    }
+                    break;
+                case 6: // total_compressed_size
+                    if (header.type() == 0x06) {
+                        totalCompressedSize = reader.readI64();
+                    }
+                    else {
+                        reader.skipField(header.type());
+                    }
+                    break;
+                case 7: // ordinal
+                    if (header.type() == 0x04) {
+                        ordinal = (short) reader.readI32();
+                    }
+                    else {
+                        reader.skipField(header.type());
+                    }
+                    break;
                 default:
                     reader.skipField(header.type());
                     break;
             }
         }
 
-        return new RowGroup(columns, totalByteSize, numRows);
+        return new RowGroup(columns, totalByteSize, numRows, fileOffset, totalCompressedSize, ordinal);
     }
 }

--- a/core/src/main/java/dev/hardwood/internal/thrift/RowGroupWriter.java
+++ b/core/src/main/java/dev/hardwood/internal/thrift/RowGroupWriter.java
@@ -32,6 +32,19 @@ public class RowGroupWriter {
             writer.writeFieldBegin(3, ThriftCompactConstants.FieldType.I64);
             writer.writeI64(rowGroup.numRows());
 
+            if (rowGroup.fileOffset() != null) {
+                writer.writeFieldBegin(5, ThriftCompactConstants.FieldType.I64);
+                writer.writeI64(rowGroup.fileOffset());
+            }
+            if (rowGroup.totalCompressedSize() != null) {
+                writer.writeFieldBegin(6, ThriftCompactConstants.FieldType.I64);
+                writer.writeI64(rowGroup.totalCompressedSize());
+            }
+            if (rowGroup.ordinal() != null) {
+                writer.writeFieldBegin(7, ThriftCompactConstants.FieldType.I16);
+                writer.writeI32(rowGroup.ordinal());
+            }
+
             writer.writeFieldStop();
         }
         finally {

--- a/core/src/main/java/dev/hardwood/internal/thrift/StatisticsWriter.java
+++ b/core/src/main/java/dev/hardwood/internal/thrift/StatisticsWriter.java
@@ -1,0 +1,47 @@
+/*
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Copyright The original authors
+ *
+ *  Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package dev.hardwood.internal.thrift;
+
+import dev.hardwood.metadata.Statistics;
+
+final class StatisticsWriter {
+    private StatisticsWriter() {}
+
+    static void write(ThriftCompactWriter writer, Statistics statistics) {
+        short saved = writer.pushFieldIdContext();
+        int minField = statistics.isMinMaxDeprecated() ? 2 : 6;
+        int maxField = statistics.isMinMaxDeprecated() ? 1 : 5;
+        if (statistics.maxValue() != null && maxField == 1) {
+            writeBinary(writer, 1, statistics.maxValue());
+        }
+        if (statistics.minValue() != null && minField == 2) {
+            writeBinary(writer, 2, statistics.minValue());
+        }
+        if (statistics.nullCount() != null) {
+            writer.writeFieldBegin(3, ThriftCompactConstants.FieldType.I64);
+            writer.writeI64(statistics.nullCount());
+        }
+        if (statistics.distinctCount() != null) {
+            writer.writeFieldBegin(4, ThriftCompactConstants.FieldType.I64);
+            writer.writeI64(statistics.distinctCount());
+        }
+        if (statistics.maxValue() != null && maxField == 5) {
+            writeBinary(writer, 5, statistics.maxValue());
+        }
+        if (statistics.minValue() != null && minField == 6) {
+            writeBinary(writer, 6, statistics.minValue());
+        }
+        writer.writeFieldStop();
+        writer.popFieldIdContext(saved);
+    }
+
+    private static void writeBinary(ThriftCompactWriter writer, int field, byte[] value) {
+        writer.writeFieldBegin(field, ThriftCompactConstants.FieldType.BINARY);
+        writer.writeBinary(value);
+    }
+}

--- a/core/src/main/java/dev/hardwood/internal/writer/ParquetFileStitcher.java
+++ b/core/src/main/java/dev/hardwood/internal/writer/ParquetFileStitcher.java
@@ -1,0 +1,181 @@
+/*
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Copyright The original authors
+ *
+ *  Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package dev.hardwood.internal.writer;
+
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+
+import dev.hardwood.InputFile;
+import dev.hardwood.OutputFile;
+import dev.hardwood.internal.reader.ParquetMetadataReader;
+import dev.hardwood.internal.thrift.FileMetaDataWriter;
+import dev.hardwood.internal.thrift.ThriftCompactWriter;
+import dev.hardwood.metadata.ColumnChunk;
+import dev.hardwood.metadata.ColumnMetaData;
+import dev.hardwood.metadata.FileMetaData;
+import dev.hardwood.metadata.RowGroup;
+
+/// Assembles same-schema Parquet files by copying their encoded bodies and rebuilding the footer.
+public final class ParquetFileStitcher {
+    private static final byte[] MAGIC = "PAR1".getBytes(StandardCharsets.UTF_8);
+    private static final int MAGIC_SIZE = 4;
+    private static final int FOOTER_TRAILER_SIZE = 8;
+    private static final int COPY_BUFFER_SIZE = 8 * 1024 * 1024;
+
+    private ParquetFileStitcher() {}
+
+    public static void stitch(List<InputFile> inputs, OutputFile output) throws IOException {
+        Objects.requireNonNull(inputs, "inputs must not be null");
+        Objects.requireNonNull(output, "output must not be null");
+        if (inputs.isEmpty()) {
+            throw new IllegalArgumentException("At least one input file is required");
+        }
+
+        List<Source> sources = new ArrayList<>(inputs.size());
+        try {
+            for (InputFile input : inputs) {
+                input.open();
+                FileMetaData metadata = ParquetMetadataReader.readMetadata(input);
+                sources.add(new Source(input, metadata, footerStart(input)));
+            }
+            validateCompatible(sources);
+            write(sources, output);
+        }
+        finally {
+            IOException failure = null;
+            for (InputFile input : inputs) {
+                try {
+                    input.close();
+                }
+                catch (IOException e) {
+                    if (failure == null) {
+                        failure = e;
+                    }
+                    else {
+                        failure.addSuppressed(e);
+                    }
+                }
+            }
+            if (failure != null) {
+                throw failure;
+            }
+        }
+    }
+
+    private static void write(List<Source> sources, OutputFile output) throws IOException {
+        output.create();
+        try {
+            output.write(ByteBuffer.wrap(MAGIC));
+            List<RowGroup> rowGroups = new ArrayList<>();
+            long numRows = 0;
+            int ordinal = 0;
+            for (Source source : sources) {
+                long delta = Math.subtractExact(output.position(), MAGIC_SIZE);
+                copyBody(source, output);
+                for (RowGroup rowGroup : source.metadata().rowGroups()) {
+                    rowGroups.add(relocate(rowGroup, delta, ordinal++));
+                    numRows = Math.addExact(numRows, rowGroup.numRows());
+                }
+            }
+
+            FileMetaData first = sources.get(0).metadata();
+            FileMetaData merged = new FileMetaData(first.version(), first.schema(), numRows,
+                    List.copyOf(rowGroups), first.keyValueMetadata(), "hardwood merge",
+                    first.columnOrders());
+            ThriftCompactWriter footer = new ThriftCompactWriter();
+            FileMetaDataWriter.write(footer, merged);
+            byte[] bytes = footer.toByteArray();
+            output.write(ByteBuffer.wrap(bytes));
+            output.write(ByteBuffer.allocate(4).order(ByteOrder.LITTLE_ENDIAN).putInt(bytes.length).flip());
+            output.write(ByteBuffer.wrap(MAGIC));
+            output.close();
+        }
+        catch (IOException | RuntimeException e) {
+            try {
+                output.discard();
+            }
+            catch (IOException suppressed) {
+                e.addSuppressed(suppressed);
+            }
+            throw e;
+        }
+    }
+
+    private static void copyBody(Source source, OutputFile output) throws IOException {
+        long offset = MAGIC_SIZE;
+        while (offset < source.footerStart()) {
+            int length = (int) Math.min(COPY_BUFFER_SIZE, source.footerStart() - offset);
+            output.write(source.input().readRange(offset, length));
+            offset += length;
+        }
+    }
+
+    private static RowGroup relocate(RowGroup rowGroup, long delta, int ordinal) {
+        List<ColumnChunk> chunks = new ArrayList<>(rowGroup.columns().size());
+        for (ColumnChunk chunk : rowGroup.columns()) {
+            chunks.add(relocate(chunk, delta));
+        }
+        Long fileOffset = add(rowGroup.fileOffset(), delta);
+        Short outputOrdinal = ordinal <= Short.MAX_VALUE ? (short) ordinal : null;
+        return new RowGroup(List.copyOf(chunks), rowGroup.totalByteSize(), rowGroup.numRows(),
+                fileOffset, rowGroup.totalCompressedSize(), outputOrdinal);
+    }
+
+    private static ColumnChunk relocate(ColumnChunk chunk, long delta) {
+        ColumnMetaData m = chunk.metaData();
+        ColumnMetaData relocated = new ColumnMetaData(m.type(), m.encodings(), m.pathInSchema(),
+                m.codec(), m.numValues(), m.totalUncompressedSize(), m.totalCompressedSize(),
+                m.keyValueMetadata(), Math.addExact(m.dataPageOffset(), delta),
+                add(m.indexPageOffset(), delta), add(m.dictionaryPageOffset(), delta),
+                m.statistics(), m.geospatialStatistics(), add(m.bloomFilterOffset(), delta),
+                m.bloomFilterLength());
+        return new ColumnChunk(relocated, add(chunk.offsetIndexOffset(), delta),
+                chunk.offsetIndexLength(), add(chunk.columnIndexOffset(), delta),
+                chunk.columnIndexLength());
+    }
+
+    private static Long add(Long value, long delta) {
+        return value == null ? null : Math.addExact(value, delta);
+    }
+
+    private static void validateCompatible(List<Source> sources) {
+        FileMetaData first = sources.get(0).metadata();
+        for (int i = 1; i < sources.size(); i++) {
+            FileMetaData candidate = sources.get(i).metadata();
+            if (!first.schema().equals(candidate.schema())) {
+                throw new IllegalArgumentException("Schema mismatch: " + sources.get(i).input().name());
+            }
+            if (!first.columnOrders().equals(candidate.columnOrders())) {
+                throw new IllegalArgumentException("Column-order mismatch: " + sources.get(i).input().name());
+            }
+            if (!metadataEquals(first.keyValueMetadata(), candidate.keyValueMetadata())) {
+                throw new IllegalArgumentException("File metadata mismatch: " + sources.get(i).input().name());
+            }
+        }
+    }
+
+    private static boolean metadataEquals(Map<String, String> first, Map<String, String> second) {
+        return first.equals(second);
+    }
+
+    private static long footerStart(InputFile input) throws IOException {
+        long length = input.length();
+        ByteBuffer trailer = input.readRange(length - FOOTER_TRAILER_SIZE, FOOTER_TRAILER_SIZE)
+                .order(ByteOrder.LITTLE_ENDIAN);
+        int footerLength = trailer.getInt();
+        return Math.subtractExact(length - FOOTER_TRAILER_SIZE, footerLength);
+    }
+
+    private record Source(InputFile input, FileMetaData metadata, long footerStart) {}
+}

--- a/core/src/main/java/dev/hardwood/metadata/ColumnMetaData.java
+++ b/core/src/main/java/dev/hardwood/metadata/ColumnMetaData.java
@@ -38,9 +38,22 @@ public record ColumnMetaData(
         long totalCompressedSize,
         Map<String, String> keyValueMetadata,
         long dataPageOffset,
+        Long indexPageOffset,
         Long dictionaryPageOffset,
         Statistics statistics,
         GeospatialStatistics geospatialStatistics,
         Long bloomFilterOffset,
         Integer bloomFilterLength) {
+
+    public ColumnMetaData(PhysicalType type, List<Encoding> encodings, FieldPath pathInSchema,
+            CompressionCodec codec, long numValues, long totalUncompressedSize,
+            long totalCompressedSize, Map<String, String> keyValueMetadata, long dataPageOffset,
+            Long dictionaryPageOffset, Statistics statistics,
+            GeospatialStatistics geospatialStatistics, Long bloomFilterOffset,
+            Integer bloomFilterLength) {
+        this(type, encodings, pathInSchema, codec, numValues, totalUncompressedSize,
+                totalCompressedSize, keyValueMetadata, dataPageOffset, null,
+                dictionaryPageOffset, statistics, geospatialStatistics, bloomFilterOffset,
+                bloomFilterLength);
+    }
 }

--- a/core/src/main/java/dev/hardwood/metadata/RowGroup.java
+++ b/core/src/main/java/dev/hardwood/metadata/RowGroup.java
@@ -19,5 +19,12 @@ import java.util.List;
 public record RowGroup(
         List<ColumnChunk> columns,
         long totalByteSize,
-        long numRows) {
+        long numRows,
+        Long fileOffset,
+        Long totalCompressedSize,
+        Short ordinal) {
+
+    public RowGroup(List<ColumnChunk> columns, long totalByteSize, long numRows) {
+        this(columns, totalByteSize, numRows, null, null, null);
+    }
 }

--- a/core/src/test/java/dev/hardwood/internal/writer/ParquetFileStitcherTest.java
+++ b/core/src/test/java/dev/hardwood/internal/writer/ParquetFileStitcherTest.java
@@ -1,0 +1,91 @@
+/*
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Copyright The original authors
+ *
+ *  Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package dev.hardwood.internal.writer;
+
+import java.nio.ByteBuffer;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+
+import dev.hardwood.InputFile;
+import dev.hardwood.metadata.PhysicalType;
+import dev.hardwood.metadata.RepetitionType;
+import dev.hardwood.reader.ColumnReader;
+import dev.hardwood.reader.ParquetFileReader;
+import dev.hardwood.schema.FileSchema;
+import dev.hardwood.writer.ParquetFileWriter;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class ParquetFileStitcherTest {
+    @Test
+    void stitchesBodiesAndRowGroupsWithoutReencoding() throws Exception {
+        byte[] first = file(schema("id"), 1, 2, 3);
+        byte[] second = file(schema("id"), 4, 5);
+        ByteBufferOutputFile output = new ByteBufferOutputFile();
+
+        ParquetFileStitcher.stitch(List.of(
+                InputFile.of(ByteBuffer.wrap(first)), InputFile.of(ByteBuffer.wrap(second))), output);
+
+        byte[] merged = output.toByteArray();
+        try (ParquetFileReader reader = ParquetFileReader.open(InputFile.of(ByteBuffer.wrap(merged)))) {
+            assertThat(reader.getFileMetaData().numRows()).isEqualTo(5);
+            assertThat(reader.getFileMetaData().rowGroups()).hasSize(2);
+            assertThat(readInts(reader)).containsExactly(1, 2, 3, 4, 5);
+        }
+        int firstFooter = footerStart(first);
+        int secondFooter = footerStart(second);
+        assertThat(Arrays.copyOfRange(merged, 4, firstFooter)).isEqualTo(Arrays.copyOfRange(first, 4, firstFooter));
+        assertThat(Arrays.copyOfRange(merged, firstFooter, firstFooter + secondFooter - 4))
+                .isEqualTo(Arrays.copyOfRange(second, 4, secondFooter));
+    }
+
+    @Test
+    void rejectsMismatchedSchemasBeforeCreatingOutput() throws Exception {
+        ByteBufferOutputFile output = new ByteBufferOutputFile();
+        assertThatThrownBy(() -> ParquetFileStitcher.stitch(List.of(
+                InputFile.of(ByteBuffer.wrap(file(schema("a"), 1))),
+                InputFile.of(ByteBuffer.wrap(file(schema("b"), 2)))), output))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("Schema mismatch");
+    }
+
+    private static FileSchema schema(String name) {
+        return FileSchema.builder("schema")
+                .addColumn(name, PhysicalType.INT32, RepetitionType.REQUIRED)
+                .build();
+    }
+
+    private static byte[] file(FileSchema schema, int... values) throws Exception {
+        ByteBufferOutputFile output = new ByteBufferOutputFile();
+        try (ParquetFileWriter writer = ParquetFileWriter.create(output, schema)) {
+            writer.writeBatch(batch -> batch.ints(0, values));
+        }
+        return output.toByteArray();
+    }
+
+    private static List<Integer> readInts(ParquetFileReader reader) {
+        List<Integer> values = new ArrayList<>();
+        try (ColumnReader column = reader.columnReader(0)) {
+            while (column.nextBatch()) {
+                for (int i = 0; i < column.getRecordCount(); i++) {
+                    values.add(column.getInts()[i]);
+                }
+            }
+        }
+        return values;
+    }
+
+    private static int footerStart(byte[] file) {
+        return file.length - 8 - ByteBuffer.wrap(file, file.length - 8, 4)
+                .order(java.nio.ByteOrder.LITTLE_ENDIAN).getInt();
+    }
+}

--- a/docs/content/reference/cli.md
+++ b/docs/content/reference/cli.md
@@ -31,8 +31,22 @@ run the CLI via Docker without installing it locally — see the [Docker section
 | `hardwood schema` | Print the file schema, including logical-type annotations such as `VARIANT(1)` on Variant groups |
 | `hardwood print` | Print rows as an ASCII table (head, tail, or all); Variant columns are decoded to JSON-like text |
 | `hardwood convert` | Convert a Parquet file to CSV or JSON (head, tail, or all); Variant columns are emitted as a JSON string in CSV and as a native JSON subtree in JSON |
+| `hardwood merge` | Merge same-schema local Parquet files without decoding or re-encoding their pages |
 | `hardwood footer` | Print decoded footer length, offset, and file structure |
 | `hardwood inspect pages` | List data and dictionary pages per column chunk; includes per-page min/max when the file has a page index |
+
+## Merge files
+
+```shell
+hardwood merge --output combined.parquet part-1.parquet part-2.parquet
+```
+
+`merge` preserves the input order and keeps every input row group intact. Input
+schemas and column orders must match exactly. Compression codecs and encodings may
+differ because Parquet records them per column chunk. Conflicting file-level
+key/value metadata is rejected. The command accepts local paths and writes the
+destination atomically; an incomplete output is discarded if validation or copying
+fails.
 | `hardwood inspect dictionary` | Print dictionary entries for a column |
 | `hardwood inspect columns` | Show compressed and uncompressed byte sizes per column, ranked |
 | `hardwood inspect rowgroups` | Display per-row-group column chunk metadata (sizes, codec) |


### PR DESCRIPTION
Reuse encoded input bodies and rebuild relocated footer metadata so same-schema files can be combined without the cost or fidelity loss of decoding and rewriting every row.

Fixes #767 

## Test validation

- Verified merged files preserve input bodies byte-for-byte without re-encoding.
- Verified row counts, row-group order, and values across multiple inputs.
- Verified mismatched schemas are rejected before output creation.
- Verified using the output file as an input is rejected.
- Verified the CLI produces a readable merged Parquet file.
- Focused core and CLI tests pass.
- The full core test suite passes.
- Full `./mvnw clean verify` is blocked because Docker is unavailable for the existing S3 Testcontainers tests.

## Checklist

- [ ] Build via `./mvnw clean verify` passes — blocked by unavailable Docker; existing S3 Testcontainers tests could not start
- [x] The commit message is prefixed with the issue key (`#767 Add zero-decode Parquet merge command`)
- [x] Code changes are covered by tests
- [x] User-facing behavior is documented under `docs/`