### PR TITLE
#795 Skip per-row filter evaluation when statistics prove a row group matches in full

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -345,6 +345,7 @@ For field-level `parquet.thrift` metadata coverage (which spec fields are read/p
 - [x] Drain-side per-batch record filtering (`BatchFilterCompiler` + `ColumnBatchMatcher`, on by default for column-local AND queries; see `_designs/DRAIN_SIDE_RECORD_FILTERING.md`)
 - [x] Exact column-reader filtering — `buildColumnReader(...).filter(...)` / `buildColumnReaders(...).filter(...)` return only matching rows with no client-side residual (`SelectionEngine` + `FilterCoordinator`; see `_designs/EXACT_COLUMN_READER_FILTERING.md`)
 - [x] Bloom filter-based row group filtering: `eq` on INT32, INT64, FLOAT, DOUBLE, and binary columns, and `in` on the integer and binary types (`RowGroupBloomFilterSource`; see `_designs/BLOOM_FILTER_PUSHDOWN.md`)
+- [x] Always-match statistics decision: tri-state `StatsDecision` proves from statistics when every row in a row group matches, skipping per-row filter evaluation for that group and dropping the filter wholesale when all surviving groups fully match (see `_designs/ALWAYS_MATCH_STATISTICS.md`)
 
 ### 9.5 Fixed-size-list read fast path
 - [x] Detect fixed-width fixed-*k* `LIST` pages from level streams alone (`FixedSizeListDetector`): O(1) definition-level gate + O(rows) repetition verification

--- a/_designs/ALWAYS_MATCH_STATISTICS.md
+++ b/_designs/ALWAYS_MATCH_STATISTICS.md
@@ -1,0 +1,100 @@
+# Design: always-match statistics decisions (#795)
+
+**Status: Implemented** (row-group granularity; page-level pre-approved ranges are a
+follow-up, see "Boundaries" below).
+
+## Problem
+
+Statistics evaluation is drop-only: `StatisticsFilterSupport.canDropLeaf`,
+`RowGroupFilterEvaluator.canDropRowGroup`, and `PageDropPredicates.canDropPage` answer
+only "can no rows match?". Every surviving unit is then evaluated row by row — the
+compiled `RowMatcher` on the record path, per-column `ColumnBatchMatcher`s on the
+drain-side path.
+
+For a range predicate over a sorted or clustered column, the statistics of most
+*surviving* row groups prove the opposite extreme: every row matches (the whole
+`[min, max]` interval satisfies the predicate and the null count is zero). Per-row
+evaluation over those groups reproduces a foregone conclusion at full decode-side cost.
+
+## The decision model
+
+`StatsDecision` (internal.predicate) is the three-valued extension of the boolean drop:
+
+| decision         | meaning                             | today's equivalent |
+|------------------|-------------------------------------|--------------------|
+| `CANNOT_MATCH`   | no row matches; skip the unit       | `canDrop == true`  |
+| `MIGHT_MATCH`    | undecided; evaluate rows            | `canDrop == false` |
+| `ALWAYS_MATCHES` | every row matches; skip evaluation  | — (new)            |
+
+`canDropRowGroup` is now defined as `decideRowGroup(...) == CANNOT_MATCH`; there is one
+evaluation implementation, not two.
+
+### Leaf rule
+
+A value leaf is `ALWAYS_MATCHES` when all of:
+
+- min and max are present and trusted (deprecated unsigned min/max fields are already
+  nulled out by `MinMaxStats.of`), and
+- every value in `[min, max]` satisfies the operator
+  (`StatisticsFilterSupport.alwaysMatches` / `alwaysMatchesCompared`; for `IN`,
+  the single-point case `min == max ∈ values`), and
+- `null_count == 0` — a null row satisfies no value predicate.
+
+`IS NOT NULL` is `ALWAYS_MATCHES` on `null_count == 0` alone. Everything else that
+cannot be proven is `MIGHT_MATCH`, which preserves today's behavior exactly.
+
+Truncated (inexact) bounds need no special handling: truncation only widens
+`[min, max]`, and a predicate satisfied by the widened interval is satisfied by the
+actual values.
+
+### Deliberate non-promises
+
+- **Floating point** (`FLOAT`, `DOUBLE`, `FLOAT16`): NaN sits outside the min/max
+  ordering and `nan_count` is not consumed (#607), so a fully-satisfying interval may
+  still hide non-matching NaN rows. FP value leaves never yield `ALWAYS_MATCHES`.
+- **`IS NULL`**: the null count tallies leaf values, not rows, so `null_count ==
+  numRows` does not prove every row's leaf is null for nested columns.
+- **Bloom filters** prove absence only; they can force `CANNOT_MATCH` but never upgrade
+  a decision.
+- **Composition**: `AND` is `ALWAYS_MATCHES` only when every child is; `OR` when any
+  child is; empty composites stay `MIGHT_MATCH`.
+
+## Consumption (row-group granularity)
+
+`RowGroupIterator.filterRowGroups` evaluates the tri-state per row group: `CANNOT_MATCH`
+groups are dropped (unchanged), and each surviving `WorkItem` carries
+`filterAlwaysMatches`.
+
+Two consumers:
+
+1. **Wholesale**: when every work-list row group is `ALWAYS_MATCHES`
+   (`RowGroupIterator.isFilterSatisfiedByStatistics`), `FlatRowReader.create` /
+   `NestedRowReader.create` treat the read as unfiltered — no matcher compilation, no
+   `FilteredRowReader` wrapper, and `maxRows` caps scanned rows directly since
+   scanned == matching.
+2. **Per-batch, drain-side**: batches must be homogeneous for a batch-level skip, so
+   the drain flushes the current batch when a page crosses a row-group boundary that
+   changes the flag — the same mechanism as the existing file-boundary flush, and
+   applied **uniformly across all workers of a projection** so batches stay
+   row-aligned (a per-column flush would desynchronize the merge). For an
+   always-matching batch the worker skips `ColumnBatchMatcher.test` and writes the
+   all-ones mask a matcher would have produced; `Batch.filterAlwaysMatches` records
+   the proof for downstream consumers.
+
+The flag travels retriever → drain through a per-slot buffer written alongside
+`fileNameBuffer[slot]`, under the same happens-before chain.
+
+`RowGroupFilterEvent` gains `rowGroupsFullyMatching` so the effect is observable in JFR.
+
+## Boundaries
+
+- **Page-level pre-approved ranges** (skip evaluation inside surviving pages whose
+  ColumnIndex entry is `ALWAYS_MATCHES`) extend `RowRanges` and compose with the
+  intra-page skip-decode work (#728); follow-up to #795.
+- **`ColumnReader` / `SelectionEngine`**: `computeSelection` already has an every-record
+  fast path (`-1`); feeding it from `Batch.filterAlwaysMatches` is part of the same
+  follow-up.
+- **Record-matcher path** (`FilteredRowReader`): benefits from the wholesale case only;
+  the wrapper has no row-group visibility for per-group skips.
+- The row-group decision is exactly the trigger condition the rewrite capability's
+  byte-copy fast path needs (#791, item 6).

--- a/core/src/main/java/dev/hardwood/internal/predicate/MinMaxStats.java
+++ b/core/src/main/java/dev/hardwood/internal/predicate/MinMaxStats.java
@@ -7,6 +7,8 @@
  */
 package dev.hardwood.internal.predicate;
 
+import java.util.List;
+
 import dev.hardwood.metadata.ColumnIndex;
 import dev.hardwood.metadata.Statistics;
 
@@ -19,6 +21,9 @@ interface MinMaxStats {
 
     /// @return the maximum value as raw bytes, or `null` if absent
     byte[] maxValue();
+
+    /// @return the number of null values in the unit, or `null` if unknown
+    Long nullCount();
 
     /// Wraps a [Statistics] record.
     ///
@@ -39,6 +44,11 @@ interface MinMaxStats {
             public byte[] maxValue() {
                 return deprecated ? null : stats.maxValue();
             }
+
+            @Override
+            public Long nullCount() {
+                return stats.nullCount();
+            }
         };
     }
 
@@ -53,6 +63,12 @@ interface MinMaxStats {
             @Override
             public byte[] maxValue() {
                 return columnIndex.maxValues().get(pageIndex);
+            }
+
+            @Override
+            public Long nullCount() {
+                List<Long> nullCounts = columnIndex.nullCounts();
+                return nullCounts != null ? nullCounts.get(pageIndex) : null;
             }
         };
     }

--- a/core/src/main/java/dev/hardwood/internal/predicate/RowGroupFilterEvaluator.java
+++ b/core/src/main/java/dev/hardwood/internal/predicate/RowGroupFilterEvaluator.java
@@ -16,15 +16,17 @@ import dev.hardwood.metadata.Statistics;
 import dev.hardwood.reader.FilterPredicate;
 
 /// Evaluates filter predicates against row group statistics and bloom filters to determine
-/// whether a row group can be skipped.
+/// whether a row group can be skipped — or read without per-row filtering.
 ///
 /// Uses a conservative approach: if statistics are absent for a column,
-/// the row group is never dropped (it may contain matching rows).
+/// the row group is never dropped (it may contain matching rows) and never
+/// promised to match in full.
 ///
 /// Equality (`EQ`) and membership (`IN`) leaves additionally consult the column's bloom filter
 /// when one is supplied via a [BloomFilterSource]: a value that hashes to a definitely-absent
 /// slot drops the row group even when it falls inside the statistics min/max range. The two
-/// checks are complementary — either one proving no match is sufficient.
+/// checks are complementary — either one proving no match is sufficient. A bloom filter can
+/// only prove absence, so it never upgrades a decision to [StatsDecision#ALWAYS_MATCHES].
 public class RowGroupFilterEvaluator {
 
     /// Determines whether a row group can be skipped using statistics only (no bloom filters).
@@ -47,108 +49,170 @@ public class RowGroupFilterEvaluator {
     ///         `false` if it may contain matching rows
     public static boolean canDropRowGroup(ResolvedPredicate predicate, RowGroup rowGroup,
             BloomFilterSource bloomFilters) {
+        return decideRowGroup(predicate, rowGroup, bloomFilters) == StatsDecision.CANNOT_MATCH;
+    }
+
+    /// Evaluates the predicate against the row group's statistics and bloom filters as a
+    /// three-valued [StatsDecision].
+    ///
+    /// [StatsDecision#CANNOT_MATCH] row groups can be skipped entirely;
+    /// [StatsDecision#ALWAYS_MATCHES] row groups can be read with per-row predicate
+    /// evaluation skipped, since statistics prove every row satisfies the predicate.
+    ///
+    /// @param predicate the resolved predicate to evaluate
+    /// @param rowGroup the row group to check
+    /// @param bloomFilters source of the row group's bloom filters, or `null` to evaluate
+    ///        statistics only
+    /// @return the statistics decision for the row group
+    public static StatsDecision decideRowGroup(ResolvedPredicate predicate, RowGroup rowGroup,
+            BloomFilterSource bloomFilters) {
         return switch (predicate) {
             case ResolvedPredicate.IntPredicate p -> {
-                if (statisticsDrop(p, p.columnIndex(), rowGroup)) {
-                    yield true;
+                StatsDecision decision = statisticsDecision(p, p.columnIndex(), rowGroup);
+                if (decision != StatsDecision.CANNOT_MATCH
+                        && p.op() == FilterPredicate.Operator.EQ
+                        && BloomFilterSupport.valueAbsent(bloomFilters, p.columnIndex(), p.value())) {
+                    yield StatsDecision.CANNOT_MATCH;
                 }
-                yield p.op() == FilterPredicate.Operator.EQ
-                        && BloomFilterSupport.valueAbsent(bloomFilters, p.columnIndex(), p.value());
+                yield decision;
             }
             case ResolvedPredicate.LongPredicate p -> {
-                if (statisticsDrop(p, p.columnIndex(), rowGroup)) {
-                    yield true;
+                StatsDecision decision = statisticsDecision(p, p.columnIndex(), rowGroup);
+                if (decision != StatsDecision.CANNOT_MATCH
+                        && p.op() == FilterPredicate.Operator.EQ
+                        && BloomFilterSupport.valueAbsent(bloomFilters, p.columnIndex(), p.value())) {
+                    yield StatsDecision.CANNOT_MATCH;
                 }
-                yield p.op() == FilterPredicate.Operator.EQ
-                        && BloomFilterSupport.valueAbsent(bloomFilters, p.columnIndex(), p.value());
+                yield decision;
             }
             case ResolvedPredicate.FloatPredicate p -> {
-                if (statisticsDrop(p, p.columnIndex(), rowGroup)) {
-                    yield true;
+                StatsDecision decision = statisticsDecision(p, p.columnIndex(), rowGroup);
+                if (decision != StatsDecision.CANNOT_MATCH
+                        && p.op() == FilterPredicate.Operator.EQ
+                        && BloomFilterSupport.valueAbsent(bloomFilters, p.columnIndex(), p.value())) {
+                    yield StatsDecision.CANNOT_MATCH;
                 }
-                yield p.op() == FilterPredicate.Operator.EQ
-                        && BloomFilterSupport.valueAbsent(bloomFilters, p.columnIndex(), p.value());
+                yield decision;
             }
             case ResolvedPredicate.Float16Predicate p ->
-                    statisticsDrop(p, p.columnIndex(), rowGroup);
+                    statisticsDecision(p, p.columnIndex(), rowGroup);
             case ResolvedPredicate.DoublePredicate p -> {
-                if (statisticsDrop(p, p.columnIndex(), rowGroup)) {
-                    yield true;
+                StatsDecision decision = statisticsDecision(p, p.columnIndex(), rowGroup);
+                if (decision != StatsDecision.CANNOT_MATCH
+                        && p.op() == FilterPredicate.Operator.EQ
+                        && BloomFilterSupport.valueAbsent(bloomFilters, p.columnIndex(), p.value())) {
+                    yield StatsDecision.CANNOT_MATCH;
                 }
-                yield p.op() == FilterPredicate.Operator.EQ
-                        && BloomFilterSupport.valueAbsent(bloomFilters, p.columnIndex(), p.value());
+                yield decision;
             }
             case ResolvedPredicate.BooleanPredicate p ->
-                    statisticsDrop(p, p.columnIndex(), rowGroup);
+                    statisticsDecision(p, p.columnIndex(), rowGroup);
             case ResolvedPredicate.BinaryPredicate p -> {
-                if (statisticsDrop(p, p.columnIndex(), rowGroup)) {
-                    yield true;
+                StatsDecision decision = statisticsDecision(p, p.columnIndex(), rowGroup);
+                if (decision != StatsDecision.CANNOT_MATCH
+                        && p.op() == FilterPredicate.Operator.EQ
+                        && BloomFilterSupport.valueAbsent(bloomFilters, p.columnIndex(), p.value())) {
+                    yield StatsDecision.CANNOT_MATCH;
                 }
-                yield p.op() == FilterPredicate.Operator.EQ
-                        && BloomFilterSupport.valueAbsent(bloomFilters, p.columnIndex(), p.value());
+                yield decision;
             }
             case ResolvedPredicate.IntInPredicate p -> {
-                if (statisticsDrop(p, p.columnIndex(), rowGroup)) {
-                    yield true;
+                StatsDecision decision = statisticsDecision(p, p.columnIndex(), rowGroup);
+                if (decision != StatsDecision.CANNOT_MATCH
+                        && BloomFilterSupport.absentAll(bloomFilters, p.columnIndex(), p.values())) {
+                    yield StatsDecision.CANNOT_MATCH;
                 }
-                yield BloomFilterSupport.absentAll(bloomFilters, p.columnIndex(), p.values());
+                yield decision;
             }
             case ResolvedPredicate.LongInPredicate p -> {
-                if (statisticsDrop(p, p.columnIndex(), rowGroup)) {
-                    yield true;
+                StatsDecision decision = statisticsDecision(p, p.columnIndex(), rowGroup);
+                if (decision != StatsDecision.CANNOT_MATCH
+                        && BloomFilterSupport.absentAll(bloomFilters, p.columnIndex(), p.values())) {
+                    yield StatsDecision.CANNOT_MATCH;
                 }
-                yield BloomFilterSupport.absentAll(bloomFilters, p.columnIndex(), p.values());
+                yield decision;
             }
             case ResolvedPredicate.BinaryInPredicate p -> {
-                if (statisticsDrop(p, p.columnIndex(), rowGroup)) {
-                    yield true;
+                StatsDecision decision = statisticsDecision(p, p.columnIndex(), rowGroup);
+                if (decision != StatsDecision.CANNOT_MATCH
+                        && BloomFilterSupport.absentAll(bloomFilters, p.columnIndex(), p.values())) {
+                    yield StatsDecision.CANNOT_MATCH;
                 }
-                yield BloomFilterSupport.absentAll(bloomFilters, p.columnIndex(), p.values());
+                yield decision;
             }
             case ResolvedPredicate.IsNullPredicate p -> {
                 Statistics stats = getStatistics(p.columnIndex(), rowGroup);
-                // Can drop IS NULL if nullCount is known to be 0 (no nulls exist)
-                yield stats != null && stats.nullCount() != null && stats.nullCount() == 0;
+                // Can drop IS NULL if nullCount is known to be 0 (no nulls exist).
+                // The always-matching dual (every row null) is deliberately not derived:
+                // for nested columns the null count tallies leaf values, not rows, so
+                // nullCount == numRows does not prove every row's leaf is null.
+                yield stats != null && stats.nullCount() != null && stats.nullCount() == 0
+                        ? StatsDecision.CANNOT_MATCH
+                        : StatsDecision.MIGHT_MATCH;
             }
             case ResolvedPredicate.IsNotNullPredicate p -> {
                 Statistics stats = getStatistics(p.columnIndex(), rowGroup);
+                if (stats == null || stats.nullCount() == null) {
+                    yield StatsDecision.MIGHT_MATCH;
+                }
                 // Can drop IS NOT NULL if all values are null (nullCount == numRows)
-                yield stats != null && stats.nullCount() != null && stats.nullCount() == rowGroup.numRows();
+                if (stats.nullCount() == rowGroup.numRows()) {
+                    yield StatsDecision.CANNOT_MATCH;
+                }
+                yield stats.nullCount() == 0
+                        ? StatsDecision.ALWAYS_MATCHES
+                        : StatsDecision.MIGHT_MATCH;
             }
             case ResolvedPredicate.And a -> {
+                if (a.children().isEmpty()) {
+                    yield StatsDecision.MIGHT_MATCH;
+                }
+                StatsDecision result = StatsDecision.ALWAYS_MATCHES;
                 for (ResolvedPredicate child : a.children()) {
-                    if (canDropRowGroup(child, rowGroup, bloomFilters)) {
-                        yield true;
+                    result = StatsDecision.and(result, decideRowGroup(child, rowGroup, bloomFilters));
+                    if (result == StatsDecision.CANNOT_MATCH) {
+                        break;
                     }
                 }
-                yield false;
+                yield result;
             }
             case ResolvedPredicate.Or o -> {
+                if (o.children().isEmpty()) {
+                    yield StatsDecision.MIGHT_MATCH;
+                }
+                StatsDecision result = StatsDecision.CANNOT_MATCH;
                 for (ResolvedPredicate child : o.children()) {
-                    if (!canDropRowGroup(child, rowGroup, bloomFilters)) {
-                        yield false;
+                    result = StatsDecision.or(result, decideRowGroup(child, rowGroup, bloomFilters));
+                    if (result == StatsDecision.ALWAYS_MATCHES) {
+                        break;
                     }
                 }
-                yield true;
+                yield result;
             }
             case ResolvedPredicate.GeospatialPredicate p -> {
                 ColumnMetaData cmd = rowGroup.columns().get(p.columnIndex()).metaData();
                 GeospatialStatistics geospatialStatistics = cmd.geospatialStatistics();
                 if (geospatialStatistics == null || geospatialStatistics.bbox() == null) {
-                    yield false; // no stats, can't drop
+                    yield StatsDecision.MIGHT_MATCH; // no stats, can't drop
                 }
                 BoundingBox bbox = geospatialStatistics.bbox();
                 yield !Geospatial.xAxisOverlaps(bbox.xmin(), bbox.xmax(), p.xmin(), p.xmax()) ||
                         bbox.ymax() < p.ymin() ||
-                        bbox.ymin() > p.ymax();
+                        bbox.ymin() > p.ymax()
+                        ? StatsDecision.CANNOT_MATCH
+                        : StatsDecision.MIGHT_MATCH;
             }
         };
     }
 
-    /// Whether the column's min/max statistics prove the leaf matches no rows.
-    private static boolean statisticsDrop(ResolvedPredicate leaf, int columnIndex, RowGroup rowGroup) {
+    /// The column's min/max statistics decision for the leaf, [StatsDecision#MIGHT_MATCH]
+    /// when statistics are absent.
+    private static StatsDecision statisticsDecision(ResolvedPredicate leaf, int columnIndex,
+            RowGroup rowGroup) {
         Statistics stats = getStatistics(columnIndex, rowGroup);
-        return stats != null && StatisticsFilterSupport.canDropLeaf(leaf, MinMaxStats.of(stats));
+        return stats == null
+                ? StatsDecision.MIGHT_MATCH
+                : StatisticsFilterSupport.decideLeaf(leaf, MinMaxStats.of(stats));
     }
 
     /// Gets statistics for a column by its pre-resolved index.

--- a/core/src/main/java/dev/hardwood/internal/predicate/StatisticsFilterSupport.java
+++ b/core/src/main/java/dev/hardwood/internal/predicate/StatisticsFilterSupport.java
@@ -77,6 +77,82 @@ final class StatisticsFilterSupport {
         };
     }
 
+    /// Evaluates a resolved leaf predicate against [MinMaxStats] as a three-valued
+    /// [StatsDecision].
+    ///
+    /// [StatsDecision#ALWAYS_MATCHES] requires the whole `[min, max]` interval to satisfy
+    /// the predicate **and** a proven-zero null count — a null row satisfies no value
+    /// predicate, so without it a fully-matching range still cannot promise every row.
+    /// Truncated (inexact) bounds are safe by construction: they only widen the interval,
+    /// and a predicate satisfied by the widened interval is satisfied by the actual values.
+    static StatsDecision decideLeaf(ResolvedPredicate leaf, MinMaxStats stats) {
+        // IS NOT NULL is decided by the null count alone; min/max are irrelevant.
+        if (leaf instanceof ResolvedPredicate.IsNotNullPredicate) {
+            return isNullFree(stats) ? StatsDecision.ALWAYS_MATCHES : StatsDecision.MIGHT_MATCH;
+        }
+        if (canDropLeaf(leaf, stats)) {
+            return StatsDecision.CANNOT_MATCH;
+        }
+        if (!isNullFree(stats) || stats.minValue() == null || stats.maxValue() == null) {
+            return StatsDecision.MIGHT_MATCH;
+        }
+        return alwaysMatchesLeaf(leaf, stats) ? StatsDecision.ALWAYS_MATCHES : StatsDecision.MIGHT_MATCH;
+    }
+
+    private static boolean isNullFree(MinMaxStats stats) {
+        Long nullCount = stats.nullCount();
+        return nullCount != null && nullCount == 0;
+    }
+
+    /// Whether the min/max statistics prove the leaf matches every row. Assumes the caller
+    /// has already established a zero null count and present bounds.
+    private static boolean alwaysMatchesLeaf(ResolvedPredicate leaf, MinMaxStats stats) {
+        return switch (leaf) {
+            case ResolvedPredicate.IntPredicate p -> alwaysMatches(p.op(), p.value(),
+                    StatisticsDecoder.decodeInt(stats.minValue()),
+                    StatisticsDecoder.decodeInt(stats.maxValue()));
+            case ResolvedPredicate.LongPredicate p -> alwaysMatches(p.op(), p.value(),
+                    StatisticsDecoder.decodeLong(stats.minValue()),
+                    StatisticsDecoder.decodeLong(stats.maxValue()));
+            case ResolvedPredicate.BooleanPredicate p -> alwaysMatches(p.op(), p.value() ? 1 : 0,
+                    StatisticsDecoder.decodeBoolean(stats.minValue()) ? 1 : 0,
+                    StatisticsDecoder.decodeBoolean(stats.maxValue()) ? 1 : 0);
+            // NaN values sit outside the min/max ordering, and nan_count is not read yet:
+            // a floating-point unit whose [min, max] fully satisfies the predicate may
+            // still hold non-matching NaN rows. Never promise a full match for FP columns.
+            case ResolvedPredicate.FloatPredicate ignored -> false;
+            case ResolvedPredicate.Float16Predicate ignored -> false;
+            case ResolvedPredicate.DoublePredicate ignored -> false;
+            case ResolvedPredicate.BinaryPredicate p -> {
+                if (p.signed()) {
+                    yield alwaysMatchesCompared(p.op(),
+                            BinaryComparator.compareSigned(p.value(), stats.minValue()),
+                            BinaryComparator.compareSigned(p.value(), stats.maxValue()),
+                            BinaryComparator.compareSigned(stats.minValue(), stats.maxValue()));
+                }
+                yield alwaysMatchesCompared(p.op(),
+                        BinaryComparator.compareUnsigned(p.value(), stats.minValue()),
+                        BinaryComparator.compareUnsigned(p.value(), stats.maxValue()),
+                        BinaryComparator.compareUnsigned(stats.minValue(), stats.maxValue()));
+            }
+            case ResolvedPredicate.IntInPredicate p ->
+                    alwaysMatchesIntIn(p.values(),
+                            StatisticsDecoder.decodeInt(stats.minValue()),
+                            StatisticsDecoder.decodeInt(stats.maxValue()));
+            case ResolvedPredicate.LongInPredicate p ->
+                    alwaysMatchesLongIn(p.values(),
+                            StatisticsDecoder.decodeLong(stats.minValue()),
+                            StatisticsDecoder.decodeLong(stats.maxValue()));
+            case ResolvedPredicate.BinaryInPredicate p ->
+                    alwaysMatchesBinaryIn(p.values(), stats.minValue(), stats.maxValue());
+            case ResolvedPredicate.IsNullPredicate ignored -> false;
+            case ResolvedPredicate.IsNotNullPredicate ignored -> false;
+            case ResolvedPredicate.And ignored -> false;
+            case ResolvedPredicate.Or ignored -> false;
+            case ResolvedPredicate.GeospatialPredicate ignored -> false;
+        };
+    }
+
     // ==================== Range comparison logic ====================
 
     /// Determines if a range can be dropped given integer-comparable min/max statistics.
@@ -156,6 +232,37 @@ final class StatisticsFilterSupport {
         };
     }
 
+    /// Determines if every value in `[min, max]` satisfies the operator, given
+    /// integer-comparable min/max statistics. Works for int, long, boolean (mapped to 0/1).
+    static boolean alwaysMatches(FilterPredicate.Operator op, long value, long min, long max) {
+        return switch (op) {
+            case EQ -> min == max && value == min;
+            case NOT_EQ -> value < min || value > max;
+            case LT -> max < value;
+            case LT_EQ -> max <= value;
+            case GT -> min > value;
+            case GT_EQ -> min >= value;
+        };
+    }
+
+    /// Determines if every value in `[min, max]` satisfies the operator, given pre-computed
+    /// comparison results for binary values.
+    ///
+    /// @param cmpMin comparison of value vs min (negative if value < min)
+    /// @param cmpMax comparison of value vs max (positive if value > max)
+    /// @param minEqMax comparison of min vs max (0 if min == max)
+    static boolean alwaysMatchesCompared(FilterPredicate.Operator op, int cmpMin, int cmpMax,
+            int minEqMax) {
+        return switch (op) {
+            case EQ -> minEqMax == 0 && cmpMin == 0;
+            case NOT_EQ -> cmpMin < 0 || cmpMax > 0;
+            case LT -> cmpMax > 0;
+            case LT_EQ -> cmpMax >= 0;
+            case GT -> cmpMin < 0;
+            case GT_EQ -> cmpMin <= 0;
+        };
+    }
+
     // ==================== IN predicate range checks ====================
 
     static boolean canDropIntIn(int[] values, int min, int max) {
@@ -184,5 +291,45 @@ final class StatisticsFilterSupport {
             }
         }
         return true;
+    }
+
+    // ==================== IN predicate always-match checks ====================
+    // An IN predicate matches every row only in the single-point case: min == max
+    // and that one value is a member of the set.
+
+    static boolean alwaysMatchesIntIn(int[] values, int min, int max) {
+        if (min != max) {
+            return false;
+        }
+        for (int value : values) {
+            if (value == min) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    static boolean alwaysMatchesLongIn(long[] values, long min, long max) {
+        if (min != max) {
+            return false;
+        }
+        for (long value : values) {
+            if (value == min) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    static boolean alwaysMatchesBinaryIn(byte[][] values, byte[] min, byte[] max) {
+        if (BinaryComparator.compareUnsigned(min, max) != 0) {
+            return false;
+        }
+        for (byte[] value : values) {
+            if (BinaryComparator.compareUnsigned(value, min) == 0) {
+                return true;
+            }
+        }
+        return false;
     }
 }

--- a/core/src/main/java/dev/hardwood/internal/predicate/StatsDecision.java
+++ b/core/src/main/java/dev/hardwood/internal/predicate/StatsDecision.java
@@ -1,0 +1,54 @@
+/*
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Copyright The original authors
+ *
+ *  Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package dev.hardwood.internal.predicate;
+
+/// Three-valued outcome of evaluating a filter predicate against statistics.
+///
+/// Extends the boolean "can this unit be dropped?" question with its dual:
+/// statistics can also prove that **every** row of a unit matches, in which
+/// case per-row predicate evaluation over the unit is redundant.
+///
+/// A decision is always conservative: when statistics are absent, partial, or
+/// untrusted, the decision is [#MIGHT_MATCH], which preserves today's behavior
+/// exactly (evaluate rows individually).
+public enum StatsDecision {
+
+    /// Statistics prove no row matches; the unit can be skipped entirely.
+    /// Equivalent to `canDrop == true`.
+    CANNOT_MATCH,
+
+    /// Statistics cannot decide; rows must be evaluated individually.
+    /// Equivalent to `canDrop == false`.
+    MIGHT_MATCH,
+
+    /// Statistics prove every row matches; the unit can be read with
+    /// per-row predicate evaluation skipped.
+    ALWAYS_MATCHES;
+
+    /// Combines two decisions under logical AND.
+    static StatsDecision and(StatsDecision a, StatsDecision b) {
+        if (a == CANNOT_MATCH || b == CANNOT_MATCH) {
+            return CANNOT_MATCH;
+        }
+        if (a == ALWAYS_MATCHES && b == ALWAYS_MATCHES) {
+            return ALWAYS_MATCHES;
+        }
+        return MIGHT_MATCH;
+    }
+
+    /// Combines two decisions under logical OR.
+    static StatsDecision or(StatsDecision a, StatsDecision b) {
+        if (a == ALWAYS_MATCHES || b == ALWAYS_MATCHES) {
+            return ALWAYS_MATCHES;
+        }
+        if (a == CANNOT_MATCH && b == CANNOT_MATCH) {
+            return CANNOT_MATCH;
+        }
+        return MIGHT_MATCH;
+    }
+}

--- a/core/src/main/java/dev/hardwood/internal/reader/BatchExchange.java
+++ b/core/src/main/java/dev/hardwood/internal/reader/BatchExchange.java
@@ -62,6 +62,11 @@ public class BatchExchange<B> {
         /// When non-null, sized to `(batchCapacity + 63) >>> 6` and overwritten on every
         /// drain-side test call.
         public long[] matches;
+
+        /// Whether statistics proved every record of this batch matches the filter
+        /// predicate, making [#matches] all-ones without per-record evaluation.
+        /// Only set on the drain-side filter path; `false` is always safe.
+        public boolean filterAlwaysMatches;
     }
 
     private final ArrayBlockingQueue<B> readyQueue;

--- a/core/src/main/java/dev/hardwood/internal/reader/ColumnWorker.java
+++ b/core/src/main/java/dev/hardwood/internal/reader/ColumnWorker.java
@@ -85,6 +85,11 @@ public abstract class ColumnWorker<B> implements AutoCloseable {
     // preserve this invariant.
     private final String[] fileNameBuffer;
 
+    // Per-slot filter-always-matches flag, written by the retriever alongside
+    // fileNameBuffer[slot] under the same happens-before chain: whether the page's
+    // row group was proven by statistics to match the filter in full.
+    private final boolean[] filterAlwaysMatchesBuffer;
+
     // === Drain position (only modified by drain thread, read by retriever for throttle) ===
     private volatile int consumePosition;
 
@@ -116,6 +121,11 @@ public abstract class ColumnWorker<B> implements AutoCloseable {
     /// Written only by the drain thread.
     String currentBatchFileName;
 
+    /// Whether every page of the current batch comes from a row group whose statistics
+    /// prove the filter matches all rows. Only maintained (with batch flushes on
+    /// transitions) when [#flushOnFilterAlwaysMatchesTransition] is `true`.
+    boolean currentBatchFilterAlwaysMatches;
+
     // === Instrumentation (drain thread only) ===
     long publishBlockNanos;
     int batchesPublished;
@@ -144,6 +154,7 @@ public abstract class ColumnWorker<B> implements AutoCloseable {
         this.maxRows = maxRows;
         this.reorderBuffer = new AtomicReferenceArray<>(MAX_INFLIGHT_PAGES);
         this.fileNameBuffer = new String[MAX_INFLIGHT_PAGES];
+        this.filterAlwaysMatchesBuffer = new boolean[MAX_INFLIGHT_PAGES];
     }
 
     /// Initializes subclass-specific drain state (called at the start of `runDrain`).
@@ -157,6 +168,14 @@ public abstract class ColumnWorker<B> implements AutoCloseable {
 
     /// Publishes the current batch to the [BatchExchange] and takes a new free batch.
     abstract void publishCurrentBatch();
+
+    /// Whether the drain should flush the current batch when crossing a row-group
+    /// boundary that changes the filter-always-matches flag. Only workers that
+    /// evaluate a per-batch filter benefit; for the rest the extra flushes would
+    /// shrink batches for nothing.
+    boolean flushOnFilterAlwaysMatchesTransition() {
+        return false;
+    }
 
     /// Starts both virtual threads. Must be called once.
     ///
@@ -265,6 +284,7 @@ public abstract class ColumnWorker<B> implements AutoCloseable {
                 totalPagesSubmitted++;
                 int slot = seq % MAX_INFLIGHT_PAGES;
                 fileNameBuffer[slot] = pageSource.getCurrentFileName();
+                filterAlwaysMatchesBuffer[slot] = pageSource.isCurrentFilterAlwaysMatches();
                 PageInfo pi = pageInfo;
                 PageDecoder rdr = pageDecoder;
                 CompletableFuture<Void> f = CompletableFuture.runAsync(
@@ -383,6 +403,18 @@ public abstract class ColumnWorker<B> implements AutoCloseable {
                     publishCurrentBatch();
                 }
                 currentBatchFileName = pageFileName;
+            }
+
+            // Detect a filter-always-matches boundary: flush so that each batch is
+            // homogeneous and the per-batch filter can be skipped for batches whose
+            // row groups are proven to match in full. Row groups only ever share a
+            // batch within one file, so this composes with the file flush above.
+            if (flushOnFilterAlwaysMatchesTransition()) {
+                boolean pageAlwaysMatches = filterAlwaysMatchesBuffer[slot];
+                if (pageAlwaysMatches != currentBatchFilterAlwaysMatches && rowsInCurrentBatch > 0) {
+                    publishCurrentBatch();
+                }
+                currentBatchFilterAlwaysMatches = pageAlwaysMatches;
             }
 
             assemblePage(decoded.page(), decoded.mask());

--- a/core/src/main/java/dev/hardwood/internal/reader/FlatColumnWorker.java
+++ b/core/src/main/java/dev/hardwood/internal/reader/FlatColumnWorker.java
@@ -23,6 +23,7 @@ public class FlatColumnWorker extends ColumnWorker<BatchExchange.Batch> {
 
     private long[] currentValidity;
     private final ColumnBatchMatcher columnFilter;
+    private final boolean flushOnFilterBoundaries;
     /// Tracks whether any absent (null) leaf has been seen in the current
     /// batch; cleared by [#publishCurrentBatch]. When still false at publish
     /// time, [BatchExchange.Batch#validity] is set to `null` to signal
@@ -47,15 +48,47 @@ public class FlatColumnWorker extends ColumnWorker<BatchExchange.Batch> {
                             DecompressorFactory decompressorFactory,
                             Executor decodeExecutor, long maxRows,
                             ColumnBatchMatcher columnFilter) {
+        this(pageSource, exchange, column, batchCapacity, decompressorFactory,
+              decodeExecutor, maxRows, columnFilter, false);
+    }
+
+    /// @param flushOnFilterBoundaries whether the drain flushes the current batch at
+    ///                    row-group boundaries where the filter-always-matches decision
+    ///                    changes. Must be uniform across all workers of one projection —
+    ///                    batches stay row-aligned only when every worker flushes at the
+    ///                    same rows.
+    public FlatColumnWorker(PageSource pageSource, BatchExchange<BatchExchange.Batch> exchange,
+                            ColumnSchema column, int batchCapacity,
+                            DecompressorFactory decompressorFactory,
+                            Executor decodeExecutor, long maxRows,
+                            ColumnBatchMatcher columnFilter, boolean flushOnFilterBoundaries) {
         super(pageSource, exchange, column, batchCapacity, decompressorFactory,
               decodeExecutor, maxRows);
         this.columnFilter = columnFilter;
+        this.flushOnFilterBoundaries = flushOnFilterBoundaries;
     }
 
     @Override
     void initDrainState() {
         currentValidity = maxDefinitionLevel > 0 ? new long[(batchCapacity + 63) >>> 6] : null;
         currentBatchHasAbsents = false;
+    }
+
+    @Override
+    boolean flushOnFilterAlwaysMatchesTransition() {
+        return flushOnFilterBoundaries;
+    }
+
+    /// Writes the mask a matcher would produce when every record matches: all-ones
+    /// for `[0, recordCount)` bits, tail bits of the last active word zeroed, words
+    /// beyond the active range untouched.
+    private static void fillAllOnes(long[] words, int recordCount) {
+        int fullWords = recordCount >>> 6;
+        int tail = recordCount & 63;
+        Arrays.fill(words, 0, fullWords, -1L);
+        if (tail != 0) {
+            words[fullWords] = -1L >>> (64 - tail);
+        }
     }
 
     @Override
@@ -127,11 +160,19 @@ public class FlatColumnWorker extends ColumnWorker<BatchExchange.Batch> {
                 ? Arrays.copyOf(currentValidity, (rowsInCurrentBatch + 63) >>> 6)
                 : null;
         currentBatch.fileName = currentBatchFileName;
+        currentBatch.filterAlwaysMatches = flushOnFilterBoundaries && currentBatchFilterAlwaysMatches;
 
         if (columnFilter != null) {
-            // Drain-side filter: evaluate while the just-filled value array is hot in
-            // this drain core's L1. Writes into currentBatch.matches in place.
-            columnFilter.test(currentBatch, currentBatch.matches);
+            if (currentBatchFilterAlwaysMatches) {
+                // Statistics proved every record of this batch's row group matches the
+                // predicate: emit the all-ones mask directly instead of evaluating records.
+                fillAllOnes(currentBatch.matches, rowsInCurrentBatch);
+            }
+            else {
+                // Drain-side filter: evaluate while the just-filled value array is hot in
+                // this drain core's L1. Writes into currentBatch.matches in place.
+                columnFilter.test(currentBatch, currentBatch.matches);
+            }
         }
 
         long t0 = System.nanoTime();

--- a/core/src/main/java/dev/hardwood/internal/reader/FlatRowReader.java
+++ b/core/src/main/java/dev/hardwood/internal/reader/FlatRowReader.java
@@ -226,6 +226,14 @@ public final class FlatRowReader implements RowReader {
                                    HardwoodContextImpl context,
                                    ResolvedPredicate filter,
                                    long maxRows) {
+        // When statistics prove every surviving row group matches the filter in
+        // full, the read is equivalent to an unfiltered read: skip matcher
+        // compilation and per-row evaluation entirely, and let maxRows cap
+        // scanned rows directly (scanned == matching).
+        if (filter != null && rowGroupIterator.isFilterSatisfiedByStatistics()) {
+            filter = null;
+        }
+
         int batchSize = BatchSizing.computeOptimalBatchSize(projectedSchema);
         int projectedColumnCount = projectedSchema.getProjectedColumnCount();
 
@@ -272,7 +280,7 @@ public final class FlatRowReader implements RowReader {
             FlatColumnWorker worker = new FlatColumnWorker(
                     pageSource, buffer, columnSchema, batchSize,
                     context.decompressorFactory(), context.executor(), workerMaxRows,
-                    columnFilter);
+                    columnFilter, drainSide);
 
             buffers[i] = buffer;
             workers[i] = worker;

--- a/core/src/main/java/dev/hardwood/internal/reader/NestedRowReader.java
+++ b/core/src/main/java/dev/hardwood/internal/reader/NestedRowReader.java
@@ -110,6 +110,14 @@ public final class NestedRowReader implements RowReader {
                             ResolvedPredicate filter,
                             long maxRows,
                             List<RowGroup> rowGroups) {
+        // When statistics prove every surviving row group matches the filter in
+        // full, the read is equivalent to an unfiltered read: skip matcher
+        // compilation and per-row evaluation entirely, and let maxRows cap
+        // scanned rows directly (scanned == matching).
+        if (filter != null && rowGroupIterator.isFilterSatisfiedByStatistics()) {
+            filter = null;
+        }
+
         int batchSize = BatchSizing.computeOptimalBatchSize(projectedSchema,
                 BatchSizing.valuesPerRow(projectedSchema, rowGroups));
         int projectedColumnCount = projectedSchema.getProjectedColumnCount();

--- a/core/src/main/java/dev/hardwood/internal/reader/PageSource.java
+++ b/core/src/main/java/dev/hardwood/internal/reader/PageSource.java
@@ -50,6 +50,12 @@ public class PageSource {
         return currentWorkItem != null ? currentWorkItem.inputFile().name() : null;
     }
 
+    /// Whether statistics proved the current work item's row group matches the filter
+    /// predicate in full. Only valid on the retriever thread.
+    public boolean isCurrentFilterAlwaysMatches() {
+        return currentWorkItem != null && currentWorkItem.filterAlwaysMatches();
+    }
+
     public PageInfo next() {
         while (true) {
             if (currentPlan != null && currentPlan.hasNext()) {

--- a/core/src/main/java/dev/hardwood/internal/reader/RowGroupIterator.java
+++ b/core/src/main/java/dev/hardwood/internal/reader/RowGroupIterator.java
@@ -28,6 +28,7 @@ import dev.hardwood.internal.predicate.PageFilterEvaluator;
 import dev.hardwood.internal.predicate.ResolvedPredicate;
 import dev.hardwood.internal.predicate.RowGroupBloomFilterSource;
 import dev.hardwood.internal.predicate.RowGroupFilterEvaluator;
+import dev.hardwood.internal.predicate.StatsDecision;
 import dev.hardwood.internal.schema.ProjectedSchema;
 import dev.hardwood.internal.thrift.OffsetIndexReader;
 import dev.hardwood.internal.thrift.ThriftCompactReader;
@@ -88,6 +89,7 @@ public class RowGroupIterator {
     private FileSchema referenceSchema;
     private ProjectedSchema projectedSchema;
     private ResolvedPredicate filterPredicate;
+    private boolean filterSatisfiedByStatistics;
 
     /// AND-necessary leaves per column index, derived once from `filterPredicate`.
     /// Feeds [SequentialFetchPlan]'s inline-stats page-drop check.
@@ -127,7 +129,8 @@ public class RowGroupIterator {
             int fileIndex,
             int rowGroupIndex,
             int workItemIndex,
-            long rowsConsumedBefore
+            long rowsConsumedBefore,
+            boolean filterAlwaysMatches
     ) {}
 
     /// Cached shared metadata for one row group, reused across columns.
@@ -898,12 +901,14 @@ public class RowGroupIterator {
         long physicalSkipRemaining = physicalSkip;
         boolean hasFilter = filterPredicate != null;
 
+        boolean allKeptAlwaysMatch = true;
         for (int fileIndex = 0; fileIndex < inputFiles.size() && rowBudget > 0; fileIndex++) {
             PreparedFile prepared = getPreparedFile(fileIndex);
-            List<RowGroup> rowGroups = filterRowGroups(prepared.rowGroups, prepared.inputFile);
+            List<FilteredRowGroup> rowGroups = filterRowGroups(prepared.rowGroups, prepared.inputFile);
 
             for (int rgIndex = 0; rgIndex < rowGroups.size() && rowBudget > 0; rgIndex++) {
-                RowGroup rg = rowGroups.get(rgIndex);
+                FilteredRowGroup decided = rowGroups.get(rgIndex);
+                RowGroup rg = decided.rowGroup();
                 long rgRows = rg.numRows();
                 if (physicalSkipRemaining >= rgRows) {
                     physicalSkipRemaining -= rgRows;
@@ -916,6 +921,7 @@ public class RowGroupIterator {
                     firstRowGroupSkip = leadingSkip;
                 }
 
+                allKeptAlwaysMatch &= decided.alwaysMatches();
                 workItems.add(new WorkItem(
                         prepared.inputFile,
                         rg,
@@ -923,7 +929,8 @@ public class RowGroupIterator {
                         fileIndex,
                         rgIndex,
                         workItems.size(),
-                        rowsConsumed));
+                        rowsConsumed,
+                        decided.alwaysMatches()));
 
                 // maxRows limiting: deduct row count from budget.
                 // With a filter active, actual match count is unpredictable,
@@ -938,8 +945,19 @@ public class RowGroupIterator {
             triggerPrefetch(fileIndex + 1);
         }
 
+        filterSatisfiedByStatistics = hasFilter && !workItems.isEmpty() && allKeptAlwaysMatch;
+
         LOG.log(System.Logger.Level.DEBUG, "Built work list: {0} row groups across {1} files",
                 workItems.size(), inputFiles.size());
+    }
+
+    /// Whether statistics prove that every row of every work-list row group satisfies the
+    /// filter predicate — every unit either fully matched or was dropped. Readers may then
+    /// skip per-row predicate evaluation entirely and treat the read as unfiltered.
+    ///
+    /// Only meaningful after [#initialize]; `false` when no filter is set.
+    public boolean isFilterSatisfiedByStatistics() {
+        return filterSatisfiedByStatistics;
     }
 
     /// Gets or loads a prepared file, blocking if necessary.
@@ -1026,20 +1044,37 @@ public class RowGroupIterator {
         }
     }
 
-    private List<RowGroup> filterRowGroups(List<RowGroup> rowGroups, InputFile inputFile) {
+    /// A row group surviving predicate push-down, and whether its statistics prove
+    /// every row matches (so per-row filtering can be skipped for it).
+    private record FilteredRowGroup(RowGroup rowGroup, boolean alwaysMatches) {}
+
+    private List<FilteredRowGroup> filterRowGroups(List<RowGroup> rowGroups, InputFile inputFile) {
         if (filterPredicate == null) {
-            return rowGroups;
+            return rowGroups.stream()
+                    .map(rg -> new FilteredRowGroup(rg, false))
+                    .toList();
         }
-        List<RowGroup> filtered = rowGroups.stream()
-                .filter(rg -> !RowGroupFilterEvaluator.canDropRowGroup(filterPredicate, rg,
-                        new RowGroupBloomFilterSource(inputFile, rg)))
-                .toList();
+        List<FilteredRowGroup> filtered = new ArrayList<>(rowGroups.size());
+        int fullyMatching = 0;
+        for (RowGroup rg : rowGroups) {
+            StatsDecision decision = RowGroupFilterEvaluator.decideRowGroup(filterPredicate, rg,
+                    new RowGroupBloomFilterSource(inputFile, rg));
+            if (decision == StatsDecision.CANNOT_MATCH) {
+                continue;
+            }
+            boolean alwaysMatches = decision == StatsDecision.ALWAYS_MATCHES;
+            if (alwaysMatches) {
+                fullyMatching++;
+            }
+            filtered.add(new FilteredRowGroup(rg, alwaysMatches));
+        }
 
         RowGroupFilterEvent event = new RowGroupFilterEvent();
         event.file = inputFile.name();
         event.totalRowGroups = rowGroups.size();
         event.rowGroupsKept = filtered.size();
         event.rowGroupsSkipped = rowGroups.size() - filtered.size();
+        event.rowGroupsFullyMatching = fullyMatching;
         event.commit();
 
         return filtered;

--- a/core/src/main/java/dev/hardwood/jfr/RowGroupFilterEvent.java
+++ b/core/src/main/java/dev/hardwood/jfr/RowGroupFilterEvent.java
@@ -37,4 +37,8 @@ public class RowGroupFilterEvent extends Event {
     @Label("Row Groups Skipped")
     @Description("Number of row groups skipped by the filter")
     public int rowGroupsSkipped;
+
+    @Label("Fully Matching Row Groups")
+    @Description("Kept row groups whose statistics prove every row matches the predicate")
+    public int rowGroupsFullyMatching;
 }

--- a/core/src/test/java/dev/hardwood/AlwaysMatchingRowGroupTest.java
+++ b/core/src/test/java/dev/hardwood/AlwaysMatchingRowGroupTest.java
@@ -49,6 +49,31 @@ class AlwaysMatchingRowGroupTest {
     }
 
     @Test
+    void nonFilterColumnsStayRowAlignedAcrossMixedGroups() throws Exception {
+        // gtEq(150) drops RG1, partially matches RG2 (150-200), and fully matches RG3
+        // (201-300). Reading all three columns crosses the batch-flush boundary between
+        // the evaluated group and the always-matching group on every worker, so any
+        // desync between the filter column and the non-filter columns surfaces as a
+        // value/label misaligned with its id.
+        try (ParquetFileReader reader = ParquetFileReader.open(InputFile.of(FIXTURE));
+             RowReader rows = reader.buildRowReader()
+                     .filter(FilterPredicate.gtEq("id", 150L))
+                     .build()) {
+            long expected = 150;
+            while (rows.hasNext()) {
+                rows.next();
+                long id = rows.getLong("id");
+                assertThat(id).isEqualTo(expected);
+                assertThat(rows.getLong("value")).isEqualTo(id);
+                String prefix = id <= 200 ? "rg2_" : "rg3_";
+                assertThat(rows.getString("label")).isEqualTo(prefix + id);
+                expected++;
+            }
+            assertThat(expected).as("all rows with id in [150, 300] returned").isEqualTo(301);
+        }
+    }
+
+    @Test
     void fullyMatchingRangePredicateKeepsEveryRow() throws Exception {
         // AND of two bounds, both satisfied by all three row groups.
         try (ParquetFileReader reader = ParquetFileReader.open(InputFile.of(FIXTURE));

--- a/core/src/test/java/dev/hardwood/AlwaysMatchingRowGroupTest.java
+++ b/core/src/test/java/dev/hardwood/AlwaysMatchingRowGroupTest.java
@@ -1,0 +1,127 @@
+/*
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Copyright The original authors
+ *
+ *  Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package dev.hardwood;
+
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+
+import dev.hardwood.reader.FilterPredicate;
+import dev.hardwood.reader.ParquetFileReader;
+import dev.hardwood.reader.RowReader;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/// Row-set correctness when statistics prove row groups match a filter in full.
+///
+/// `filter_pushdown_int.parquet` holds `id`/`value` 1–300 across three row groups
+/// (1–100, 101–200, 201–300) with statistics, so threshold sweeps cross every
+/// configuration of dropped, partially-matching, and fully-matching row groups —
+/// including the all-groups-fully-matching case where filtering is skipped
+/// wholesale, and mixed cases where fully-matching groups skip per-row evaluation
+/// while partially-matching groups are still evaluated exactly.
+class AlwaysMatchingRowGroupTest {
+
+    private static final Path FIXTURE =
+            Paths.get("src/test/resources/filter_pushdown_int.parquet");
+
+    private static final List<InputFile> MULTI_FIXTURE = InputFile.ofPaths(
+            Paths.get("src/test/resources/multi_file_part0.parquet"),
+            Paths.get("src/test/resources/multi_file_part1.parquet")
+    );
+
+    @Test
+    void thresholdSweepMatchesBruteForce() throws Exception {
+        // Thresholds cross row-group boundaries (100, 200, 300) exactly, adjacently,
+        // and far outside, exercising every mix of full/partial/dropped groups.
+        int[] thresholds = { 0, 1, 2, 50, 100, 101, 102, 150, 200, 201, 250, 300, 301 };
+        for (int threshold : thresholds) {
+            assertGtEqMatchesBruteForce(threshold);
+            assertLtMatchesBruteForce(threshold);
+        }
+    }
+
+    @Test
+    void fullyMatchingRangePredicateKeepsEveryRow() throws Exception {
+        // AND of two bounds, both satisfied by all three row groups.
+        try (ParquetFileReader reader = ParquetFileReader.open(InputFile.of(FIXTURE));
+             RowReader rows = reader.buildRowReader()
+                     .filter(FilterPredicate.and(
+                             FilterPredicate.gtEq("id", 1L),
+                             FilterPredicate.ltEq("id", 300L)))
+                     .build()) {
+            long count = 0;
+            long sum = 0;
+            while (rows.hasNext()) {
+                rows.next();
+                sum += rows.getLong("id");
+                count++;
+            }
+            assertThat(count).isEqualTo(300);
+            assertThat(sum).isEqualTo(300L * 301 / 2);
+        }
+    }
+
+    @Test
+    void multiFileReadWithFullyMatchingAndDroppedRowGroups() throws Exception {
+        // Files hold id 0–149 and 150–249 in row groups of 50: lt(200) fully matches
+        // every surviving row group and drops the last one entirely.
+        try (ParquetFileReader reader = ParquetFileReader.openAll(MULTI_FIXTURE);
+             RowReader rows = reader.buildRowReader()
+                     .filter(FilterPredicate.lt("id", 200L))
+                     .build()) {
+            long expected = 0;
+            while (rows.hasNext()) {
+                rows.next();
+                assertThat(rows.getLong("id")).isEqualTo(expected);
+                expected++;
+            }
+            assertThat(expected).isEqualTo(200);
+        }
+    }
+
+    private static void assertGtEqMatchesBruteForce(int threshold) throws Exception {
+        try (ParquetFileReader reader = ParquetFileReader.open(InputFile.of(FIXTURE));
+             RowReader rows = reader.buildRowReader()
+                     .filter(FilterPredicate.gtEq("id", (long) threshold))
+                     .build()) {
+            long expected = Math.max(threshold, 1);
+            long count = 0;
+            while (rows.hasNext()) {
+                rows.next();
+                assertThat(rows.getLong("id"))
+                        .as("gtEq(%s), match %s", threshold, count)
+                        .isEqualTo(expected);
+                expected++;
+                count++;
+            }
+            assertThat(count).isEqualTo(Math.max(0, 300 - Math.max(threshold, 1) + 1));
+        }
+    }
+
+    private static void assertLtMatchesBruteForce(int threshold) throws Exception {
+        try (ParquetFileReader reader = ParquetFileReader.open(InputFile.of(FIXTURE));
+             RowReader rows = reader.buildRowReader()
+                     .filter(FilterPredicate.lt("id", (long) threshold))
+                     .build()) {
+            long expected = 1;
+            long count = 0;
+            while (rows.hasNext()) {
+                rows.next();
+                assertThat(rows.getLong("id"))
+                        .as("lt(%s), match %s", threshold, count)
+                        .isEqualTo(expected);
+                expected++;
+                count++;
+            }
+            assertThat(count).isEqualTo(Math.max(0, Math.min(threshold - 1, 300)));
+        }
+    }
+}

--- a/core/src/test/java/dev/hardwood/RowGroupFilterEventTest.java
+++ b/core/src/test/java/dev/hardwood/RowGroupFilterEventTest.java
@@ -83,8 +83,27 @@ class RowGroupFilterEventTest extends AbstractJfrRecorderTest {
 
         List<RecordedEvent> pushDown = events(PUSH_DOWN_EVENT).toList();
         assertThat(pushDown).hasSize(1);
+        assertThat(pushDown.getFirst().getInt("rowGroupsKept")).isEqualTo(2);
         assertThat(pushDown.getFirst().getInt("rowGroupsFullyMatching"))
                 .as("only RG3 is proven fully matching; partial RG2 must not count")
+                .isEqualTo(1);
+    }
+
+    @Test
+    void boundaryAlignedCutoffLeavesNoPartiallyMatchingGroup() throws Exception {
+        // gtEq(201) lands exactly on RG3's first id: RG1/RG2 drop outright, and
+        // RG3's min satisfies the bound, so every *surviving* group is fully
+        // matching and the read collapses onto the wholesale path. The complement
+        // of predicatePushDownReportsFullyMatchingRowGroups, where an interior
+        // cutoff leaves RG2 partial and forces the per-batch path.
+        readIdColumn(reader -> reader.buildColumnReaders(ColumnProjection.columns("id"))
+                .filter(FilterPredicate.gtEq("id", 201L))
+                .build());
+
+        RecordedEvent pushDown = events(PUSH_DOWN_EVENT).findFirst().orElseThrow();
+        assertThat(pushDown.getInt("rowGroupsKept")).isEqualTo(1);
+        assertThat(pushDown.getInt("rowGroupsFullyMatching"))
+                .as("a boundary-aligned cutoff leaves no partially matching group")
                 .isEqualTo(1);
     }
 

--- a/core/src/test/java/dev/hardwood/RowGroupFilterEventTest.java
+++ b/core/src/test/java/dev/hardwood/RowGroupFilterEventTest.java
@@ -71,6 +71,24 @@ class RowGroupFilterEventTest extends AbstractJfrRecorderTest {
     }
 
     @Test
+    void predicatePushDownReportsFullyMatchingRowGroups() throws Exception {
+        // gt(150) skips RG1 (1-100), partially matches RG2 (101-200), and fully
+        // matches RG3 (201-300): exactly one group must be reported as fully
+        // matching. Pins that the ALWAYS_MATCHES decision actually fires — the
+        // row-set correctness tests would still pass if it silently degraded to
+        // MIGHT_MATCH.
+        readIdColumn(reader -> reader.buildColumnReaders(ColumnProjection.columns("id"))
+                .filter(FilterPredicate.gt("id", 150L))
+                .build());
+
+        List<RecordedEvent> pushDown = events(PUSH_DOWN_EVENT).toList();
+        assertThat(pushDown).hasSize(1);
+        assertThat(pushDown.getFirst().getInt("rowGroupsFullyMatching"))
+                .as("only RG3 is proven fully matching; partial RG2 must not count")
+                .isEqualTo(1);
+    }
+
+    @Test
     void byteRangeEmitsByteRangeEventNotPushDownEvent() throws Exception {
         readIdColumn(reader -> reader.buildColumnReaders(ColumnProjection.columns("id"))
                 .filter(RowGroupPredicate.byteRange(0, fileLen))

--- a/core/src/test/java/dev/hardwood/internal/predicate/RowGroupDecideTest.java
+++ b/core/src/test/java/dev/hardwood/internal/predicate/RowGroupDecideTest.java
@@ -1,0 +1,166 @@
+/*
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Copyright The original authors
+ *
+ *  Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package dev.hardwood.internal.predicate;
+
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
+import java.util.List;
+import java.util.Map;
+
+import org.junit.jupiter.api.Test;
+
+import dev.hardwood.metadata.ColumnChunk;
+import dev.hardwood.metadata.ColumnMetaData;
+import dev.hardwood.metadata.CompressionCodec;
+import dev.hardwood.metadata.Encoding;
+import dev.hardwood.metadata.FieldPath;
+import dev.hardwood.metadata.PhysicalType;
+import dev.hardwood.metadata.RowGroup;
+import dev.hardwood.metadata.Statistics;
+import dev.hardwood.reader.FilterPredicate;
+
+import static dev.hardwood.internal.predicate.StatsDecision.ALWAYS_MATCHES;
+import static dev.hardwood.internal.predicate.StatsDecision.CANNOT_MATCH;
+import static dev.hardwood.internal.predicate.StatsDecision.MIGHT_MATCH;
+import static org.assertj.core.api.Assertions.assertThat;
+
+/// [RowGroupFilterEvaluator#decideRowGroup] behavior over whole row groups: leaf decisions
+/// with row-group [Statistics], `AND`/`OR` composition, null predicates, and the
+/// equivalence of `canDropRowGroup` with the [StatsDecision#CANNOT_MATCH] decision.
+class RowGroupDecideTest {
+
+    private static final int COL = 0;
+
+    @Test
+    void rangePredicateOverFullySatisfyingRowGroup() {
+        // Rows [10, 20], no nulls; GT 5 is satisfied by the whole interval.
+        RowGroup rg = intRowGroup(10, 20, 0L);
+        assertThat(decide(intGt(5), rg)).isEqualTo(ALWAYS_MATCHES);
+        assertThat(decide(intGt(15), rg)).isEqualTo(MIGHT_MATCH);
+        assertThat(decide(intGt(20), rg)).isEqualTo(CANNOT_MATCH);
+    }
+
+    @Test
+    void nullsInRowGroupPreventAlwaysMatches() {
+        RowGroup rg = intRowGroup(10, 20, 5L);
+        assertThat(decide(intGt(5), rg)).isEqualTo(MIGHT_MATCH);
+    }
+
+    @Test
+    void missingStatisticsYieldMightMatch() {
+        RowGroup rg = rowGroup(PhysicalType.INT32, null, 100);
+        assertThat(decide(intGt(5), rg)).isEqualTo(MIGHT_MATCH);
+    }
+
+    @Test
+    void andComposition() {
+        RowGroup rg = intRowGroup(10, 20, 0L);
+        assertThat(decide(and(intGt(5), intLt(25)), rg)).isEqualTo(ALWAYS_MATCHES);
+        assertThat(decide(and(intGt(5), intLt(15)), rg)).isEqualTo(MIGHT_MATCH);
+        assertThat(decide(and(intGt(5), intGt(25)), rg)).isEqualTo(CANNOT_MATCH);
+    }
+
+    @Test
+    void orComposition() {
+        RowGroup rg = intRowGroup(10, 20, 0L);
+        // One always-matching branch decides the disjunction.
+        assertThat(decide(or(intGt(25), intGt(5)), rg)).isEqualTo(ALWAYS_MATCHES);
+        assertThat(decide(or(intGt(25), intGt(15)), rg)).isEqualTo(MIGHT_MATCH);
+        assertThat(decide(or(intGt(25), intLt(5)), rg)).isEqualTo(CANNOT_MATCH);
+    }
+
+    @Test
+    void isNotNullDecisions() {
+        assertThat(decide(isNotNull(), intRowGroup(10, 20, 0L))).isEqualTo(ALWAYS_MATCHES);
+        assertThat(decide(isNotNull(), intRowGroup(10, 20, 5L))).isEqualTo(MIGHT_MATCH);
+        // All 100 rows null
+        assertThat(decide(isNotNull(), rowGroup(PhysicalType.INT32,
+                new Statistics(null, null, 100L, null, false), 100))).isEqualTo(CANNOT_MATCH);
+    }
+
+    @Test
+    void isNullNeverPromisesAlwaysMatches() {
+        // Even a fully-null row group is not promised: null counts tally values, not rows.
+        assertThat(decide(isNull(), rowGroup(PhysicalType.INT32,
+                new Statistics(null, null, 100L, null, false), 100))).isEqualTo(MIGHT_MATCH);
+        assertThat(decide(isNull(), intRowGroup(10, 20, 0L))).isEqualTo(CANNOT_MATCH);
+    }
+
+    @Test
+    void bloomFilterSourceDoesNotAffectAlwaysMatches() {
+        // A bloom filter proves absence only; its presence must not change the
+        // always-matching decision derived from statistics.
+        RowGroup rg = intRowGroup(10, 20, 0L);
+        BloomFilterSource noFilters = columnIndex -> null;
+        assertThat(RowGroupFilterEvaluator.decideRowGroup(intGt(5), rg, noFilters))
+                .isEqualTo(ALWAYS_MATCHES);
+    }
+
+    @Test
+    void canDropRowGroupIsTheCannotMatchDecision() {
+        RowGroup rg = intRowGroup(10, 20, 0L);
+        assertThat(RowGroupFilterEvaluator.canDropRowGroup(intGt(20), rg)).isTrue();
+        assertThat(RowGroupFilterEvaluator.canDropRowGroup(intGt(15), rg)).isFalse();
+        assertThat(RowGroupFilterEvaluator.canDropRowGroup(intGt(5), rg)).isFalse();
+    }
+
+    @Test
+    void deprecatedMinMaxNeverPromisesAlwaysMatches() {
+        Statistics deprecated = new Statistics(intBytes(10), intBytes(20), 0L, null, true);
+        RowGroup rg = rowGroup(PhysicalType.INT32, deprecated, 100);
+        assertThat(decide(intGt(5), rg)).isEqualTo(MIGHT_MATCH);
+    }
+
+    // ==================== Fixtures ====================
+
+    private static StatsDecision decide(ResolvedPredicate predicate, RowGroup rowGroup) {
+        return RowGroupFilterEvaluator.decideRowGroup(predicate, rowGroup, null);
+    }
+
+    private static ResolvedPredicate intGt(int value) {
+        return new ResolvedPredicate.IntPredicate(COL, FilterPredicate.Operator.GT, value);
+    }
+
+    private static ResolvedPredicate intLt(int value) {
+        return new ResolvedPredicate.IntPredicate(COL, FilterPredicate.Operator.LT, value);
+    }
+
+    private static ResolvedPredicate isNull() {
+        return new ResolvedPredicate.IsNullPredicate(COL);
+    }
+
+    private static ResolvedPredicate isNotNull() {
+        return new ResolvedPredicate.IsNotNullPredicate(COL);
+    }
+
+    private static ResolvedPredicate and(ResolvedPredicate... children) {
+        return new ResolvedPredicate.And(List.of(children));
+    }
+
+    private static ResolvedPredicate or(ResolvedPredicate... children) {
+        return new ResolvedPredicate.Or(List.of(children));
+    }
+
+    private static RowGroup intRowGroup(int min, int max, Long nullCount) {
+        return rowGroup(PhysicalType.INT32,
+                new Statistics(intBytes(min), intBytes(max), nullCount, null, false), 100);
+    }
+
+    private static RowGroup rowGroup(PhysicalType type, Statistics stats, long numRows) {
+        ColumnMetaData cmd = new ColumnMetaData(
+                type, List.of(Encoding.PLAIN), FieldPath.of("col"),
+                CompressionCodec.UNCOMPRESSED, 100, 1000, 1000, Map.of(), 0, null, stats,
+                null, null, null);
+        ColumnChunk chunk = new ColumnChunk(cmd, null, null, null, null);
+        return new RowGroup(List.of(chunk), 1000, numRows);
+    }
+
+    private static byte[] intBytes(int value) {
+        return ByteBuffer.allocate(4).order(ByteOrder.LITTLE_ENDIAN).putInt(value).array();
+    }
+}

--- a/core/src/test/java/dev/hardwood/internal/predicate/StatsDecisionTest.java
+++ b/core/src/test/java/dev/hardwood/internal/predicate/StatsDecisionTest.java
@@ -1,0 +1,297 @@
+/*
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Copyright The original authors
+ *
+ *  Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package dev.hardwood.internal.predicate;
+
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
+import java.nio.charset.StandardCharsets;
+import java.util.Random;
+
+import org.junit.jupiter.api.Test;
+
+import dev.hardwood.reader.FilterPredicate;
+
+import static dev.hardwood.internal.predicate.StatsDecision.ALWAYS_MATCHES;
+import static dev.hardwood.internal.predicate.StatsDecision.CANNOT_MATCH;
+import static dev.hardwood.internal.predicate.StatsDecision.MIGHT_MATCH;
+import static org.assertj.core.api.Assertions.assertThat;
+
+/// Unit matrix for the three-valued statistics decision: [StatsDecision] combinators and
+/// [StatisticsFilterSupport#decideLeaf] over synthetic [MinMaxStats].
+///
+/// The [#decisionAgreesWithBruteForceOnRandomData] property pins the decision's meaning
+/// against decoded values: [StatsDecision#ALWAYS_MATCHES] must imply zero non-matching
+/// rows and [StatsDecision#CANNOT_MATCH] zero matching rows, over randomized
+/// high-cardinality data (low-cardinality fixtures satisfy broken decisions silently).
+class StatsDecisionTest {
+
+    // ==================== Combinators ====================
+
+    @Test
+    void andCombinator() {
+        assertThat(StatsDecision.and(ALWAYS_MATCHES, ALWAYS_MATCHES)).isEqualTo(ALWAYS_MATCHES);
+        assertThat(StatsDecision.and(ALWAYS_MATCHES, MIGHT_MATCH)).isEqualTo(MIGHT_MATCH);
+        assertThat(StatsDecision.and(MIGHT_MATCH, ALWAYS_MATCHES)).isEqualTo(MIGHT_MATCH);
+        assertThat(StatsDecision.and(MIGHT_MATCH, MIGHT_MATCH)).isEqualTo(MIGHT_MATCH);
+        assertThat(StatsDecision.and(CANNOT_MATCH, ALWAYS_MATCHES)).isEqualTo(CANNOT_MATCH);
+        assertThat(StatsDecision.and(ALWAYS_MATCHES, CANNOT_MATCH)).isEqualTo(CANNOT_MATCH);
+        assertThat(StatsDecision.and(CANNOT_MATCH, MIGHT_MATCH)).isEqualTo(CANNOT_MATCH);
+        assertThat(StatsDecision.and(CANNOT_MATCH, CANNOT_MATCH)).isEqualTo(CANNOT_MATCH);
+    }
+
+    @Test
+    void orCombinator() {
+        assertThat(StatsDecision.or(ALWAYS_MATCHES, ALWAYS_MATCHES)).isEqualTo(ALWAYS_MATCHES);
+        assertThat(StatsDecision.or(ALWAYS_MATCHES, MIGHT_MATCH)).isEqualTo(ALWAYS_MATCHES);
+        assertThat(StatsDecision.or(ALWAYS_MATCHES, CANNOT_MATCH)).isEqualTo(ALWAYS_MATCHES);
+        assertThat(StatsDecision.or(CANNOT_MATCH, ALWAYS_MATCHES)).isEqualTo(ALWAYS_MATCHES);
+        assertThat(StatsDecision.or(MIGHT_MATCH, MIGHT_MATCH)).isEqualTo(MIGHT_MATCH);
+        assertThat(StatsDecision.or(MIGHT_MATCH, CANNOT_MATCH)).isEqualTo(MIGHT_MATCH);
+        assertThat(StatsDecision.or(CANNOT_MATCH, MIGHT_MATCH)).isEqualTo(MIGHT_MATCH);
+        assertThat(StatsDecision.or(CANNOT_MATCH, CANNOT_MATCH)).isEqualTo(CANNOT_MATCH);
+    }
+
+    // ==================== Integer leaf decisions ====================
+
+    @Test
+    void intRangeDecisions() {
+        // Stats: [10, 20], no nulls
+        assertThat(decideInt(FilterPredicate.Operator.GT, 5, 10, 20)).isEqualTo(ALWAYS_MATCHES);
+        assertThat(decideInt(FilterPredicate.Operator.GT, 9, 10, 20)).isEqualTo(ALWAYS_MATCHES);
+        assertThat(decideInt(FilterPredicate.Operator.GT, 10, 10, 20)).isEqualTo(MIGHT_MATCH);
+        assertThat(decideInt(FilterPredicate.Operator.GT, 20, 10, 20)).isEqualTo(CANNOT_MATCH);
+
+        assertThat(decideInt(FilterPredicate.Operator.GT_EQ, 10, 10, 20)).isEqualTo(ALWAYS_MATCHES);
+        assertThat(decideInt(FilterPredicate.Operator.GT_EQ, 11, 10, 20)).isEqualTo(MIGHT_MATCH);
+
+        assertThat(decideInt(FilterPredicate.Operator.LT, 21, 10, 20)).isEqualTo(ALWAYS_MATCHES);
+        assertThat(decideInt(FilterPredicate.Operator.LT, 20, 10, 20)).isEqualTo(MIGHT_MATCH);
+        assertThat(decideInt(FilterPredicate.Operator.LT, 10, 10, 20)).isEqualTo(CANNOT_MATCH);
+
+        assertThat(decideInt(FilterPredicate.Operator.LT_EQ, 20, 10, 20)).isEqualTo(ALWAYS_MATCHES);
+        assertThat(decideInt(FilterPredicate.Operator.LT_EQ, 19, 10, 20)).isEqualTo(MIGHT_MATCH);
+
+        assertThat(decideInt(FilterPredicate.Operator.EQ, 42, 42, 42)).isEqualTo(ALWAYS_MATCHES);
+        assertThat(decideInt(FilterPredicate.Operator.EQ, 15, 10, 20)).isEqualTo(MIGHT_MATCH);
+        assertThat(decideInt(FilterPredicate.Operator.EQ, 5, 10, 20)).isEqualTo(CANNOT_MATCH);
+
+        assertThat(decideInt(FilterPredicate.Operator.NOT_EQ, 5, 10, 20)).isEqualTo(ALWAYS_MATCHES);
+        assertThat(decideInt(FilterPredicate.Operator.NOT_EQ, 25, 10, 20)).isEqualTo(ALWAYS_MATCHES);
+        assertThat(decideInt(FilterPredicate.Operator.NOT_EQ, 15, 10, 20)).isEqualTo(MIGHT_MATCH);
+        assertThat(decideInt(FilterPredicate.Operator.NOT_EQ, 42, 42, 42)).isEqualTo(CANNOT_MATCH);
+    }
+
+    @Test
+    void intInDecisions() {
+        ResolvedPredicate in = new ResolvedPredicate.IntInPredicate(0, new int[]{ 5, 42, 99 });
+        assertThat(StatisticsFilterSupport.decideLeaf(in, intStats(42, 42, 0L)))
+                .isEqualTo(ALWAYS_MATCHES);
+        assertThat(StatisticsFilterSupport.decideLeaf(in, intStats(42, 43, 0L)))
+                .isEqualTo(MIGHT_MATCH);
+        assertThat(StatisticsFilterSupport.decideLeaf(in, intStats(6, 41, 0L)))
+                .isEqualTo(CANNOT_MATCH);
+    }
+
+    // ==================== Null-count gating ====================
+
+    @Test
+    void nullsPreventAlwaysMatchesForValuePredicates() {
+        // [10, 20] fully satisfies GT 5, but nulls (or an unknown null count) may hide
+        // non-matching rows: a null row satisfies no value predicate.
+        ResolvedPredicate gt = new ResolvedPredicate.IntPredicate(0, FilterPredicate.Operator.GT, 5);
+        assertThat(StatisticsFilterSupport.decideLeaf(gt, intStats(10, 20, 0L)))
+                .isEqualTo(ALWAYS_MATCHES);
+        assertThat(StatisticsFilterSupport.decideLeaf(gt, intStats(10, 20, 3L)))
+                .isEqualTo(MIGHT_MATCH);
+        assertThat(StatisticsFilterSupport.decideLeaf(gt, intStats(10, 20, null)))
+                .isEqualTo(MIGHT_MATCH);
+    }
+
+    @Test
+    void missingBoundsNeverPromiseAlwaysMatches() {
+        ResolvedPredicate gt = new ResolvedPredicate.IntPredicate(0, FilterPredicate.Operator.GT, 5);
+        assertThat(StatisticsFilterSupport.decideLeaf(gt, stats(null, null, 0L)))
+                .isEqualTo(MIGHT_MATCH);
+    }
+
+    // ==================== Floating point: never ALWAYS_MATCHES ====================
+
+    @Test
+    void floatingPointNeverPromisesAlwaysMatches() {
+        // nan_count is not consumed yet: NaN rows sit outside [min, max], so even a
+        // fully-satisfying interval cannot promise every row for FP columns.
+        ResolvedPredicate gtDouble =
+                new ResolvedPredicate.DoublePredicate(0, FilterPredicate.Operator.GT, 1.0);
+        assertThat(StatisticsFilterSupport.decideLeaf(gtDouble, doubleStats(10.0, 20.0, 0L)))
+                .isEqualTo(MIGHT_MATCH);
+
+        ResolvedPredicate gtFloat =
+                new ResolvedPredicate.FloatPredicate(0, FilterPredicate.Operator.GT, 1.0f);
+        assertThat(StatisticsFilterSupport.decideLeaf(gtFloat, floatStats(10.0f, 20.0f, 0L)))
+                .isEqualTo(MIGHT_MATCH);
+
+        // The CANNOT_MATCH side is unaffected.
+        ResolvedPredicate gtOutside =
+                new ResolvedPredicate.DoublePredicate(0, FilterPredicate.Operator.GT, 25.0);
+        assertThat(StatisticsFilterSupport.decideLeaf(gtOutside, doubleStats(10.0, 20.0, 0L)))
+                .isEqualTo(CANNOT_MATCH);
+    }
+
+    // ==================== Binary leaf decisions ====================
+
+    @Test
+    void binaryRangeDecisions() {
+        // Stats: ["mango", "peach"], unsigned comparison, no nulls
+        assertThat(decideBinary(FilterPredicate.Operator.GT, "apple", "mango", "peach"))
+                .isEqualTo(ALWAYS_MATCHES);
+        assertThat(decideBinary(FilterPredicate.Operator.GT, "mango", "mango", "peach"))
+                .isEqualTo(MIGHT_MATCH);
+        assertThat(decideBinary(FilterPredicate.Operator.LT, "plum", "mango", "peach"))
+                .isEqualTo(ALWAYS_MATCHES);
+        assertThat(decideBinary(FilterPredicate.Operator.EQ, "kiwi", "kiwi", "kiwi"))
+                .isEqualTo(ALWAYS_MATCHES);
+        assertThat(decideBinary(FilterPredicate.Operator.NOT_EQ, "apple", "mango", "peach"))
+                .isEqualTo(ALWAYS_MATCHES);
+        assertThat(decideBinary(FilterPredicate.Operator.EQ, "apple", "mango", "peach"))
+                .isEqualTo(CANNOT_MATCH);
+    }
+
+    // ==================== IS NOT NULL ====================
+
+    @Test
+    void isNotNullDecidedByNullCountAlone() {
+        ResolvedPredicate isNotNull = new ResolvedPredicate.IsNotNullPredicate(0);
+        assertThat(StatisticsFilterSupport.decideLeaf(isNotNull, stats(null, null, 0L)))
+                .isEqualTo(ALWAYS_MATCHES);
+        assertThat(StatisticsFilterSupport.decideLeaf(isNotNull, stats(null, null, 3L)))
+                .isEqualTo(MIGHT_MATCH);
+        assertThat(StatisticsFilterSupport.decideLeaf(isNotNull, stats(null, null, null)))
+                .isEqualTo(MIGHT_MATCH);
+    }
+
+    // ==================== Property: decision agrees with brute force ====================
+
+    @Test
+    void decisionAgreesWithBruteForceOnRandomData() {
+        Random random = new Random(795);
+        FilterPredicate.Operator[] ops = FilterPredicate.Operator.values();
+
+        for (int round = 0; round < 10_000; round++) {
+            int size = 1 + random.nextInt(50);
+            long[] values = new long[size];
+            long min = Long.MAX_VALUE;
+            long max = Long.MIN_VALUE;
+            for (int i = 0; i < size; i++) {
+                // Narrow domain so single-point and boundary cases occur often
+                values[i] = random.nextInt(100);
+                min = Math.min(min, values[i]);
+                max = Math.max(max, values[i]);
+            }
+            long literal = random.nextInt(120) - 10;
+            FilterPredicate.Operator op = ops[random.nextInt(ops.length)];
+
+            ResolvedPredicate leaf = new ResolvedPredicate.LongPredicate(0, op, literal);
+            StatsDecision decision =
+                    StatisticsFilterSupport.decideLeaf(leaf, longStats(min, max, 0L));
+
+            int matching = 0;
+            for (long value : values) {
+                if (matches(op, value, literal)) {
+                    matching++;
+                }
+            }
+            if (decision == ALWAYS_MATCHES) {
+                assertThat(matching)
+                        .as("ALWAYS_MATCHES for %s %s over [%s, %s]", op, literal, min, max)
+                        .isEqualTo(size);
+            }
+            if (decision == CANNOT_MATCH) {
+                assertThat(matching)
+                        .as("CANNOT_MATCH for %s %s over [%s, %s]", op, literal, min, max)
+                        .isZero();
+            }
+        }
+    }
+
+    private static boolean matches(FilterPredicate.Operator op, long value, long literal) {
+        return switch (op) {
+            case EQ -> value == literal;
+            case NOT_EQ -> value != literal;
+            case LT -> value < literal;
+            case LT_EQ -> value <= literal;
+            case GT -> value > literal;
+            case GT_EQ -> value >= literal;
+        };
+    }
+
+    // ==================== Fixtures ====================
+
+    private static StatsDecision decideInt(FilterPredicate.Operator op, int value, int min, int max) {
+        ResolvedPredicate leaf = new ResolvedPredicate.IntPredicate(0, op, value);
+        return StatisticsFilterSupport.decideLeaf(leaf, intStats(min, max, 0L));
+    }
+
+    private static StatsDecision decideBinary(FilterPredicate.Operator op, String value,
+            String min, String max) {
+        ResolvedPredicate leaf = new ResolvedPredicate.BinaryPredicate(
+                0, op, value.getBytes(StandardCharsets.UTF_8), false);
+        return StatisticsFilterSupport.decideLeaf(leaf, stats(
+                min.getBytes(StandardCharsets.UTF_8), max.getBytes(StandardCharsets.UTF_8), 0L));
+    }
+
+    private static MinMaxStats intStats(int min, int max, Long nullCount) {
+        return stats(intBytes(min), intBytes(max), nullCount);
+    }
+
+    private static MinMaxStats longStats(long min, long max, Long nullCount) {
+        return stats(longBytes(min), longBytes(max), nullCount);
+    }
+
+    private static MinMaxStats floatStats(float min, float max, Long nullCount) {
+        return stats(floatBytes(min), floatBytes(max), nullCount);
+    }
+
+    private static MinMaxStats doubleStats(double min, double max, Long nullCount) {
+        return stats(doubleBytes(min), doubleBytes(max), nullCount);
+    }
+
+    private static MinMaxStats stats(byte[] min, byte[] max, Long nullCount) {
+        return new MinMaxStats() {
+            @Override
+            public byte[] minValue() {
+                return min;
+            }
+
+            @Override
+            public byte[] maxValue() {
+                return max;
+            }
+
+            @Override
+            public Long nullCount() {
+                return nullCount;
+            }
+        };
+    }
+
+    private static byte[] intBytes(int value) {
+        return ByteBuffer.allocate(4).order(ByteOrder.LITTLE_ENDIAN).putInt(value).array();
+    }
+
+    private static byte[] longBytes(long value) {
+        return ByteBuffer.allocate(8).order(ByteOrder.LITTLE_ENDIAN).putLong(value).array();
+    }
+
+    private static byte[] floatBytes(float value) {
+        return ByteBuffer.allocate(4).order(ByteOrder.LITTLE_ENDIAN).putFloat(value).array();
+    }
+
+    private static byte[] doubleBytes(double value) {
+        return ByteBuffer.allocate(8).order(ByteOrder.LITTLE_ENDIAN).putDouble(value).array();
+    }
+}

--- a/docs/content/reference/configuration.md
+++ b/docs/content/reference/configuration.md
@@ -94,7 +94,7 @@ Or attach dynamically via `jcmd <pid> JFR.start`.
 | `dev.hardwood.FileMapping` | I/O | Memory-mapping of a file region. Fields: file, offset, size |
 | `dev.hardwood.RowGroupScanned` | Decode | Page boundaries scanned in a column chunk. Fields: file, rowGroupIndex, column, pageCount, scanStrategy (`sequential` or `offset-index`) |
 | `dev.hardwood.PageDecoded` | Decode | Single data page decoded. Fields: column, compressedSize, uncompressedSize |
-| `dev.hardwood.RowGroupFilter` | Filter | Row groups dropped by statistics/bloom predicate pushdown. Fields: file, totalRowGroups, rowGroupsKept, rowGroupsSkipped |
+| `dev.hardwood.RowGroupFilter` | Filter | Row groups dropped by statistics/bloom predicate pushdown. Fields: file, totalRowGroups, rowGroupsKept, rowGroupsSkipped, rowGroupsFullyMatching |
 | `dev.hardwood.RowGroupByteRangeFilter` | Filter | Row groups selected by a byte-range split predicate (split-aware reading). Fields: file, totalRowGroups, rowGroupsKept, rowGroupsSkipped |
 | `dev.hardwood.PageFilter` | Filter | Pages filtered by Column Index predicate pushdown. Fields: file, rowGroupIndex, column, totalPages, pagesKept, pagesSkipped |
 | `dev.hardwood.RecordFilter` | Filter | Records filtered by record-level predicate evaluation. Fields: totalRecords, recordsKept, recordsSkipped |

--- a/performance-testing/generate_filter_pushdown_data.py
+++ b/performance-testing/generate_filter_pushdown_data.py
@@ -1,0 +1,78 @@
+#
+#  SPDX-License-Identifier: Apache-2.0
+#
+#  Copyright The original authors
+#
+#  Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+#
+
+"""Generate the sorted, multi-row-group fixture for the always-match filter
+benchmark (AlwaysMatchReadBenchmark).
+
+Writes:
+  <output_dir>/sorted_filter.parquet
+    - `id`: int64, 0..NUM_ROWS-1 sorted ascending.
+    - `label`: 12-digit zero-padded string of `id`, so lexicographic order
+      equals numeric order and a string range predicate maps onto row-group
+      min/max exactly like the numeric one.
+    - `value`: int64 payload equal to `id`, read on the non-filter side.
+
+The sort plus ROW_GROUP_SIZE-row groups give each row group tight, disjoint
+statistics, so a range predicate splits the file into dropped, partially
+matching, and fully matching groups purely by its cutoff. Dictionary encoding
+is disabled: every value is distinct, and a fallback mid-file would skew page
+decode cost across row groups.
+
+Usage: python performance-testing/generate_filter_pushdown_data.py [output_dir]
+"""
+import os
+import sys
+
+import numpy as np
+import pyarrow as pa
+import pyarrow.parquet as pq
+
+DEFAULT_OUTPUT_DIR = os.path.join(
+    "performance-testing", "test-data-setup", "target", "benchmark-data"
+)
+FILE_NAME = "sorted_filter.parquet"
+NUM_ROWS = 10_000_000
+ROW_GROUP_SIZE = 1_000_000
+LABEL_WIDTH = 12
+
+
+def build_table(num_rows: int) -> pa.Table:
+    ids = np.arange(num_rows, dtype=np.int64)
+    labels = np.char.zfill(ids.astype(str), LABEL_WIDTH)
+    return pa.table(
+        {
+            "id": pa.array(ids, type=pa.int64()),
+            "label": pa.array(labels, type=pa.string()),
+            "value": pa.array(ids, type=pa.int64()),
+        }
+    )
+
+
+def main() -> None:
+    output_dir = sys.argv[1] if len(sys.argv) > 1 else DEFAULT_OUTPUT_DIR
+    os.makedirs(output_dir, exist_ok=True)
+    path = os.path.join(output_dir, FILE_NAME)
+    if os.path.exists(path):
+        print(f"{path} already exists, skipping")
+        return
+
+    print(f"Generating {NUM_ROWS:,} sorted rows ...")
+    table = build_table(NUM_ROWS)
+    pq.write_table(
+        table,
+        path,
+        row_group_size=ROW_GROUP_SIZE,
+        use_dictionary=False,
+        compression="snappy",
+    )
+    print(f"Wrote {path} ({os.path.getsize(path) / 1024 / 1024:.0f} MiB, "
+          f"{NUM_ROWS // ROW_GROUP_SIZE} row groups)")
+
+
+if __name__ == "__main__":
+    main()

--- a/performance-testing/micro-benchmarks/README.md
+++ b/performance-testing/micro-benchmarks/README.md
@@ -1,0 +1,58 @@
+<!--
+
+     SPDX-License-Identifier: Apache-2.0
+
+     Copyright The original authors
+
+     Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+
+-->
+# Micro-benchmarks
+
+JMH benchmarks isolating individual read-path costs (predicate dispatch, page
+decode, level handling, SIMD kernels, filtered scans). For polished, publication-grade
+end-to-end comparisons against parquet-java, use
+[hardwood-benchmarks](https://github.com/hardwood-hq/hardwood-benchmarks) instead.
+
+## Running
+
+```shell
+./mvnw -pl core install -DskipTests
+./mvnw -pl performance-testing/micro-benchmarks package -Pperformance-test
+java -jar performance-testing/micro-benchmarks/target/benchmarks.jar <BenchmarkName> [-p dataDir=<dir>]
+```
+
+Every benchmark class carries its exact run recipe (including any extra
+parameters) in its JavaDoc header. Standard JMH flags apply: `-prof gc` for
+allocation profiling, `-rf json -rff out.json` for machine-readable results,
+`-p name=value` to override any `@Param`.
+
+## The benchmarks
+
+| Benchmark | Measures | Fixture |
+| --- | --- | --- |
+| `RecordFilterMicroBenchmark` | Per-row predicate compile + dispatch cost across predicate shapes, no I/O | none (in-memory) |
+| `SimdBenchmark` | Scalar vs. Vector API kernels (null counting, dictionary lookup, …) | none (in-memory) |
+| `ValidityIterationBenchmark` | Null-bitmap iteration strategies over a `long[]` column | none (in-memory) |
+| `AlwaysMatchReadBenchmark` | Filtered end-to-end reads when statistics prove row groups match in full (#795) | `generate_filter_pushdown_data.py` |
+| `DictionaryStringReadBenchmark` | Allocation per full-column scan of a dictionary-encoded string column (run with `-prof gc`) | `generate_dict_string_data.py` |
+| `PageScanBenchmark` | Sequential header-based page scan vs. offset-index lookup | `generate_benchmark_data.py` |
+| `PageHandlingBenchmark` | Per-page decompression vs. full page decode | taxi data, downloaded by `./mvnw verify -Pperformance-test` |
+| `MemoryMapBenchmark` | Raw I/O floor: mmap + copy of a whole file, no decode | taxi data, downloaded by `./mvnw verify -Pperformance-test` |
+| `FixedSizeListDecodeBenchmark` | Fixed-size-list fast path vs. general list decode across vector widths | `generate_fixed_size_list_data.py` |
+| `FixedSizeListFallbackBenchmark` | Detector cost on almost-fixed-width pages that fall back | `generate_fixed_size_list_data.py` |
+| `nested/NestedListReadBenchmark` | `LIST<primitive>` reads across element types and null densities vs. a flat floor | self-generating (`NestedListFileGenerator`) |
+| `nested/NestedMultiListReadBenchmark` | Multi-list-column schema effects on the nested read path | self-generating (`NestedListFileGenerator`) |
+| `mixed/MixedSchemaReadBenchmark` | Schema-composition effects (scalars next to lists, structs, depth) on the nested path (#732) | self-generating (`MixedSchemaFileGenerator`) |
+
+Python generator scripts live in the parent `performance-testing/` directory and
+default their output to `performance-testing/test-data-setup/target/benchmark-data`;
+pass that directory as `-p dataDir=...`. Fixture generation is idempotent —
+existing files are skipped.
+
+## Correctness gates
+
+The nested and mixed-schema benchmarks have companion gate classes
+(`NestedListGate`, `MixedSchemaGate`) that generate their corpus and assert all
+read paths produce identical folds. Run the gate before trusting timings from
+its benchmark.

--- a/performance-testing/micro-benchmarks/src/main/java/dev/hardwood/benchmarks/AlwaysMatchReadBenchmark.java
+++ b/performance-testing/micro-benchmarks/src/main/java/dev/hardwood/benchmarks/AlwaysMatchReadBenchmark.java
@@ -43,14 +43,21 @@ import dev.hardwood.reader.RowReader;
 ///
 /// - `noFilter` — unfiltered scan, the floor the always-match path converges to
 /// - `full` — cutoff below the file minimum: every group fully matches, the
-///   filter is discarded before any worker starts
-/// - `half` — cutoff mid-file: dropped groups, one partially matching group
-///   (evaluated per row), and fully matching groups (skipped) in one read
+///   filter is discarded before any worker starts (wholesale path)
+/// - `mixed` — cutoff strictly inside a row group: dropped groups, one partially
+///   matching group (evaluated per row), and fully matching groups (skipped) in
+///   one read, so the per-batch flush and mask-skip are what is measured
+///
+/// `mixed` deliberately offsets the cutoff off the group boundary: an aligned
+/// cutoff satisfies the boundary group's min as well, which would leave every
+/// surviving group fully matching and collapse the scenario back onto `full`.
 ///
 /// Each selectivity runs on two read paths: `rowReaderString` filters on the
 /// string column through the record-matcher path (where per-row evaluation is
-/// most expensive), `columnReaderLong` filters on `id` while draining `value`
-/// through the vectorized batch-matcher path.
+/// most expensive), `columnReaderLong` filters on `id` while draining `value`.
+/// The latter reads through `SelectionEngine`, which does not yet consume the
+/// always-match proof (a #795 follow-up), so it stands as a control rather than
+/// a scenario expected to improve.
 ///
 /// Run:
 /// ```shell
@@ -62,8 +69,8 @@ import dev.hardwood.reader.RowReader;
 @OutputTimeUnit(TimeUnit.MILLISECONDS)
 @State(Scope.Benchmark)
 @Fork(value = 1, jvmArgs = { "-Xms1g", "-Xmx1g", "--add-modules", "jdk.incubator.vector" })
-@Warmup(iterations = 3, time = 1)
-@Measurement(iterations = 5, time = 1)
+@Warmup(iterations = 5, time = 1)
+@Measurement(iterations = 9, time = 1)
 public class AlwaysMatchReadBenchmark {
 
     private static final int LABEL_WIDTH = 12;
@@ -74,7 +81,7 @@ public class AlwaysMatchReadBenchmark {
     @Param({ "sorted_filter.parquet" })
     private String fileName;
 
-    @Param({ "noFilter", "full", "half" })
+    @Param({ "noFilter", "full", "mixed" })
     private String selectivity;
 
     private Path path;
@@ -89,13 +96,16 @@ public class AlwaysMatchReadBenchmark {
                     + ". Run 'python performance-testing/generate_filter_pushdown_data.py' first.");
         }
         long numRows;
+        long rowGroupRows;
         try (ParquetFileReader reader = ParquetFileReader.open(InputFile.of(path))) {
             numRows = reader.getFileMetaData().numRows();
+            rowGroupRows = reader.getFileMetaData().rowGroups().getFirst().numRows();
         }
         long cutoff = switch (selectivity) {
             case "noFilter" -> -1;
             case "full" -> 0;
-            case "half" -> numRows / 2;
+            // Half a row group past the midpoint, landing strictly inside a group.
+            case "mixed" -> numRows / 2 + rowGroupRows / 2;
             default -> throw new IllegalStateException("Unknown selectivity: " + selectivity);
         };
         if (cutoff >= 0) {

--- a/performance-testing/micro-benchmarks/src/main/java/dev/hardwood/benchmarks/AlwaysMatchReadBenchmark.java
+++ b/performance-testing/micro-benchmarks/src/main/java/dev/hardwood/benchmarks/AlwaysMatchReadBenchmark.java
@@ -69,8 +69,8 @@ import dev.hardwood.reader.RowReader;
 @OutputTimeUnit(TimeUnit.MILLISECONDS)
 @State(Scope.Benchmark)
 @Fork(value = 1, jvmArgs = { "-Xms1g", "-Xmx1g", "--add-modules", "jdk.incubator.vector" })
-@Warmup(iterations = 5, time = 1)
-@Measurement(iterations = 9, time = 1)
+@Warmup(iterations = 3, time = 1)
+@Measurement(iterations = 5, time = 1)
 public class AlwaysMatchReadBenchmark {
 
     private static final int LABEL_WIDTH = 12;

--- a/performance-testing/micro-benchmarks/src/main/java/dev/hardwood/benchmarks/AlwaysMatchReadBenchmark.java
+++ b/performance-testing/micro-benchmarks/src/main/java/dev/hardwood/benchmarks/AlwaysMatchReadBenchmark.java
@@ -1,0 +1,149 @@
+/*
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Copyright The original authors
+ *
+ *  Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package dev.hardwood.benchmarks;
+
+import java.io.IOException;
+import java.nio.file.Path;
+import java.util.concurrent.TimeUnit;
+
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
+import org.openjdk.jmh.infra.Blackhole;
+
+import dev.hardwood.InputFile;
+import dev.hardwood.reader.ColumnReader;
+import dev.hardwood.reader.FilterPredicate;
+import dev.hardwood.reader.ParquetFileReader;
+import dev.hardwood.reader.RowReader;
+
+/// End-to-end filtered reads over a sorted file, measuring what the always-match
+/// statistics decision (#795) saves: when row-group min/max prove every row of a
+/// group matches, per-row predicate evaluation is skipped for that group, and when
+/// every surviving group fully matches the filter is dropped wholesale.
+///
+/// Fixture: `sorted_filter.parquet` (10M rows, 10 tight-statistics row groups) —
+/// run `python performance-testing/generate_filter_pushdown_data.py` first.
+///
+/// The `selectivity` parameter positions one `>=` cutoff against the row-group
+/// statistics:
+///
+/// - `noFilter` — unfiltered scan, the floor the always-match path converges to
+/// - `full` — cutoff below the file minimum: every group fully matches, the
+///   filter is discarded before any worker starts
+/// - `half` — cutoff mid-file: dropped groups, one partially matching group
+///   (evaluated per row), and fully matching groups (skipped) in one read
+///
+/// Each selectivity runs on two read paths: `rowReaderString` filters on the
+/// string column through the record-matcher path (where per-row evaluation is
+/// most expensive), `columnReaderLong` filters on `id` while draining `value`
+/// through the vectorized batch-matcher path.
+///
+/// Run:
+/// ```shell
+/// ./mvnw -pl core install -DskipTests
+/// ./mvnw -pl performance-testing/micro-benchmarks package -Pperformance-test
+/// java -jar performance-testing/micro-benchmarks/target/benchmarks.jar AlwaysMatchReadBenchmark -p dataDir=performance-testing/test-data-setup/target/benchmark-data
+/// ```
+@BenchmarkMode(Mode.AverageTime)
+@OutputTimeUnit(TimeUnit.MILLISECONDS)
+@State(Scope.Benchmark)
+@Fork(value = 1, jvmArgs = { "-Xms1g", "-Xmx1g", "--add-modules", "jdk.incubator.vector" })
+@Warmup(iterations = 3, time = 1)
+@Measurement(iterations = 5, time = 1)
+public class AlwaysMatchReadBenchmark {
+
+    private static final int LABEL_WIDTH = 12;
+
+    @Param({})
+    private String dataDir;
+
+    @Param({ "sorted_filter.parquet" })
+    private String fileName;
+
+    @Param({ "noFilter", "full", "half" })
+    private String selectivity;
+
+    private Path path;
+    private FilterPredicate longFilter;
+    private FilterPredicate stringFilter;
+
+    @Setup
+    public void setup() throws IOException {
+        path = Path.of(dataDir).resolve(fileName).toAbsolutePath().normalize();
+        if (!path.toFile().exists()) {
+            throw new IllegalStateException("Parquet file not found: " + path
+                    + ". Run 'python performance-testing/generate_filter_pushdown_data.py' first.");
+        }
+        long numRows;
+        try (ParquetFileReader reader = ParquetFileReader.open(InputFile.of(path))) {
+            numRows = reader.getFileMetaData().numRows();
+        }
+        long cutoff = switch (selectivity) {
+            case "noFilter" -> -1;
+            case "full" -> 0;
+            case "half" -> numRows / 2;
+            default -> throw new IllegalStateException("Unknown selectivity: " + selectivity);
+        };
+        if (cutoff >= 0) {
+            longFilter = FilterPredicate.gtEq("id", cutoff);
+            stringFilter = FilterPredicate.gtEq("label",
+                    String.format("%0" + LABEL_WIDTH + "d", cutoff));
+        }
+    }
+
+    @Benchmark
+    public void rowReaderString(Blackhole blackhole) throws IOException {
+        try (ParquetFileReader reader = ParquetFileReader.open(InputFile.of(path))) {
+            ParquetFileReader.RowReaderBuilder builder = reader.buildRowReader();
+            if (stringFilter != null) {
+                builder.filter(stringFilter);
+            }
+            try (RowReader rows = builder.build()) {
+                long idSum = 0;
+                int labelLengthSum = 0;
+                while (rows.hasNext()) {
+                    rows.next();
+                    idSum += rows.getLong("id");
+                    labelLengthSum += rows.getString("label").length();
+                }
+                blackhole.consume(idSum);
+                blackhole.consume(labelLengthSum);
+            }
+        }
+    }
+
+    @Benchmark
+    public void columnReaderLong(Blackhole blackhole) throws IOException {
+        try (ParquetFileReader reader = ParquetFileReader.open(InputFile.of(path))) {
+            ParquetFileReader.ColumnReaderBuilder builder = reader.buildColumnReader("value");
+            if (longFilter != null) {
+                builder.filter(longFilter);
+            }
+            try (ColumnReader values = builder.build()) {
+                long sum = 0;
+                while (values.nextBatch()) {
+                    long[] batch = values.getLongs();
+                    int count = values.getRecordCount();
+                    for (int i = 0; i < count; i++) {
+                        sum += batch[i];
+                    }
+                }
+                blackhole.consume(sum);
+            }
+        }
+    }
+}

--- a/performance-testing/micro-benchmarks/src/main/java/dev/hardwood/benchmarks/MemoryMapBenchmark.java
+++ b/performance-testing/micro-benchmarks/src/main/java/dev/hardwood/benchmarks/MemoryMapBenchmark.java
@@ -27,6 +27,13 @@ import org.openjdk.jmh.annotations.State;
 import org.openjdk.jmh.annotations.Warmup;
 import org.openjdk.jmh.infra.Blackhole;
 
+/// Measures the raw I/O floor: memory-mapping a whole Parquet file and copying it
+/// into a heap `byte[]`, with no header parsing, decompression, or decoding. Any
+/// full-file read strategy pays at least this; compare against the end-to-end read
+/// benchmarks to see how much time is I/O versus decode.
+///
+/// Fixture: `yellow_tripdata_2016-03.parquet` — downloaded by
+/// `./mvnw verify -Pperformance-test` (test-data-setup module).
 @BenchmarkMode(Mode.AverageTime)
 @OutputTimeUnit(TimeUnit.MILLISECONDS)
 @State(Scope.Benchmark)

--- a/performance-testing/micro-benchmarks/src/main/java/dev/hardwood/benchmarks/PageHandlingBenchmark.java
+++ b/performance-testing/micro-benchmarks/src/main/java/dev/hardwood/benchmarks/PageHandlingBenchmark.java
@@ -45,6 +45,18 @@ import dev.hardwood.reader.ParquetFileReader;
 import dev.hardwood.schema.ColumnSchema;
 import dev.hardwood.schema.FileSchema;
 
+/// Isolates the two per-page costs downstream of I/O, over every page of every
+/// column chunk in the fixture (pages are pre-scanned once in setup, so neither
+/// benchmark measures header discovery):
+///
+/// - `a_decompressPages` — header parse + codec decompression only
+/// - `b_decodePages` — full [PageDecoder] page decode (decompression, levels,
+///   values)
+///
+/// The difference between the two is the pure decode cost.
+///
+/// Fixture: `yellow_tripdata_2025-05.parquet` — downloaded by
+/// `./mvnw verify -Pperformance-test` (test-data-setup module).
 @BenchmarkMode(Mode.AverageTime)
 @OutputTimeUnit(TimeUnit.MILLISECONDS)
 @State(Scope.Benchmark)


### PR DESCRIPTION
## Summary

Filtered reads over sorted or clustered data should run at unfiltered-scan speed when row-group statistics already decide the filter's outcome.  That's what this PR enables.

The common shape is a time-range scan over data laid down in timestamp order: most surviving row groups don't just *survive* the min/max check - their statistics prove **every** row matches. Hardwood still evaluated the predicate row by row across those groups, re-deriving a foregone conclusion; on a 30M-row string-predicate read that per-row work was nearly half the total read time (565 -> 294 ms once skipped, within ~3% of the unfiltered scan). This PR teaches the reader to recognize the proven-full-match case and skip per-row evaluation for it, while leaving every undecided case exactly as it is today.

### Mechanism

Implements the row-group half of #795: a three-valued `StatsDecision` (`CANNOT_MATCH` / `MIGHT_MATCH` / `ALWAYS_MATCHES`) replacing the boolean drop as the single statistics evaluation (`canDropRowGroup` is now defined as `decideRowGroup(...) == CANNOT_MATCH`), plus two consumers:

- **Wholesale**: when every surviving row group is proven to match in full, the read is built as an unfiltered read - no matcher compilation, no `FilteredRowReader` wrapper.
- **Per-batch (drain-side)**: the drain flushes batches at row-group boundaries where the always-matches flag changes - the same mechanism as the existing file-boundary flush, applied uniformly across all workers of a projection so batches stay row-aligned - and fully-matching batches emit the all-ones mask without running the `ColumnBatchMatcher`.

The correctness gates: `ALWAYS_MATCHES` requires whole-`[min, max]` satisfaction *and* `null_count == 0`; floating-point value leaves never promise a full match while `nan_count` is unread (#607); `IS NULL` never promises one (null counts tally values, not rows); bloom filters only ever force `CANNOT_MATCH`; deprecated min/max fields are already nulled by MinMaxStats.of`. Truncated bounds are safe by construction - they only widen the interval. Design notes in `_designs/ALWAYS_MATCH_STATISTICS.md`.

Page-level pre-approved ranges and the `ColumnReader`/`SelectionEngine` fast path are the planned follow-up (they compose with #728), and the row-group decision is the byte-copy trigger #791 item 6 calls for.

Prior art: this is the shape zpq ships as [`Decision.always_match`](https://github.com/chicagobuss/zpq/blob/v0.3.0/src/core/filter/prune.zig#L17-L43)
- the same [leaf rule](https://github.com/chicagobuss/zpq/blob/v0.3.0/src/core/filter/prune.zig#L136-L142) (whole-`[min, max]` satisfaction via [`rangeAlwaysMatches`](https://github.com/chicagobuss/zpq/blob/v0.3.0/src/core/filter/encoded.zig#L57-L59), gated on `null_count == 0`), introduced there for the byte-copy passthrough in [`1f29c0e`](https://github.com/chicagobuss/zpq/commit/1f29c0e65631200ea757381d2ec0a20669099d9d).


## Testing

- `./mvnw verify` (full multi-module, JDK 25): green, 1719 core tests.
- `StatsDecisionTest` — combinator truth tables, per-operator/type leaf matrix, null-count gating, FP never-always, plus a seeded 10,000-round property test:  whenever the evaluator returns `ALWAYS_MATCHES` over random data, brute-force evaluation finds zero non-matching rows (and zero matching for `CANNOT_MATCH`).
- `RowGroupDecideTest` - row-group-level decisions, `AND`/`OR` composition, null predicates, deprecated-stats and missing-stats conservatism, `canDropRowGroup` equivalence.
- `AlwaysMatchingRowGroupTest` — end-to-end row-set correctness over `filter_pushdown_int.parquet` (threshold sweep crossing every full/partial/dropped row-group configuration, asserting exact row sequences) and a multi-file read mixing fully-matching and dropped row groups.

## Performance

Sorted 30M-row file (30 row groups of 1M, uncompressed, local mmap), best of 9, `RowReader` summing a payload column; baseline is `24607ee`:

| scenario | baseline | this PR | |
|---|---|---|---|
| string `gtEq`, all row groups fully match | 565 ms | 294 ms | **1.9x** - within ~3% of the 285 ms unfiltered scan |
| string `gtEq`, 15 of 30 groups match (all fully) | 267 ms | 149 ms | **1.8x** |
| int `gtEq`, all row groups fully match | 201 ms | 194 ms | ~3% (see below) |
| unfiltered scan (control) | 304 ms | 285 ms | noise band |

The record-matcher path (string/binary predicates via `FilteredRowReader`) is where the win lives - per-row evaluation disappears. The drain-side int path barely moves because its vectorized matchers were already a small fraction of the read; for that path the value of this PR is the mask-skip plumbing plus the `Batch.filterAlwaysMatches` proof that the follow-up `SelectionEngine` fast path consumes. Row counts and sums are byte-identical to baseline in every scenario.

Fixes #795

## Checklist

- [x] Build via `./mvnw clean verify` passes
- [x] The commit message is prefixed with the issue key (`#795 Add always-match statistics decision to skip per-row filtering`)
- [x] Code changes are covered by tests
- [x] If this PR adds or changes user-facing behaviour, `docs/` has been updated *(no public-API change — everything stays in `internal.*`; the new JFR field is additive)*
