### PR TITLE
#822 Add parquet-dev mailing list search skill

### DIFF
--- a/.claude/skills/parquet-dev-ml/SKILL.md
+++ b/.claude/skills/parquet-dev-ml/SKILL.md
@@ -53,7 +53,7 @@ SKILL="/workspace/.claude/skills/parquet-dev-ml"
    "$SKILL/thread.py" "inline parquet.thrift" "$CACHE"/parquet-dev-2026-07.mbox
    ```
 
-   `thread.py` takes a case-insensitive Subject substring and one or more mbox files, matches every message in that thread, dedupes by `Message-ID`, drops `>`-quoted lines and signatures, and prints each message's From/Date/body.
+   `thread.py` takes a case-insensitive Subject substring and one or more existing mbox files, matches every message in that thread, dedupes by `Message-ID` (or message content when the ID is absent), drops `>`-quoted lines, reply attributions, and signatures, and prints each message's From/Date/body.
 
 ## Reporting back
 

--- a/.claude/skills/parquet-dev-ml/mlfetch.sh
+++ b/.claude/skills/parquet-dev-ml/mlfetch.sh
@@ -18,14 +18,18 @@ mkdir -p "$CACHE"
 CUR="$(date +%Y-%m)"
 
 for d in "$@"; do
-  if [[ ! "$d" =~ ^[0-9]{4}-[0-9]{2}$ ]]; then
-    echo "skipping malformed month: $d (expected YYYY-MM)" >&2
-    continue
+  if [[ ! "$d" =~ ^[0-9]{4}-(0[1-9]|1[0-2])$ ]]; then
+    echo "invalid month: $d (expected YYYY-MM)" >&2
+    exit 2
   fi
   out="$CACHE/parquet-dev-$d.mbox"
   if [[ "$d" == "$CUR" || ! -s "$out" ]]; then
     url="https://lists.apache.org/api/mbox.lua?list=dev&domain=parquet.apache.org&d=$d"
-    curl -fsSL "$url" -o "$out"
+    tmp="$out.tmp.$$"
+    trap 'rm -f "$tmp"' EXIT
+    curl -fsSL "$url" -o "$tmp"
+    mv "$tmp" "$out"
+    trap - EXIT
   fi
   echo "$out"
 done

--- a/.claude/skills/parquet-dev-ml/thread.py
+++ b/.claude/skills/parquet-dev-ml/thread.py
@@ -11,7 +11,10 @@ each message's From/Date/body with '>'-quoted lines and signatures removed.
 import sys
 import mailbox
 import email.utils
+import hashlib
 from email.header import make_header, decode_header
+from pathlib import Path
+import re
 
 
 def hdr(value):
@@ -23,14 +26,14 @@ def hdr(value):
 def when(msg):
     try:
         return email.utils.parsedate_to_datetime(msg.get("date")).timestamp()
-    except Exception:
+    except (TypeError, ValueError, OverflowError):
         return 0.0
 
 
 def body(msg):
     if msg.is_multipart():
         for part in msg.walk():
-            if part.get_content_type() == "text/plain":
+            if part.get_content_type() == "text/plain" and not part.get_filename():
                 payload = part.get_payload(decode=True) or b""
                 return payload.decode(part.get_content_charset() or "utf-8", "replace")
         return ""
@@ -44,6 +47,7 @@ def strip_quotes(text):
     for line in text.splitlines():
         stripped = line.strip()
         if stripped.startswith(">"):
+            strip_quote_attribution(out)
             continue
         if stripped.startswith("--") and len(stripped) < 40:
             break  # signature delimiter
@@ -57,36 +61,66 @@ def strip_quotes(text):
     return "\n".join(out).strip()
 
 
+def strip_quote_attribution(lines):
+    end = len(lines) - 1
+    while end >= 0 and not lines[end].strip():
+        end -= 1
+    if end < 0 or not re.search(
+        r"(?:\bwrote|\ba écrit)\s*:$", lines[end].strip(), re.IGNORECASE
+    ):
+        return
+    start = end
+    while start > 0 and lines[start - 1].strip():
+        start -= 1
+    del lines[start:]
+
+
+def identity(msg, text):
+    message_id = msg.get("message-id")
+    if message_id:
+        return message_id
+    fallback = "\0".join(
+        (hdr(msg.get("from")), hdr(msg.get("date")), hdr(msg.get("subject")), text)
+    )
+    return hashlib.sha256(fallback.encode("utf-8")).hexdigest()
+
+
 def main():
     if len(sys.argv) < 3:
         print(__doc__.strip(), file=sys.stderr)
         sys.exit(2)
-    needle = sys.argv[1].lower()
+    needle = sys.argv[1].casefold()
+    paths = [Path(path) for path in sys.argv[2:]]
+    missing = [str(path) for path in paths if not path.is_file()]
+    if missing:
+        print(f"mbox file not found: {missing[0]}", file=sys.stderr)
+        sys.exit(2)
     seen = set()
     msgs = []
-    for path in sys.argv[2:]:
-        for msg in mailbox.mbox(path):
+    for path in paths:
+        for msg in mailbox.mbox(path, create=False):
             subject = hdr(msg.get("subject"))
-            if needle not in subject.lower():
+            if needle not in subject.casefold():
                 continue
-            mid = msg.get("message-id")
+            text = body(msg)
+            mid = identity(msg, text)
             if mid in seen:
                 continue
             seen.add(mid)
-            msgs.append(msg)
+            msgs.append((msg, text))
 
     if not msgs:
         print(f"no messages matched subject substring: {sys.argv[1]!r}", file=sys.stderr)
         sys.exit(1)
 
-    msgs.sort(key=when)
+    msgs.sort(key=lambda item: when(item[0]))
     print(f"Thread: {len(msgs)} message(s) matching {sys.argv[1]!r}\n")
-    for i, msg in enumerate(msgs, 1):
+    for i, (msg, text) in enumerate(msgs, 1):
         print("#" * 90)
         print(f"[{i}] {hdr(msg.get('from'))}  |  {msg.get('date')}")
         print(f"    {hdr(msg.get('subject'))}")
         print("#" * 90)
-        print(strip_quotes(body(msg)))
+        print(strip_quotes(text))
         print()
 
 


### PR DESCRIPTION
## Summary

Adds a repository skill for searching the Apache `dev@parquet.apache.org` mailing-list archive through raw monthly mbox files.

The skill:

- Caches immutable historical months and refreshes the current month.
- Searches downloaded archives locally instead of relying on the JavaScript-rendered archive.
- Extracts complete threads in chronological order.
- Removes duplicate messages, quoted replies, attribution lines, and signatures.
- Validates inputs and fails early for missing archives.
- Uses atomic downloads to protect valid cached archives from incomplete downloads.

## Differences from #823

This is an alternative implementation of the same issue. It follows the overall mbox-based workflow introduced in #823 while adding several safeguards:

- Validates the complete `YYYY-MM` range instead of accepting invalid months or silently skipping malformed input.
- Downloads into a temporary file and atomically replaces the cache entry only after a successful transfer.
- Rejects missing mbox paths instead of allowing Python's mailbox API to create empty files.
- Uses a content-derived identity when a message lacks a `Message-ID`, preventing unrelated messages without IDs from being collapsed.
- Ignores named multipart attachments when selecting the plain-text body.
- Removes common reply-attribution blocks alongside `>`-quoted content.
- Uses Unicode-aware case-insensitive subject matching.

Closes #822.

## Checklist

- [ ] Build via `./mvnw clean verify` passes
- [x] The commit message is prefixed with the issue key ("#123 Adding support for...")
- [ ] Code changes are covered by tests
- [x] If this PR adds or changes user-facing behaviour, `docs/` has been updated