### PR TITLE
fix: allow bloom pruning for NaN predicates

### DIFF
--- a/core/src/main/java/dev/hardwood/internal/predicate/BloomFilterSupport.java
+++ b/core/src/main/java/dev/hardwood/internal/predicate/BloomFilterSupport.java
@@ -43,22 +43,21 @@ final class BloomFilterSupport {
 
     /// Single-value bloom check for `FLOAT` values; see the `INT32` overload.
     ///
-    /// Bloom filters hash the raw IEEE-754 bits, which distinguish `-0.0f` from `+0.0f` and every
-    /// NaN bit pattern — but `FLOAT` equality treats `-0.0f == +0.0f` and `NaN != NaN`. Probing
-    /// those by raw bits could prove a value absent that an equal stored value would match, so they
-    /// are never pruned here (statistics still apply).
+    /// Bloom filters hash the raw IEEE-754 bits, while `FLOAT` equality uses `Float.compare`.
+    /// The matcher treats every NaN payload as equal, but the hash distinguishes those payloads,
+    /// so NaN probes stay conservative here (statistics still apply).
     static boolean valueAbsent(BloomFilterSource bloomFilters, int columnIndex, float value) {
-        if (value == 0.0f || Float.isNaN(value)) {
+        if (Float.isNaN(value)) {
             return false;
         }
         BloomFilter bloomFilter = filterFor(bloomFilters, columnIndex);
         return bloomFilter != null && !bloomFilter.mightContain(XxHash64.hash(value));
     }
 
-    /// Single-value bloom check for `DOUBLE` values. See the `FLOAT` overload for the `±0` / `NaN`
+    /// Single-value bloom check for `DOUBLE` values. See the `FLOAT` overload for the NaN
     /// carve-out.
     static boolean valueAbsent(BloomFilterSource bloomFilters, int columnIndex, double value) {
-        if (value == 0.0 || Double.isNaN(value)) {
+        if (Double.isNaN(value)) {
             return false;
         }
         BloomFilter bloomFilter = filterFor(bloomFilters, columnIndex);

--- a/core/src/test/java/dev/hardwood/internal/predicate/BloomFilterPushDownTest.java
+++ b/core/src/test/java/dev/hardwood/internal/predicate/BloomFilterPushDownTest.java
@@ -128,13 +128,31 @@ class BloomFilterPushDownTest {
     }
 
     @Test
-    void negativeZeroFloatIsNeverPrunedByBloom() {
-        // `price` stores +0.0; a query for -0.0f must still match it (-0.0f == +0.0f) even though the
-        // two have different IEEE-754 bits and therefore different bloom hashes. The ±0 carve-out
-        // keeps the row group rather than pruning on the raw-bit hash.
+    void negativeZeroFloatCanBePrunedByBloom() {
+        // `price` stores +0.0; Float.compare treats -0.0f as distinct, so its raw-bit bloom probe
+        // can prove the row group absent.
         FilterPredicate negZero = FilterPredicate.eq("price", -0.0f);
         assertThat(statisticsDrop(negZero)).isFalse();
-        assertThat(bloomDrop(negZero)).isFalse();
+        assertThat(bloomDrop(negZero)).isTrue();
+    }
+
+    @Test
+    void negativeZeroDoubleCanBePrunedByBloom() {
+        FilterPredicate negZero = FilterPredicate.eq("ratio", -0.0);
+        assertThat(statisticsDrop(negZero)).isFalse();
+        assertThat(bloomDrop(negZero)).isTrue();
+    }
+
+    @Test
+    void nanFloatIsNeverPrunedByBloom() {
+        FilterPredicate nan = FilterPredicate.eq("price", Float.NaN);
+        assertThat(bloomDrop(nan)).isFalse();
+    }
+
+    @Test
+    void nanDoubleIsNeverPrunedByBloom() {
+        FilterPredicate nan = FilterPredicate.eq("ratio", Double.NaN);
+        assertThat(bloomDrop(nan)).isFalse();
     }
 
     @Test


### PR DESCRIPTION
## What changed

- remove the unnecessary zero guard from FLOAT and DOUBLE bloom-filter probes
- retain the NaN carve-out because Float.compare/Double.compare collapse NaN payloads while raw-bit hashing distinguishes them
- update the predicate JavaDocs and add focused signed-zero and NaN regression coverage

Closes #829

## Validation

- `git diff --check` passes
- Focused Maven test was attempted with `./mvnw -pl core -am -Dtest=BloomFilterPushDownTest -DfailIfNoTests=false test`
- The local environment has Java 17, while the project enforces Java 25, and the temporary Docker Java 25 fallback could not connect because the Docker daemon is unavailable

This is an AI-assisted contribution prepared under maintainer direction. The diff is limited to `BloomFilterSupport` and its focused regression tests.