### PR TITLE
#822 Add parquet-dev mailing list search skill

### DIFF
--- a/.claude/skills/parquet-dev-ml/SKILL.md
+++ b/.claude/skills/parquet-dev-ml/SKILL.md
@@ -1,0 +1,60 @@
+---
+name: parquet-dev-ml
+description: Search the Apache parquet-dev mailing list by downloading the raw monthly mbox archives from lists.apache.org and grepping them locally. Use whenever the user wants to find, read, or quote a thread on the Parquet dev list (dev@parquet.apache.org) — e.g. "search the parquet-dev ML", "find the thread about X on the parquet mailing list", "what did the parquet community decide about Y". Always go via the mbox download; never rely on the JS-rendered list.html page or a summarizing web fetch.
+---
+
+# Search the parquet-dev mailing list
+
+The `lists.apache.org` browse UI is a JavaScript app and its `stats.lua` JSON gets truncated/hallucinated when read through a summarizing web fetch. The reliable path is to **download the raw monthly `mbox` archive and grep it locally**. This skill encodes that path.
+
+Archive URL (per calendar month):
+
+```
+https://lists.apache.org/api/mbox.lua?list=dev&domain=parquet.apache.org&d=YYYY-MM
+```
+
+## Caching rule
+
+- **Past months are immutable** — download once and reuse the cached copy.
+- **The current month is live** — always re-download it, because new messages arrive continuously.
+
+`mlfetch.sh` implements exactly this: it re-fetches `YYYY-MM` if it equals the current month (`date +%Y-%m`) or the cache file is missing/empty, otherwise it reuses the cache. Cache lives at `${PARQUET_ML_CACHE:-${XDG_CACHE_HOME:-$HOME/.cache}/parquet-dev-ml}`.
+
+## Procedure
+
+All commands assume the skill directory:
+
+```bash
+SKILL="/workspace/.claude/skills/parquet-dev-ml"
+```
+
+1. **Fetch the month(s) you need.** Pass one or more `YYYY-MM`. It prints the local mbox path(s):
+
+   ```bash
+   "$SKILL/mlfetch.sh" 2026-07                 # current month → always re-downloaded
+   "$SKILL/mlfetch.sh" 2026-05 2026-06 2026-07 # older months served from cache
+   ```
+
+   If you don't know when a thread happened, fetch the last few months and grep across all of them. Widen the range rather than guessing a single month.
+
+2. **List subjects / find the thread.** Grep the mbox(es) directly:
+
+   ```bash
+   CACHE="${PARQUET_ML_CACHE:-$HOME/.cache/parquet-dev-ml}"
+   grep -hi '^Subject:' "$CACHE"/parquet-dev-2026-07.mbox | sort -u        # every subject
+   grep -hi '^Subject:.*thrift' "$CACHE"/parquet-dev-*.mbox | sort -u      # by keyword
+   ```
+
+   Note the wording of subjects: a `[DISCUSS]`/`[VOTE]`/`[ANNOUNCE]` prefix and phrasing may differ from how the user remembers it (e.g. the user's "Inline parquet.thrift" was really `[DISCUSS] Inline parquet.thrift into parquet-java`). Match on a distinctive substring, not the exact remembered title.
+
+3. **Read a full thread**, de-duplicated (the mbox lists each message twice) and with quoted reply-text stripped, ordered oldest→newest:
+
+   ```bash
+   "$SKILL/thread.py" "inline parquet.thrift" "$CACHE"/parquet-dev-2026-07.mbox
+   ```
+
+   `thread.py` takes a case-insensitive Subject substring and one or more mbox files, matches every message in that thread, dedupes by `Message-ID`, drops `>`-quoted lines and signatures, and prints each message's From/Date/body.
+
+## Reporting back
+
+When summarizing a thread for the user, give the exact subject line, the participants, and the outcome/consensus — quote the load-bearing sentences rather than paraphrasing a vote. Point them at the saved mbox path so they can read the raw thread if they want.

--- a/.claude/skills/parquet-dev-ml/mlfetch.sh
+++ b/.claude/skills/parquet-dev-ml/mlfetch.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+# Download parquet-dev monthly mbox archives with caching.
+#
+# Usage: mlfetch.sh YYYY-MM [YYYY-MM ...]
+# Prints the local path of each requested month's mbox on its own line.
+#
+# Caching: past months are immutable and fetched once; the current month is
+# live and always re-downloaded. Cache dir overridable via $PARQUET_ML_CACHE.
+set -euo pipefail
+
+if [[ $# -eq 0 ]]; then
+  echo "usage: mlfetch.sh YYYY-MM [YYYY-MM ...]" >&2
+  exit 2
+fi
+
+CACHE="${PARQUET_ML_CACHE:-${XDG_CACHE_HOME:-$HOME/.cache}/parquet-dev-ml}"
+mkdir -p "$CACHE"
+CUR="$(date +%Y-%m)"
+
+for d in "$@"; do
+  if [[ ! "$d" =~ ^[0-9]{4}-[0-9]{2}$ ]]; then
+    echo "skipping malformed month: $d (expected YYYY-MM)" >&2
+    continue
+  fi
+  out="$CACHE/parquet-dev-$d.mbox"
+  if [[ "$d" == "$CUR" || ! -s "$out" ]]; then
+    url="https://lists.apache.org/api/mbox.lua?list=dev&domain=parquet.apache.org&d=$d"
+    curl -fsSL "$url" -o "$out"
+  fi
+  echo "$out"
+done

--- a/.claude/skills/parquet-dev-ml/thread.py
+++ b/.claude/skills/parquet-dev-ml/thread.py
@@ -1,0 +1,94 @@
+#!/usr/bin/env python3
+"""Print a de-duplicated parquet-dev thread with quoted text stripped.
+
+Usage: thread.py SUBJECT_SUBSTRING mbox [mbox ...]
+
+Matches every message whose Subject contains SUBJECT_SUBSTRING (case-insensitive,
+so it catches both the root and its "Re:" replies), dedupes by Message-ID (the
+lists.apache.org mbox lists each message twice), orders oldest->newest, and prints
+each message's From/Date/body with '>'-quoted lines and signatures removed.
+"""
+import sys
+import mailbox
+import email.utils
+from email.header import make_header, decode_header
+
+
+def hdr(value):
+    if not value:
+        return ""
+    return str(make_header(decode_header(value)))
+
+
+def when(msg):
+    try:
+        return email.utils.parsedate_to_datetime(msg.get("date")).timestamp()
+    except Exception:
+        return 0.0
+
+
+def body(msg):
+    if msg.is_multipart():
+        for part in msg.walk():
+            if part.get_content_type() == "text/plain":
+                payload = part.get_payload(decode=True) or b""
+                return payload.decode(part.get_content_charset() or "utf-8", "replace")
+        return ""
+    payload = msg.get_payload(decode=True) or b""
+    return payload.decode(msg.get_content_charset() or "utf-8", "replace")
+
+
+def strip_quotes(text):
+    out = []
+    blanks = 0
+    for line in text.splitlines():
+        stripped = line.strip()
+        if stripped.startswith(">"):
+            continue
+        if stripped.startswith("--") and len(stripped) < 40:
+            break  # signature delimiter
+        if not stripped:
+            blanks += 1
+            if blanks > 1:
+                continue
+        else:
+            blanks = 0
+        out.append(line.rstrip())
+    return "\n".join(out).strip()
+
+
+def main():
+    if len(sys.argv) < 3:
+        print(__doc__.strip(), file=sys.stderr)
+        sys.exit(2)
+    needle = sys.argv[1].lower()
+    seen = set()
+    msgs = []
+    for path in sys.argv[2:]:
+        for msg in mailbox.mbox(path):
+            subject = hdr(msg.get("subject"))
+            if needle not in subject.lower():
+                continue
+            mid = msg.get("message-id")
+            if mid in seen:
+                continue
+            seen.add(mid)
+            msgs.append(msg)
+
+    if not msgs:
+        print(f"no messages matched subject substring: {sys.argv[1]!r}", file=sys.stderr)
+        sys.exit(1)
+
+    msgs.sort(key=when)
+    print(f"Thread: {len(msgs)} message(s) matching {sys.argv[1]!r}\n")
+    for i, msg in enumerate(msgs, 1):
+        print("#" * 90)
+        print(f"[{i}] {hdr(msg.get('from'))}  |  {msg.get('date')}")
+        print(f"    {hdr(msg.get('subject'))}")
+        print("#" * 90)
+        print(strip_quotes(body(msg)))
+        print()
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
The lists.apache.org archive UI is JavaScript-rendered and its stats API gets truncated when read through a summarizing fetch, so thread lookups were unreliable. Search the raw monthly mbox archives instead: cache the immutable past months, always re-fetch the live current month, and print threads with quoting stripped.