### PR TITLE
#433 Add head and skip to column readers

### DIFF
--- a/_designs/ROW_SELECTION_SEMANTICS.md
+++ b/_designs/ROW_SELECTION_SEMANTICS.md
@@ -1,14 +1,15 @@
 # Design: row selection semantics
 
-**Status: In progress.** Tracking issues: #538 (`head` + filter), #540 / #541
-(`skip` + filter), #542 (`tail` + filter), #543 (`firstRow` → `skip` rename).
+**Status: In progress.** Tracking issues: #433 (column-reader parity), #538 (`head` + filter),
+#540 / #541 (`skip` + filter), #542 (`tail` + filter), #543 (`firstRow` → `skip` rename).
 The reader-facing counterpart is `docs/content/concepts/row-selection.md`.
 
 ## Scope
 
-How the row-selection controls on `RowReaderBuilder` — `head`, `tail`, `skip` —
-relate to the two filtering mechanisms — the row-level `FilterPredicate` and the
-group-level `RowGroupPredicate` (e.g. `byteRange`). The goal is a single model
+How the row-selection controls on `RowReaderBuilder`, `ColumnReaderBuilder`, and
+`ColumnReadersBuilder` — `head`, `skip`, and the row-reader-only `tail` — relate to the two
+filtering mechanisms — the row-level `FilterPredicate` and the group-level
+`RowGroupPredicate` (e.g. `byteRange`). The goal is a single model
 under which the controls compose predictably, so a caller can reason about
 `skip(a).filter(p).head(b)` without knowing the file's row-group structure or
 the filter's selectivity.
@@ -32,7 +33,8 @@ in file order.
 
 ## The one rule
 
-`head`, `tail`, and `skip` count over the surviving relation, in file order:
+`head` and `skip` count over the surviving relation, in file order on every reader builder;
+`tail` follows the same model on `RowReaderBuilder`:
 
 - `skip(n)` discards the first `n` rows of the relation (SQL `OFFSET`).
 - `head(n)` keeps at most the first `n` rows (SQL `LIMIT`).

--- a/core/src/main/java/dev/hardwood/reader/ColumnReader.java
+++ b/core/src/main/java/dev/hardwood/reader/ColumnReader.java
@@ -88,6 +88,10 @@ public class ColumnReader implements AutoCloseable {
     private int recordCount;
     private boolean exhausted;
     private boolean closed;
+    private long rowsToSkip;
+    private long rowsRemaining;
+    private boolean rowLimit;
+    private int[] windowSelection;
 
     // Real-items-only view for nested batches, computed lazily and cached per
     // batch. Invalidated in `nextBatch()`.
@@ -187,7 +191,44 @@ public class ColumnReader implements AutoCloseable {
             consumedGeneration = coordinator.generation();
             return coordinator.hasBatch();
         }
-        return rawNextBatch();
+        if (rowLimit && rowsRemaining == 0) {
+            currentFlatBatch = null;
+            currentNestedBatch = null;
+            exhausted = true;
+            return false;
+        }
+        while (rawNextBatch()) {
+            if (applyWindow()) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private boolean applyWindow() {
+        int start = (int) Math.min(rowsToSkip, recordCount);
+        rowsToSkip -= start;
+
+        int available = recordCount - start;
+        int count = rowLimit ? (int) Math.min(rowsRemaining, available) : available;
+        if (count == 0) {
+            return false;
+        }
+
+        if (start != 0 || count != recordCount) {
+            if (windowSelection == null || windowSelection.length < count) {
+                windowSelection = new int[count];
+            }
+            for (int i = 0; i < count; i++) {
+                windowSelection[i] = start + i;
+            }
+            applySelection(windowSelection, count);
+        }
+
+        if (rowLimit) {
+            rowsRemaining -= count;
+        }
+        return true;
     }
 
     /// Advances this reader to its next decoded batch without applying any
@@ -527,6 +568,12 @@ public class ColumnReader implements AutoCloseable {
         this.coordinator = coordinator;
     }
 
+    void configureWindow(long skip, long maxRows) {
+        this.rowsToSkip = skip;
+        this.rowsRemaining = maxRows;
+        this.rowLimit = maxRows > 0;
+    }
+
     /// Whether this reader decodes through the nested pipeline.
     boolean isNested() {
         return nested;
@@ -852,9 +899,9 @@ public class ColumnReader implements AutoCloseable {
     static ColumnReader create(String columnName, FileSchema schema,
                                InputFile inputFile, List<RowGroup> rowGroups,
                                HardwoodContextImpl context, boolean fixedListFastPathEnabled,
-                               ResolvedPredicate filter, int batchSize) {
+                               ResolvedPredicate filter, int batchSize, long maxRows, long skip) {
         return create(schema.getColumn(columnName), schema, inputFile, rowGroups, context,
-                fixedListFastPathEnabled, filter, batchSize);
+                fixedListFastPathEnabled, filter, batchSize, maxRows, skip);
     }
 
     /// Create a ColumnReader for a column by index with optional page-level
@@ -862,15 +909,15 @@ public class ColumnReader implements AutoCloseable {
     static ColumnReader create(int columnIndex, FileSchema schema,
                                InputFile inputFile, List<RowGroup> rowGroups,
                                HardwoodContextImpl context, boolean fixedListFastPathEnabled,
-                               ResolvedPredicate filter, int batchSize) {
+                               ResolvedPredicate filter, int batchSize, long maxRows, long skip) {
         return create(schema.getColumn(columnIndex), schema, inputFile, rowGroups, context,
-                fixedListFastPathEnabled, filter, batchSize);
+                fixedListFastPathEnabled, filter, batchSize, maxRows, skip);
     }
 
     private static ColumnReader create(ColumnSchema columnSchema, FileSchema schema,
                                        InputFile inputFile, List<RowGroup> rowGroups,
                                        HardwoodContextImpl context, boolean fixedListFastPathEnabled,
-                                       ResolvedPredicate filter, int batchSize) {
+                                       ResolvedPredicate filter, int batchSize, long maxRows, long skip) {
         ProjectedSchema projectedSchema = ProjectedSchema.create(schema,
                 ColumnProjection.columns(columnSchema.fieldPath().toString()));
 
@@ -880,12 +927,15 @@ public class ColumnReader implements AutoCloseable {
                         BatchSizing.valuesPerRow(projectedSchema, rowGroups));
 
         RowGroupIterator rowGroupIterator = new RowGroupIterator(
-                List.of(inputFile), context, 0);
+                List.of(inputFile), context, maxRows, 0L, skip);
         rowGroupIterator.setFirstFile(schema, rowGroups);
         rowGroupIterator.initialize(projectedSchema, filter);
 
-        return createFromIterator(columnSchema, schema, rowGroupIterator, context, fixedListFastPathEnabled,
+        ColumnReader reader = createFromIterator(
+                columnSchema, schema, rowGroupIterator, context, fixedListFastPathEnabled,
                 0, rowGroupIterator, resolvedBatchSize, NestedColumnWorker.IndexMode.REAL_VIEW);
+        reader.configureWindow(rowGroupIterator.firstRowGroupSkip(), maxRows);
+        return reader;
     }
 
     /// Creates a ColumnReader from a pre-configured RowGroupIterator.

--- a/core/src/main/java/dev/hardwood/reader/ColumnReaders.java
+++ b/core/src/main/java/dev/hardwood/reader/ColumnReaders.java
@@ -60,7 +60,9 @@ public class ColumnReaders implements AutoCloseable {
                   RowGroupIterator rowGroupIterator,
                   FileSchema schema,
                   ProjectedSchema projectedSchema,
-                  int batchSize) {
+                  int batchSize,
+                  long skip,
+                  long maxRows) {
         int projectedColumnCount = projectedSchema.getProjectedColumnCount();
         this.readersByName = new LinkedHashMap<>(projectedColumnCount);
         this.readersByIndex = new ColumnReader[projectedColumnCount];
@@ -73,6 +75,7 @@ public class ColumnReaders implements AutoCloseable {
             ColumnReader reader = ColumnReader.createFromIterator(
                     columnSchema, schema, rowGroupIterator, context, fixedListFastPathEnabled, i, null, batchSize,
                     NestedColumnWorker.IndexMode.REAL_VIEW);
+            reader.configureWindow(skip, maxRows);
 
             readersByName.put(columnSchema.fieldPath().toString(), reader);
             readersByIndex[i] = reader;
@@ -100,7 +103,9 @@ public class ColumnReaders implements AutoCloseable {
                                   ProjectedSchema augProjected,
                                   ProjectedSchema payloadProjected,
                                   ResolvedPredicate resolved,
-                                  int batchSize) {
+                                  int batchSize,
+                                  long skip,
+                                  long maxRows) {
         int augCount = augProjected.getProjectedColumnCount();
         ColumnReader[] allReaders = new ColumnReader[augCount];
         Map<String, ColumnReader> byPath = new LinkedHashMap<>(augCount);
@@ -124,7 +129,8 @@ public class ColumnReaders implements AutoCloseable {
         }
 
         SelectionEngine engine = SelectionEngine.create(schema, augProjected, resolved, allReaders, batchSize);
-        FilterCoordinator coordinator = new FilterCoordinator(allReaders, payloadReaders, engine);
+        FilterCoordinator coordinator = new FilterCoordinator(
+                allReaders, payloadReaders, engine, skip, maxRows);
         for (ColumnReader reader : allReaders) {
             reader.setCoordinator(coordinator);
         }

--- a/core/src/main/java/dev/hardwood/reader/FilterCoordinator.java
+++ b/core/src/main/java/dev/hardwood/reader/FilterCoordinator.java
@@ -25,16 +25,23 @@ final class FilterCoordinator {
     /// The exposed subset, compacted to the matching records each batch.
     private final ColumnReader[] payloadReaders;
     private final SelectionEngine engine;
+    private long rowsToSkip;
+    private long rowsRemaining;
+    private final boolean rowLimit;
 
     private long generation;
     private boolean hasBatch;
     private int recordCount;
     private boolean closed;
 
-    FilterCoordinator(ColumnReader[] allReaders, ColumnReader[] payloadReaders, SelectionEngine engine) {
+    FilterCoordinator(ColumnReader[] allReaders, ColumnReader[] payloadReaders, SelectionEngine engine,
+                      long skip, long maxRows) {
         this.allReaders = allReaders;
         this.payloadReaders = payloadReaders;
         this.engine = engine;
+        this.rowsToSkip = skip;
+        this.rowsRemaining = maxRows;
+        this.rowLimit = maxRows > 0;
     }
 
     long generation() {
@@ -53,6 +60,41 @@ final class FilterCoordinator {
     /// the payload readers. Returns `false` (without incrementing the
     /// generation) once the input is exhausted.
     boolean advance() {
+        if (rowLimit && rowsRemaining == 0) {
+            hasBatch = false;
+            recordCount = 0;
+            return false;
+        }
+
+        while (advanceFilteredBatch()) {
+            int start = (int) Math.min(rowsToSkip, recordCount);
+            rowsToSkip -= start;
+            int available = recordCount - start;
+            int count = rowLimit ? (int) Math.min(rowsRemaining, available) : available;
+            if (count == 0) {
+                continue;
+            }
+
+            if (start != 0 || count != recordCount) {
+                int[] kept = engine.selection();
+                for (int i = 0; i < count; i++) {
+                    kept[i] = start + i;
+                }
+                for (ColumnReader reader : payloadReaders) {
+                    reader.applySelection(kept, count);
+                }
+            }
+
+            recordCount = count;
+            if (rowLimit) {
+                rowsRemaining -= count;
+            }
+            return true;
+        }
+        return false;
+    }
+
+    private boolean advanceFilteredBatch() {
         if (!allReaders[0].rawNextBatch()) {
             hasBatch = false;
             recordCount = 0;

--- a/core/src/main/java/dev/hardwood/reader/ParquetFileReader.java
+++ b/core/src/main/java/dev/hardwood/reader/ParquetFileReader.java
@@ -488,55 +488,65 @@ public class ParquetFileReader implements AutoCloseable {
     }
 
     ColumnReader buildColumnReader(String columnName, FilterPredicate filter) {
-        return buildColumnReader(columnName, filter, null, AUTO_BATCH_SIZE);
+        return buildColumnReader(columnName, filter, null, AUTO_BATCH_SIZE, 0L, 0L);
     }
 
     ColumnReader buildColumnReader(
-            String columnName, FilterPredicate filter, RowGroupPredicate rowGroupFilter, int batchSize) {
+            String columnName, FilterPredicate filter, RowGroupPredicate rowGroupFilter, int batchSize,
+            long maxRows, long skip) {
         ensureSingleFile("columnReader(String)");
         if (filter != null) {
             // Exact filtering routes through the shared filtered-projection
             // engine and exposes the single requested column.
-            return buildColumnReaders(ColumnProjection.columns(columnName), filter, rowGroupFilter, batchSize)
+            return buildColumnReaders(
+                    ColumnProjection.columns(columnName), filter, rowGroupFilter, batchSize, maxRows, skip)
                     .getColumnReader(0);
         }
         InputFile inputFile = inputFiles.get(0);
         List<RowGroup> rowGroups = filterRowGroups(rowGroupFilter);
-        return ColumnReader.create(columnName, schema, inputFile, rowGroups, context, fixedListFastPathEnabled, null, batchSize);
+        return ColumnReader.create(
+                columnName, schema, inputFile, rowGroups, context, fixedListFastPathEnabled,
+                null, batchSize, maxRows, skip);
     }
 
     ColumnReader buildColumnReader(int columnIndex, FilterPredicate filter) {
-        return buildColumnReader(columnIndex, filter, null, AUTO_BATCH_SIZE);
+        return buildColumnReader(columnIndex, filter, null, AUTO_BATCH_SIZE, 0L, 0L);
     }
 
     ColumnReader buildColumnReader(
-            int columnIndex, FilterPredicate filter, RowGroupPredicate rowGroupFilter, int batchSize) {
+            int columnIndex, FilterPredicate filter, RowGroupPredicate rowGroupFilter, int batchSize,
+            long maxRows, long skip) {
         ensureSingleFile("columnReader(int)");
         if (filter != null) {
             String columnName = schema.getColumn(columnIndex).fieldPath().toString();
-            return buildColumnReaders(ColumnProjection.columns(columnName), filter, rowGroupFilter, batchSize)
+            return buildColumnReaders(
+                    ColumnProjection.columns(columnName), filter, rowGroupFilter, batchSize, maxRows, skip)
                     .getColumnReader(0);
         }
         InputFile inputFile = inputFiles.get(0);
         List<RowGroup> rowGroups = filterRowGroups(rowGroupFilter);
-        return ColumnReader.create(columnIndex, schema, inputFile, rowGroups, context, fixedListFastPathEnabled, null, batchSize);
+        return ColumnReader.create(
+                columnIndex, schema, inputFile, rowGroups, context, fixedListFastPathEnabled,
+                null, batchSize, maxRows, skip);
     }
 
     ColumnReaders buildColumnReaders(ColumnProjection projection, FilterPredicate filter) {
-        return buildColumnReaders(projection, filter, null, AUTO_BATCH_SIZE);
+        return buildColumnReaders(projection, filter, null, AUTO_BATCH_SIZE, 0L, 0L);
     }
 
     ColumnReaders buildColumnReaders(
             ColumnProjection projection,
             FilterPredicate filter,
             RowGroupPredicate rowGroupFilter,
-            int batchSize) {
+            int batchSize,
+            long maxRows,
+            long skip) {
         ResolvedPredicate resolved = filter != null
                 ? FilterPredicateResolver.resolve(filter, schema, firstFileMetaData.columnOrders()) : null;
         List<RowGroup> rowGroups = filterRowGroups(rowGroupFilter);
 
         if (resolved == null) {
-            RowGroupIterator iterator = new RowGroupIterator(inputFiles, context, 0);
+            RowGroupIterator iterator = new RowGroupIterator(inputFiles, context, maxRows, 0L, skip);
             iterator.setFirstFile(schema, rowGroups);
             ProjectedSchema projected = iterator.initialize(projection, null);
             rowGroupIterators.add(iterator);
@@ -546,7 +556,7 @@ public class ParquetFileReader implements AutoCloseable {
                 return ColumnReaders.noRows(schema, projected);
             }
             return new ColumnReaders(context, fixedListFastPathEnabled, iterator, schema, projected,
-                    resolveBatchSize(batchSize, projected, rowGroups));
+                    resolveBatchSize(batchSize, projected, rowGroups), iterator.firstRowGroupSkip(), maxRows);
         }
 
         // Exact filtering (#624): decode the payload columns *and* the predicate
@@ -571,7 +581,7 @@ public class ParquetFileReader implements AutoCloseable {
         // per-batch arrays too, so they count toward the byte budget.
         return ColumnReaders.filtered(
                 context, fixedListFastPathEnabled, iterator, schema, augProjected, payloadProjected, resolved,
-                resolveBatchSize(batchSize, augProjected, rowGroups));
+                resolveBatchSize(batchSize, augProjected, rowGroups), skip, maxRows);
     }
 
     /// Resolves a requested batch size to a concrete record count. A positive
@@ -842,6 +852,8 @@ public class ParquetFileReader implements AutoCloseable {
         private FilterPredicate filter;
         private RowGroupPredicate rowGroupFilter;
         private int batchSize = AUTO_BATCH_SIZE;
+        private long headRows;
+        private long skip;
 
         private ColumnReaderBuilder(ParquetFileReader fileReader, String columnName) {
             this.fileReader = fileReader;
@@ -876,6 +888,22 @@ public class ParquetFileReader implements AutoCloseable {
             return this;
         }
 
+        public ColumnReaderBuilder head(long maxRows) {
+            if (maxRows <= 0) {
+                throw new IllegalArgumentException("head row count must be positive: " + maxRows);
+            }
+            this.headRows = maxRows;
+            return this;
+        }
+
+        public ColumnReaderBuilder skip(long skip) {
+            if (skip < 0) {
+                throw new IllegalArgumentException("skip must be non-negative: " + skip);
+            }
+            this.skip = skip;
+            return this;
+        }
+
         /// Set the maximum number of records to return in each batch.
         ///
         /// When unset, the batch size is chosen adaptively from the column's
@@ -892,9 +920,11 @@ public class ParquetFileReader implements AutoCloseable {
 
         public ColumnReader build() {
             if (byName) {
-                return fileReader.buildColumnReader(columnName, filter, rowGroupFilter, batchSize);
+                return fileReader.buildColumnReader(
+                        columnName, filter, rowGroupFilter, batchSize, headRows, skip);
             }
-            return fileReader.buildColumnReader(columnIndex, filter, rowGroupFilter, batchSize);
+            return fileReader.buildColumnReader(
+                    columnIndex, filter, rowGroupFilter, batchSize, headRows, skip);
         }
     }
 
@@ -920,6 +950,8 @@ public class ParquetFileReader implements AutoCloseable {
         private FilterPredicate filter;
         private RowGroupPredicate rowGroupFilter;
         private int batchSize = AUTO_BATCH_SIZE;
+        private long headRows;
+        private long skip;
 
         private ColumnReadersBuilder(ParquetFileReader fileReader, ColumnProjection projection) {
             if (projection == null) {
@@ -948,6 +980,22 @@ public class ParquetFileReader implements AutoCloseable {
             return this;
         }
 
+        public ColumnReadersBuilder head(long maxRows) {
+            if (maxRows <= 0) {
+                throw new IllegalArgumentException("head row count must be positive: " + maxRows);
+            }
+            this.headRows = maxRows;
+            return this;
+        }
+
+        public ColumnReadersBuilder skip(long skip) {
+            if (skip < 0) {
+                throw new IllegalArgumentException("skip must be non-negative: " + skip);
+            }
+            this.skip = skip;
+            return this;
+        }
+
         /// Set the maximum number of records to return in each batch for all columns.
         ///
         /// When unset, the batch size is chosen adaptively from the projected
@@ -963,7 +1011,8 @@ public class ParquetFileReader implements AutoCloseable {
         }
 
         public ColumnReaders build() {
-            return fileReader.buildColumnReaders(projection, filter, rowGroupFilter, batchSize);
+            return fileReader.buildColumnReaders(
+                    projection, filter, rowGroupFilter, batchSize, headRows, skip);
         }
     }
 

--- a/core/src/test/java/dev/hardwood/ColumnReaderWindowTest.java
+++ b/core/src/test/java/dev/hardwood/ColumnReaderWindowTest.java
@@ -1,0 +1,214 @@
+/*
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Copyright The original authors
+ *
+ *  Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package dev.hardwood;
+
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.LongStream;
+
+import org.junit.jupiter.api.Test;
+
+import dev.hardwood.metadata.ColumnChunk;
+import dev.hardwood.metadata.RowGroup;
+import dev.hardwood.reader.ColumnReader;
+import dev.hardwood.reader.ColumnReaders;
+import dev.hardwood.reader.FilterPredicate;
+import dev.hardwood.reader.ParquetFileReader;
+import dev.hardwood.reader.RowGroupPredicate;
+import dev.hardwood.schema.ColumnProjection;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class ColumnReaderWindowTest {
+
+    private static final Path FIXTURE =
+            Paths.get("src/test/resources/filter_pushdown_int.parquet");
+
+    @Test
+    void singleColumnWindowSpansBatchesAndRowGroups() throws Exception {
+        try (ParquetFileReader reader = ParquetFileReader.open(InputFile.of(FIXTURE))) {
+            assertThat(ids(reader.buildColumnReader("id")
+                    .batchSize(8)
+                    .skip(95)
+                    .head(20)
+                    .build()))
+                    .containsExactlyElementsOf(range(96, 115));
+        }
+    }
+
+    @Test
+    void skipZeroIsNoOpAndPastEndIsEmpty() throws Exception {
+        try (ParquetFileReader reader = ParquetFileReader.open(InputFile.of(FIXTURE))) {
+            assertThat(ids(reader.buildColumnReader(0).skip(0).head(3).build()))
+                    .containsExactly(1L, 2L, 3L);
+            assertThat(ids(reader.buildColumnReader("id").skip(300).build()))
+                    .isEmpty();
+            assertThat(ids(reader.buildColumnReader("id").skip(301).build()))
+                    .isEmpty();
+        }
+    }
+
+    @Test
+    void projectedColumnsUseTheSameWindow() throws Exception {
+        try (ParquetFileReader reader = ParquetFileReader.open(InputFile.of(FIXTURE));
+             ColumnReaders columns = reader.buildColumnReaders(
+                             ColumnProjection.columns("id", "value"))
+                     .batchSize(7)
+                     .skip(95)
+                     .head(20)
+                     .build()) {
+            List<Long> ids = new ArrayList<>();
+            List<Long> values = new ArrayList<>();
+            while (columns.nextBatch()) {
+                int count = columns.getRecordCount();
+                long[] idBatch = columns.getColumnReader("id").getLongs();
+                long[] valueBatch = columns.getColumnReader("value").getLongs();
+                for (int i = 0; i < count; i++) {
+                    ids.add(idBatch[i]);
+                    values.add(valueBatch[i]);
+                }
+            }
+            assertThat(ids).containsExactlyElementsOf(range(96, 115));
+            assertThat(values).containsExactlyElementsOf(ids);
+        }
+    }
+
+    @Test
+    void filteredWindowCountsMatchingRows() throws Exception {
+        try (ParquetFileReader reader = ParquetFileReader.open(InputFile.of(FIXTURE))) {
+            assertThat(ids(reader.buildColumnReader("id")
+                    .filter(FilterPredicate.gt("id", 150L))
+                    .batchSize(7)
+                    .skip(20)
+                    .head(5)
+                    .build()))
+                    .containsExactly(171L, 172L, 173L, 174L, 175L);
+        }
+    }
+
+    @Test
+    void filteredProjectionUsesTheSameLogicalWindow() throws Exception {
+        try (ParquetFileReader reader = ParquetFileReader.open(InputFile.of(FIXTURE));
+             ColumnReaders columns = reader.buildColumnReaders(
+                             ColumnProjection.columns("id", "value"))
+                     .filter(FilterPredicate.gt("id", 150L))
+                     .batchSize(7)
+                     .skip(20)
+                     .head(5)
+                     .build()) {
+            List<Long> ids = new ArrayList<>();
+            List<Long> values = new ArrayList<>();
+            while (columns.nextBatch()) {
+                int count = columns.getRecordCount();
+                long[] idBatch = columns.getColumnReader("id").getLongs();
+                long[] valueBatch = columns.getColumnReader("value").getLongs();
+                for (int i = 0; i < count; i++) {
+                    ids.add(idBatch[i]);
+                    values.add(valueBatch[i]);
+                }
+            }
+            assertThat(ids).containsExactly(171L, 172L, 173L, 174L, 175L);
+            assertThat(values).containsExactlyElementsOf(ids);
+        }
+    }
+
+    @Test
+    void rowGroupFilterDefinesTheSkipOrigin() throws Exception {
+        try (ParquetFileReader reader = ParquetFileReader.open(InputFile.of(FIXTURE))) {
+            List<RowGroup> rowGroups = reader.getFileMetaData().rowGroups();
+            RowGroupPredicate lastTwoGroups = RowGroupPredicate.byteRange(
+                    midpoint(rowGroups.get(1)), FIXTURE.toFile().length());
+
+            assertThat(ids(reader.buildColumnReaders(ColumnProjection.columns("id"))
+                    .filter(lastTwoGroups)
+                    .skip(50)
+                    .head(3)
+                    .build()))
+                    .containsExactly(151L, 152L, 153L);
+        }
+    }
+
+    @Test
+    void multiFileWindowUsesTheGlobalOffset() throws Exception {
+        List<InputFile> files = InputFile.ofPaths(
+                Paths.get("src/test/resources/multi_file_part0.parquet"),
+                Paths.get("src/test/resources/multi_file_part1.parquet"));
+
+        try (ParquetFileReader reader = ParquetFileReader.openAll(files)) {
+            assertThat(ids(reader.buildColumnReaders(ColumnProjection.columns("id"))
+                    .skip(140)
+                    .head(20)
+                    .build()))
+                    .containsExactlyElementsOf(range(140, 159));
+        }
+    }
+
+    @Test
+    void invalidBoundsAreRejectedByBothBuilders() throws Exception {
+        try (ParquetFileReader reader = ParquetFileReader.open(InputFile.of(FIXTURE))) {
+            assertThatThrownBy(() -> reader.buildColumnReader("id").head(0))
+                    .isInstanceOf(IllegalArgumentException.class)
+                    .hasMessageContaining("head row count must be positive");
+            assertThatThrownBy(() -> reader.buildColumnReader("id").skip(-1))
+                    .isInstanceOf(IllegalArgumentException.class)
+                    .hasMessageContaining("skip must be non-negative");
+            assertThatThrownBy(() -> reader.buildColumnReaders(
+                    ColumnProjection.columns("id")).head(-1))
+                    .isInstanceOf(IllegalArgumentException.class)
+                    .hasMessageContaining("head row count must be positive");
+            assertThatThrownBy(() -> reader.buildColumnReaders(
+                    ColumnProjection.columns("id")).skip(-1))
+                    .isInstanceOf(IllegalArgumentException.class)
+                    .hasMessageContaining("skip must be non-negative");
+        }
+    }
+
+    private static List<Long> ids(ColumnReader reader) {
+        List<Long> ids = new ArrayList<>();
+        try (reader) {
+            while (reader.nextBatch()) {
+                int count = reader.getRecordCount();
+                long[] batch = reader.getLongs();
+                for (int i = 0; i < count; i++) {
+                    ids.add(batch[i]);
+                }
+            }
+        }
+        return ids;
+    }
+
+    private static List<Long> ids(ColumnReaders readers) {
+        List<Long> ids = new ArrayList<>();
+        try (readers) {
+            ColumnReader reader = readers.getColumnReader("id");
+            while (readers.nextBatch()) {
+                int count = readers.getRecordCount();
+                long[] batch = reader.getLongs();
+                for (int i = 0; i < count; i++) {
+                    ids.add(batch[i]);
+                }
+            }
+        }
+        return ids;
+    }
+
+    private static long midpoint(RowGroup rowGroup) {
+        long compressedSize = 0;
+        for (ColumnChunk column : rowGroup.columns()) {
+            compressedSize += column.metaData().totalCompressedSize();
+        }
+        return rowGroup.columns().get(0).chunkStartOffset() + compressedSize / 2;
+    }
+
+    private static List<Long> range(long startInclusive, long endInclusive) {
+        return LongStream.rangeClosed(startInclusive, endInclusive).boxed().toList();
+    }
+}

--- a/docs/content/concepts/row-selection.md
+++ b/docs/content/concepts/row-selection.md
@@ -11,10 +11,10 @@
 -->
 # Row Selection
 
-You rarely want every row of a Parquet file. Hardwood gives a `RowReader` five controls for
-narrowing what comes back — `filter`, `head`, `tail`, `skip`, and the `byteRange` row-group
-predicate. They compose predictably once you hold one idea: **row selection counts over the
-result set, not over the file.** For the step-by-step recipes, see
+You rarely want every row of a Parquet file. Hardwood's row and column reader builders provide
+`filter`, `head`, `skip`, and the `byteRange` row-group predicate; `RowReaderBuilder` also provides
+`tail`. They compose predictably once you hold one idea: **row selection counts over the result
+set, not over the file.** For the step-by-step recipes, see
 [Predicate Pushdown, Projection, Limits, and Splits](../how-to/query-controls.md).
 
 ## Two questions: which rows, and where they live
@@ -22,7 +22,7 @@ result set, not over the file.** For the step-by-step recipes, see
 Selection has two independent axes, and each control belongs to exactly one of them.
 
 - **Which rows you want — the logical result.** A `FilterPredicate` (`WHERE`), and the
-  positional controls `head`, `tail`, and `skip`.
+  positional controls `head` and `skip`, plus `tail` for row readers.
 - **Where data lives in the file — the physical layout.** `RowGroupPredicate.byteRange(...)`,
   at row-group granularity. This is the lever for splitting a file across parallel readers, not
   for shaping what a single reader returns.
@@ -85,8 +85,9 @@ wrong tool — that is what `byteRange` is for.
 
 ## Currently supported combinations
 
-`head`, `skip`, and `byteRange` each compose with a `FilterPredicate`; `head`/`skip` count over
-the matched rows. `tail` + filter is **not** supported and is rejected at `build()`: unlike the
+`head`, `skip`, and `byteRange` each compose with a `FilterPredicate` on the row and column
+reader builders; `head`/`skip` count over the matched rows. `tail` + filter is **not** supported
+on `RowReaderBuilder` and is rejected at `build()`: unlike the
 forward-streaming `head`/`skip`, the *last* `n` matching rows have no row-group-statistics
 shortcut, so it would require a reverse scan over the whole file. Until that lands, take the tail
 of the unfiltered file, or filter and keep the trailing matches yourself.

--- a/docs/content/how-to/column-reader.md
+++ b/docs/content/how-to/column-reader.md
@@ -54,6 +54,25 @@ Column readers can also be created by index via `columnReader(int columnIndex)`.
 
 A filtered column reader returns **only** the matching rows — exact, with no client-side residual filtering required. Each batch's `getRecordCount()` and typed arrays already exclude non-matching rows, so a direct aggregate over the output is correct. The predicate may reference the column being read, another column, or a column that is not read at all; for `columnReaders(projection)` every column is filtered to the same row set and stays row-aligned. Predicate columns that are not part of the projection are decoded internally to evaluate the filter but are not exposed.
 
+### Limiting and Skipping Rows
+
+Both column reader builders support `skip(long)` and `head(long)`. They can be combined to read a bounded window:
+
+```java
+try (ColumnReader id = reader.buildColumnReader("id")
+        .skip(150)
+        .head(20)
+        .build()) {
+    while (id.nextBatch()) {
+        process(id.getLongs(), id.getRecordCount());
+    }
+}
+```
+
+Without a row filter, `skip(n)` is a physical offset and earlier row groups are not decoded. With a `FilterPredicate`, it is a logical offset over matching rows, so `filter(p).skip(n).head(k)` has the same meaning as `WHERE p OFFSET n LIMIT k`. A `RowGroupPredicate` is applied first, and the window is counted within the row groups it keeps.
+
+On `ColumnReadersBuilder`, the window is shared by the whole projection. Every projected column therefore returns the same records and remains aligned across batch and row-group boundaries.
+
 ### Reading Multiple Columns
 
 For reading multiple columns together, use `columnReaders(projection)` which returns a `ColumnReaders` collection. Drive every reader in lockstep with `ColumnReaders.nextBatch()`:

--- a/docs/content/how-to/query-controls.md
+++ b/docs/content/how-to/query-controls.md
@@ -258,7 +258,7 @@ try (ParquetFileReader fileReader = ParquetFileReader.open(InputFile.of(path));
 
 A row group is included if and only if its **midpoint** — the start of its first column chunk plus half of its on-disk compressed size — falls in `[start, end)`. This is the standard Hadoop-input-format split convention: across a partitioning of the file into disjoint byte ranges, every row group lands in exactly one range, regardless of where the split boundary falls inside the row group itself.
 
-**Granularity is row-group, not row.** A row group whose midpoint is in `[0, 1000)` is read in full, including any rows whose data extends beyond byte 1000. If you need true row-level windowing, combine `RowGroupPredicate` with [`RowReaderBuilder.skip(...)`](#skipping-rows-skip) and [`head(...)`](#row-limit).
+**Granularity is row-group, not row.** A row group whose midpoint is in `[0, 1000)` is read in full, including any rows whose data extends beyond byte 1000. If you need true row-level windowing, combine `RowGroupPredicate` with [`skip(...)`](#skipping-rows-skip) and [`head(...)`](#row-limit).
 
 `RowGroupPredicate` composes with [`FilterPredicate`](#predicate-pushdown-filter) via intersection — both apply, and a row group is read if and only if it passes both:
 
@@ -277,7 +277,7 @@ ColumnReader col = fileReader.buildColumnReader("price")
         RowGroupPredicate.byteRange(otherStart, otherEnd)))
 ```
 
-The same `filter(RowGroupPredicate)` overload is available on `RowReaderBuilder` and `ColumnReadersBuilder`. On `RowReaderBuilder`, `skip(N)` and `head(N)` index over the *row-group-filtered* sequence — `skip(N)` skips `N` rows of the kept set, `head(N)` caps reading at `N` rows of the kept set. Combining `RowGroupPredicate` with `tail(N)` is rejected: tail mode requires a known total row count, which row-group filtering invalidates.
+The same `filter(RowGroupPredicate)` overload is available on `RowReaderBuilder`, `ColumnReaderBuilder`, and `ColumnReadersBuilder`. On all three builders, `skip(N)` and `head(N)` index over the *row-group-filtered* sequence — `skip(N)` skips `N` rows of the kept set, and `head(N)` caps reading at `N` rows of the kept set. Combining `RowGroupPredicate` with `tail(N)` is rejected on `RowReaderBuilder`: tail mode requires a known total row count, which row-group filtering invalidates.
 
 ### Empty ranges
 
@@ -303,7 +303,7 @@ Tail mode cannot currently be combined with a filter predicate — the set of ma
 
 ### Skipping Rows (`skip`)
 
-The `skip(long)` builder method is SQL `OFFSET`: it discards leading rows before reading. What "leading rows" means depends on whether a filter is present — see [Row Selection](../concepts/row-selection.md) for the model.
+The `skip(long)` builder method is available on the row and column reader builders. It is SQL `OFFSET`: it discards leading rows before reading. What "leading rows" means depends on whether a filter is present — see [Row Selection](../concepts/row-selection.md) for the model.
 
 **Without a filter,** `skip(n)` is a physical absolute row index. Earlier row groups are not opened — their pages are not fetched or decoded — making this an O(1 row group) seek on remote backends, in contrast to walking `next()` from row 0.
 

--- a/docs/content/release-notes.md
+++ b/docs/content/release-notes.md
@@ -15,6 +15,7 @@ See [GitHub Releases](https://github.com/hardwood-hq/hardwood/releases) for down
 
 ## 1.1.0-SNAPSHOT
 
+- `ColumnReaderBuilder` and `ColumnReadersBuilder` now support `head(N)` and `skip(N)`, including logical `OFFSET`/`LIMIT` semantics for filtered reads and aligned windows across projected columns.
 - Physical `skip(N)` on multi-file row readers is now a true global offset over the concatenated input files; skipped files have their footers read for row counts, but their data pages are not decoded.
 - The `hardwood` CLI is now built on the aesh command framework instead of picocli/Quarkus; removing the Quarkus/CDI bootstrap makes the CLI start faster
 - `hardwood help <command>` is removed — use `hardwood <command> --help` (or `-h`)


### PR DESCRIPTION
Adds head() and skip() to both column reader builders. Unfiltered reads seek to the physical offset, while filtered reads apply OFFSET/LIMIT to matches. Projected columns share the same window.

## Checklist
- [x] Build via ./mvnw clean verify passes
- [x] The commit message is prefixed with the issue key ("#123 Adding support for...")
- [x] Code changes are covered by tests
- [x] If this PR adds or changes user-facing behaviour, docs/ has been updated

Closes #433
