### PR TITLE
#740 Speed up the fixed-size-list detector's scalar rep-level walk

### DIFF
--- a/core/src/main/java/dev/hardwood/internal/reader/FixedSizeListDetector.java
+++ b/core/src/main/java/dev/hardwood/internal/reader/FixedSizeListDetector.java
@@ -440,15 +440,43 @@ public final class FixedSizeListDetector {
 
             if ((header & 1) == 1) {
                 // Bit-packed run: (header >> 1) groups of 8 values, one byte each.
+                // The width-1 rep stream packs one bit per value, so a `0` bit is a
+                // record boundary. Scan boundaries a 64-bit word (64 values) at a
+                // time: the boundary mask is the word's zero bits (`~word`), which
+                // `Long.numberOfTrailingZeros` walks in order — skipping the runs of
+                // `1`s between boundaries rather than visiting every bit. Only full
+                // words (`levelsLeft >= 64`) take this path, so no padding bit is ever
+                // read; `levelsLeft`, clamped to `numValues`, is the padding-safe
+                // count. The sub-word remainder (and any run shorter than a word)
+                // falls to the scalar bit loop below.
                 int groups = (int) (header >> 1);
                 if (groups > end - pos) {
                     return FixedSizeListShape.NOT_APPLICABLE;
                 }
-                for (int g = 0; g < groups && idx < numValues; g++) {
+                int levelsLeft = Math.min(groups * 8, numValues - idx);
+                while (levelsLeft >= 64) {
+                    long boundaries = ~readLongLE(data, pos);
+                    if (idx == 0 && (boundaries & 1L) == 0) {
+                        return FixedSizeListShape.NOT_APPLICABLE; // must start on a boundary
+                    }
+                    while (boundaries != 0) {
+                        int b = idx + Long.numberOfTrailingZeros(boundaries);
+                        k = closeAndCheck(b, lastStart, k);
+                        if (k == FAILED) {
+                            return FixedSizeListShape.NOT_APPLICABLE;
+                        }
+                        lastStart = b;
+                        boundaries &= boundaries - 1;
+                    }
+                    idx += 64;
+                    pos += 8;
+                    levelsLeft -= 64;
+                }
+                while (levelsLeft > 0) {
                     int packed = data[pos++] & 0xFF;
-                    for (int bit = 0; bit < 8 && idx < numValues; bit++) {
-                        int value = (packed >> bit) & 1;
-                        if (value == 0) {
+                    int bits = Math.min(8, levelsLeft);
+                    for (int bit = 0; bit < bits; bit++) {
+                        if (((packed >> bit) & 1) == 0) {
                             k = closeAndCheck(idx, lastStart, k);
                             if (k == FAILED) {
                                 return FixedSizeListShape.NOT_APPLICABLE;
@@ -460,6 +488,7 @@ public final class FixedSizeListDetector {
                         }
                         idx++;
                     }
+                    levelsLeft -= bits;
                 }
             }
             else {

--- a/core/src/main/java/dev/hardwood/internal/reader/FixedSizeListDetector.java
+++ b/core/src/main/java/dev/hardwood/internal/reader/FixedSizeListDetector.java
@@ -508,13 +508,27 @@ public final class FixedSizeListDetector {
                     idx += runLen; // interior skipped in O(1) — never scanned
                 }
                 else {
-                    for (int j = 0; j < runLen; j++) {
-                        k = closeAndCheck(idx, lastStart, k);
-                        if (k == FAILED) {
+                    // A run of runLen boundaries. The first closes the previous
+                    // record with its real gap; each of the remaining runLen - 1
+                    // boundaries is exactly one apart, so they all imply k == 1.
+                    // Collapse them to O(1) rather than a per-boundary loop — a list
+                    // of single elements (k == 1) is one long run of zeros, so this
+                    // is the whole cost of detecting it.
+                    k = closeAndCheck(idx, lastStart, k);
+                    if (k == FAILED) {
+                        return FixedSizeListShape.NOT_APPLICABLE;
+                    }
+                    lastStart = idx;
+                    idx++;
+                    if (runLen > 1) {
+                        if (k == -1) {
+                            k = 1;
+                        }
+                        else if (k != 1) {
                             return FixedSizeListShape.NOT_APPLICABLE;
                         }
-                        lastStart = idx;
-                        idx++;
+                        idx += runLen - 1;
+                        lastStart = idx - 1;
                     }
                 }
             }

--- a/core/src/test/java/dev/hardwood/internal/reader/FixedSizeListDetectorTest.java
+++ b/core/src/test/java/dev/hardwood/internal/reader/FixedSizeListDetectorTest.java
@@ -132,6 +132,28 @@ class FixedSizeListDetectorTest {
         assertThat(detect(rep, 768, 1)).isEqualTo(new FixedWidth(768));
     }
 
+    @Test
+    void detectsAllBitPackedScalarWithWordScan() {
+        // k = 9 is the scalar regime (no byte-aligned per-record stride): an all
+        // bit-packed page whose single run exceeds a word, so the scalar walk's
+        // word-at-a-time boundary scan runs over two full 64-value words and a
+        // sub-byte remainder (135 = 2*64 + 7), with the last byte carrying a
+        // padding 0-bit that must not be mistaken for a boundary.
+        byte[] rep = bitPacked(repeatVector(9, 15));
+        assertThat(detect(rep, 135, 15)).isEqualTo(new FixedWidth(9));
+    }
+
+    @Test
+    void rejectsShortenedRecordInWordScannedRegion() {
+        // A k = 9 all-bit-packed page with one interior 1 turned into a boundary at
+        // level 100 — past the first word — so the shortened record is caught by the
+        // word-at-a-time scan's per-gap check, not the sub-word tail.
+        int[] levels = repeatVector(9, 21);
+        levels[100] = 0; // was an interior 1; now an extra, early row start
+        byte[] rep = bitPacked(levels);
+        assertThat(detect(rep, 189, 21)).isEqualTo(FixedSizeListShape.NOT_APPLICABLE);
+    }
+
     // --- Definition-level gate rejections -----------------------------------
 
     @Test

--- a/performance-testing/generate_fixed_size_list_data.py
+++ b/performance-testing/generate_fixed_size_list_data.py
@@ -41,7 +41,7 @@ import pyarrow.parquet as pq
 
 # k=3 covers the multi-byte-period bit-packed regime (period 3 bytes, the RGB /
 # 3D-vector case); 4 and 8 are single-byte-period; 16+ have an RLE interior.
-K_SWEEP = [3, 4, 8, 16, 128, 768, 1536]
+K_SWEEP = [1, 3, 4, 8, 16, 128, 768, 1536]
 TOTAL_VALUES = 8_000_000  # leaf floats per file; rows = TOTAL_VALUES // k
 
 # Almost-fixed corpus for FixedSizeListFallbackBenchmark (the detector's fallback

--- a/performance-testing/generate_fixed_size_list_data.py
+++ b/performance-testing/generate_fixed_size_list_data.py
@@ -45,7 +45,8 @@ K_SWEEP = [3, 4, 8, 16, 128, 768, 1536]
 TOTAL_VALUES = 8_000_000  # leaf floats per file; rows = TOTAL_VALUES // k
 
 # Almost-fixed corpus for FixedSizeListFallbackBenchmark (the detector's fallback
-# price). k=4 is the bit-packed regime, k=768 the RLE interior. Every real Parquet
+# price). k=4 is the bit-packed regime, k=768 the RLE interior, and k=9 the scalar
+# fallback (9..15 is not a byte-aligned per-record stride). Every real Parquet
 # page must carry exactly one odd row so the detector fails and each page falls
 # back — the whole file, page by page. PyArrow paginates by both a byte budget and
 # a rows cap, so a fixed logical stride does not line up with real page boundaries
@@ -53,7 +54,7 @@ TOTAL_VALUES = 8_000_000  # leaf floats per file; rows = TOTAL_VALUES // k
 # which the fast path then legitimately accelerates). Make it deterministic instead:
 # one row group == one page (row_group_size rows, data_page_size large enough not to
 # split it), sized per k for a ~1 MiB page and kept under the rows cap.
-NONFIXED_K = [4, 768]
+NONFIXED_K = [4, 9, 768]
 NONFIXED_VALUES = 2_000_000
 NONFIXED_PAGE_BYTES = 1 << 20    # ~1 MiB target per page
 NONFIXED_ROW_CAP = 16_000        # stay under PyArrow's rows-per-page cap

--- a/performance-testing/micro-benchmarks/src/main/java/dev/hardwood/benchmarks/FixedSizeListDecodeBenchmark.java
+++ b/performance-testing/micro-benchmarks/src/main/java/dev/hardwood/benchmarks/FixedSizeListDecodeBenchmark.java
@@ -87,7 +87,7 @@ public class FixedSizeListDecodeBenchmark {
 
     // k=3 covers the multi-byte-period bit-packed regime (RGB / 3D vectors);
     // 4 and 8 are single-byte-period; 16 and up carry an RLE interior.
-    @Param({ "3", "4", "8", "16", "128", "768", "1536" })
+    @Param({ "1", "3", "4", "8", "16", "128", "768", "1536" })
     private int k;
 
     private Path listPath;

--- a/performance-testing/micro-benchmarks/src/main/java/dev/hardwood/benchmarks/FixedSizeListFallbackBenchmark.java
+++ b/performance-testing/micro-benchmarks/src/main/java/dev/hardwood/benchmarks/FixedSizeListFallbackBenchmark.java
@@ -41,8 +41,10 @@ import dev.hardwood.reader.ReaderConfig;
 /// regular decode of the same file; only the former also runs the (failing)
 /// detector. `differPos` places the odd row `last` (the detector scans nearly the
 /// whole level stream before failing) or `second` (it fails almost immediately).
-/// `k = 4` exercises the bit-packed rep regime, `k = 768` the RLE-interior regime.
-/// `flatFloor` is the plain-column decode floor.
+/// `k = 4` exercises the bit-packed rep regime, `k = 768` the RLE-interior regime,
+/// and `k = 9` the scalar fallback (`9..15` has no byte-aligned per-record stride,
+/// so the rep scan walks bit-by-bit — where a `differPos = last` failure is the
+/// most expensive). `flatFloor` is the plain-column decode floor.
 ///
 /// The corpus generator writes each file as one page per row group with exactly one
 /// odd row in every page, so every page falls back — the whole file, page by page
@@ -63,7 +65,7 @@ public class FixedSizeListFallbackBenchmark {
     @Param({})
     private String dataDir;
 
-    @Param({ "4", "768" })
+    @Param({ "4", "9", "768" })
     private int k;
 
     @Param({ "last", "second" })


### PR DESCRIPTION
Part of #740. Two optimizations to the fixed-size-list detector's **scalar fallback** — the rep-level path taken when neither bulk probe applies (list widths `9..15`, non-uniform large-`k` encoder splits, and the degenerate `k=1`) — plus the benchmark coverage that motivated and verifies them.

Before this, both scalar sub-paths walked the rep stream one element at a time. After it, no scalar sub-path has an O(rows) loop left.

### 1. Word-at-a-time boundary scan (bit-packed runs)

The width-1 rep stream packs one bit per value, so a record boundary is a `0` bit. Instead of visiting every bit, the bit-packed branch now scans a 64-bit word at a time: the boundary mask is the word's zero bits (`~word`), and `numberOfTrailingZeros` walks them in order, skipping the runs of `1`s between boundaries. Only full 64-value words take the fast path (no padding bit is read); the sub-word remainder keeps the scalar bit loop.

### 2. O(1) collapse of the RLE-of-zeros run (`k=1`)

A run of boundaries (an RLE run of `0`s) was closed one boundary at a time. Within such a run every gap is exactly `1`, so after the first boundary closes the previous record the remaining `runLen-1` gaps all imply `k==1` — verified in O(1). A list of single elements is one long run of zeros, so this is the whole detector cost for that shape.

### Measured (N300, `perfnorm`; cross-checked on Apple silicon)

Scalar case, detector's wasted-scan penalty on a failing page (`FixedSizeListFallbackBenchmark`, `k=9`):

| metric | before | after |
|--|--:|--:|
| cycles penalty | +6.40M (+8%) | +0.05M (~0) |
| instructions penalty | +31.5M | +8.3M |

Independently on Apple silicon (wall-clock): the `k=9` scalar penalty went from a cleanly-resolved +2.6% to within noise of zero. Bulk regimes (`k=4`, `k=768`) unchanged.

Detector-only for `k=1` (`FixedSizeListDecodeBenchmark.repScanOnly`): **82.2M → 0.22M instructions/op (-99.7%)**; end-to-end `columnFast[1]`: **213M → 128M instructions (-40%)**, cycles -4.7%. Controls (`columnBaseline`, `flatFloor`, `repScanOnly[4]`) flat — the effect is isolated to the detector.

### Notes

- `k=1` is a shape writers do not actually produce (a scalar stored as a `LIST`), so its win is completeness, not a workload gain. The concrete value is that the scalar path is no longer the detector's expensive case.
- Benchmark scaffolding added: `k=9` to the fallback benchmark and `k=1` to the decode benchmark (+ generator corpus), so both scalar regimes are covered.
- Two coverage follow-ups (two-level legacy lists; nullable vectors) are tracked in separate issues.

### Tests

`FixedSizeListDetectorTest` gains two cases driving the word loop directly (an all-bit-packed `k=9` page spanning two words plus a padding tail, and a shortened record whose extra boundary lands past the first word). Existing `k=1` and differential/read suites cover the RLE-of-zeros collapse.
