### PR TITLE
#845 Automate publishing the CLI agent skill to hardwood-skills

### DIFF
--- a/.github/workflows/skills-trigger.yml
+++ b/.github/workflows/skills-trigger.yml
@@ -1,0 +1,38 @@
+#
+#  SPDX-License-Identifier: Apache-2.0
+#
+#  Copyright The original authors
+#
+#  Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+#
+
+name: Trigger skills publish
+
+# Publishes the agent skills under skills/ to the standalone
+# hardwood-hq/hardwood-skills distribution repository whenever they change on
+# main. This repository stays the single source of truth; the sibling repo only
+# wraps skills/ in the Claude Code plugin manifests. Mirrors the documentation
+# publish flow (docs-trigger.yml): fire a repository_dispatch and let the
+# destination repo do the work with its own token. Unlike the docs, skills are
+# static Markdown with no build to gate on, so this fires directly on the change
+# rather than on a completed Main Build.
+
+on:
+  push:
+    branches: [main]
+    paths: ['skills/**']
+  workflow_dispatch:
+
+jobs:
+  dispatch:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Fire repository_dispatch to skills repo
+        env:
+          GH_TOKEN: ${{ secrets.SKILLS_DISPATCH_TOKEN }}
+          SHA: ${{ github.sha }}
+        run: |
+          jq -n \
+            --arg ref "$SHA" \
+            '{event_type: "publish-skills", client_payload: {source_ref: $ref}}' \
+          | gh api repos/hardwood-hq/hardwood-skills/dispatches --input -

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -30,13 +30,15 @@ Larger changes — new features, refactorings that affect the system design — 
 
 This repository is the source of truth for the [agent skills](https://agentskills.io) under `skills/` (e.g. `skills/hardwood-cli/`, which teaches AI coding agents how to drive the `hardwood` CLI). They live here, alongside the code they document, so a change to a CLI flag, output label, or command is made in the same PR as the matching skill edit — the skill can't drift from the tool.
 
-Distribution is separate. The [`hardwood-hq/hardwood-skills`](https://github.com/hardwood-hq/hardwood-skills) repository wraps `skills/` in the Claude Code plugin and marketplace manifests and is what users install. It is a **published mirror** — never edit its `skills/` directly. After changing a skill here, publish it to a local checkout of that repository:
+Distribution is automated. The [`hardwood-hq/hardwood-skills`](https://github.com/hardwood-hq/hardwood-skills) repository wraps `skills/` in the Claude Code plugin and marketplace manifests and is what users install. It is a **published mirror** — never edit its `skills/` directly. When a change to `skills/` lands on `main`, the [Trigger skills publish](.github/workflows/skills-trigger.yml) workflow fires a `repository_dispatch` at that repository, which re-syncs `skills/` from here and commits it; you don't need to do anything.
+
+To publish out-of-band — testing against a local checkout, or a manual backfill — run the same sync by hand:
 
 ```shell
 tools/publish-skills.sh /path/to/hardwood-skills
 ```
 
-then commit and push in that checkout (the script prints the exact commands). When you edit a skill, note in the PR that `hardwood-skills` needs a follow-up publish so it isn't forgotten.
+then commit and push in that checkout (the script prints the exact commands).
 
 ## Commit messages
 

--- a/tools/publish-skills.sh
+++ b/tools/publish-skills.sh
@@ -1,5 +1,13 @@
 #!/usr/bin/env bash
 #
+#  SPDX-License-Identifier: Apache-2.0
+#
+#  Copyright The original authors
+#
+#  Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+#
+
+#
 # Publishes the agent skills from this repository to a local checkout of
 # hardwood-hq/hardwood-skills, which distributes them as a Claude Code plugin.
 #
@@ -22,6 +30,7 @@ fi
 
 rm -rf "$dest/skills"
 cp -a "$repo_root/skills" "$dest/skills"
+"$repo_root/tools/stamp-skill-banner.sh" "$dest/skills"
 
 sha="$(git -C "$repo_root" rev-parse --short HEAD)"
 echo "Synced skills/ -> $dest/skills/ (from hardwood@$sha)"

--- a/tools/stamp-skill-banner.sh
+++ b/tools/stamp-skill-banner.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+#
+# Stamps a "generated file" banner into each published SKILL.md so nobody edits
+# the mirror by hand. Shared by the publish path — tools/publish-skills.sh and
+# the hardwood-skills receiver workflow both call it, so the banner can't drift.
+#
+# The banner is inserted as YAML comments immediately after the opening `---` of
+# the frontmatter: a comment before `---`, or an HTML comment inside the
+# frontmatter, would stop the skill's frontmatter from parsing.
+#
+# Usage: tools/stamp-skill-banner.sh <skills-dir>
+
+set -euo pipefail
+
+dir="${1:?Usage: tools/stamp-skill-banner.sh <skills-dir>}"
+
+while IFS= read -r -d '' skill; do
+  name="$(basename "$(dirname "$skill")")"
+  if [ "$(head -n 1 "$skill")" != "---" ]; then
+    echo "error: $skill does not start with YAML frontmatter ('---')" >&2
+    exit 1
+  fi
+  url="https://github.com/hardwood-hq/hardwood/blob/main/skills/$name/SKILL.md"
+  tmp="$(mktemp)"
+  {
+    printf -- '---\n'
+    printf '# =============================================================================\n'
+    printf '# ATTENTION: GENERATED FILE — DO NOT EDIT.\n'
+    printf '# This is a published copy. Edit the source of truth in hardwood-hq/hardwood\n'
+    printf '# and CI republishes it here:\n'
+    printf '#   %s\n' "$url"
+    printf '# =============================================================================\n'
+    tail -n +2 "$skill"
+  } > "$tmp"
+  mv "$tmp" "$skill"
+done < <(find "$dir" -name SKILL.md -print0)


### PR DESCRIPTION
Closes #845.

## Why

The `hardwood-cli` agent skill lives under `skills/` here (the source of truth, kept in lockstep with the CLI it documents) and is distributed to users through the standalone [`hardwood-hq/hardwood-skills`](https://github.com/hardwood-hq/hardwood-skills) repository. Until now that mirror was refreshed by running `tools/publish-skills.sh` by hand — easy to forget.

## How

Mirrors the documentation publish flow (`docs-trigger.yml`):

- **`.github/workflows/skills-trigger.yml`** (this repo) fires a `publish-skills` `repository_dispatch` at `hardwood-skills` when `skills/**` changes on `main` (also `workflow_dispatch` for manual backfills), carrying the source commit as `source_ref`.
- A receiver workflow in `hardwood-skills` (already pushed) checks out that ref, re-syncs `skills/`, and commits it with its own `GITHUB_TOKEN` — the commit is stamped from `source_ref`, not the mirror's own SHA.

`tools/publish-skills.sh` stays as the local / out-of-band fallback; CONTRIBUTING is updated to describe the automated path.

## Required setup

A repository secret **`SKILLS_DISPATCH_TOKEN`** with permission to create `repository_dispatch` events on `hardwood-skills` (fine-grained: Contents read/write on that repo, or a GitHub App token). The trigger step 401s without it.

## Checklist

- [x] The commit message is prefixed with the issue key
- [ ] Build via \`./mvnw clean verify\` passes (no build impact — CI-only change)
- [x] If this PR adds or changes user-facing behaviour, docs updated (CONTRIBUTING)