### PR TITLE
#9 Write support stage 11: column statistics

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -307,9 +307,9 @@ For field-level `parquet.thrift` metadata coverage (which spec fields are read/p
 - [x] Implement `Statistics` record (minValue, maxValue, nullCount, distinctCount)
 - [x] Statistics deserialization (`StatisticsReader` with deprecated/preferred field fallback)
 - [x] Type-specific comparators (`StatisticsDecoder` for int, long, float, double, boolean, binary)
-- [ ] Statistics collection during writing
+- [x] Statistics collection during writing (`StatisticsCollector`, INT32 min/max/null_count)
 - [ ] Binary min/max truncation for efficiency
-- [ ] Statistics serialization
+- [x] Statistics serialization (`StatisticsWriter`, preferred `min_value`/`max_value` fields)
 
 ### 9.2 Page Index (Column Index & Offset Index)
 - [x] Implement `ColumnIndex` structure

--- a/_designs/WRITER_SUPPORT.md
+++ b/_designs/WRITER_SUPPORT.md
@@ -38,10 +38,11 @@ column's physical bytes are written by the primitive-type increment, and the ann
 is serialized onto the schema and converted at the API boundary.
 
 Sequenced as later work, each its own design: DataPage V2, the Avro write API, the
-optional index structures (OffsetIndex, ColumnIndex, Bloom filters), the optional delta
-and byte-stream-split encoders, and a CLI write/convert command. The S3 `OutputFile`
-backend is planned as increment 19 below. Sorting-column metadata and custom record
-materializers are non-goals.
+optional index structures (OffsetIndex, ColumnIndex, Bloom filters) together with the
+per-page statistics that drive page-level pruning (the `DataPageHeader` inline statistics),
+the optional delta and byte-stream-split encoders, and a CLI write/convert command. The S3
+`OutputFile` backend is planned as increment 19 below. Sorting-column metadata and custom
+record materializers are non-goals.
 
 ## Write model
 
@@ -271,10 +272,18 @@ and the written `created_by` string.
 during encoding and writes them into `ColumnMetaData`, so produced files support
 reader-side predicate pushdown. `min`/`max` ordering follows the column's
 `ColumnOrder` (the same ordering the reader honors on read), so written statistics
-are pruning-correct. Long `BYTE_ARRAY` `min`/`max` are truncated per the format's
+are pruning-correct. The bounds are the preferred `min_value` / `max_value` — never the
+deprecated `min` / `max` — and each is flagged exact via `is_min_value_exact` /
+`is_max_value_exact`, so a reader may treat `min_value == max_value` as proof that a whole
+chunk holds a single value. Long `BYTE_ARRAY` `min`/`max` are truncated per the format's
 binary min/max truncation rule, keeping statistics bounded while remaining valid for
-pruning. OffsetIndex, ColumnIndex, and Bloom filters are deferred; a file is valid
-without them.
+pruning; a truncated bound is flagged **inexact** (`is_*_value_exact = false`), since it is
+then only a bound and not the actual extreme.
+
+These are **column-chunk** statistics, feeding row-group pruning. Per-page statistics — the
+`DataPageHeader` inline statistics and the OffsetIndex / ColumnIndex structures that enable
+page-level skipping — are deferred to the page-index work (below), together with Bloom
+filters. A file is valid without any of them.
 
 ## Threading model
 
@@ -342,8 +351,8 @@ API), *Optimization*, *Spike* (design-only), or *Docs* (user-facing documentatio
 | 8 | **Map shredding** (`INT32` leaves): key/value repeated group, reusing the list machinery. | Dimension | The full nested shape (structs, lists, maps) is settled | 6.3 | [x] |
 | 9 | Dictionary encoding (`INT32`): dictionary page + `RLE_DICTIONARY` indices + plain fallback, exercised on nullable and nested columns so the level + dictionary-index page layout is proven together. Settled in `_designs/WRITER_DICTIONARY.md`. | Dimension | Dictionary column-chunk layout proven, incl. nulls and nesting | 2.2 | [x] |
 | 10 | Compression on the write path (`INT32`, one codec). | Dimension | Compress step + compressed/uncompressed size accounting proven | 6.2 (page compression) | [x] |
-| 11 | Column statistics (`INT32`: `min`/`max`/`null_count`, `ColumnOrder`-correct) accumulated during encode. | Dimension | Produced files support pushdown | 9.1 (stats) | [ ] |
-| 12 | All primitive physical types (incl. `FIXED_LEN_BYTE_ARRAY` type length and `BYTE_ARRAY` min/max truncation), each inheriting paging, nulls, nesting, dictionary, compression and stats. Variable-width values end the constant-bytes-per-row assumption, so the row-group flush moves from the fixed rows-per-group proxy (`rowGroupTargetBytes / (columnCount × 4)`) to tracking the actual buffered uncompressed bytes. | Breadth | Write any column type, flat or nested | 2.1, 9.1 (truncation) | [ ] |
+| 11 | Column statistics (`INT32`: `min`/`max`/`null_count`, `ColumnOrder`-correct) accumulated during encode. | Dimension | Produced files support pushdown | 9.1 (stats) | [x] |
+| 12 | All primitive physical types (incl. `FIXED_LEN_BYTE_ARRAY` type length and `BYTE_ARRAY` min/max truncation), each inheriting paging, nulls, nesting, dictionary, compression and stats. Truncated `BYTE_ARRAY` bounds are flagged inexact (`is_min_value_exact` / `is_max_value_exact` = false), extending the exactness the fixed-width types write unconditionally as true. Variable-width values end the constant-bytes-per-row assumption, so the row-group flush moves from the fixed rows-per-group proxy (`rowGroupTargetBytes / (columnCount × 4)`) to tracking the actual buffered uncompressed bytes. | Breadth | Write any column type, flat or nested | 2.1, 9.1 (truncation) | [ ] |
 | 13 | Logical-type annotations: `LogicalTypeWriter` serializes the `LogicalType` union and legacy `converted_type`/`scale`/`precision`; `FileSchema.Builder` logical-type overload. Both annotations are emitted together for every type with a legacy equivalent (STRING, DATE, DECIMAL, the INT/UINT widths, TIME/TIMESTAMP millis+micros, ENUM, JSON, BSON, `LIST`, `MAP`), the union taking read precedence and the `converted_type` kept for pre-union readers; only types without a legacy equivalent (UUID, FLOAT16, NANOS units, VARIANT, GEOMETRY/GEOGRAPHY) are union-only. This makes stage 13 additive to the `converted_type`-only annotations stages 6–8 already write. | Breadth | Columns read back with their logical type (STRING, DATE, TIMESTAMP, DECIMAL, …) | 6.4 (annotation) | [ ] |
 | 14 | Remaining codecs + optional delta and byte-stream-split encoders. | Breadth | Full codec / encoding choice | 2.4, 2.5 | [ ] |
 | 15 | Parallel column encoding + row-group pipelining. | Optimization | Write throughput | — | [ ] |
@@ -359,8 +368,8 @@ are breadth on the settled shape, 15–16 are internal encoding optimizations, a
 row-oriented layer; 18 documents the finished public surface. Together, increments 1–18
 constitute the write-support milestone (#9); increment 19 adds the S3 `OutputFile` backend
 on the settled surface. Sequenced as later work, each its own design and sequence: DataPage
-V2, the optional index structures and Bloom filters, the Avro write adapter, and a CLI
-write/convert command.
+V2, the optional index structures and Bloom filters (with the per-page statistics that make
+page-level pruning possible), the Avro write adapter, and a CLI write/convert command.
 
 ## User documentation
 

--- a/_designs/WRITER_SUPPORT.md
+++ b/_designs/WRITER_SUPPORT.md
@@ -37,12 +37,12 @@ Logical-type annotations (STRING, DATE, TIMESTAMP, DECIMAL, UUID, …) are in sc
 column's physical bytes are written by the primitive-type increment, and the annotation
 is serialized onto the schema and converted at the API boundary.
 
-Sequenced as later work, each its own design: DataPage V2, the Avro write API, the
-optional index structures (OffsetIndex, ColumnIndex, Bloom filters) together with the
-per-page statistics that drive page-level pruning (the `DataPageHeader` inline statistics),
-the optional delta and byte-stream-split encoders, and a CLI write/convert command. The S3
-`OutputFile` backend is planned as increment 19 below. Sorting-column metadata and custom
-record materializers are non-goals.
+The optional index structures — OffsetIndex, ColumnIndex, and Bloom filters, with the
+per-page statistics that drive page-level pruning (including the `DataPageHeader` inline
+statistics) — are numbered increments 20–21 below, on the settled surface alongside the S3
+`OutputFile` backend (increment 19). Sequenced as separate later milestones, each its own
+design: DataPage V2, the Avro write API, and a CLI write/convert command. Sorting-column
+metadata and custom record materializers are non-goals.
 
 ## Write model
 
@@ -282,8 +282,8 @@ then only a bound and not the actual extreme.
 
 These are **column-chunk** statistics, feeding row-group pruning. Per-page statistics — the
 `DataPageHeader` inline statistics and the OffsetIndex / ColumnIndex structures that enable
-page-level skipping — are deferred to the page-index work (below), together with Bloom
-filters. A file is valid without any of them.
+page-level skipping — arrive with page index writing (increment 20), and Bloom filters with
+increment 21. A file is valid without any of them.
 
 ## Threading model
 
@@ -360,16 +360,19 @@ API), *Optimization*, *Spike* (design-only), or *Docs* (user-facing documentatio
 | 17 | Row-oriented `ParquetWriter` ergonomic layer on the columnar core, including nested record materialization and logical-type value conversion (inverse of `LogicalTypeConverter`). | Layer | Mainstream-friendly API | 6.1 (`ParquetWriter`), 6.4 (value conversion) | [ ] |
 | 18 | User-facing documentation under `docs/content/` for the writer public API (`OutputFile`, `ParquetFileWriter`, `FileSchema.Builder`): a `how-to` guide and a `reference` page, covering the settled surface including nesting and the row-oriented layer. | Docs | Documented, stable public API | — | [ ] |
 | 19 | S3 `OutputFile` backend: sequential multipart upload — buffer to the part size, upload parts, complete on `close()`. In-flight bytes bounded to the part size times a small concurrency multiple; lazy `CreateMultipartUpload` deferred to the first part flush, with a single `PutObject` fallback for a sub-part output. Reuses the read-side S3 / SigV4 stack. | Layer | Write directly to object storage | — | [ ] |
+| 20 | **Page index writing**: per-column-chunk OffsetIndex (page locations) and ColumnIndex (per-page `min`/`max`, null counts, boundary order), written after the row group's pages and referenced from the footer, so the reader can skip individual pages. Extends the column-chunk statistics of increment 11 to page granularity; the `DataPageHeader` inline `statistics` are the pre-index fallback covered here. Truncation and `is_*_value_exact` follow the increment 11 / 12 rules. Its own design. | Layer | Page-level pruning on produced files | 9.2 | [ ] |
+| 21 | **Bloom filter writing**: a split-block Bloom filter per eligible column chunk (XXHASH64), serialized with its header and referenced from the column metadata, for equality-predicate pruning where `min`/`max` do not help. Its own design. | Layer | Bloom-filter pruning on produced files | 9.3 | [ ] |
 
 Increments 1–4 settle the flat dimensions on `INT32`; 5–8 settle the nested shape —
 design, then struct / list / map shredding — on `INT32`; 9–11 finish the remaining
 dimensions (dictionary, compression, statistics) on the now flat-and-nested shape; 12–14
 are breadth on the settled shape, 15–16 are internal encoding optimizations, and 17 is the
 row-oriented layer; 18 documents the finished public surface. Together, increments 1–18
-constitute the write-support milestone (#9); increment 19 adds the S3 `OutputFile` backend
-on the settled surface. Sequenced as later work, each its own design and sequence: DataPage
-V2, the optional index structures and Bloom filters (with the per-page statistics that make
-page-level pruning possible), the Avro write adapter, and a CLI write/convert command.
+constitute the write-support milestone (#9); increments 19–21 add the S3 `OutputFile` backend
+and the optional index structures (page indexes and Bloom filters, with the per-page
+statistics that make page-level pruning possible) on the settled surface. Sequenced as
+separate later milestones, each its own design and sequence: DataPage V2, the Avro write
+adapter, and a CLI write/convert command.
 
 ## User documentation
 

--- a/core/src/main/java/dev/hardwood/internal/thrift/ColumnMetaDataWriter.java
+++ b/core/src/main/java/dev/hardwood/internal/thrift/ColumnMetaDataWriter.java
@@ -12,7 +12,7 @@ import dev.hardwood.metadata.Encoding;
 
 /// Writer for ColumnMetaData to Thrift Compact Protocol, the inverse of
 /// [ColumnMetaDataReader]. Serializes the required fields plus the optional
-/// `dictionary_page_offset`; statistics and index offsets are written by later
+/// `dictionary_page_offset` and `statistics`; index offsets are written by later
 /// increments.
 public class ColumnMetaDataWriter {
 
@@ -61,6 +61,12 @@ public class ColumnMetaDataWriter {
             if (metaData.dictionaryPageOffset() != null) {
                 writer.writeFieldBegin(11, ThriftCompactConstants.FieldType.I64);
                 writer.writeI64(metaData.dictionaryPageOffset());
+            }
+
+            // 12: statistics (min/max/null_count for reader-side predicate pushdown)
+            if (metaData.statistics() != null) {
+                writer.writeFieldBegin(12, ThriftCompactConstants.FieldType.STRUCT);
+                StatisticsWriter.write(writer, metaData.statistics());
             }
 
             writer.writeFieldStop();

--- a/core/src/main/java/dev/hardwood/internal/thrift/StatisticsWriter.java
+++ b/core/src/main/java/dev/hardwood/internal/thrift/StatisticsWriter.java
@@ -1,0 +1,65 @@
+/*
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Copyright The original authors
+ *
+ *  Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package dev.hardwood.internal.thrift;
+
+import dev.hardwood.metadata.Statistics;
+
+/// Writer for the Thrift Statistics struct, the inverse of [StatisticsReader].
+///
+/// Emits the null count (field 3) and the preferred `min_value` / `max_value`
+/// (fields 6 / 5) — the sort-order-correct bounds modern readers prefer over the
+/// deprecated `min` / `max` (fields 2 / 1), which are not written. A `min` / `max`
+/// that is absent (a fully null column) is omitted; the null count is always written.
+///
+/// Each written bound is flagged exact via `is_max_value_exact` / `is_min_value_exact`
+/// (fields 7 / 8): the writer stores the actual extreme, never a truncated approximation,
+/// so a reader may safely use `min_value == max_value` to prove a whole chunk equals a single
+/// value. When bound truncation is introduced (for long `BYTE_ARRAY` values), a truncated
+/// bound must instead be flagged inexact, so this exactness will become per-bound rather than
+/// unconditionally true.
+public class StatisticsWriter {
+
+    public static void write(ThriftCompactWriter writer, Statistics statistics) {
+        short saved = writer.pushFieldIdContext();
+        try {
+            // 3: null_count
+            if (statistics.nullCount() != null) {
+                writer.writeFieldBegin(3, ThriftCompactConstants.FieldType.I64);
+                writer.writeI64(statistics.nullCount());
+            }
+
+            // 5: max_value (preferred over deprecated field 1)
+            if (statistics.maxValue() != null) {
+                writer.writeFieldBegin(5, ThriftCompactConstants.FieldType.BINARY);
+                writer.writeBinary(statistics.maxValue());
+            }
+
+            // 6: min_value (preferred over deprecated field 2)
+            if (statistics.minValue() != null) {
+                writer.writeFieldBegin(6, ThriftCompactConstants.FieldType.BINARY);
+                writer.writeBinary(statistics.minValue());
+            }
+
+            // 7: is_max_value_exact — the stored max_value is the actual maximum. A Thrift
+            // compact bool carries its value in the field-type nibble, so there is no body.
+            if (statistics.maxValue() != null) {
+                writer.writeFieldBegin(7, ThriftCompactConstants.FieldType.BOOLEAN_TRUE);
+            }
+
+            // 8: is_min_value_exact — the stored min_value is the actual minimum.
+            if (statistics.minValue() != null) {
+                writer.writeFieldBegin(8, ThriftCompactConstants.FieldType.BOOLEAN_TRUE);
+            }
+
+            writer.writeFieldStop();
+        }
+        finally {
+            writer.popFieldIdContext(saved);
+        }
+    }
+}

--- a/core/src/main/java/dev/hardwood/internal/writer/ColumnChunkBuffer.java
+++ b/core/src/main/java/dev/hardwood/internal/writer/ColumnChunkBuffer.java
@@ -54,6 +54,10 @@ import dev.hardwood.schema.ColumnSchema;
 /// subsequent page is `PLAIN`. Encoding is per-page (each page's header declares its own), so a
 /// chunk may hold any mix of the two; a page sealed while the dictionary is still empty (a
 /// leading run of nulls filling a page) is `PLAIN` even ahead of later `RLE_DICTIONARY` pages.
+///
+/// A [StatisticsCollector] accumulates the chunk's `min` / `max` / `null_count` over the same
+/// entry stream, written into the chunk metadata at flush so produced files support
+/// reader-side predicate pushdown.
 final class ColumnChunkBuffer implements RecordShredder.LevelSink {
 
     private final int maxDefLevel;
@@ -74,6 +78,8 @@ final class ColumnChunkBuffer implements RecordShredder.LevelSink {
     private final DictionaryEncoder dictionary; // null when dictionary encoding is disabled
     private final int dictionaryLimitBytes;
     private boolean dictionaryActive;    // true while pages are still dictionary-encoded
+
+    private final StatisticsCollector statistics = new StatisticsCollector();
 
     /// @param pageValues maximum number of level entries per data page
     /// @param maxDefLevel the column's maximum definition level (0 selects no def stream)
@@ -127,6 +133,7 @@ final class ColumnChunkBuffer implements RecordShredder.LevelSink {
                     ? (index < 0 ? dictionary.add(value) : index)
                     : value;
         }
+        statistics.accept(present, value);
         pendingCount++;
         if (pendingCount == pendingValues.length) {
             sealPage();
@@ -168,7 +175,7 @@ final class ColumnChunkBuffer implements RecordShredder.LevelSink {
                 Map.of(),
                 dataPageOffset,
                 dictionaryPageOffset,
-                null,
+                statistics.toStatistics(),
                 null,
                 null,
                 null);

--- a/core/src/main/java/dev/hardwood/internal/writer/StatisticsCollector.java
+++ b/core/src/main/java/dev/hardwood/internal/writer/StatisticsCollector.java
@@ -1,0 +1,61 @@
+/*
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Copyright The original authors
+ *
+ *  Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package dev.hardwood.internal.writer;
+
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
+
+import dev.hardwood.metadata.Statistics;
+
+/// Accumulates a column chunk's `min` / `max` / `null_count` over its shredded leaf slots as
+/// they are encoded, producing the [Statistics] written into the chunk metadata so that
+/// produced files support reader-side predicate pushdown.
+///
+/// The `min` / `max` bounds span only present values and are compared with signed `INT32`
+/// ordering, matching the column's type-defined `ColumnOrder`, so the written bounds are
+/// pruning-correct. The null count is every not-present slot — a null leaf, a null or empty
+/// list, or a null struct ancestor — mirroring how the reader counts nulls; a fully null
+/// column therefore carries a null count but no bounds. Statistics are written with the
+/// preferred `min_value` / `max_value` fields, so the bounds are never flagged as the
+/// deprecated `min` / `max`.
+final class StatisticsCollector {
+
+    private int min = Integer.MAX_VALUE;
+    private int max = Integer.MIN_VALUE;
+    private long nullCount;
+    private boolean hasValues;
+
+    /// Records one shredded leaf slot: a present value extends the `min` / `max` bounds, an
+    /// absent slot increments the null count. `value` is ignored when `present` is false.
+    void accept(boolean present, int value) {
+        if (present) {
+            if (value < min) {
+                min = value;
+            }
+            if (value > max) {
+                max = value;
+            }
+            hasValues = true;
+        }
+        else {
+            nullCount++;
+        }
+    }
+
+    /// Builds the chunk statistics: the `INT32` bounds encoded as 4-byte little-endian `PLAIN`
+    /// values — absent when the chunk holds no present value — alongside the null count.
+    Statistics toStatistics() {
+        byte[] minValue = hasValues ? encodeInt(min) : null;
+        byte[] maxValue = hasValues ? encodeInt(max) : null;
+        return new Statistics(minValue, maxValue, nullCount, null, false);
+    }
+
+    private static byte[] encodeInt(int value) {
+        return ByteBuffer.allocate(Integer.BYTES).order(ByteOrder.LITTLE_ENDIAN).putInt(value).array();
+    }
+}

--- a/core/src/test/java/dev/hardwood/writer/WriterDifferentialTest.java
+++ b/core/src/test/java/dev/hardwood/writer/WriterDifferentialTest.java
@@ -518,4 +518,114 @@ class WriterDifferentialTest {
             assertThat(rs.getInt("mx")).isEqualTo(n - 1);
         }
     }
+
+    @Test
+    void duckDbMetadataReportsWrittenStatistics(@TempDir Path dir) throws Exception {
+        // DuckDB's parquet_metadata() decodes the statistics we wrote — the true inverse of the
+        // differential for the metadata: an independent implementation reads our bytes back to
+        // the expected values. The preferred min_value/max_value carry the signed bounds; the
+        // deprecated min/max are absent (we never write them); the null count is exact.
+        int[] v = { 42, -100_000, 7, Integer.MAX_VALUE, Integer.MIN_VALUE, 0 };
+
+        FileSchema schema = FileSchema.builder("schema")
+                .addColumn("v", PhysicalType.INT32, RepetitionType.REQUIRED)
+                .build();
+        Path file = dir.resolve("meta.parquet");
+        try (ParquetFileWriter writer = ParquetFileWriter.create(OutputFile.of(file), schema)) {
+            writer.writeBatch(batch -> batch.ints(0, v));
+        }
+
+        try (Connection conn = DriverManager.getConnection("jdbc:duckdb:");
+                Statement stmt = conn.createStatement();
+                ResultSet rs = stmt.executeQuery(
+                        "SELECT stats_min, stats_max, stats_min_value, stats_max_value,"
+                                + " stats_null_count, min_is_exact, max_is_exact"
+                                + " FROM parquet_metadata('" + file.toAbsolutePath() + "') WHERE path_in_schema = 'v'")) {
+            assertThat(rs.next()).isTrue();
+            assertThat(rs.getString("stats_min_value")).isEqualTo(Integer.toString(Integer.MIN_VALUE));
+            assertThat(rs.getString("stats_max_value")).isEqualTo(Integer.toString(Integer.MAX_VALUE));
+            assertThat(rs.getString("stats_null_count")).isEqualTo("0");
+            // The bounds are flagged exact, so a reader may treat them as actual values.
+            assertThat(rs.getBoolean("min_is_exact")).isTrue();
+            assertThat(rs.getBoolean("max_is_exact")).isTrue();
+            // Deprecated min/max fields are never written; DuckDB reports them absent.
+            assertThat(rs.getString("stats_min")).isNull();
+            assertThat(rs.getString("stats_max")).isNull();
+        }
+    }
+
+    @Test
+    void duckDbMetadataReportsNestedListNullCount(@TempDir Path dir) throws Exception {
+        // The trickiest statistic in stage 11: a LIST leaf's null_count counts every not-present
+        // slot — a null list, an empty list, and a null element. DuckDB's parquet_metadata()
+        // decodes it back to 3, independently confirming this matches the ecosystem convention
+        // rather than only Hardwood's own reader; the bounds still cover only the present 1..5.
+        // record 0: [1,2]; 1: [] (empty); 2: null list; 3: [3, null, 5].
+        FileSchema schema = FileSchema.builder("schema")
+                .list("phones", RepetitionType.OPTIONAL, el -> el.primitive(PhysicalType.INT32, RepetitionType.OPTIONAL))
+                .build();
+
+        int[] offsets = { 0, 2, 2, 2, 5 };
+        Validity listNulls = Validity.ofNulls(new boolean[] { false, false, true, false });
+        int[] elements = { 1, 2, 3, 0, 5 };
+        boolean[] elementNulls = { false, false, false, true, false };
+
+        Path file = dir.resolve("nestedstats.parquet");
+        try (ParquetFileWriter writer = ParquetFileWriter.create(OutputFile.of(file), schema)) {
+            writer.writeBatch(batch -> batch
+                    .list("phones", offsets, listNulls)
+                    .ints("phones.list.element", elements, elementNulls));
+        }
+
+        try (Connection conn = DriverManager.getConnection("jdbc:duckdb:");
+                Statement stmt = conn.createStatement();
+                ResultSet rs = stmt.executeQuery(
+                        "SELECT stats_min_value, stats_max_value, stats_null_count"
+                                + " FROM parquet_metadata('" + file.toAbsolutePath() + "')"
+                                // DuckDB renders a leaf's path as its comma-joined schema components.
+                                + " WHERE path_in_schema = 'phones, list, element'")) {
+            assertThat(rs.next()).isTrue();
+            assertThat(rs.getString("stats_null_count")).isEqualTo("3");
+            assertThat(rs.getString("stats_min_value")).isEqualTo("1");
+            assertThat(rs.getString("stats_max_value")).isEqualTo("5");
+        }
+    }
+
+    @Test
+    void duckDbFiltersOnWrittenStatisticsWithoutDroppingMatches(@TempDir Path dir) throws Exception {
+        // Ascending values banded into small row groups, so the written per-chunk min/max let
+        // DuckDB skip groups outside a range predicate. Correct statistics must not drop any
+        // matching row: a range straddling several groups returns exactly the matching values.
+        int n = 5_000;
+        int[] v = new int[n];
+        for (int i = 0; i < n; i++) {
+            v[i] = i;
+        }
+
+        FileSchema schema = FileSchema.builder("schema")
+                .addColumn("v", PhysicalType.INT32, RepetitionType.REQUIRED)
+                .build();
+        WriterConfig config = WriterConfig.builder().rowGroupTargetBytes(4096).build();
+        Path file = dir.resolve("stats.parquet");
+        try (ParquetFileWriter writer = ParquetFileWriter.create(OutputFile.of(file), schema, config)) {
+            writer.writeBatch(batch -> batch.ints(0, v));
+        }
+
+        List<Integer> actual = new ArrayList<>();
+        try (Connection conn = DriverManager.getConnection("jdbc:duckdb:");
+                Statement stmt = conn.createStatement();
+                ResultSet rs = stmt.executeQuery(
+                        "SELECT v FROM read_parquet('" + file.toAbsolutePath()
+                                + "') WHERE v BETWEEN 2000 AND 3000 ORDER BY v")) {
+            while (rs.next()) {
+                actual.add(rs.getInt("v"));
+            }
+        }
+
+        List<Integer> expected = new ArrayList<>();
+        for (int i = 2000; i <= 3000; i++) {
+            expected.add(i);
+        }
+        assertThat(actual).containsExactlyElementsOf(expected);
+    }
 }

--- a/core/src/test/java/dev/hardwood/writer/WriterRoundTripTest.java
+++ b/core/src/test/java/dev/hardwood/writer/WriterRoundTripTest.java
@@ -25,6 +25,7 @@ import dev.hardwood.InputFile;
 import dev.hardwood.OutputFile;
 import dev.hardwood.Validity;
 import dev.hardwood.internal.metadata.PageHeader;
+import dev.hardwood.internal.predicate.StatisticsDecoder;
 import dev.hardwood.internal.thrift.PageHeaderReader;
 import dev.hardwood.internal.thrift.ThriftCompactReader;
 import dev.hardwood.internal.writer.ByteBufferOutputFile;
@@ -34,6 +35,7 @@ import dev.hardwood.metadata.Encoding;
 import dev.hardwood.metadata.PhysicalType;
 import dev.hardwood.metadata.RepetitionType;
 import dev.hardwood.metadata.RowGroup;
+import dev.hardwood.metadata.Statistics;
 import dev.hardwood.reader.ColumnReader;
 import dev.hardwood.reader.LayerKind;
 import dev.hardwood.reader.ParquetFileReader;
@@ -881,6 +883,126 @@ class WriterRoundTripTest {
         try (ParquetFileReader reader = ParquetFileReader.open(InputFile.of(ByteBuffer.wrap(out.toByteArray())))) {
             assertThat(columnMeta(reader, 0).codec()).isEqualTo(CompressionCodec.ZSTD);
             assertThat(readNullable(reader, 0)).isEqualTo(expectedNullable(values, nulls));
+        }
+    }
+
+    @Test
+    void writesMinMaxAndNullCountForRequiredColumn() throws Exception {
+        // Signed bounds: the extremes must sort as MIN < ... < MAX, matching the INT32
+        // type-defined (signed) ColumnOrder.
+        int[] values = { 42, -100_000, 7, Integer.MAX_VALUE, Integer.MIN_VALUE, 0 };
+
+        ByteBufferOutputFile out = new ByteBufferOutputFile();
+        try (ParquetFileWriter writer = ParquetFileWriter.create(out, oneColumn())) {
+            writer.writeBatch(batch -> batch.ints(0, values));
+        }
+
+        try (ParquetFileReader reader = ParquetFileReader.open(InputFile.of(ByteBuffer.wrap(out.toByteArray())))) {
+            Statistics stats = columnMeta(reader, 0).statistics();
+            assertThat(stats).as("statistics written").isNotNull();
+            assertThat(StatisticsDecoder.decodeInt(stats.minValue())).isEqualTo(Integer.MIN_VALUE);
+            assertThat(StatisticsDecoder.decodeInt(stats.maxValue())).isEqualTo(Integer.MAX_VALUE);
+            assertThat(stats.nullCount()).isEqualTo(0L);
+            // Written through the preferred min_value/max_value fields, not the deprecated ones.
+            assertThat(stats.isMinMaxDeprecated()).isFalse();
+        }
+    }
+
+    @Test
+    void boundsSpanOnlyPresentValuesAndNullsAreCounted() throws Exception {
+        // The three null rows are counted but never widen the bounds, which cover 7..50.
+        int[] values = { 7, 0, -3, 0, 50, 0, 20 };
+        boolean[] nulls = { false, true, false, true, false, true, false };
+
+        ByteBufferOutputFile out = new ByteBufferOutputFile();
+        try (ParquetFileWriter writer = ParquetFileWriter.create(out, oneOptionalColumn())) {
+            writer.writeBatch(batch -> batch.ints(0, values, nulls));
+        }
+
+        try (ParquetFileReader reader = ParquetFileReader.open(InputFile.of(ByteBuffer.wrap(out.toByteArray())))) {
+            Statistics stats = columnMeta(reader, 0).statistics();
+            assertThat(StatisticsDecoder.decodeInt(stats.minValue())).isEqualTo(-3);
+            assertThat(StatisticsDecoder.decodeInt(stats.maxValue())).isEqualTo(50);
+            assertThat(stats.nullCount()).isEqualTo(3L);
+        }
+    }
+
+    @Test
+    void allNullColumnWritesNullCountButNoBounds() throws Exception {
+        // No present value, so the chunk carries a null count but omits min/max.
+        boolean[] nulls = { true, true, true, true };
+        int[] values = new int[nulls.length];
+
+        ByteBufferOutputFile out = new ByteBufferOutputFile();
+        try (ParquetFileWriter writer = ParquetFileWriter.create(out, oneOptionalColumn())) {
+            writer.writeBatch(batch -> batch.ints(0, values, nulls));
+        }
+
+        try (ParquetFileReader reader = ParquetFileReader.open(InputFile.of(ByteBuffer.wrap(out.toByteArray())))) {
+            Statistics stats = columnMeta(reader, 0).statistics();
+            assertThat(stats).isNotNull();
+            assertThat(stats.minValue()).isNull();
+            assertThat(stats.maxValue()).isNull();
+            assertThat(stats.nullCount()).isEqualTo(4L);
+        }
+    }
+
+    @Test
+    void eachRowGroupCarriesItsOwnStatistics() throws Exception {
+        // Ascending values with a 4 KiB row-group target (1024 rows per group): each chunk's
+        // bounds cover only its own slice, so they advance group by group.
+        int n = 5_000;
+        int[] values = new int[n];
+        for (int i = 0; i < n; i++) {
+            values[i] = i;
+        }
+
+        WriterConfig config = WriterConfig.builder().rowGroupTargetBytes(4096).build();
+        ByteBufferOutputFile out = new ByteBufferOutputFile();
+        try (ParquetFileWriter writer = ParquetFileWriter.create(out, oneColumn(), config)) {
+            writer.writeBatch(batch -> batch.ints(0, values));
+        }
+
+        try (ParquetFileReader reader = ParquetFileReader.open(InputFile.of(ByteBuffer.wrap(out.toByteArray())))) {
+            List<RowGroup> groups = reader.getFileMetaData().rowGroups();
+            assertThat(groups.size()).isGreaterThan(1);
+            Statistics first = groups.get(0).columns().get(0).metaData().statistics();
+            assertThat(StatisticsDecoder.decodeInt(first.minValue())).isEqualTo(0);
+            assertThat(StatisticsDecoder.decodeInt(first.maxValue())).isEqualTo(1023);
+            Statistics second = groups.get(1).columns().get(0).metaData().statistics();
+            assertThat(StatisticsDecoder.decodeInt(second.minValue())).isEqualTo(1024);
+            assertThat(StatisticsDecoder.decodeInt(second.maxValue())).isEqualTo(2047);
+        }
+    }
+
+    @Test
+    void listColumnNullCountCountsNullAndEmptyLists() throws Exception {
+        // The leaf's null count spans every not-present slot — a null list, an empty list, and
+        // a null element — while the bounds cover only the present elements 1..5.
+        // record 0: [1,2]; 1: [] (empty); 2: null list; 3: [3, null, 5].
+        FileSchema schema = FileSchema.builder("schema")
+                .list("phones", RepetitionType.OPTIONAL, el -> el.primitive(PhysicalType.INT32, RepetitionType.OPTIONAL))
+                .build();
+
+        int[] offsets = { 0, 2, 2, 2, 5 };
+        Validity listNulls = Validity.ofNulls(new boolean[] { false, false, true, false });
+        int[] elements = { 1, 2, 3, 0, 5 };
+        boolean[] elementNulls = { false, false, false, true, false };
+
+        ByteBufferOutputFile out = new ByteBufferOutputFile();
+        try (ParquetFileWriter writer = ParquetFileWriter.create(out, schema)) {
+            writer.writeBatch(batch -> batch
+                    .list("phones", offsets, listNulls)
+                    .ints("phones.list.element", elements, elementNulls));
+        }
+
+        try (ParquetFileReader reader = ParquetFileReader.open(InputFile.of(ByteBuffer.wrap(out.toByteArray())))) {
+            int leaf = reader.getFileSchema().getColumn("phones.list.element").columnIndex();
+            Statistics stats = columnMeta(reader, leaf).statistics();
+            assertThat(StatisticsDecoder.decodeInt(stats.minValue())).isEqualTo(1);
+            assertThat(StatisticsDecoder.decodeInt(stats.maxValue())).isEqualTo(5);
+            // 1 empty list + 1 null list + 1 null element.
+            assertThat(stats.nullCount()).isEqualTo(3L);
         }
     }
 


### PR DESCRIPTION
Stage 11 of the writer delivery plan ([`_designs/WRITER_SUPPORT.md`](_designs/WRITER_SUPPORT.md)): produced files now carry column statistics, so a reader can prune row groups against a predicate. Tracking issue: #9.

## What

- **`StatisticsCollector`** accumulates each column chunk’s `min` / `max` / `null_count` over the shredded entry stream as it is encoded.
- **`StatisticsWriter`** (inverse of `StatisticsReader`) serializes them into `ColumnMetaData` (thrift field 12).

## Correctness notes

- **Bounds** span only present values and use signed `INT32` comparison, matching the column’s type-defined `ColumnOrder`, so they are pruning-correct.
- **Null count** is every not-present slot — a null leaf, a null or empty list, or a null struct ancestor — mirroring how the reader counts nulls, so a fully null column carries a count but no bounds.
- Written through the **preferred** `min_value` / `max_value` fields, never the deprecated `min` / `max`.
- Each bound is flagged **exact** (`is_min_value_exact` / `is_max_value_exact`), since the writer stores the actual extreme, never a truncated approximation. Stage 12 will flag truncated `BYTE_ARRAY` bounds inexact.

This is **column-chunk** statistics (row-group pruning). Per-page statistics (inline `DataPageHeader` stats + ColumnIndex/OffsetIndex, for page-level skipping) are deferred to the page-index work, as recorded in the design.

## Validation

- **Round-trip** (`WriterRoundTripTest`): min/max/null_count for required, nullable, all-null, per-row-group, and nested-list columns (the list case pins the null-count semantics: null list + empty list + null element = 3).
- **DuckDB differential** (`WriterDifferentialTest`): `parquet_metadata()` decodes our bytes back to the expected `min_value` / `max_value` / `null_count` and `min_is_exact` / `max_is_exact = true`, with the deprecated fields absent — an independent implementation reading our statistics. A second test confirms a `BETWEEN` filter across row groups drops no matching rows.
- Full core suite green (1741 tests).

## Follow-up

- #815 — read side should honor `is_*_value_exact` **if/when** aggregate-from-statistics pushdown is added (not a current bug; pushdown uses stats only as bounds).