### PR TITLE
#814 Pool per-page level scratch by decode slot

### DIFF
--- a/_designs/POOLED_LEVEL_DECODE_SCRATCH.md
+++ b/_designs/POOLED_LEVEL_DECODE_SCRATCH.md
@@ -1,0 +1,77 @@
+# Design: pooled repetition/definition level decode scratch
+
+**Status: Implemented.** Tracking issue: #814.
+
+## Goal
+
+Stop allocating a fresh repetition/definition level array on every page
+decode. Level decoding runs on the hot read path for every optional or
+repeated column, and each page previously allocated `new int[numValues]`
+per level stream. For a full nested column scan this is the single
+largest `int[]` allocation site, and the per-page churn is a meaningful
+source of GC pressure — which surfaces as run-to-run throughput variance
+on the general reconstruction path (the fixed-size-list fast path, which
+skips level materialization, does not exhibit it).
+
+The batch holders and the value/level *accumulators* are already reused
+across batches; the per-page *decode scratch* is a separate array
+population that was not pooled. This design pools it.
+
+## Behaviour
+
+Level scratch is reused per in-flight reorder-buffer slot.
+
+`ColumnWorker` submits page decodes to a pooled executor, keeping up to
+`MAX_INFLIGHT_PAGES` decoded pages parked in an `AtomicReferenceArray`
+reorder buffer indexed by `slot = seq % MAX_INFLIGHT_PAGES`. The drain
+thread assembles each page synchronously and advances `consumePosition`;
+the retriever throttles submission while `nextSeq - consumePosition >=
+MAX_INFLIGHT_PAGES`, so a slot is never reused for a new decode until its
+previous occupant has been fully drained.
+
+That throttle is the exclusion guarantee the pooling relies on. Each slot
+owns one `PageDecoder.LevelScratch` holder, allocated once. The holder
+lends reusable repetition and definition buffers through
+`repetitionLevels(size)` / `definitionLevels(size)`, which grow the
+backing array in place when a page needs more than the current capacity
+and return it. `PageDecoder.decodePage` is passed the slot's holder; the
+level decoders write into the lent buffers and the decoded `Page`
+references them. Single-page callers (tooling, tests) pass a null holder
+and fall back to fresh allocation.
+
+Over a scan the buffers grow to the largest page's value count once and
+then stop allocating. The fix lives in the shared `PageDecoder` and the
+shared `ColumnWorker`, so both the nested (rep + def) and flat
+(optional-column def) paths benefit.
+
+### Buffers may be longer than the page
+
+A reused buffer is sized to the largest page seen, so it can be longer
+than the current page's `numValues`. Level arrays are therefore no longer
+guaranteed to have length equal to the value count, and consumers must
+scan `page.size()` / an explicit length rather than `array.length`.
+
+All consumers already used an explicit count except `countNonNulls`
+(`SimdOperations`), which derived the count from `defLevels.length` when
+sizing the dictionary-index read. It now takes an explicit `length`
+parameter — the caller already had the correct value count — and scans
+only the leading `length` entries. This also removes a latent fragility:
+a decode primitive should count over the logical value count, not the
+physical buffer size.
+
+## Safety argument
+
+1. **No concurrent access to a slot's holder.** A slot holds one page at a
+   time; the throttle keeps a slot's previous page drained before reuse,
+   so at most one decode task touches a given holder at any moment. No
+   synchronization is required, and `PageDecoder` remains stateless
+   (the holder is passed per call, not held as a field).
+2. **Page level arrays are not retained past assembly.** `assembleRegularPage`
+   consumes the page's repetition/definition levels element-by-element
+   into the reused accumulators during the synchronous drain.
+   `REAL_VIEW_KEEP_LEVELS` keeps the *accumulator* levels, not the page
+   arrays. Nothing references a page's level arrays after its assemble
+   call returns, so overwriting the slot buffer on the next decode is
+   safe.
+3. **No length dependence.** Consumers scan the logical value count, not
+   the buffer length (see above).

--- a/core/src/main/java/dev/hardwood/internal/encoding/RleBitPackingHybridDecoder.java
+++ b/core/src/main/java/dev/hardwood/internal/encoding/RleBitPackingHybridDecoder.java
@@ -145,7 +145,7 @@ public class RleBitPackingHybridDecoder {
     }
 
     private int[] decodeIndices(int len, int[] defLevels, int maxDef) {
-        int count = defLevels == null ? len : countNonNulls(defLevels, maxDef);
+        int count = defLevels == null ? len : countNonNulls(defLevels, len, maxDef);
         int[] indices = borrowTemp(count);
         if (bitWidth == 0) {
             Arrays.fill(indices, 0, count, 0);
@@ -245,8 +245,8 @@ public class RleBitPackingHybridDecoder {
         }
     }
 
-    private static int countNonNulls(int[] defLevels, int maxDef) {
-        return SIMD_OPS.countNonNulls(defLevels, maxDef);
+    private static int countNonNulls(int[] defLevels, int length, int maxDef) {
+        return SIMD_OPS.countNonNulls(defLevels, length, maxDef);
     }
 
     private void readNextRun() {

--- a/core/src/main/java/dev/hardwood/internal/encoding/simd/ScalarOperations.java
+++ b/core/src/main/java/dev/hardwood/internal/encoding/simd/ScalarOperations.java
@@ -17,13 +17,12 @@ import java.util.BitSet;
 public final class ScalarOperations implements SimdOperations {
 
     @Override
-    public int countNonNulls(int[] defLevels, int maxDef) {
+    public int countNonNulls(int[] defLevels, int length, int maxDef) {
         int count0 = 0, count1 = 0, count2 = 0, count3 = 0;
         int i = 0;
-        int len = defLevels.length;
 
         // Process 8 elements at a time with 4 accumulators to minimize dependencies
-        for (; i + 8 <= len; i += 8) {
+        for (; i + 8 <= length; i += 8) {
             count0 += (defLevels[i] == maxDef ? 1 : 0) + (defLevels[i + 4] == maxDef ? 1 : 0);
             count1 += (defLevels[i + 1] == maxDef ? 1 : 0) + (defLevels[i + 5] == maxDef ? 1 : 0);
             count2 += (defLevels[i + 2] == maxDef ? 1 : 0) + (defLevels[i + 6] == maxDef ? 1 : 0);
@@ -33,7 +32,7 @@ public final class ScalarOperations implements SimdOperations {
         int count = count0 + count1 + count2 + count3;
 
         // Handle remaining elements
-        for (; i < len; i++) {
+        for (; i < length; i++) {
             if (defLevels[i] == maxDef) {
                 count++;
             }

--- a/core/src/main/java/dev/hardwood/internal/encoding/simd/SimdOperations.java
+++ b/core/src/main/java/dev/hardwood/internal/encoding/simd/SimdOperations.java
@@ -23,7 +23,11 @@ public interface SimdOperations {
     /// @param defLevels definition levels array
     /// @param maxDef maximum definition level (indicates non-null)
     /// @return count of non-null values
-    int countNonNulls(int[] defLevels, int maxDef);
+    default int countNonNulls(int[] defLevels, int maxDef) {
+        return countNonNulls(defLevels, defLevels.length, maxDef);
+    }
+
+    int countNonNulls(int[] defLevels, int length, int maxDef);
 
     /// Mark null positions in a BitSet where `defLevels[srcPos + i] < maxDefLevel`.
     ///

--- a/core/src/main/java/dev/hardwood/internal/reader/ColumnWorker.java
+++ b/core/src/main/java/dev/hardwood/internal/reader/ColumnWorker.java
@@ -71,6 +71,10 @@ public abstract class ColumnWorker<B> implements AutoCloseable {
     // === Circular reorder buffer: decode tasks write, drain thread reads ===
     private final AtomicReferenceArray<DecodedPage> reorderBuffer;
 
+    // Level buffers share the lifecycle of their reorder-buffer slot. The
+    // retriever throttle prevents reuse until the drain has consumed the page.
+    private final PageDecoder.LevelScratch[] levelScratchBuffer;
+
     // === File name per reorder-buffer slot (retriever writes, drain reads) ===
     // Visibility: retriever writes fileNameBuffer[slot] before submitting the
     // decode task. The decode task's volatile write to reorderBuffer[slot]
@@ -153,6 +157,10 @@ public abstract class ColumnWorker<B> implements AutoCloseable {
         this.decodeExecutor = decodeExecutor;
         this.maxRows = maxRows;
         this.reorderBuffer = new AtomicReferenceArray<>(MAX_INFLIGHT_PAGES);
+        this.levelScratchBuffer = new PageDecoder.LevelScratch[MAX_INFLIGHT_PAGES];
+        for (int i = 0; i < levelScratchBuffer.length; i++) {
+            levelScratchBuffer[i] = new PageDecoder.LevelScratch();
+        }
         this.fileNameBuffer = new String[MAX_INFLIGHT_PAGES];
         this.filterAlwaysMatchesBuffer = new boolean[MAX_INFLIGHT_PAGES];
     }
@@ -326,7 +334,7 @@ public abstract class ColumnWorker<B> implements AutoCloseable {
         try {
             Page page = pageInfo.isNullPlaceholder()
                     ? pageDecoder.nullPage(pageInfo.placeholderNumValues())
-                    : pageDecoder.decodePage(pageInfo.pageData(), pageInfo.dictionary());
+                    : pageDecoder.decodePage(pageInfo.pageData(), pageInfo.dictionary(), levelScratchBuffer[slot]);
             reorderBuffer.set(slot, new DecodedPage(page, pageInfo.mask()));
         }
         catch (Throwable t) {

--- a/core/src/main/java/dev/hardwood/internal/reader/Page.java
+++ b/core/src/main/java/dev/hardwood/internal/reader/Page.java
@@ -22,12 +22,27 @@ package dev.hardwood.internal.reader;
 /// - [ByteArrayPage] - BYTE_ARRAY, FIXED_LEN_BYTE_ARRAY, INT96
 public sealed interface Page {
 
+    /// The number of values (leaves) on this page — the logical length of the
+    /// level and value arrays. The level arrays may be physically longer (see
+    /// [#definitionLevels]), so this is the count callers must iterate, never
+    /// `definitionLevels().length`.
     int size();
 
     int maxDefinitionLevel();
 
+    /// Definition levels for this page, or `null` when every leaf is present
+    /// (the all-present convention; see [#allPresent]).
+    ///
+    /// When non-null the array holds one level per value but **may be longer than
+    /// [#size]**: it is a pooled decode buffer reused across pages and grown to the
+    /// largest page seen, so its tail beyond `size()` is stale. Read only the first
+    /// `size()` entries; never use `definitionLevels().length` as the value count.
     int[] definitionLevels();
 
+    /// Repetition levels for this page, or `null` for a non-repeated (flat) column.
+    ///
+    /// As with [#definitionLevels], when non-null the array is a pooled buffer that
+    /// **may be longer than [#size]**; only the first `size()` entries are valid.
     int[] repetitionLevels();
 
     /// Number of elements per row when this page is a fixed-width fixed-size-list

--- a/core/src/main/java/dev/hardwood/internal/reader/PageDecoder.java
+++ b/core/src/main/java/dev/hardwood/internal/reader/PageDecoder.java
@@ -37,6 +37,26 @@ import dev.hardwood.schema.ColumnSchema;
 /// Page scanning and dictionary parsing are handled by [PageScanner].
 public class PageDecoder {
 
+    /// Reusable level-decoding buffers owned by one in-flight page slot.
+    static final class LevelScratch {
+        private int[] repetitionLevels;
+        private int[] definitionLevels;
+
+        int[] repetitionLevels(int size) {
+            if (repetitionLevels == null || repetitionLevels.length < size) {
+                repetitionLevels = new int[size];
+            }
+            return repetitionLevels;
+        }
+
+        int[] definitionLevels(int size) {
+            if (definitionLevels == null || definitionLevels.length < size) {
+                definitionLevels = new int[size];
+            }
+            return definitionLevels;
+        }
+    }
+
     private final ColumnMetaData columnMetaData;
     private final ColumnSchema column;
     private final DecompressorFactory decompressorFactory;
@@ -118,6 +138,11 @@ public class PageDecoder {
     /// @param dictionary dictionary for this page, or null if not dictionary-encoded
     /// @return decoded page
     public Page decodePage(ByteBuffer pageBuffer, Dictionary dictionary) throws IOException {
+        return decodePage(pageBuffer, dictionary, null);
+    }
+
+    /// Decode a single data page, reusing the supplied slot-owned level scratch.
+    Page decodePage(ByteBuffer pageBuffer, Dictionary dictionary, LevelScratch scratch) throws IOException {
         PageDecodedEvent event = new PageDecodedEvent();
         event.begin();
 
@@ -138,10 +163,11 @@ public class PageDecoder {
             case DATA_PAGE -> {
                 Decompressor decompressor = decompressorFactory.getDecompressor(columnMetaData.codec());
                 byte[] uncompressedData = decompressor.decompress(pageData, pageHeader.uncompressedPageSize());
-                yield parseDataPage(pageHeader.dataPageHeader(), uncompressedData, dictionary);
+                yield parseDataPage(pageHeader.dataPageHeader(), uncompressedData, dictionary, scratch);
             }
             case DATA_PAGE_V2 -> {
-                yield parseDataPageV2(pageHeader.dataPageHeaderV2(), pageData, pageHeader.uncompressedPageSize(), dictionary);
+                yield parseDataPageV2(pageHeader.dataPageHeaderV2(), pageData,
+                        pageHeader.uncompressedPageSize(), dictionary, scratch);
             }
             default -> throw new IOException("Unexpected page type for single-page decode: " + pageHeader.type());
         };
@@ -155,8 +181,9 @@ public class PageDecoder {
     }
 
     /// Decode levels using RLE/Bit-Packing Hybrid encoding.
-    private int[] decodeRepetitionLevels(byte[] levelData, int offset, int length, int numValues, int maxLevel) {
-        int[] levels = new int[numValues];
+    private int[] decodeRepetitionLevels(byte[] levelData, int offset, int length, int numValues, int maxLevel,
+            LevelScratch scratch) {
+        int[] levels = scratch == null ? new int[numValues] : scratch.repetitionLevels(numValues);
         RleBitPackingHybridDecoder decoder = new RleBitPackingHybridDecoder(levelData, offset, length, getBitWidth(maxLevel));
         decoder.readInts(levels, 0, numValues);
         return levels;
@@ -172,7 +199,8 @@ public class PageDecoder {
     /// definition-level array as all-present (every leaf at `maxDef`) and takes a
     /// whole-page bulk-copy path; the repetition levels are still materialised, so
     /// record boundaries are preserved.
-    private int[] decodeDefinitionLevels(byte[] levelData, int offset, int length, int numValues) {
+    private int[] decodeDefinitionLevels(byte[] levelData, int offset, int length, int numValues,
+            LevelScratch scratch) {
         int maxDef = column.maxDefinitionLevel();
         int bitWidth = getBitWidth(maxDef);
         RleBitPackingHybridDecoder decoder = new RleBitPackingHybridDecoder(levelData, offset, length, bitWidth);
@@ -181,7 +209,7 @@ public class PageDecoder {
         if (decoder.isSingleRleRunOf(maxDef, numValues)) {
             return null;
         }
-        int[] levels = new int[numValues];
+        int[] levels = scratch == null ? new int[numValues] : scratch.definitionLevels(numValues);
         decoder.readInts(levels, 0, numValues);
         return levels;
     }
@@ -238,7 +266,8 @@ public class PageDecoder {
         };
     }
 
-    private Page parseDataPage(DataPageHeader header, byte[] data, Dictionary dictionary) throws IOException {
+    private Page parseDataPage(DataPageHeader header, byte[] data, Dictionary dictionary, LevelScratch scratch)
+            throws IOException {
         int numValues = header.numValues();
         int offset = 0;
 
@@ -283,10 +312,11 @@ public class PageDecoder {
         }
 
         int[] repetitionLevels = column.maxRepetitionLevel() > 0
-                ? decodeRepetitionLevels(data, repLevelOffset, repLevelLength, numValues, column.maxRepetitionLevel())
+                ? decodeRepetitionLevels(data, repLevelOffset, repLevelLength, numValues,
+                        column.maxRepetitionLevel(), scratch)
                 : null;
         int[] definitionLevels = column.maxDefinitionLevel() > 0
-                ? decodeDefinitionLevels(data, defLevelOffset, defLevelLength, numValues)
+                ? decodeDefinitionLevels(data, defLevelOffset, defLevelLength, numValues, scratch)
                 : null;
 
         return decodeTypedValues(
@@ -295,7 +325,7 @@ public class PageDecoder {
     }
 
     private Page parseDataPageV2(DataPageHeaderV2 header, ByteBuffer pageData, int uncompressedPageSize,
-            Dictionary dictionary) throws IOException {
+            Dictionary dictionary, LevelScratch scratch) throws IOException {
         int repLevelLen = header.repetitionLevelsByteLength();
         int defLevelLen = header.definitionLevelsByteLength();
         int valuesOffset = repLevelLen + defLevelLen;
@@ -336,10 +366,11 @@ public class PageDecoder {
         }
 
         int[] repetitionLevels = repLevelData != null
-                ? decodeRepetitionLevels(repLevelData, 0, repLevelLen, numValues, column.maxRepetitionLevel())
+                ? decodeRepetitionLevels(repLevelData, 0, repLevelLen, numValues,
+                        column.maxRepetitionLevel(), scratch)
                 : null;
         int[] definitionLevels = defLevelData != null
-                ? decodeDefinitionLevels(defLevelData, 0, defLevelLen, numValues)
+                ? decodeDefinitionLevels(defLevelData, 0, defLevelLen, numValues, scratch)
                 : null;
 
         byte[] valuesData = readValueRegion(header, pageData, uncompressedPageSize,

--- a/core/src/main/java/dev/hardwood/internal/reader/PageDecoder.java
+++ b/core/src/main/java/dev/hardwood/internal/reader/PageDecoder.java
@@ -138,10 +138,15 @@ public class PageDecoder {
     /// @param dictionary dictionary for this page, or null if not dictionary-encoded
     /// @return decoded page
     public Page decodePage(ByteBuffer pageBuffer, Dictionary dictionary) throws IOException {
-        return decodePage(pageBuffer, dictionary, null);
+        // Standalone callers have no reorder slot to reuse across, so a throwaway
+        // scratch (allocated fresh here, buffers grown lazily) matches the old
+        // per-call allocation while keeping the decode path free of null handling.
+        return decodePage(pageBuffer, dictionary, new LevelScratch());
     }
 
     /// Decode a single data page, reusing the supplied slot-owned level scratch.
+    /// `scratch` must not be null; standalone callers pass a throwaway instance via
+    /// the two-argument overload.
     Page decodePage(ByteBuffer pageBuffer, Dictionary dictionary, LevelScratch scratch) throws IOException {
         PageDecodedEvent event = new PageDecodedEvent();
         event.begin();
@@ -183,7 +188,7 @@ public class PageDecoder {
     /// Decode levels using RLE/Bit-Packing Hybrid encoding.
     private int[] decodeRepetitionLevels(byte[] levelData, int offset, int length, int numValues, int maxLevel,
             LevelScratch scratch) {
-        int[] levels = scratch == null ? new int[numValues] : scratch.repetitionLevels(numValues);
+        int[] levels = scratch.repetitionLevels(numValues);
         RleBitPackingHybridDecoder decoder = new RleBitPackingHybridDecoder(levelData, offset, length, getBitWidth(maxLevel));
         decoder.readInts(levels, 0, numValues);
         return levels;
@@ -209,7 +214,7 @@ public class PageDecoder {
         if (decoder.isSingleRleRunOf(maxDef, numValues)) {
             return null;
         }
-        int[] levels = scratch == null ? new int[numValues] : scratch.definitionLevels(numValues);
+        int[] levels = scratch.definitionLevels(numValues);
         decoder.readInts(levels, 0, numValues);
         return levels;
     }

--- a/core/src/main/java22/dev/hardwood/internal/encoding/simd/VectorOperations.java
+++ b/core/src/main/java22/dev/hardwood/internal/encoding/simd/VectorOperations.java
@@ -35,12 +35,10 @@ public final class VectorOperations implements SimdOperations {
     private static final int MIN_BATCH_SIZE = INT_VECTOR_LENGTH * 2;
 
     @Override
-    public int countNonNulls(int[] defLevels, int maxDef) {
-        int len = defLevels.length;
-
+    public int countNonNulls(int[] defLevels, int length, int maxDef) {
         // Use scalar for small arrays
-        if (len < MIN_BATCH_SIZE) {
-            return countNonNullsScalar(defLevels, maxDef);
+        if (length < MIN_BATCH_SIZE) {
+            return countNonNullsScalar(defLevels, length, maxDef);
         }
 
         IntVector maxDefVec = IntVector.broadcast(INT_SPECIES, maxDef);
@@ -48,14 +46,14 @@ public final class VectorOperations implements SimdOperations {
         int i = 0;
 
         // Main SIMD loop
-        for (; i + INT_VECTOR_LENGTH <= len; i += INT_VECTOR_LENGTH) {
+        for (; i + INT_VECTOR_LENGTH <= length; i += INT_VECTOR_LENGTH) {
             IntVector vec = IntVector.fromArray(INT_SPECIES, defLevels, i);
             VectorMask<Integer> mask = vec.eq(maxDefVec);
             count += mask.trueCount();
         }
 
         // Scalar tail
-        for (; i < len; i++) {
+        for (; i < length; i++) {
             if (defLevels[i] == maxDef) {
                 count++;
             }
@@ -64,10 +62,10 @@ public final class VectorOperations implements SimdOperations {
         return count;
     }
 
-    private int countNonNullsScalar(int[] defLevels, int maxDef) {
+    private int countNonNullsScalar(int[] defLevels, int length, int maxDef) {
         int count = 0;
-        for (int level : defLevels) {
-            if (level == maxDef) {
+        for (int i = 0; i < length; i++) {
+            if (defLevels[i] == maxDef) {
                 count++;
             }
         }

--- a/core/src/test/java/dev/hardwood/internal/encoding/simd/SimdOperationsTest.java
+++ b/core/src/test/java/dev/hardwood/internal/encoding/simd/SimdOperationsTest.java
@@ -76,6 +76,26 @@ class SimdOperationsTest {
         assertThat(SIMD.countNonNulls(defLevels, 3, 3)).isEqualTo(2);
     }
 
+    @ParameterizedTest
+    @ValueSource(ints = {1, 7, 8, 9, 63, 64, 65, 200})
+    void countNonNullsIgnoresEntriesBeyondLen(int len) {
+        // A reused level buffer is longer than the page's value count: the tail
+        // holds stale present-looking values that must not be counted. The lengths
+        // straddle the SIMD main-loop/tail boundary (MIN_BATCH_SIZE and vector
+        // width), so the vectorised path is exercised with a truncated length —
+        // not just the scalar fallback that a single small length would hit.
+        int[] defLevels = IntStream.range(0, len + 137).map(i -> 3).toArray();
+        int expected = 0;
+        for (int i = 0; i < len; i++) {
+            defLevels[i] = i % 3 == 0 ? 3 : 0;
+            if (defLevels[i] == 3) {
+                expected++;
+            }
+        }
+        assertThat(SCALAR.countNonNulls(defLevels, len, 3)).isEqualTo(expected);
+        assertThat(SIMD.countNonNulls(defLevels, len, 3)).isEqualTo(expected);
+    }
+
     // ==================== markNulls Tests ====================
 
     @ParameterizedTest

--- a/core/src/test/java/dev/hardwood/internal/encoding/simd/SimdOperationsTest.java
+++ b/core/src/test/java/dev/hardwood/internal/encoding/simd/SimdOperationsTest.java
@@ -69,6 +69,13 @@ class SimdOperationsTest {
         assertThat(SIMD.countNonNulls(defLevels, 3)).isEqualTo(50);
     }
 
+    @Test
+    void countNonNullsIgnoresScratchTail() {
+        int[] defLevels = {3, 0, 3, 3, 3, 3};
+        assertThat(SCALAR.countNonNulls(defLevels, 3, 3)).isEqualTo(2);
+        assertThat(SIMD.countNonNulls(defLevels, 3, 3)).isEqualTo(2);
+    }
+
     // ==================== markNulls Tests ====================
 
     @ParameterizedTest

--- a/core/src/test/java/dev/hardwood/internal/reader/FixedSizeListEngagementTest.java
+++ b/core/src/test/java/dev/hardwood/internal/reader/FixedSizeListEngagementTest.java
@@ -87,6 +87,44 @@ class FixedSizeListEngagementTest {
         assertThat(perPageK).as("some pages fall back").contains(0);
     }
 
+    @Test
+    void levelDecodeReusesSlotScratchAcrossPages() throws Exception {
+        InputFile inputFile = InputFile.of(PAGED);
+        inputFile.open();
+        HardwoodContextImpl context = HardwoodContextImpl.create();
+        int decodedPages = 0;
+        try (ParquetFileReader reader = ParquetFileReader.open(InputFile.of(PAGED))) {
+            FileSchema schema = reader.getFileSchema();
+            int leaf = columnIndex(schema, "vec_mixed");
+            ColumnSchema columnSchema = schema.getColumn(leaf);
+            PageDecoder.LevelScratch scratch = new PageDecoder.LevelScratch();
+
+            for (RowGroup rowGroup : reader.getFileMetaData().rowGroups()) {
+                SequentialFetchPlan plan = SequentialFetchPlan.build(
+                        inputFile, columnSchema, rowGroup.columns().get(leaf), context, 0, inputFile.name(), 0);
+                Iterator<PageInfo> pages = plan.pages();
+                while (pages.hasNext()) {
+                    PageInfo pageInfo = pages.next();
+                    PageDecoder decoder = new PageDecoder(
+                            pageInfo.columnMetaData(), pageInfo.columnSchema(),
+                            context.decompressorFactory(), false);
+                    Page page = decoder.decodePage(pageInfo.pageData(), pageInfo.dictionary(), scratch);
+
+                    assertThat(page.repetitionLevels()).isSameAs(scratch.repetitionLevels(page.size()));
+                    if (page.definitionLevels() != null) {
+                        assertThat(page.definitionLevels()).isSameAs(scratch.definitionLevels(page.size()));
+                    }
+                    decodedPages++;
+                }
+            }
+        }
+        finally {
+            inputFile.close();
+            context.close();
+        }
+        assertThat(decodedPages).isGreaterThan(1);
+    }
+
     /// Decodes the column's first data page with the fast path forced on or off
     /// and returns the resulting page's `fixedListK` (`> 0` iff the fast path
     /// engaged).
@@ -133,13 +171,7 @@ class FixedSizeListEngagementTest {
         List<Integer> result = new ArrayList<>();
         try (ParquetFileReader reader = ParquetFileReader.open(InputFile.of(path))) {
             FileSchema schema = reader.getFileSchema();
-            int leaf = -1;
-            for (int c = 0; c < schema.getColumnCount(); c++) {
-                if (schema.getColumn(c).fieldPath().topLevelName().equals(topLevelName)) {
-                    leaf = c;
-                    break;
-                }
-            }
+            int leaf = columnIndex(schema, topLevelName);
             ColumnSchema columnSchema = schema.getColumn(leaf);
             List<RowGroup> rowGroups = reader.getFileMetaData().rowGroups();
             for (RowGroup rowGroup : rowGroups) {
@@ -162,5 +194,14 @@ class FixedSizeListEngagementTest {
             context.close();
         }
         return result;
+    }
+
+    private static int columnIndex(FileSchema schema, String topLevelName) {
+        for (int c = 0; c < schema.getColumnCount(); c++) {
+            if (schema.getColumn(c).fieldPath().topLevelName().equals(topLevelName)) {
+                return c;
+            }
+        }
+        throw new IllegalArgumentException("Unknown column: " + topLevelName);
     }
 }


### PR DESCRIPTION
## Summary

Pools repetition and definition-level decode scratch buffers per in-flight reorder slot, avoiding fresh `int[]` allocations for each decoded page.

- Reuses and grows slot-owned level buffers as needed.
- Preserves fresh allocation for standalone page-decoder callers.
- Preserves the all-present `null` definition-level fast path.
- Ensures dictionary decoding only examines the active page region when a reused buffer is larger than the current page.
- Supports both scalar and SIMD non-null counting paths.

Closes #814

## Testing

- Added coverage verifying level scratch reuse across pages.
- Added coverage ensuring unused scratch-buffer tails are ignored.
- All 1,743 core tests pass.
- Full verification reaches the S3 module but cannot run its Testcontainers tests without Docker.

## Checklist

- [ ] Build via `./mvnw clean verify` passes
- [ ] The commit message is prefixed with the issue key ("#123 Adding support for...")
- [x] Code changes are covered by tests
- [x] If this PR adds or changes user-facing behaviour, `docs/` has been updated

The documentation item is marked complete because this is an internal allocation optimization with no user-facing behavior or public API changes.