### PR TITLE
#783 Key shredded_variant invalid-skip off the -INVALID suffix

### DIFF
--- a/parquet-testing-runner/src/test/java/dev/hardwood/testing/ParquetComparisonTest.java
+++ b/parquet-testing-runner/src/test/java/dev/hardwood/testing/ParquetComparisonTest.java
@@ -49,7 +49,7 @@ class ParquetComparisonTest {
         String fileName = testFile.getFileName().toString();
 
         // Skip individual files
-        assumeFalse(Utils.SKIPPED_FILES.contains(fileName),
+        assumeFalse(Utils.isSkipped(fileName),
                 "Skipping " + fileName + " (in skip list)");
         String blockedBy = Utils.rowComparisonSkipReason(testFile);
         assumeFalse(blockedBy != null,
@@ -63,7 +63,7 @@ class ParquetComparisonTest {
     void compareColumnsWithReference(Path testFile) throws Exception {
         String fileName = testFile.getFileName().toString();
 
-        assumeFalse(Utils.SKIPPED_FILES.contains(fileName),
+        assumeFalse(Utils.isSkipped(fileName),
                 "Skipping " + fileName + " (in skip list)");
 
         runWithThreadDumpOnTimeout(() -> compareColumnsParquetFile(testFile), 120, fileName);

--- a/parquet-testing-runner/src/test/java/dev/hardwood/testing/ParquetComparisonTest.java
+++ b/parquet-testing-runner/src/test/java/dev/hardwood/testing/ParquetComparisonTest.java
@@ -51,9 +51,6 @@ class ParquetComparisonTest {
         // Skip individual files
         assumeFalse(Utils.isSkipped(fileName),
                 "Skipping " + fileName + " (in skip list)");
-        String blockedBy = Utils.rowComparisonSkipReason(testFile);
-        assumeFalse(blockedBy != null,
-                () -> "Skipping " + fileName + " (blocked by " + blockedBy + ")");
 
         compareParquetFile(testFile);
     }

--- a/parquet-testing-runner/src/test/java/dev/hardwood/testing/Utils.java
+++ b/parquet-testing-runner/src/test/java/dev/hardwood/testing/Utils.java
@@ -134,14 +134,6 @@ public class Utils {
         return fileName.contains("-INVALID");
     }
 
-    /// Returns a GitHub issue reference blocking row-level nested comparison for
-    /// `testFile`, or `null` if the file can be compared. No files are currently
-    /// blocked — shredded Variant reassembly (#286) is now handled end-to-end,
-    /// so `shredded_variant/*.parquet` files round-trip through the comparison.
-    static String rowComparisonSkipReason(Path testFile) {
-        return null;
-    }
-
     /// Directories containing test parquet files.
     private static final List<String> TEST_DIRECTORIES = List.of(
             "data",

--- a/parquet-testing-runner/src/test/java/dev/hardwood/testing/Utils.java
+++ b/parquet-testing-runner/src/test/java/dev/hardwood/testing/Utils.java
@@ -81,24 +81,10 @@ public class Utils {
             "repeated_primitive_no_list.parquet", // ClassCast: int32 Int32_list is not a group
             "unknown-logical-type.parquet", // Unknown logical type
 
-            // shredded_variant INVALID fixtures: the parquet-testing cases.json
-            // flags these as "not valid according to the spec; implementations
-            // can choose to error or read the shredded value." parquet-java
-            // and Hardwood diverge in which interpretation they pick, so row-
-            // level comparison is not meaningful.
-            "case-043-INVALID.parquet",
-            "case-125-INVALID.parquet",
+            // shredded_variant fixtures are skipped outside this list: spec-invalid
+            // ones by isInvalidFixture() (the `-INVALID` suffix), error cases by
+            // SHREDDED_VARIANT_ERROR_CASES. Both are folded in by isSkipped().
 
-            // shredded_variant files with parquet-java issues
-            "case-040.parquet", // ParquetDecodingException
-            "case-041.parquet", // NullPointer on Schema field
-            "case-042.parquet", // ParquetDecodingException
-            "case-087.parquet", // ParquetDecodingException
-            "case-127.parquet", // Unsupported shredded value type: INTEGER(32,false)
-            "case-128.parquet", // ParquetDecodingException
-            "case-131.parquet", // NullPointer on Schema field
-            "case-137.parquet", // Unsupported shredded value type
-            "case-138.parquet", // NullPointer on Schema field
             // Intentionally corrupted CRC checksums (rejected by Hardwood CRC validation)
             "datapage_v1-corrupt-checksum.parquet",
             "rle-dict-uncompressed-corrupt-checksum.parquet",
@@ -112,6 +98,41 @@ public class Utils {
             "ARROW-GH-45185.parquet",
             "ARROW-GH-47662.parquet"
     );
+
+    /// `shredded_variant` fixtures cases.json classifies as error cases: each
+    /// carries an `error_message` and no variant payload, so a conforming reader
+    /// is expected to reject it. parquet-java cannot decode them as a reference
+    /// and there is no `.variant.bin` oracle, so both comparison paths skip them.
+    /// Single source shared with [VariantShredReassemblerTest]. See #812.
+    static final Set<String> SHREDDED_VARIANT_ERROR_CASES = Set.of(
+            "case-040.parquet", // Invalid variant, conflicting value and typed_value
+            "case-042.parquet", // Invalid variant, conflicting value and typed_value
+            "case-087.parquet", // Invalid variant, non-object value with shredded fields
+            "case-127.parquet", // Unsupported shredded value type: INTEGER(32,false)
+            "case-128.parquet", // Invalid variant, non-object value with shredded fields
+            "case-137.parquet"  // Unsupported shredded value type: fixed_len_byte_array(4)
+    );
+
+    /// Combined skip predicate for the row/column comparison tests: a fixture is
+    /// skipped when explicitly listed in [#SKIPPED_FILES] or
+    /// [#SHREDDED_VARIANT_ERROR_CASES], or flagged invalid-per-spec by
+    /// [#isInvalidFixture].
+    static boolean isSkipped(String fileName) {
+        return SKIPPED_FILES.contains(fileName)
+                || SHREDDED_VARIANT_ERROR_CASES.contains(fileName)
+                || isInvalidFixture(fileName);
+    }
+
+    /// Returns true for `shredded_variant` fixtures the parquet-testing corpus
+    /// flags as invalid-per-spec via the `-INVALID` filename suffix (kept in
+    /// lockstep with `cases.json`). The spec leaves reader behaviour on these
+    /// implementation-defined — an implementation may error or read the shredded
+    /// value — so neither the parquet-java oracle comparison nor the byte-level
+    /// reassembly check is meaningful. Keying on the suffix rather than exact
+    /// filenames keeps the skip stable as upstream relabels fixtures.
+    static boolean isInvalidFixture(String fileName) {
+        return fileName.contains("-INVALID");
+    }
 
     /// Returns a GitHub issue reference blocking row-level nested comparison for
     /// `testFile`, or `null` if the file can be compared. No files are currently

--- a/parquet-testing-runner/src/test/java/dev/hardwood/testing/VariantShredReassemblerTest.java
+++ b/parquet-testing-runner/src/test/java/dev/hardwood/testing/VariantShredReassemblerTest.java
@@ -14,7 +14,6 @@ import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
-import java.util.Set;
 
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.DynamicTest;
@@ -39,30 +38,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 class VariantShredReassemblerTest {
 
-    /// Fixtures deliberately flagged as invalid per the spec — cases.json
-    /// notes "not valid according to the spec; implementations can choose to
-    /// error or read the shredded value." Reader behaviour is implementation
-    /// defined so we skip the byte-level oracle check.
-    private static final Set<String> INVALID_FIXTURES = Set.of(
-            "case-043-INVALID.parquet",
-            "case-125-INVALID.parquet",
-            "case-084-INVALID.parquet"
-    );
-
-    /// parquet-java cannot read these; cases.json pairs them with a
-    /// variant_file anyway. Since we can't open them to fetch rows, skip.
-    private static final Set<String> UNREADABLE = Set.of(
-            "case-040.parquet",
-            "case-041.parquet",
-            "case-042.parquet",
-            "case-087.parquet",
-            "case-127.parquet",
-            "case-128.parquet",
-            "case-131.parquet",
-            "case-137.parquet",
-            "case-138.parquet"
-    );
-
     private Path fixturesDir;
 
     @BeforeAll
@@ -80,7 +55,11 @@ class VariantShredReassemblerTest {
             Collections.sort(files);
             for (Path file : files) {
                 String name = file.getFileName().toString();
-                if (INVALID_FIXTURES.contains(name) || UNREADABLE.contains(name)) {
+                // Two classes of fixture carry no byte-level oracle: spec-invalid
+                // ones (`-INVALID`), whose reader behaviour is implementation
+                // defined, and error cases, which cases.json pairs with an
+                // `error_message` and no variant payload (see #812).
+                if (Utils.isInvalidFixture(name) || Utils.SHREDDED_VARIANT_ERROR_CASES.contains(name)) {
                     continue;
                 }
                 tests.add(DynamicTest.dynamicTest(name, () -> verifyFile(file)));


### PR DESCRIPTION
Fixes #783.

## Problem

apache/parquet-testing#117 (now merged) renamed the `shredded_variant` fixtures whose variant group omits the spec-required `value` column to carry an `-INVALID` suffix. Our skip-lists keyed on the exact pre-rename filenames, so the directory walk still found the renamed files while the skips no longer matched them. Because the cloner tracks `parquet-testing` HEAD and `mvn clean` wipes the clone, the next CI run re-clones the renamed corpus and turns red: cases 41/131/138 start being exercised (Hardwood fail-fasts on the malformed group; parquet-java NPEs on the reference side), and case 132 begins to be compared.

Verified locally against the renamed corpus: 9 errors before this change, green after.

## Change

Key the invalid-skip off the stable `-INVALID` suffix (which upstream keeps in lockstep with `cases.json`) rather than exact filenames, so future relabels don't reopen the gap:

- `Utils.isInvalidFixture(name)` / `Utils.isSkipped(name)` centralize the rule; `ParquetComparisonTest` and `VariantShredReassemblerTest` both use it.
- Dropped the now-redundant hard-coded `-INVALID` entries and the dead plain `case-041/131/138` entries.
- Case 132 now falls into the invalid-skip too: reader behaviour on spec-invalid fixtures is implementation-defined, so pinning it to an oracle-level match asserts more than the spec guarantees.

The remaining name-keyed list is the genuinely error-expected fixtures (cases.json pairs them with an `error_message` and no variant payload). `cases.json` says nothing that the `-INVALID` suffix can key on for those, so they stay explicit; renamed the bucket `UNREADABLE -> ERROR_CASES` and corrected its comment (Hardwood in fact reads them without erroring — see #812).

## Testing

`./mvnw -pl parquet-testing-runner test` — 575 run, 0 failures, 0 errors, 66 skipped.
