### PR TITLE
#265 Fix wide-character alignment in print output

### DIFF
--- a/cli/src/main/java/dev/hardwood/cli/command/PrintCommand.java
+++ b/cli/src/main/java/dev/hardwood/cli/command/PrintCommand.java
@@ -26,8 +26,6 @@ import org.aesh.command.invocation.CommandInvocation;
 import org.aesh.command.option.Mixin;
 import org.aesh.command.option.Option;
 
-import com.github.freva.asciitable.AsciiTable;
-
 import dev.hardwood.InputFile;
 import dev.hardwood.cli.internal.table.RowTable;
 import dev.hardwood.cli.internal.table.StreamedTable;
@@ -104,15 +102,14 @@ public class PrintCommand implements Command<CommandInvocation> {
 
     private void printTransposed(Stream<Object[]> stream, String[] headers, List<SchemaNode> fields, AtomicLong rowIndex) {
         stream.forEach(r -> {
-            Stream<Object[]> data = IntStream.range(0, headers.length)
-                    .mapToObj(i -> new Object[]{headers[i], RowTable.renderValue(r[i], fields.get(i))});
-            System.out.println(
-                    AsciiTable.builder()
-                            .data((rowIndex != null ?
-                                    Stream.concat(
-                                            Stream.of(new Object[][]{new Object[]{"rowIndex", Long.toString(rowIndex.getAndIncrement())}}), data) : data)
-                                    .toArray(Object[][]::new))
-                            .asString());
+            Stream<String[]> data = IntStream.range(0, headers.length)
+                    .mapToObj(i -> new String[]{headers[i], RowTable.renderValue(r[i], fields.get(i))});
+            List<String[]> tableRows = (rowIndex != null ?
+                    Stream.concat(
+                            Stream.<String[]>of(new String[]{"rowIndex", Long.toString(rowIndex.getAndIncrement())}), data) : data)
+                    .toList();
+            System.out.println(RowTable.renderTransposedTable(
+                    tableRows.get(0), tableRows.subList(1, tableRows.size())));
         });
     }
 

--- a/cli/src/main/java/dev/hardwood/cli/internal/table/RowTable.java
+++ b/cli/src/main/java/dev/hardwood/cli/internal/table/RowTable.java
@@ -20,6 +20,7 @@ import java.util.HexFormat;
 import java.util.List;
 import java.util.Set;
 import java.util.UUID;
+import java.util.stream.IntStream;
 
 import dev.hardwood.cli.internal.Fmt;
 import dev.hardwood.cli.internal.RowValueFormatter;
@@ -331,7 +332,12 @@ public final class RowTable {
     }
 
     public static String renderTable(String[] headers, List<String[]> rows) {
-        return renderTable(headers, rows, Collections.emptyList(), Collections.emptyList());
+        return renderTable(headers, rows, Collections.emptyList(), Collections.emptyList(), false);
+    }
+
+    public static String renderTransposedTable(String[] headers, List<String[]> rows) {
+        List<Integer> separatorsBefore = IntStream.range(1, rows.size()).boxed().toList();
+        return renderTable(headers, rows, separatorsBefore, Collections.emptyList(), true);
     }
 
     /// Renders a table like [renderTable(String[], List)], but inserts a horizontal
@@ -346,6 +352,13 @@ public final class RowTable {
     public static String renderTable(String[] headers, List<String[]> rows,
                                      List<Integer> separatorsBefore,
                                      List<Integer> heavySeparatorsBefore) {
+        return renderTable(headers, rows, separatorsBefore, heavySeparatorsBefore, false);
+    }
+
+    private static String renderTable(String[] headers, List<String[]> rows,
+                                      List<Integer> separatorsBefore,
+                                      List<Integer> heavySeparatorsBefore,
+                                      boolean rightAlignHeaders) {
         int cols = headers.length;
         int[] widths = new int[cols];
         for (int i = 0; i < cols; i++) {
@@ -364,7 +377,7 @@ public final class RowTable {
 
         StringBuilder sb = new StringBuilder();
         sb.append(lightBorder).append('\n');
-        sb.append(renderCells(headers, widths, false)).append('\n');
+        sb.append(renderCells(headers, widths, rightAlignHeaders)).append('\n');
         sb.append(lightBorder).append('\n');
         for (int r = 0; r < rows.size(); r++) {
             if (heavySet.contains(r)) {

--- a/cli/src/main/java/dev/hardwood/cli/internal/table/RowTable.java
+++ b/cli/src/main/java/dev/hardwood/cli/internal/table/RowTable.java
@@ -440,10 +440,16 @@ public final class RowTable {
         int len = s.length();
         while (i < len) {
             int cp = s.codePointAt(i);
-            width += isWideCodePoint(cp) ? 2 : 1;
+            width += charWidth(cp);
             i += Character.charCount(cp);
         }
         return width;
+    }
+
+    /// Returns the number of terminal cells a single code point occupies: 2 for East
+    /// Asian wide characters (CJK ideographs, Hangul, Kana, Fullwidth forms), 1 otherwise.
+    static int charWidth(int cp) {
+        return isWideCodePoint(cp) ? 2 : 1;
     }
 
     private static boolean isWideCodePoint(int cp) {

--- a/cli/src/main/java/dev/hardwood/cli/internal/table/StreamedTable.java
+++ b/cli/src/main/java/dev/hardwood/cli/internal/table/StreamedTable.java
@@ -35,13 +35,13 @@ public class StreamedTable {
         // compute column widths based on headers + sample rows
         int[] widths = new int[n];
         for (int i = 0; i < n; i++) {
-            widths[i] = headers[i].length();
+            widths[i] = RowTable.displayWidth(headers[i]);
         }
         for (String[] rowFunc : sampleRows) {
             for (int i = 0; i < n; i++) {
                 String cell = rowFunc[i];
                 if (cell != null) {
-                    widths[i] = Math.max(widths[i], cell.length());
+                    widths[i] = Math.max(widths[i], RowTable.displayWidth(cell));
                 }
             }
         }
@@ -97,10 +97,11 @@ public class StreamedTable {
                 if (cell == null) {
                     cell = "";
                 }
-                if (cell.length() > widths[i]) {
-                    cell = cell.substring(0, widths[i] - 1) + "\u2026";
+                if (RowTable.displayWidth(cell) > widths[i]) {
+                    int end = displayPrefixEnd(cell, 0, widths[i] - 1);
+                    cell = cell.substring(0, end) + "\u2026";
                 }
-                out.printf(" %-" + widths[i] + "s |", cell);
+                printCell(out, cell, widths[i]);
             }
             out.println();
             return;
@@ -115,9 +116,13 @@ public class StreamedTable {
                 cell = "";
             }
             List<String> lines = new ArrayList<>();
-            for (int start = 0; start < cell.length(); start += widths[i]) {
-                int end = Math.min(start + widths[i], cell.length());
+            for (int start = 0; start < cell.length();) {
+                int end = displayPrefixEnd(cell, start, widths[i]);
+                if (end == start) {
+                    end += Character.charCount(cell.codePointAt(start));
+                }
                 lines.add(cell.substring(start, end));
+                start = end;
             }
             maxLines = Math.max(maxLines, lines.size());
             wrappedCells.add(lines.toArray(new String[0]));
@@ -128,9 +133,32 @@ public class StreamedTable {
             for (int i = 0; i < n; i++) {
                 String[] lines = wrappedCells.get(i);
                 String content = (line < lines.length) ? lines[line] : "";
-                out.printf(" %-" + widths[i] + "s |", content);
+                printCell(out, content, widths[i]);
             }
             out.println();
         }
+    }
+
+    private void printCell(PrintWriter out, String content, int width) {
+        out.print(" ");
+        out.print(content);
+        out.print(" ".repeat(Math.max(0, width - RowTable.displayWidth(content))));
+        out.print(" |");
+    }
+
+    private static int displayPrefixEnd(String value, int start, int maxWidth) {
+        int width = 0;
+        int end = start;
+        while (end < value.length()) {
+            int codePoint = value.codePointAt(end);
+            int next = end + Character.charCount(codePoint);
+            int codePointWidth = RowTable.displayWidth(value.substring(end, next));
+            if (width + codePointWidth > maxWidth) {
+                break;
+            }
+            width += codePointWidth;
+            end = next;
+        }
+        return end;
     }
 }

--- a/cli/src/main/java/dev/hardwood/cli/internal/table/StreamedTable.java
+++ b/cli/src/main/java/dev/hardwood/cli/internal/table/StreamedTable.java
@@ -152,7 +152,7 @@ public class StreamedTable {
         while (end < value.length()) {
             int codePoint = value.codePointAt(end);
             int next = end + Character.charCount(codePoint);
-            int codePointWidth = RowTable.displayWidth(value.substring(end, next));
+            int codePointWidth = RowTable.charWidth(codePoint);
             if (width + codePointWidth > maxWidth) {
                 break;
             }

--- a/cli/src/test/java/dev/hardwood/cli/internal/table/RowTableTest.java
+++ b/cli/src/test/java/dev/hardwood/cli/internal/table/RowTableTest.java
@@ -99,4 +99,25 @@ class RowTableTest {
                     .isEqualTo(expected);
         }
     }
+
+    @Test
+    void rendersTransposedTableWithWideCharsAligned() {
+        String out = RowTable.renderTransposedTable(
+                new String[]{"name", "말도"},
+                List.of(
+                        new String[]{"city", "漢字水"},
+                        new String[]{"note", "x"}));
+
+        assertThat(out).isEqualTo("""
+                +------+--------+
+                | name |   말도 |
+                +------+--------+
+                | city | 漢字水 |
+                +------+--------+
+                | note |      x |
+                +------+--------+""");
+        int expectedWidth = RowTable.displayWidth(out.lines().findFirst().orElseThrow());
+        assertThat(out.lines()).allSatisfy(line ->
+                assertThat(RowTable.displayWidth(line)).isEqualTo(expectedWidth));
+    }
 }

--- a/cli/src/test/java/dev/hardwood/cli/internal/table/StreamedTableTest.java
+++ b/cli/src/test/java/dev/hardwood/cli/internal/table/StreamedTableTest.java
@@ -1,0 +1,81 @@
+/*
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Copyright The original authors
+ *
+ *  Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package dev.hardwood.cli.internal.table;
+
+import java.io.PrintWriter;
+import java.io.StringWriter;
+import java.util.List;
+import java.util.function.IntFunction;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class StreamedTableTest {
+
+    @Test
+    void truncatesWideCharactersWithoutMisaligningTheTable() {
+        String output = render(List.<String[]>of(new String[]{"말도나도주"}), 6, true);
+
+        assertThat(output).isEqualTo("""
+                +--------+
+                | name   |
+                +--------+
+                | 말도…  |
+                +--------+""");
+        assertEqualDisplayWidths(output);
+    }
+
+    @Test
+    void wrapsWideCharactersAtDisplayWidthBoundaries() {
+        String output = render(List.<String[]>of(new String[]{"말도나"}), 4, false);
+
+        assertThat(output).isEqualTo("""
+                +------+
+                | name |
+                +------+
+                | 말도 |
+                | 나   |
+                +------+""");
+        assertEqualDisplayWidths(output);
+    }
+
+    @Test
+    void doesNotTruncateSurrogatePairsThatFitTheDisplayWidth() {
+        String output = render(List.<String[]>of(new String[]{"😀abcd"}), 5, true);
+
+        assertThat(output).isEqualTo("""
+                +-------+
+                | name  |
+                +-------+
+                | 😀abcd |
+                +-------+""");
+        assertEqualDisplayWidths(output);
+    }
+
+    private static String render(List<String[]> rows, int maxWidth, boolean truncate) {
+        StringWriter output = new StringWriter();
+        new StreamedTable().print(
+                new PrintWriter(output),
+                new String[]{"name"},
+                rows.stream()
+                        .<IntFunction<String>>map(row -> column -> row[column])
+                        .iterator(),
+                rows.size(),
+                maxWidth,
+                truncate,
+                false);
+        return output.toString().stripTrailing();
+    }
+
+    private static void assertEqualDisplayWidths(String output) {
+        int expectedWidth = RowTable.displayWidth(output.lines().findFirst().orElseThrow());
+        assertThat(output.lines()).allSatisfy(line ->
+                assertThat(RowTable.displayWidth(line)).isEqualTo(expectedWidth));
+    }
+}

--- a/cli/src/test/java/dev/hardwood/cli/internal/table/StreamedTableTest.java
+++ b/cli/src/test/java/dev/hardwood/cli/internal/table/StreamedTableTest.java
@@ -58,11 +58,47 @@ class StreamedTableTest {
         assertEqualDisplayWidths(output);
     }
 
+    @Test
+    void truncatesSurrogatePairsOnCodePointBoundaries() {
+        // The truncation boundary falls mid-cell where an emoji sits: it must be dropped
+        // whole, never split into a lone surrogate. "😀" occupies two char units, so a
+        // code-unit-based cut would land inside the pair.
+        String output = render(List.<String[]>of(new String[]{"😀😀😀"}), "x", 2, true);
+
+        assertThat(output).isEqualTo("""
+                +----+
+                | x  |
+                +----+
+                | 😀… |
+                +----+""");
+        assertEqualDisplayWidths(output);
+    }
+
+    @Test
+    void emitsWideCharacterInColumnNarrowerThanOneWideCell() {
+        // Guards the wrap force-progress branch: a wide char whose width (2) exceeds the
+        // column width (1) must still advance one code point per line rather than loop
+        // forever. It necessarily overflows the border — nothing narrower is possible.
+        String output = render(List.<String[]>of(new String[]{"가나"}), "x", 1, false);
+
+        assertThat(output).isEqualTo("""
+                +---+
+                | x |
+                +---+
+                | 가 |
+                | 나 |
+                +---+""");
+    }
+
     private static String render(List<String[]> rows, int maxWidth, boolean truncate) {
+        return render(rows, "name", maxWidth, truncate);
+    }
+
+    private static String render(List<String[]> rows, String header, int maxWidth, boolean truncate) {
         StringWriter output = new StringWriter();
         new StreamedTable().print(
                 new PrintWriter(output),
-                new String[]{"name"},
+                new String[]{header},
                 rows.stream()
                         .<IntFunction<String>>map(row -> column -> row[column])
                         .iterator(),


### PR DESCRIPTION
Fixes #265.

`hardwood print` used string length when it sized, wrapped, and truncated cells. East Asian wide characters could shift table borders, and truncation could split a Unicode code point.

This change:

- uses terminal display width for streamed output;
- renders transpose mode through `RowTable` so both paths share the same width handling;
- keeps wrapping and truncation on code-point boundaries.

## Verification

- `./mvnw clean verify` with Java 25 and Docker: passed
- focused `RowTable`, `StreamedTable`, and `PrintCommand` tests: 36 passed

## Checklist

- [x] Build via `./mvnw clean verify` passes
- [x] The commit message is prefixed with the issue key ("#123 Adding support for...")
- [x] Code changes are covered by tests
- [x] Documentation is unchanged because this fixes existing rendering without changing a command or public API
