### PR TITLE
fix: floor streamed table columns at min-content width

### DIFF
--- a/cli/src/main/java/dev/hardwood/cli/command/PrintCommand.java
+++ b/cli/src/main/java/dev/hardwood/cli/command/PrintCommand.java
@@ -44,7 +44,7 @@ public class PrintCommand implements Command<CommandInvocation> {
     @Option(shortName = 's', name = "sample-size", defaultValue = "10", description = "Max number of lines used to auto-adjust the column width.")
     int sampleSize;
 
-    @Option(shortName = 'w', name = "max-width", defaultValue = "50", description = "Max width in characters of a column.")
+    @Option(shortName = 'w', name = "max-width", defaultValue = "50", description = "Max width of a column.")
     int maxWidth;
 
     @Option(shortName = 't', name = "truncate", hasValue = false, negatable = true, defaultValue = "true", description = "Should rows be truncated instead of wrapping on next line when too long.")
@@ -73,6 +73,7 @@ public class PrintCommand implements Command<CommandInvocation> {
         }
 
         try (ParquetFileReader reader = ParquetFileReader.open(inputFile)) {
+            validateMaxWidth();
             int rowLimit = RowLimits.parse(n);
             ColumnProjection projection = parseColumnProjection();
             FileSchema fileSchema = reader.getFileSchema();
@@ -98,6 +99,16 @@ public class PrintCommand implements Command<CommandInvocation> {
         }
 
         return CommandResult.SUCCESS;
+    }
+
+    /// Rejects widths below one cell. A column has to be at least one cell wide to
+    /// render anything at all, so a smaller value has no faithful rendering rather
+    /// than merely an ugly one.
+    private void validateMaxWidth() {
+        if (maxWidth < 1) {
+            throw new IllegalArgumentException(
+                    "Invalid value for option '-w': expected a positive integer, got '" + maxWidth + "'");
+        }
     }
 
     private void printTransposed(Stream<Object[]> stream, String[] headers, List<SchemaNode> fields, AtomicLong rowIndex) {

--- a/cli/src/main/java/dev/hardwood/cli/internal/table/RowTable.java
+++ b/cli/src/main/java/dev/hardwood/cli/internal/table/RowTable.java
@@ -446,6 +446,28 @@ public final class RowTable {
         return width;
     }
 
+    /// Returns the min-content width of the string: the number of terminal cells taken
+    /// by its widest single code point, i.e. the narrowest column the string can be
+    /// wrapped into without a glyph overflowing. Empty strings have a width of 1.
+    static int widestGlyph(String s) {
+        int widest = 1;
+        int i = 0;
+        int len = s.length();
+        while (i < len) {
+            int cp = s.codePointAt(i);
+            widest = Math.max(widest, charWidth(cp));
+            i += Character.charCount(cp);
+        }
+        return widest;
+    }
+
+    /// Returns the number of terminal cells taken by the string's first code point,
+    /// i.e. the narrowest column that can render any of the string at all. Empty
+    /// strings have a width of 1.
+    static int firstGlyph(String s) {
+        return s.isEmpty() ? 1 : charWidth(s.codePointAt(0));
+    }
+
     /// Returns the number of terminal cells a single code point occupies: 2 for East
     /// Asian wide characters (CJK ideographs, Hangul, Kana, Fullwidth forms), 1 otherwise.
     static int charWidth(int cp) {

--- a/cli/src/main/java/dev/hardwood/cli/internal/table/StreamedTable.java
+++ b/cli/src/main/java/dev/hardwood/cli/internal/table/StreamedTable.java
@@ -34,20 +34,23 @@ public class StreamedTable {
 
         // compute column widths based on headers + sample rows
         int[] widths = new int[n];
+        int[] minWidths = new int[n];
         for (int i = 0; i < n; i++) {
             widths[i] = RowTable.displayWidth(headers[i]);
+            minWidths[i] = widestGlyph(headers[i]);
         }
         for (String[] rowFunc : sampleRows) {
             for (int i = 0; i < n; i++) {
                 String cell = rowFunc[i];
                 if (cell != null) {
                     widths[i] = Math.max(widths[i], RowTable.displayWidth(cell));
+                    minWidths[i] = Math.max(minWidths[i], widestGlyph(cell));
                 }
             }
         }
 
         for (int i = 0; i < n; i++) {
-            widths[i] = Math.min(widths[i], maxWidth);
+            widths[i] = Math.max(Math.min(widths[i], maxWidth), minWidths[i]);
         }
 
         String sep = makeSeparator(widths);
@@ -160,5 +163,18 @@ public class StreamedTable {
             end = next;
         }
         return end;
+    }
+
+    private static int widestGlyph(String value) {
+        if (value == null) {
+            return 1;
+        }
+        int widest = 1;
+        for (int i = 0; i < value.length();) {
+            int codePoint = value.codePointAt(i);
+            widest = Math.max(widest, RowTable.charWidth(codePoint));
+            i += Character.charCount(codePoint);
+        }
+        return widest;
     }
 }

--- a/cli/src/main/java/dev/hardwood/cli/internal/table/StreamedTable.java
+++ b/cli/src/main/java/dev/hardwood/cli/internal/table/StreamedTable.java
@@ -37,20 +37,21 @@ public class StreamedTable {
         int[] minWidths = new int[n];
         for (int i = 0; i < n; i++) {
             widths[i] = RowTable.displayWidth(headers[i]);
-            minWidths[i] = widestGlyph(headers[i]);
+            minWidths[i] = mandatoryGlyph(headers[i], truncate);
         }
         for (String[] rowFunc : sampleRows) {
             for (int i = 0; i < n; i++) {
                 String cell = rowFunc[i];
                 if (cell != null) {
                     widths[i] = Math.max(widths[i], RowTable.displayWidth(cell));
-                    minWidths[i] = Math.max(minWidths[i], widestGlyph(cell));
+                    minWidths[i] = Math.max(minWidths[i], mandatoryGlyph(cell, truncate));
                 }
             }
         }
 
         for (int i = 0; i < n; i++) {
-            widths[i] = Math.max(Math.min(widths[i], maxWidth), minWidths[i]);
+            widths[i] = Math.max(Math.min(widths[i], maxWidth),
+                    minColumnWidth(minWidths[i], widths[i], truncate));
         }
 
         String sep = makeSeparator(widths);
@@ -81,6 +82,30 @@ public class StreamedTable {
         }
 
         out.flush();
+    }
+
+    /// The glyph of `value` the column is obliged to render, in cells.
+    ///
+    /// Wrapping owes every glyph a line, so it is the widest one anywhere in the value.
+    /// Truncating owes only the first: everything after it is a candidate for being cut,
+    /// and sizing the column to a glyph that the ellipsis may well replace pads it out
+    /// with space no render can reach.
+    private static int mandatoryGlyph(String value, boolean truncate) {
+        return truncate ? RowTable.firstGlyph(value) : RowTable.widestGlyph(value);
+    }
+
+    /// The narrowest a column can be and still render its content faithfully.
+    ///
+    /// Wrapping needs room for the glyph itself, since nothing splits a glyph across
+    /// lines. Truncating needs one cell more, for the ellipsis that sits next to it —
+    /// without that cell the ellipsis crowds out the character entirely and the column
+    /// shows a marker and no content. A column whose values all fit is never truncated,
+    /// so it keeps the plain glyph floor.
+    private static int minColumnWidth(int mandatoryGlyph, int naturalWidth, boolean truncate) {
+        if (!truncate || naturalWidth <= mandatoryGlyph) {
+            return mandatoryGlyph;
+        }
+        return mandatoryGlyph + 1;
     }
 
     private String makeSeparator(int[] widths) {
@@ -163,18 +188,5 @@ public class StreamedTable {
             end = next;
         }
         return end;
-    }
-
-    private static int widestGlyph(String value) {
-        if (value == null) {
-            return 1;
-        }
-        int widest = 1;
-        for (int i = 0; i < value.length();) {
-            int codePoint = value.codePointAt(i);
-            widest = Math.max(widest, RowTable.charWidth(codePoint));
-            i += Character.charCount(codePoint);
-        }
-        return widest;
     }
 }

--- a/cli/src/test/java/dev/hardwood/cli/command/PrintCommandContract.java
+++ b/cli/src/test/java/dev/hardwood/cli/command/PrintCommandContract.java
@@ -186,6 +186,49 @@ interface PrintCommandContract {
     }
 
     @Test
+    default void rejectsNegativeMaxWidth() {
+        Cli.Result result = Cli.launch("print", "-f", plainFile(), "-w", "-5");
+
+        assertThat(result.exitCode()).isNotZero();
+        assertThat(result.errorOutput())
+                .isEqualTo("Invalid value for option '-w': expected a positive integer, got '-5'");
+    }
+
+    @Test
+    default void rejectsZeroMaxWidth() {
+        Cli.Result result = Cli.launch("print", "-f", plainFile(), "-w", "0");
+
+        assertThat(result.exitCode()).isNotZero();
+        assertThat(result.errorOutput())
+                .isEqualTo("Invalid value for option '-w': expected a positive integer, got '0'");
+    }
+
+    @Test
+    default void acceptsMaxWidthOfOne() {
+        Cli.Result result = Cli.launch("print", "-f", plainFile(), "-w", "1", "--no-truncate");
+
+        assertThat(result.exitCode()).isZero();
+        assertThat(result.output()).isEqualTo("""
+                +---+---+
+                | i | v |
+                | d | a |
+                |   | l |
+                |   | u |
+                |   | e |
+                +---+---+
+                | 1 | 1 |
+                |   | 0 |
+                |   | 0 |
+                | 2 | 2 |
+                |   | 0 |
+                |   | 0 |
+                | 3 | 3 |
+                |   | 0 |
+                |   | 0 |
+                +---+---+""");
+    }
+
+    @Test
     default void rejectsUnknownColumn() {
         Cli.Result result = Cli.launch("print", "-f", plainFile(), "--columns", "unknown");
 

--- a/cli/src/test/java/dev/hardwood/cli/internal/table/StreamedTableTest.java
+++ b/cli/src/test/java/dev/hardwood/cli/internal/table/StreamedTableTest.java
@@ -91,6 +91,116 @@ class StreamedTableTest {
     }
 
     @Test
+    void floorsColumnWidthAtWideGlyphInTheHeader() {
+        // The header participates in the min-content width just like the sampled cells:
+        // a wide header over all-Latin data still cannot be squeezed below two cells.
+        String output = render(List.<String[]>of(new String[]{"a"}), "가", 1, false);
+
+        assertThat(output).isEqualTo("""
+                +----+
+                | 가 |
+                +----+
+                | a  |
+                +----+""");
+        assertEqualDisplayWidths(output);
+    }
+
+    @Test
+    void floorsColumnWidthAtWideGlyphWhenTruncating() {
+        // The floor is a property of the column, not of the overflow strategy, so it
+        // applies in truncate mode too: the glyph is rendered rather than replaced by
+        // an ellipsis that would fit the requested one-cell cap.
+        String output = render(List.<String[]>of(new String[]{"가"}), "x", 1, true);
+
+        assertThat(output).isEqualTo("""
+                +----+
+                | x  |
+                +----+
+                | 가 |
+                +----+""");
+        assertEqualDisplayWidths(output);
+    }
+
+    @Test
+    void truncationKeepsAWideCharacterBesideTheEllipsis() {
+        // A truncated column reserves a cell for the ellipsis on top of its widest
+        // glyph, so the marker can never crowd out the character it is marking.
+        String output = render(List.<String[]>of(new String[]{"말도나도주"}), "x", 1, true);
+
+        assertThat(output).isEqualTo("""
+                +-----+
+                | x   |
+                +-----+
+                | 말… |
+                +-----+""");
+        assertEqualDisplayWidths(output);
+    }
+
+    @Test
+    void truncationKeepsANarrowCharacterBesideTheEllipsis() {
+        // Same rule for one-cell glyphs: at maxWidth 1 the column widens to 2 rather
+        // than rendering a bare ellipsis that carries no information at all.
+        String output = render(List.<String[]>of(new String[]{"hello"}), "x", 1, true);
+
+        assertThat(output).isEqualTo("""
+                +----+
+                | x  |
+                +----+
+                | h… |
+                +----+""");
+        assertEqualDisplayWidths(output);
+    }
+
+    @Test
+    void truncationSizesToTheFirstGlyphNotTheWidestOne() {
+        // The 가 is cut away by the truncation, so the column owes it no room: sizing to
+        // the widest glyph would leave a 3-cell column rendering 2 cells of content.
+        String output = render(List.<String[]>of(new String[]{"a가b나c"}), "h", 1, true);
+
+        assertThat(output).isEqualTo("""
+                +----+
+                | h  |
+                +----+
+                | a… |
+                +----+""");
+        assertEqualDisplayWidths(output);
+    }
+
+    @Test
+    void wrappingStillSizesToTheWidestGlyph() {
+        // The counterpart: wrapping has to put every glyph on a line eventually, so the
+        // 가 does set the floor even though it is not the first character.
+        String output = render(List.<String[]>of(new String[]{"a가b나c"}), "h", 1, false);
+
+        assertThat(output).isEqualTo("""
+                +----+
+                | h  |
+                +----+
+                | a  |
+                | 가 |
+                | b  |
+                | 나 |
+                | c  |
+                +----+""");
+        assertEqualDisplayWidths(output);
+    }
+
+    @Test
+    void doesNotReserveEllipsisRoomForUntruncatedColumns() {
+        // The extra cell is only for columns that actually get truncated: a column
+        // whose values all fit is sized to the content, not content plus a marker.
+        String output = render(List.<String[]>of(new String[]{"ab"}), "id", 50, true);
+
+        assertThat(output).isEqualTo("""
+                +----+
+                | id |
+                +----+
+                | ab |
+                +----+""");
+        assertEqualDisplayWidths(output);
+    }
+
+    @Test
     void keepsForceProgressWhenWideGlyphIsOutsideSampledRows() {
         // The min-content floor only sees sampled rows. When a wide glyph appears in
         // an unsampled row, the force-progress branch still prevents an infinite loop.

--- a/cli/src/test/java/dev/hardwood/cli/internal/table/StreamedTableTest.java
+++ b/cli/src/test/java/dev/hardwood/cli/internal/table/StreamedTableTest.java
@@ -75,18 +75,38 @@ class StreamedTableTest {
     }
 
     @Test
-    void emitsWideCharacterInColumnNarrowerThanOneWideCell() {
-        // Guards the wrap force-progress branch: a wide char whose width (2) exceeds the
-        // column width (1) must still advance one code point per line rather than loop
-        // forever. It necessarily overflows the border — nothing narrower is possible.
+    void floorsColumnWidthAtWideGlyphMinContentWidth() {
+        // A column containing a 2-cell glyph cannot be squeezed below its widest
+        // unbreakable token, so the sampled wide rows render flush with the border.
         String output = render(List.<String[]>of(new String[]{"가나"}), "x", 1, false);
+
+        assertThat(output).isEqualTo("""
+                +----+
+                | x  |
+                +----+
+                | 가 |
+                | 나 |
+                +----+""");
+        assertEqualDisplayWidths(output);
+    }
+
+    @Test
+    void keepsForceProgressWhenWideGlyphIsOutsideSampledRows() {
+        // The min-content floor only sees sampled rows. When a wide glyph appears in
+        // an unsampled row, the force-progress branch still prevents an infinite loop.
+        String output = render(
+                List.<String[]>of(new String[]{"x"}, new String[]{"가"}),
+                "x",
+                1,
+                false,
+                1);
 
         assertThat(output).isEqualTo("""
                 +---+
                 | x |
                 +---+
+                | x |
                 | 가 |
-                | 나 |
                 +---+""");
     }
 
@@ -95,6 +115,10 @@ class StreamedTableTest {
     }
 
     private static String render(List<String[]> rows, String header, int maxWidth, boolean truncate) {
+        return render(rows, header, maxWidth, truncate, rows.size());
+    }
+
+    private static String render(List<String[]> rows, String header, int maxWidth, boolean truncate, int sampleSize) {
         StringWriter output = new StringWriter();
         new StreamedTable().print(
                 new PrintWriter(output),
@@ -102,7 +126,7 @@ class StreamedTableTest {
                 rows.stream()
                         .<IntFunction<String>>map(row -> column -> row[column])
                         .iterator(),
-                rows.size(),
+                sampleSize,
                 maxWidth,
                 truncate,
                 false);


### PR DESCRIPTION
## Summary

Treats `--max-width` as a cap that floors at the widest indivisible glyph per column, so a 2-cell CJK/Hangul character cannot squeeze a column below its own width.

## Changes

- Computes a min-content width per column from headers and sampled rows using the existing `RowTable.charWidth` logic.
- Applies the floor after the `max-width` cap: `Math.max(Math.min(widths[i], maxWidth), minWidths[i])`.
- Reworks the narrow-wide-character test to assert aligned borders when the wide glyph is sampled.
- Adds coverage for the retained force-progress guard when the wide glyph appears only in an unsampled row.

## Verification

- Ran `./mvnw -Dtest=StreamedTableTest -DfailIfNoTests=false -Dsurefire.failIfNoSpecifiedTests=false test` under JDK 25; all tests pass.

Closes #839