### PR TITLE
#801 Link the dive-in-browser demo from the docs nav

### DIFF
--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -52,6 +52,7 @@ nav:
     - API Changes: /api-changes/latest/
   - Contributing: contributing.md
   - Release Notes: release-notes.md
+  - dive on the Web: /experiments/dive-web/
 
 theme:
   name: material


### PR DESCRIPTION
Adds a top-level **dive on the Web** nav entry (after Release Notes) linking to `/experiments/dive-web/`, where the WebAssembly build of `hardwood dive` is published.

The demo bundle is served from a fixed, unversioned path — the site-repo publish workflow copies it there (separate PR against `hardwood-hq.github.io`). This PR is just the menu link.

Part of #801.