### PR TITLE
#853 Separate the S3 network fetcher from range-cache dispatch

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -395,6 +395,7 @@ For field-level `parquet.thrift` metadata coverage (which spec fields are read/p
 ### 11.1 S3 Support (`hardwood-s3`)
 - [x] `S3InputFile` implementation with suffix-range GET for footer pre-fetch
 - [x] Tail caching (64 KB) for Parquet footer locality
+- [x] Range backing (`RangeBacking.SPARSE_TEMPFILE`) — mmap-backed whole-file range cache for repeat reads
 - [x] Client ownership model (caller-owned vs self-owned `S3Client`)
 - [x] LocalStack integration tests
 

--- a/_designs/REMOTE_RANGE_BACKING.md
+++ b/_designs/REMOTE_RANGE_BACKING.md
@@ -1,10 +1,10 @@
 # Design: whole-file range backing for `S3InputFile`
 
-**Status: Proposed.** Tracking issue: #373.
+**Status: Completed.** Tracking issues: #373, #560, #853.
 
 ## Goal
 
-Cache fetched byte ranges inside `S3InputFile` so repeat reads of the
+Cache byte ranges fetched by an `S3InputFile` so repeat reads of the
 same offsets hit local memory instead of re-issuing HTTP GETs to S3.
 The motivating workflow is dive's Data preview path: flip-flopping
 between top and bottom of a remote file (`g`, `G`, `g`, …) currently
@@ -14,45 +14,29 @@ This sits one layer below the cross-column coalescing already
 introduced in #374. Coalesced regions become coarser cache units —
 one cached entry per region covers many columns at once.
 
-## Approach: whole-file backing, not LRU
+## Approach: whole-file backing
 
 `MappedInputFile.open()` calls `channel.map(READ_ONLY, 0, fileSize)`,
 reserves the full file as virtual address space, and lets the OS
 lazy-fault pages on `slice` calls. There is no cache structure
 because the mapping *is* the cache.
 
-The remote analogue:
+The remote analogue is a cache layer wrapping the network path:
 
-- On `S3InputFile.open()`, allocate a buffer of `fileSize` bytes and
-  track which byte ranges have been populated.
+- On `open()`, allocate a buffer of `fileSize` bytes and track which
+  byte ranges have been populated.
 - On `readRange(offset, length)`: if the range is fully within the
   populated set, return a slice of the buffer — zero-copy, no
-  network I/O. If not, fetch the missing sub-range(s) from S3, write
-  them into the buffer at their offsets, mark the ranges populated,
-  and return the slice.
+  network I/O. If not, fetch the missing sub-range(s) through the
+  wrapped file, write them into the buffer at their offsets, mark the
+  ranges populated, and return the slice.
 - On `close()`, release the buffer.
 
-No eviction. The buffer's lifetime is the `S3InputFile`'s lifetime;
-its size is the file's size. This is structurally symmetric with the
+No eviction. The buffer's lifetime is the open file's lifetime; its
+size is the file's size. This is structurally symmetric with the
 local mmap path — both expose "a buffer of size `fileSize` you can
 slice into," and the rest of the pipeline doesn't know which is
 which.
-
-### Why not LRU
-
-LRU was the obvious starting point but pays for capacity it doesn't
-need given how the rest of the pipeline already shapes I/O:
-
-- **Coalescing already produces stable request shapes.** A refill
-  against a given window always re-issues the same
-  `readRange(offset, length)` for the same `SharedRegion`. Exact-match
-  caching catches ~all the wins; replacement policy is unused work.
-- **Eviction race risk.** With an LRU of off-heap entries, eviction
-  needs to deterministically free the buffer (`Arena.close()` or
-  similar). Any concurrent slice still in use would crash. Whole-file
-  backing has one buffer for the file's lifetime, no per-entry release.
-- **"What's the right budget?" is unanswerable in the abstract.**
-  The whole-file model doesn't ask the user to pick.
 
 The trade-off is footprint: whole-file backing reserves `fileSize` of
 *virtual* address space up front, regardless of how much of the file
@@ -62,39 +46,32 @@ the dive workflow against typical analytics files.
 
 ## Implementation: sparse temp file + mmap
 
-The naive form of "allocate a buffer of `fileSize`" is
-`Arena.allocate(fileSize)` — but FFM requires zero-fill on
-allocation, which eagerly commits the full size. For a 622 MB
-Overture file that's ~600 ms of zeroing on first open and 622 MB
-resident from then on, even if the session only paged through 80 MB.
-
-Backing the buffer with a **sparse temp file** instead lets the OS
-handle lazy commit:
+The buffer is backed by a **sparse temp file**, which lets the OS
+handle lazy commit rather than committing `fileSize` up front:
 
 ```
 open():
-    create a temp file in `java.io.tmpdir` (or configurable);
-    sparse-truncate to `fileSize` (`RandomAccessFile.setLength` /
-        `FileChannel.truncate`, which on Linux/macOS / NTFS leaves a
-        file with holes);
-    mmap it READ_WRITE for the writer side, READ_ONLY for slice
-        consumers;
-    discover `fileSize` and pre-fetch the tail (`open-tail`,
-        unchanged from today) — write those bytes into the mmap at
-        their absolute offsets.
+    open the wrapped fetcher (which discovers `fileSize` and
+        pre-fetches the tail);
+    create a temp file in the configured temp dir;
+    sparse-truncate to `fileSize` (`FileChannel.truncate`, which on
+        Linux/macOS / NTFS leaves a file with holes);
+    mmap it READ_WRITE.
 
 readRange(off, len):
     if filled.contains([off, off + len)):
         return mapping.slice((int) off, len)        // zero-copy
     else:
-        fetch missing sub-ranges from S3;
+        fetch the missing sub-ranges from the wrapped fetcher;
         write each into the mapping at its absolute offset;
         filled.add(those ranges);
         return mapping.slice((int) off, len)
 
 close():
-    unmap;
-    delete temp file
+    drop the mapping reference (the unmap itself is GC-driven);
+    delete the temp file, deferring to JVM exit on platforms that
+        refuse to unlink a file that still carries a mapping;
+    close the wrapped fetcher
 ```
 
 The OS commits pages only when written; never-touched holes occupy
@@ -102,26 +79,49 @@ neither RAM nor disk on filesystems that support sparse files (ext4,
 xfs, apfs, ntfs). Logical address space = `fileSize`, real footprint
 = touched bytes.
 
-**Comparison vs in-memory variants:**
-
-| Variant                             | Up-front cost          | Real footprint    | Lazy commit            |
-|-------------------------------------|-----------------------|-------------------|------------------------|
-| `Arena.allocate(fileSize)`          | zero whole file (~1 GB/s) | full `fileSize` | no                     |
-| `Unsafe.allocateMemory(fileSize)`   | depends on glibc       | varies            | sometimes              |
-| **Sparse temp file + mmap**         | sparse-truncate (instant) | touched bytes only | yes (kernel-managed) |
-
-The third variant is the recommended implementation. The cost: an
+The cost: an
 extra disk write per fetched range (S3 → mmap'd file). On a
 `tmpfs`-backed temp dir this stays in RAM (Linux default for
 `/tmp` on many distros). On a disk-backed temp dir it incurs disk
 I/O proportional to bytes fetched — typically a fraction of the S3
 RTT savings, so net positive.
 
+### Class layout
+
+Three classes, each with one job:
+
+- **`RangeBackedInputFile`** (`dev.hardwood.internal.reader`) — the
+  sparse-tempfile cache. An `InputFile` decorator over another
+  `InputFile`; it knows nothing about S3 and is reusable over any
+  remote backend. Holds the mapping and the `RangeSet`.
+- **`S3Fetcher`** (package-private in `dev.hardwood.s3`) — the S3
+  network path. Owns the `S3Api` handle, the bucket/key, the
+  `open()` suffix-range tail fetch and its retained tail buffer, and
+  the two network counters. Knows nothing about range caching.
+- **`S3InputFile`** (public) — a facade over a single `InputFile`
+  chosen in the constructor: the `S3Fetcher` under
+  `RangeBacking.NONE`, or a `RangeBackedInputFile` wrapping it under
+  `RangeBacking.SPARSE_TEMPFILE`. `open()`, `readRange()` and
+  `close()` delegate to it unconditionally, so the read path carries
+  no per-call branch on the backing mode.
+
+Every `InputFile` method delegates to the chosen backing, including
+`length()` and `name()`. `S3InputFile` keeps a direct reference to the
+`S3Fetcher` for one purpose: `networkRequestCount()` /
+`networkBytesFetched()` report network traffic only, and under
+`SPARSE_TEMPFILE` a cache hit is served from the mapping and never
+reaches the fetcher, so it cannot be counted.
+
+The facade exists because `S3Source.inputFile(...)` returns
+`S3InputFile`, not `InputFile`: callers reach the counters without a
+cast, `ParquetModel#netStats()` can `instanceof S3InputFile`, and the
+internal `RangeBackedInputFile` type never appears in public API.
+
 ## API surface
 
 `S3InputFile` exposes the same `InputFile` contract; the
-implementation change is internal. New configuration on `S3Source`
-(or `S3InputFile.Builder`):
+range cache is an internal implementation detail and does not change
+the returned type. Configuration lives on `S3Source`:
 
 ```java
 S3Source.builder()
@@ -198,9 +198,13 @@ file), so absolute cost is negligible.
 
 ## Composition with existing layers
 
-- **Tail cache.** Already exists; populates the same buffer at
-  `[fileLength - TAIL_SIZE, fileLength)` during `open()`. Becomes a
-  trivial special case of the general flow — no separate code path.
+- **Tail cache.** Lives in `S3Fetcher`, one layer *below* the range
+  cache: the `open()` suffix-range GET fetches
+  `[fileLength - TAIL_SIZE, fileLength)` and the fetcher serves any
+  read fully inside that window from it without a network call. Under
+  `SPARSE_TEMPFILE` a footer read therefore populates the mapping from
+  the tail buffer rather than from the network, and neither layer
+  counts it as network traffic.
 - **`SharedRegion.data`** (#374). Per-RG cache that lives until
   `releaseWorkItem` evicts the workitem. Stacks above this layer:
   `SharedRegion.fetchData` calls `inputFile.readRange(...)`, which
@@ -212,8 +216,8 @@ file), so absolute cost is negligible.
   `readRange(off, len)` shape after coalescing. Repeat dive
   refills against the same window become single-region cache hits.
 - **Local files.** Unchanged. `MappedInputFile` already does the
-  whole-file backing; the new `S3InputFile` shape just brings the
-  remote path into structural alignment.
+  whole-file backing; the `S3InputFile` shape brings the remote path
+  into structural alignment.
 
 ## Limits
 
@@ -237,44 +241,54 @@ file), so absolute cost is negligible.
   with enough free space for worst-case touched bytes per file.
   `/tmp` typically suffices; environments with read-only or tiny
   `/tmp` (some container images) need `tempDir` configured.
+  `S3Source.Builder#build()` rejects a missing or read-only `tempDir`
+  when `SPARSE_TEMPFILE` is selected, so the misconfiguration surfaces
+  at configuration time rather than at the first `open()`.
+- **Deferred reclamation.** `close()` deletes the backing file, but
+  the unmap is GC-driven: the address space, and on Windows the file
+  itself, are reclaimed at the next collection or at JVM exit rather
+  than at `close()`. Java offers no portable forced unmap at the
+  language level the project targets.
 
 ## Concurrency
 
 `S3InputFile.readRange` is called from many threads (column workers,
 prefetch). The cache must be thread-safe:
 
-- `RangeSet` operations under a single object monitor (or
-  `ReentrantReadWriteLock` if profiling shows contention).
-- Per-range fetch deduplication: when two threads simultaneously
-  request the same missing range, exactly one issues the HTTP GET
-  and the other waits. Implemented via a
-  `ConcurrentHashMap<Range, CompletableFuture<Void>>` of in-flight
-  fetches. Lookup and removal happen under the `RangeSet` lock to
-  avoid a ABA window.
+- `open()`, `readRange()` and `close()` on `RangeBackedInputFile`
+  hold the instance monitor, which guards both the mapping and the
+  `RangeSet`.
+- Holding that monitor across the refill also deduplicates fetches:
+  two threads requesting the same missing range serialize, and the
+  second finds the range populated and issues no HTTP GET. Readers
+  never observe a partially written range.
 - Slices into the mmap are zero-copy `MappedByteBuffer.slice(int,
   int)` views; consumers can hold them across threads, the
   underlying mapping is alive until `close()`.
 
 ## Testing
 
-- **`S3RangeCacheHitTest`** — open a `CountingS3Api` wrapper,
-  read the same range twice, assert exactly one HTTP GET.
-- **`S3RangeCachePartialHitTest`** — read `[0, 1000)`, then read
-  `[100, 200)`. Assert the second read does not issue a network
-  call (covered by the populated set).
-- **`S3RangeCacheGapFetchTest`** — populate `[0, 100)` and
-  `[200, 300)`, then read `[0, 300)`. Assert exactly one HTTP GET
-  is issued for `[100, 200)` (the gap), the other ranges are
-  served from the buffer.
-- **`S3RangeCacheConcurrentFetchTest`** — two threads request the
-  same uncached range simultaneously. Assert exactly one HTTP GET
-  is issued.
-- **`S3RangeCacheCloseTest`** — close the file, verify the temp
-  file is deleted and the mapping is released.
-- **`S3RangeCacheCrossRgFlipFlopTest`** — end-to-end: open a
-  fixture against `LocalStack`, walk through dive's preview
-  pattern (open → page-down × N → jump-to-end → jump-to-start),
-  assert the second jump-to-start issues zero new HTTP GETs.
+- **`RangeSetTest`** (core) — the interval set in isolation:
+  `contains` / `add` merging of overlapping and touching ranges, and
+  the gaps returned by `missing`.
+- **`RangeBackedInputFileTest`** (core) — the decorator over a
+  counting in-memory `InputFile`: exact-match and enclosed-range
+  repeat reads hit the mapping, a read spanning a hole fetches only
+  the gap, and `close()` deletes the temp file.
+- **`S3RangeBackingTest`** (s3) — end-to-end against an S3 proxy
+  container with `RangeBacking.SPARSE_TEMPFILE`: an exact repeat
+  `readRange` issues no new GET, and a second full pass with
+  `ColumnReader` / `RowReader` over the same `S3InputFile` issues
+  strictly fewer GETs and fetches strictly fewer bytes than the
+  first. The counters carry the assertions, which is what pins the
+  cache to network-only accounting.
+- **`S3InputFileTest`** (s3) — the same file under the default
+  `RangeBacking.NONE`, including that the counters cover the
+  `open()` tail fetch and every network `readRange` but not
+  tail-cache hits.
+- **`S3SourceTempDirValidationTest`** (s3) — `build()` rejects a
+  missing `tempDir` under `SPARSE_TEMPFILE`, accepts an existing one,
+  and ignores the setting under `NONE`.
 
 ## Out of scope
 
@@ -289,10 +303,3 @@ prefetch). The cache must be thread-safe:
   Reasonable for dive sessions; would need revisiting for
   long-lived readers (hours+).
 - **Multi-region mmap for files > 2 GB.** Tracked as #75.
-
-## Estimated effort
-
-~150 lines of production code (RangeSet ~40, S3InputFile changes
-~70, S3Source config ~20, lifecycle plumbing ~20) + tests.
-Roughly half a day end-to-end including the dive verification run
-against the Overture fixture.

--- a/core/src/main/java/dev/hardwood/internal/reader/RangeBackedInputFile.java
+++ b/core/src/main/java/dev/hardwood/internal/reader/RangeBackedInputFile.java
@@ -8,7 +8,6 @@
 package dev.hardwood.internal.reader;
 
 import java.io.IOException;
-import java.io.UncheckedIOException;
 import java.nio.ByteBuffer;
 import java.nio.MappedByteBuffer;
 import java.nio.channels.FileChannel;
@@ -38,10 +37,16 @@ import dev.hardwood.InputFile;
 /// the mapping cannot exceed [Integer#MAX_VALUE] bytes. Files larger
 /// than 2 GB cannot be range-backed; [#open] throws on those.
 ///
-/// **Lifecycle.** [#close] unmaps the buffer (best-effort, GC drives
-/// the actual unmap) and deletes the temp file. The wrapped file is
-/// closed via the standard delegation.
+/// **Lifecycle.** [#close] drops the mapping reference and deletes the
+/// temp file. The unmap itself is GC-driven, so the address space and
+/// the file's blocks are reclaimed on the next collection rather than
+/// at `close()`. Where the platform refuses to unlink a file that still
+/// carries a mapping — Windows does — the delete is deferred to JVM
+/// exit rather than failing the close. The wrapped file is closed via
+/// the standard delegation.
 public final class RangeBackedInputFile implements InputFile {
+
+    private static final System.Logger LOG = System.getLogger(RangeBackedInputFile.class.getName());
 
     private final InputFile delegate;
     private final Path tempDir;
@@ -125,20 +130,6 @@ public final class RangeBackedInputFile implements InputFile {
         return mapping.slice(Math.toIntExact(offset), length);
     }
 
-    /// Returns true if the entire range is already in the cache. Test /
-    /// diagnostic only — the public read path goes through [#readRange].
-    public synchronized boolean isPopulated(long offset, int length) {
-        if (populated == null) {
-            return false;
-        }
-        return populated.contains(offset, offset + length);
-    }
-
-    /// Returns the wrapped [InputFile]. Test / diagnostic only.
-    public InputFile delegate() {
-        return delegate;
-    }
-
     @Override
     public long length() {
         if (fileLength < 0) {
@@ -167,17 +158,7 @@ public final class RangeBackedInputFile implements InputFile {
             }
             channel = null;
         }
-        try {
-            cleanupTempFile();
-        }
-        catch (RuntimeException e) {
-            if (firstFailure == null) {
-                firstFailure = new IOException("Failed to delete temp cache file", e);
-            }
-            else {
-                firstFailure.addSuppressed(e);
-            }
-        }
+        cleanupTempFile();
         try {
             delegate.close();
         }
@@ -194,15 +175,25 @@ public final class RangeBackedInputFile implements InputFile {
         }
     }
 
+    /// Deletes the backing file, or defers the delete to JVM exit if the
+    /// platform refuses it. Windows will not unlink a file that still
+    /// carries a mapping, and the unmap here is GC-driven, so a failure
+    /// is expected there rather than exceptional — failing [#close] over
+    /// it would break every range-backed read on that platform. The
+    /// deferral is logged so a leaked temp file is never silent.
     private void cleanupTempFile() {
-        if (tempFile != null) {
-            try {
-                Files.deleteIfExists(tempFile);
-            }
-            catch (IOException e) {
-                throw new UncheckedIOException(e);
-            }
-            tempFile = null;
+        if (tempFile == null) {
+            return;
         }
+        try {
+            Files.deleteIfExists(tempFile);
+        }
+        catch (IOException e) {
+            tempFile.toFile().deleteOnExit();
+            LOG.log(System.Logger.Level.WARNING,
+                    "Could not delete range-cache file {0} ({1}); deferred to JVM exit",
+                    tempFile, e);
+        }
+        tempFile = null;
     }
 }

--- a/docs/content/reference/packages.md
+++ b/docs/content/reference/packages.md
@@ -21,7 +21,7 @@ Hardwood is organized into public API packages and internal implementation packa
 | [`dev.hardwood.schema`](/api/latest/dev/hardwood/schema/package-summary.html) | **Public API** | Schema representation: file schema, column schemas, and column projection. |
 | [`dev.hardwood.row`](/api/latest/dev/hardwood/row/package-summary.html) | **Public API** | Value types for nested data access: structs, lists, and maps. |
 | [`dev.hardwood.avro`](/api/latest/dev/hardwood/avro/package-summary.html) | **Public API** | Avro GenericRecord support: schema conversion and row materialization (`hardwood-avro` module). |
-| [`dev.hardwood.s3`](/api/latest/dev/hardwood/s3/package-summary.html) | **Public API** | S3 object storage support: `S3Source`, `S3InputFile`, `S3Credentials`, `S3CredentialsProvider` (`hardwood-s3` module, zero external dependencies). |
+| [`dev.hardwood.s3`](/api/latest/dev/hardwood/s3/package-summary.html) | **Public API** | S3 object storage support: `S3Source`, `S3InputFile`, `S3Credentials`, `S3CredentialsProvider`, `RangeBacking` (`hardwood-s3` module, zero external dependencies). |
 | [`dev.hardwood.aws.auth`](/api/latest/dev/hardwood/aws/auth/package-summary.html) | **Public API** | Bridges the AWS SDK credential chain to Hardwood's `S3CredentialsProvider` (`hardwood-aws-auth` module, optional). |
 | [`dev.hardwood.jfr`](/api/latest/dev/hardwood/jfr/package-summary.html) | **Public API** | JFR event types emitted during file reading, decoding, and pipeline operations. |
 | `dev.hardwood.internal.*` | **Internal** | Implementation details — not part of the public API and may change without notice. |

--- a/docs/content/reference/s3.md
+++ b/docs/content/reference/s3.md
@@ -26,17 +26,67 @@ endpoints, and multi-file reads — see [Reading from S3](../how-to/s3.md).
 | `requestTimeout(Duration)` | 30s | Maximum time for an individual HTTP request to complete. |
 | `maxRetries(int)` | 3 | GET retries on transient failures (HTTP 500, 503, network errors) with exponential backoff and jitter. `0` disables retries. |
 | `httpClient(HttpClient)` | internal | Caller-supplied client for full transport control. The caller is responsible for closing it — `S3Source.close()` will not. |
+| `rangeBacking(RangeBacking)` | `RangeBacking.NONE` | Whether files opened from this source cache the byte ranges they fetch. See [Range backing](#range-backing). |
+| `tempDir(Path)` | `java.io.tmpdir` | Directory holding the sparse backing file under `RangeBacking.SPARSE_TEMPFILE`. Ignored under `RangeBacking.NONE`. |
 
 When the retry budget is exhausted, the last failure is re-thrown as an `IOException`. For HTTP
 errors the message has the form `GET s3://<bucket>/<key> failed: HTTP <status>`; for network errors
 the original `IOException` message is preserved.
 
+## Footer pre-fetch
+
+`open()` issues one GET for the last 64 KB of the object — the whole object if it is
+smaller. That single round-trip discovers the object size, so there is never a
+separate HEAD request. Those bytes are kept for as long as the file is open, and any
+read falling entirely inside that trailing window is answered without a further
+request.
+
+For most files the window also carries the Parquet footer, which is why opening a
+file usually costs one GET. It is a cost heuristic rather than a guarantee: footer
+size grows with row groups × columns and with the size of the per-column statistics,
+so a wide schema, a heavily split file, or long string min/max values can push the
+footer past 64 KB. Reading it then costs one extra GET and nothing more — the window
+bounds request count, never what is readable.
+
+This applies to every `S3InputFile`, independent of the range backing below.
+
+## Range backing
+
+`RangeBacking` sets whether an `S3InputFile` also keeps the bytes it fetches outside
+that window:
+
+| Value | Behaviour |
+|-------|-----------|
+| `NONE` (default) | Nothing beyond the footer pre-fetch is kept. Every other `readRange` issues an HTTP GET, including a repeat read of a range already fetched. |
+| `SPARSE_TEMPFILE` | Fetched ranges are written into a sparse temp file mmapped into the process. A read covered by already-fetched bytes is served from the mapping with no HTTP GET; a read spanning a gap fetches only the missing sub-ranges. |
+
+The value changes how many HTTP requests go out, not what a read returns — both give
+the reader identical bytes. The cache is per `S3InputFile` and lives until that file
+is closed.
+
+`SPARSE_TEMPFILE` applies to a whole `S3Source`, so it suits workloads that re-read
+the same byte ranges — `hardwood dive` opts in for every file it opens. Its
+properties:
+
+- Disk and memory footprint scale with bytes fetched, not with file size, on
+  filesystems that support sparse files (ext4, xfs, apfs, ntfs).
+- Files larger than `Integer.MAX_VALUE` bytes (2 GB) cannot be range-backed; `open()`
+  throws an `IOException` naming the limit. Read those with `RangeBacking.NONE`.
+- The backing file is created in `tempDir`, which must exist and be writeable with
+  room for the worst-case bytes fetched per file. `S3Source.builder().build()` rejects
+  a directory that is missing or not writeable.
+- `close()` deletes the backing file, but the mapping behind it is released by the
+  garbage collector, so the address space — and on Windows, where a mapped file cannot
+  be deleted, the file itself until JVM exit — outlives the `close()` call.
+
 ## Fetch-cost counters
 
 Each `S3InputFile` tracks the network I/O it has performed since `open()`:
 
-- `networkRequestCount()` — HTTP GET requests issued: the footer tail fetch plus every
-  column-chunk range fetch. Tail-cache hits are not counted.
+- `networkRequestCount()` — HTTP GET requests issued: the [footer pre-fetch](#footer-pre-fetch)
+  plus every column-chunk range fetch. Reads answered from the pre-fetched footer window
+  are not counted, nor are reads answered from the cache under
+  `RangeBacking.SPARSE_TEMPFILE`.
 - `networkBytesFetched()` — total bytes fetched across those requests, counted the same way.
 
 Read the counters before the try-with-resources block exits, while the `S3InputFile` is still open.

--- a/s3/src/main/java/dev/hardwood/s3/S3Fetcher.java
+++ b/s3/src/main/java/dev/hardwood/s3/S3Fetcher.java
@@ -1,0 +1,203 @@
+/*
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Copyright The original authors
+ *
+ *  Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package dev.hardwood.s3;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.http.HttpResponse;
+import java.nio.ByteBuffer;
+import java.util.concurrent.atomic.AtomicLong;
+
+import dev.hardwood.InputFile;
+import dev.hardwood.internal.FetchReason;
+import dev.hardwood.s3.internal.S3Api;
+
+/// The network path behind [S3InputFile]: every [#readRange] call issues
+/// a signed HTTP `GET` with a byte-range header against one S3 object.
+///
+/// [#open()] uses a suffix-range GET instead of a HEAD request. This
+/// discovers the file length from the `Content-Range` response header
+/// and pre-fetches the Parquet footer (which sits at the end of the file)
+/// in the same round-trip — eliminating a separate HEAD request per file.
+/// The fetched tail is retained and serves any subsequent read that falls
+/// entirely within it.
+///
+/// This class is unaware of [RangeBacking]. Under
+/// [RangeBacking#SPARSE_TEMPFILE] the mmap-backed range cache wraps an
+/// instance of this class, so cache hits never reach here and the
+/// counters keep reporting network traffic only.
+///
+/// Thread-safe once [#open()] has been called.
+final class S3Fetcher implements InputFile {
+
+    private static final System.Logger LOG = System.getLogger(S3Fetcher.class.getName());
+
+    /// Number of bytes to fetch from the tail of the file during [#open()].
+    /// Sized so that the round-trip discovering the file length usually
+    /// carries the Parquet footer with it, saving a second request.
+    ///
+    /// A cost heuristic, not an assumption about file layout. Footer size
+    /// grows with row groups × columns and with the size of the per-column
+    /// statistics, so wide schemas, heavily split files, or long min/max
+    /// values can push it past 64 KB. A footer that does not fit is read by
+    /// a second range request: [#readRange] serves only reads fully
+    /// contained in the fetched tail and goes to the network otherwise.
+    static final int TAIL_SIZE = 64 * 1024;
+
+    private final S3Api api;
+    private final String bucket;
+    private final String key;
+    private long fileLength = -1;
+    private ByteBuffer tailCache;
+    private long tailCacheOffset;
+    private final AtomicLong networkRequestCount = new AtomicLong();
+    private final AtomicLong networkBytesFetched = new AtomicLong();
+
+    S3Fetcher(S3Api api, String bucket, String key) {
+        this.api = api;
+        this.bucket = bucket;
+        this.key = key;
+    }
+
+    @Override
+    public void open() throws IOException {
+        if (fileLength >= 0) {
+            return;
+        }
+        String suffixRange = "bytes=-" + TAIL_SIZE;
+        HttpResponse<byte[]> response = api.getBytes(bucket, key, suffixRange);
+        int status = response.statusCode();
+        if (status != 206 && status != 200) {
+            throw new IOException("Failed to open " + name()
+                    + ": HTTP " + status + " " + new String(response.body()));
+        }
+        fileLength = parseFileLength(response);
+        byte[] tail = response.body();
+        long requestNo = networkRequestCount.incrementAndGet();
+        long totalBytes = networkBytesFetched.addAndGet(tail.length);
+        // Use a direct buffer so slices are usable from FFM-based decompressors
+        // (e.g. libdeflate), which require native MemorySegments.
+        tailCache = ByteBuffer.allocateDirect(tail.length);
+        tailCache.put(tail);
+        tailCache.flip();
+        tailCacheOffset = fileLength - tail.length;
+        logFetch("open-tail", tailCacheOffset, tail.length, requestNo, totalBytes);
+    }
+
+    @Override
+    public ByteBuffer readRange(long offset, int length) throws IOException {
+        // Serve from the tail cache if the requested range falls within it
+        if (tailCache != null && offset >= tailCacheOffset
+                && offset + length <= tailCacheOffset + tailCache.capacity()) {
+            int relOffset = Math.toIntExact(offset - tailCacheOffset);
+            LOG.log(System.Logger.Level.DEBUG,
+                    "[{0}] readRange offset={1} length={2} reason={3} (tail cache hit)",
+                    name(), offset, length, FetchReason.current());
+            return tailCache.slice(relOffset, length);
+        }
+
+        long requestNo = networkRequestCount.incrementAndGet();
+        long totalBytes = networkBytesFetched.addAndGet(length);
+        logFetch(FetchReason.current(), offset, length, requestNo, totalBytes);
+        String range = "bytes=" + offset + "-" + (offset + length - 1);
+        HttpResponse<InputStream> response = api.getStream(bucket, key, range);
+        int status = response.statusCode();
+        if (status != 206 && status != 200) {
+            try (InputStream body = response.body()) {
+                throw new IOException("Failed to read range [" + offset + ", " + (offset + length)
+                        + ") from " + name() + ": HTTP " + status + " " + new String(body.readAllBytes()));
+            }
+        }
+        try (InputStream stream = response.body()) {
+            ByteBuffer buf = ByteBuffer.allocateDirect(length);
+            byte[] tmp = new byte[Math.min(8192, length)];
+            while (buf.hasRemaining()) {
+                int toRead = Math.min(tmp.length, buf.remaining());
+                int read = stream.read(tmp, 0, toRead);
+                if (read < 0) {
+                    break;
+                }
+                buf.put(tmp, 0, read);
+            }
+            if (buf.position() != length) {
+                throw new IOException("Short read from " + name() + ": expected " + length
+                        + " bytes but received " + buf.position());
+            }
+            buf.flip();
+            return buf;
+        }
+    }
+
+    @Override
+    public long length() {
+        if (fileLength < 0) {
+            throw new IllegalStateException("File not opened: " + name());
+        }
+        return fileLength;
+    }
+
+    @Override
+    public String name() {
+        return "s3://" + bucket + "/" + key;
+    }
+
+    /// No-op: the fetcher holds no per-file resources. The [S3Api] and its
+    /// [java.net.http.HttpClient] are owned by the [S3Source] and outlive
+    /// individual files.
+    @Override
+    public void close() {
+    }
+
+    /// Number of HTTP requests issued against the object since [#open()].
+    long networkRequestCount() {
+        return networkRequestCount.get();
+    }
+
+    /// Number of bytes fetched from the network since [#open()].
+    long networkBytesFetched() {
+        return networkBytesFetched.get();
+    }
+
+    /// Emits a single FINE log line per network fetch carrying the byte
+    /// range, the [FetchReason] tag attributed to the caller, and the
+    /// running per-file totals. Designed to be greppable: one line per
+    /// fetch, no nested structure.
+    ///
+    /// Logged at `System.Logger.Level.DEBUG`, which the platform logger
+    /// finder maps to JUL `Level.FINE` — `DiveCommand` configures the
+    /// JUL handler at `Level.FINE`, so a refactor that lowers the level
+    /// here would silently drop dive's `--log-file` output.
+    private void logFetch(String reason, long offset, int length, long requestNo, long totalBytes) {
+        LOG.log(System.Logger.Level.DEBUG,
+                "[{0}] fetch #{1} reason={2} offset={3} length={4} range=[{3},{5}) totalBytes={6}",
+                name(), requestNo, reason, offset, length, offset + length, totalBytes);
+    }
+
+    /// Extracts the total file length from the HTTP response.
+    ///
+    /// For suffix-range requests, S3 returns a `Content-Range` header like
+    /// `bytes 1000-1999/2000` where the number after `/` is the total
+    /// object size. If the header is absent (e.g. file smaller than TAIL_SIZE),
+    /// falls back to `Content-Length`.
+    private static long parseFileLength(HttpResponse<?> response) throws IOException {
+        String contentRange = response.headers().firstValue("Content-Range").orElse(null);
+        if (contentRange != null) {
+            int slashIdx = contentRange.lastIndexOf('/');
+            if (slashIdx >= 0) {
+                try {
+                    return Long.parseLong(contentRange.substring(slashIdx + 1));
+                }
+                catch (NumberFormatException e) {
+                    throw new IOException("Failed to parse Content-Range header: " + contentRange, e);
+                }
+            }
+        }
+        return response.headers().firstValueAsLong("Content-Length")
+                .orElseThrow(() -> new IOException("Response missing both Content-Range and Content-Length headers"));
+    }
+}

--- a/s3/src/main/java/dev/hardwood/s3/S3InputFile.java
+++ b/s3/src/main/java/dev/hardwood/s3/S3InputFile.java
@@ -8,26 +8,24 @@
 package dev.hardwood.s3;
 
 import java.io.IOException;
-import java.io.InputStream;
-import java.net.http.HttpResponse;
 import java.nio.ByteBuffer;
-import java.nio.file.Path;
-import java.util.concurrent.atomic.AtomicLong;
 
 import dev.hardwood.InputFile;
-import dev.hardwood.internal.FetchReason;
 import dev.hardwood.internal.reader.RangeBackedInputFile;
-import dev.hardwood.s3.internal.S3Api;
 
 /// [InputFile] backed by an object in Amazon S3 (or an S3-compatible service).
 ///
-/// Each [#readRange] call issues a signed HTTP `GET` request with a
-/// byte-range header, so only the requested bytes are transferred.
+/// A [#readRange] call that cannot be answered locally issues a signed
+/// HTTP `GET` request with a byte-range header, so only the requested
+/// bytes are transferred.
 ///
 /// [#open()] uses a suffix-range GET instead of a HEAD request. This
 /// discovers the file length from the `Content-Range` response header
 /// and pre-fetches the Parquet footer (which sits at the end of the file) in
 /// the same round-trip — eliminating a separate HEAD request per file.
+/// Those tail bytes are retained for as long as the file is open, and a
+/// read falling entirely inside that window is answered from them
+/// without a request.
 ///
 /// When the owning [S3Source] is configured with
 /// [RangeBacking#SPARSE_TEMPFILE], an internal mmap-backed range cache
@@ -39,224 +37,61 @@ import dev.hardwood.s3.internal.S3Api;
 /// Thread-safe once [#open()] has been called.
 public class S3InputFile implements InputFile {
 
-    private static final System.Logger LOG = System.getLogger(S3InputFile.class.getName());
+    /// The S3 network path, retained so the counters report network
+    /// traffic only: under [RangeBacking#SPARSE_TEMPFILE] a cache hit is
+    /// served from the mapping and never reaches the fetcher.
+    private final S3Fetcher fetcher;
 
-    /// Number of bytes to fetch from the tail of the file during [#open()].
-    /// 64 KB is large enough to cover the Parquet footer in virtually all files
-    /// (footer + footer length + magic is typically a few KB).
-    static final int TAIL_SIZE = 64 * 1024;
-
-    private final S3Api api;
-    private final String bucket;
-    private final String key;
-    private long fileLength = -1;
-    private ByteBuffer tailCache;
-    private long tailCacheOffset;
-    private final AtomicLong networkRequestCount = new AtomicLong();
-    private final AtomicLong networkBytesFetched = new AtomicLong();
-    /// Non-null iff the owning [S3Source] was configured with
-    /// [RangeBacking#SPARSE_TEMPFILE]. Wraps a private adapter that
-    /// exposes the bare S3 fetch path, so cache hits don't re-enter
-    /// [#readRange] (and thus don't double-count network counters).
-    private final RangeBackedInputFile cache;
+    /// What the [InputFile] methods delegate to: either [#fetcher]
+    /// itself, or the range cache wrapping it. Chosen once at
+    /// construction, so the read path carries no per-call dispatch.
+    private final InputFile impl;
 
     S3InputFile(S3Source source, String bucket, String key) {
-        this.api = source.api();
-        this.bucket = bucket;
-        this.key = key;
-        Path tempDir = source.rangeBacking() == RangeBacking.SPARSE_TEMPFILE
-                ? source.tempDir()
-                : null;
-        this.cache = tempDir != null ? new RangeBackedInputFile(new BareFetcher(), tempDir) : null;
+        this.fetcher = new S3Fetcher(source.api(), bucket, key);
+        this.impl = source.rangeBacking() == RangeBacking.SPARSE_TEMPFILE
+                ? new RangeBackedInputFile(fetcher, source.tempDir())
+                : fetcher;
     }
 
     @Override
     public void open() throws IOException {
-        if (cache != null) {
-            cache.open();
-            return;
-        }
-        openBare();
+        impl.open();
     }
 
     @Override
     public ByteBuffer readRange(long offset, int length) throws IOException {
-        if (cache != null) {
-            return cache.readRange(offset, length);
-        }
-        return readRangeBare(offset, length);
-    }
-
-    private void openBare() throws IOException {
-        if (fileLength >= 0) {
-            return;
-        }
-        String suffixRange = "bytes=-" + TAIL_SIZE;
-        HttpResponse<byte[]> response = api.getBytes(bucket, key, suffixRange);
-        int status = response.statusCode();
-        if (status != 206 && status != 200) {
-            throw new IOException("Failed to open " + name()
-                    + ": HTTP " + status + " " + new String(response.body()));
-        }
-        fileLength = parseFileLength(response);
-        byte[] tail = response.body();
-        long requestNo = networkRequestCount.incrementAndGet();
-        long totalBytes = networkBytesFetched.addAndGet(tail.length);
-        // Use a direct buffer so slices are usable from FFM-based decompressors
-        // (e.g. libdeflate), which require native MemorySegments.
-        tailCache = ByteBuffer.allocateDirect(tail.length);
-        tailCache.put(tail);
-        tailCache.flip();
-        tailCacheOffset = fileLength - tail.length;
-        logFetch("open-tail", tailCacheOffset, tail.length, requestNo, totalBytes);
-    }
-
-    private ByteBuffer readRangeBare(long offset, int length) throws IOException {
-        // Serve from the tail cache if the requested range falls within it
-        if (tailCache != null && offset >= tailCacheOffset
-                && offset + length <= tailCacheOffset + tailCache.capacity()) {
-            int relOffset = Math.toIntExact(offset - tailCacheOffset);
-            LOG.log(System.Logger.Level.DEBUG,
-                    "[{0}] readRange offset={1} length={2} reason={3} (tail cache hit)",
-                    name(), offset, length, FetchReason.current());
-            return tailCache.slice(relOffset, length);
-        }
-
-        long requestNo = networkRequestCount.incrementAndGet();
-        long totalBytes = networkBytesFetched.addAndGet(length);
-        logFetch(FetchReason.current(), offset, length, requestNo, totalBytes);
-        String range = "bytes=" + offset + "-" + (offset + length - 1);
-        HttpResponse<InputStream> response = api.getStream(bucket, key, range);
-        int status = response.statusCode();
-        if (status != 206 && status != 200) {
-            try (InputStream body = response.body()) {
-                throw new IOException("Failed to read range [" + offset + ", " + (offset + length)
-                        + ") from " + name() + ": HTTP " + status + " " + new String(body.readAllBytes()));
-            }
-        }
-        try (InputStream stream = response.body()) {
-            ByteBuffer buf = ByteBuffer.allocateDirect(length);
-            byte[] tmp = new byte[Math.min(8192, length)];
-            while (buf.hasRemaining()) {
-                int toRead = Math.min(tmp.length, buf.remaining());
-                int read = stream.read(tmp, 0, toRead);
-                if (read < 0) {
-                    break;
-                }
-                buf.put(tmp, 0, read);
-            }
-            if (buf.position() != length) {
-                throw new IOException("Short read from " + name() + ": expected " + length
-                        + " bytes but received " + buf.position());
-            }
-            buf.flip();
-            return buf;
-        }
+        return impl.readRange(offset, length);
     }
 
     @Override
-    public long length() {
-        if (fileLength < 0) {
-            throw new IllegalStateException("File not opened: " + name());
-        }
-        return fileLength;
+    public long length() throws IOException {
+        return impl.length();
     }
 
     @Override
     public String name() {
-        return "s3://" + bucket + "/" + key;
+        return impl.name();
     }
 
     @Override
     public void close() throws IOException {
-        if (cache != null) {
-            cache.close();
-        }
+        impl.close();
     }
 
     /// Number of HTTP requests issued against the object since [#open()].
     /// Counts the suffix-range tail fetch from `open` plus every
-    /// network-fetch [#readRange] call. Tail-cache hits do not count.
+    /// network-fetch [#readRange] call. Tail-cache and range-cache hits
+    /// do not count.
     public long networkRequestCount() {
-        return networkRequestCount.get();
+        return fetcher.networkRequestCount();
     }
 
     /// Number of bytes fetched from the network since [#open()]. The tail
     /// fetch from `open` contributes its actual response size; each
     /// network-fetch [#readRange] contributes the requested length.
-    /// Tail-cache hits do not count.
+    /// Tail-cache and range-cache hits do not count.
     public long networkBytesFetched() {
-        return networkBytesFetched.get();
-    }
-
-    /// Emits a single FINE log line per network fetch carrying the byte
-    /// range, the [FetchReason] tag attributed to the caller, and the
-    /// running per-file totals. Designed to be greppable: one line per
-    /// fetch, no nested structure.
-    ///
-    /// Logged at `System.Logger.Level.DEBUG`, which the platform logger
-    /// finder maps to JUL `Level.FINE` — `DiveCommand` configures the
-    /// JUL handler at `Level.FINE`, so a refactor that lowers the level
-    /// here would silently drop dive's `--log-file` output.
-    private void logFetch(String reason, long offset, int length, long requestNo, long totalBytes) {
-        LOG.log(System.Logger.Level.DEBUG,
-                "[{0}] fetch #{1} reason={2} offset={3} length={4} range=[{3},{5}) totalBytes={6}",
-                name(), requestNo, reason, offset, length, offset + length, totalBytes);
-    }
-
-    /// Extracts the total file length from the HTTP response.
-    ///
-    /// For suffix-range requests, S3 returns a `Content-Range` header like
-    /// `bytes 1000-1999/2000` where the number after `/` is the total
-    /// object size. If the header is absent (e.g. file smaller than TAIL_SIZE),
-    /// falls back to `Content-Length`.
-    private static long parseFileLength(HttpResponse<?> response) throws IOException {
-        String contentRange = response.headers().firstValue("Content-Range").orElse(null);
-        if (contentRange != null) {
-            int slashIdx = contentRange.lastIndexOf('/');
-            if (slashIdx >= 0) {
-                try {
-                    return Long.parseLong(contentRange.substring(slashIdx + 1));
-                }
-                catch (NumberFormatException e) {
-                    throw new IOException("Failed to parse Content-Range header: " + contentRange, e);
-                }
-            }
-        }
-        return response.headers().firstValueAsLong("Content-Length")
-                .orElseThrow(() -> new IOException("Response missing both Content-Range and Content-Length headers"));
-    }
-
-    /// Bare-fetch adapter handed to the [RangeBackedInputFile] cache so
-    /// the cache delegates back into the enclosing [S3InputFile]'s
-    /// network path *without* recursing through [#readRange] (which
-    /// would short-circuit to the cache again). The adapter's
-    /// [#close()] is a no-op because the enclosing instance owns no
-    /// per-file resources to release.
-    private final class BareFetcher implements InputFile {
-
-        @Override
-        public void open() throws IOException {
-            openBare();
-        }
-
-        @Override
-        public ByteBuffer readRange(long offset, int length) throws IOException {
-            return readRangeBare(offset, length);
-        }
-
-        @Override
-        public long length() {
-            return S3InputFile.this.length();
-        }
-
-        @Override
-        public String name() {
-            return S3InputFile.this.name();
-        }
-
-        @Override
-        public void close() {
-        }
+        return fetcher.networkBytesFetched();
     }
 }

--- a/s3/src/main/java/dev/hardwood/s3/S3Source.java
+++ b/s3/src/main/java/dev/hardwood/s3/S3Source.java
@@ -10,6 +10,7 @@ package dev.hardwood.s3;
 import java.io.Closeable;
 import java.net.URI;
 import java.net.http.HttpClient;
+import java.nio.file.Files;
 import java.nio.file.Path;
 import java.time.Duration;
 import java.util.ArrayList;
@@ -221,6 +222,9 @@ public final class S3Source implements Closeable {
         /// for the sparse-file backing. Defaults to the JVM's
         /// `java.io.tmpdir`. Ignored when range backing is
         /// [RangeBacking#NONE].
+        ///
+        /// Under [RangeBacking#SPARSE_TEMPFILE] the directory must exist
+        /// and be writeable; [#build()] rejects it otherwise.
         public Builder tempDir(Path tempDir) {
             this.tempDir = Objects.requireNonNull(tempDir, "tempDir must not be null");
             return this;
@@ -252,7 +256,24 @@ public final class S3Source implements Closeable {
             Path effectiveTempDir = tempDir != null
                     ? tempDir
                     : Path.of(System.getProperty("java.io.tmpdir"));
+            if (rangeBacking == RangeBacking.SPARSE_TEMPFILE) {
+                requireUsableTempDir(effectiveTempDir);
+            }
             return new S3Source(api, client, externalClient, rangeBacking, effectiveTempDir);
+        }
+
+        /// Rejects a temp directory that [RangeBacking#SPARSE_TEMPFILE]
+        /// could not create its backing file in, so the misconfiguration
+        /// surfaces here rather than at the first [S3InputFile#open()].
+        private static void requireUsableTempDir(Path dir) {
+            if (!Files.isDirectory(dir)) {
+                throw new IllegalStateException("tempDir does not exist or is not a directory: " + dir
+                        + " (required by RangeBacking.SPARSE_TEMPFILE)");
+            }
+            if (!Files.isWritable(dir)) {
+                throw new IllegalStateException("tempDir is not writeable: " + dir
+                        + " (required by RangeBacking.SPARSE_TEMPFILE)");
+            }
         }
     }
 }

--- a/s3/src/test/java/dev/hardwood/s3/S3SourceTempDirValidationTest.java
+++ b/s3/src/test/java/dev/hardwood/s3/S3SourceTempDirValidationTest.java
@@ -1,0 +1,64 @@
+/*
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Copyright The original authors
+ *
+ *  Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package dev.hardwood.s3;
+
+import java.nio.file.Path;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/// Tests that [S3Source.Builder#build()] rejects a temp directory the
+/// [RangeBacking#SPARSE_TEMPFILE] backing could not use, instead of
+/// deferring the failure to the first [S3InputFile#open()].
+class S3SourceTempDirValidationTest {
+
+    @TempDir
+    Path tempDir;
+
+    @Test
+    void sparseTempFileRejectsMissingTempDir() {
+        Path missing = tempDir.resolve("does-not-exist");
+
+        assertThatThrownBy(() -> builder()
+                .rangeBacking(RangeBacking.SPARSE_TEMPFILE)
+                .tempDir(missing)
+                .build())
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessageContaining("tempDir does not exist")
+                .hasMessageContaining(missing.toString());
+    }
+
+    @Test
+    void sparseTempFileAcceptsExistingTempDir() {
+        assertThatCode(() -> builder()
+                .rangeBacking(RangeBacking.SPARSE_TEMPFILE)
+                .tempDir(tempDir)
+                .build()
+                .close())
+                .doesNotThrowAnyException();
+    }
+
+    @Test
+    void noneIgnoresMissingTempDir() {
+        assertThatCode(() -> builder()
+                .tempDir(tempDir.resolve("does-not-exist"))
+                .build()
+                .close())
+                .doesNotThrowAnyException();
+    }
+
+    private static S3Source.Builder builder() {
+        return S3Source.builder()
+                .endpoint("http://localhost:1234")
+                .pathStyle(true)
+                .credentials(S3Credentials.of("access", "secret"));
+    }
+}


### PR DESCRIPTION
Fixes #853. Also fixes #855 (second commit, docs-only).

## #853 — the split

Splits `S3InputFile` into two classes so the range cache genuinely wraps the S3 network path instead of being dispatched from inside it.

- **`S3Fetcher`** (package-private, new) — the network path: `S3Api` handle, bucket/key, the `open()` suffix-range tail fetch and its retained tail buffer, the two network counters, and the fetch logging. Has no awareness that a range cache exists.
- **`S3InputFile`** — a facade over a single `InputFile` chosen once in the constructor: the `S3Fetcher` under `RangeBacking.NONE`, or a `RangeBackedInputFile` wrapping it under `RangeBacking.SPARSE_TEMPFILE`. Every `InputFile` method delegates to it unconditionally, so the read path has no `if (cache != null)` branch. It keeps a direct `S3Fetcher` reference for one purpose: `networkRequestCount()` / `networkBytesFetched()` report network-only traffic under either backing, because a cache hit never reaches the fetcher and so cannot be counted.
- **`BareFetcher` deleted** — the inner-class re-entrancy adapter existed only to let the cache reach the network path without recursing through `readRange()`. With the split there is nothing to re-enter.
- **`RangeBackedInputFile.delegate()` and `isPopulated()` removed** — both were declared for test/diagnostic use and neither ever acquired a caller. The construct that motivated `delegate()` is gone, and the cache's behaviour is asserted through the network counters rather than by inspecting its populated set.

The composition direction from #560 is unchanged: `S3Source.inputFile(...)` still returns `S3InputFile`, so `docs/content/how-to/s3.md`, `reference/packages.md`, the external `hardwood-examples` usage, and `ParquetModel#netStats()`'s `instanceof S3InputFile` all keep working.

### `length()` now declares `IOException`

`InputFile#length()` declares `throws IOException`; `S3InputFile#length()` did not. Omitting it constrained every implementation reachable through the facade to determine the length without I/O — an accident of how `S3InputFile` happened to be written, not something the contract guarantees. It now delegates like every other method and declares the exception.

This is source-incompatible for a caller that holds an `S3InputFile` statically *and* calls `length()` outside an `IOException`-handling context. No caller in this repository is affected — `ParquetModel`, the CLI, the tests, and `parquet-java-compat` all go through `InputFile`, which already declares it. Binary compatibility is unaffected.

### Design doc

`_designs/REMOTE_RANGE_BACKING.md` was still `Status: Proposed` and described a shape that was never shipped. Reconciled with the implementation: status set to Completed, a **Class layout** section added, the tail cache corrected (it lives in the fetcher one layer *below* the range cache, not "a trivial special case of the general flow"), the concurrency section corrected (the instance monitor deduplicates in-flight fetches; there is no `ConcurrentHashMap<Range, CompletableFuture<Void>>`), and the testing section replaced with the tests that actually exist. The "Estimated effort" section was dropped as development-process commentary.

## #855 — the docs gap it surfaced

`rangeBacking(RangeBacking)` and `tempDir(Path)` have been public builder options since #373 with no mention anywhere under `docs/content/`. Second commit adds:

- Rows for both options in the `S3Source` builder-options table.
- A **Footer pre-fetch** section. The counter semantics already spoke of "tail-cache hits" without the page ever defining a tail cache, and the 64 KB pre-fetch is observable — it decides which reads cost a request — so it is now described as behaviour (`open()` GETs the last 64 KB, keeps them, answers reads inside that window without a request) and the internal name is gone from the page.
- A **Range backing** section: what each enum value does, and the three properties that decide whether `SPARSE_TEMPFILE` is usable — footprint tracks bytes fetched rather than file size, files above 2 GB are rejected at `open()`, and the temp directory must exist and be writeable.
- Counter bullets now exclude cache-served reads under `SPARSE_TEMPFILE`, not just footer-window reads.
- `RangeBacking` added to the `dev.hardwood.s3` type list in `reference/packages.md`.

Reference only — the opt-in is a single builder call, so no how-to or tutorial page is warranted.

## Verification

Acceptance criterion from #853 is that the existing tests pass unchanged — no test file is touched by this PR.

- `./mvnw -pl s3 verify` — 146 tests, all green (`S3InputFileTest` 10, `S3RangeBackingTest` 3, `S3SelectiveReadJfrTest` 10, `S3InputFileLargeFileTest`, `S3MultiFileTest`, …)
- `./mvnw -pl core test -Dtest='RangeBackedInputFileTest,RangeSetTest'` — 16 tests, green
- `cli`, `parquet-java-compat`, `avro` and `integration-test` compile against the changed signature without modification