### PR TITLE
#856 Expose ColumnMetaData.encoding_stats on the public metadata API 

### DIFF
--- a/cli/src/main/java/dev/hardwood/cli/command/InspectPagesCommand.java
+++ b/cli/src/main/java/dev/hardwood/cli/command/InspectPagesCommand.java
@@ -35,6 +35,7 @@ import dev.hardwood.metadata.ColumnIndex;
 import dev.hardwood.metadata.ColumnMetaData;
 import dev.hardwood.metadata.FileMetaData;
 import dev.hardwood.metadata.OffsetIndex;
+import dev.hardwood.metadata.PageType;
 import dev.hardwood.metadata.RowGroup;
 import dev.hardwood.metadata.Statistics;
 import dev.hardwood.reader.ParquetFileReader;
@@ -403,7 +404,7 @@ public class InspectPagesCommand implements Command<CommandInvocation> {
             PageHeader header = PageHeaderReader.read(headerReader);
             int headerSize = headerReader.getBytesRead();
 
-            boolean isDictionary = header.type() == PageHeader.PageType.DICTIONARY_PAGE;
+            boolean isDictionary = header.type() == PageType.DICTIONARY_PAGE;
             String label = isDictionary ? "dict" : String.valueOf(pageIndex);
             Long firstRowIndex = null;
             Statistics inlineStats = null;
@@ -425,7 +426,7 @@ public class InspectPagesCommand implements Command<CommandInvocation> {
                     inlineStats
             ));
 
-            if (header.type() == PageHeader.PageType.DATA_PAGE || header.type() == PageHeader.PageType.DATA_PAGE_V2) {
+            if (header.type() == PageType.DATA_PAGE || header.type() == PageType.DATA_PAGE_V2) {
                 valuesRead += numValues(header);
                 pageIndex++;
                 if (valuesRead >= cmd.numValues()) {
@@ -449,16 +450,17 @@ public class InspectPagesCommand implements Command<CommandInvocation> {
                 DataPageHeaderV2 dp = header.dataPageHeaderV2();
                 yield dp != null ? dp.statistics() : null;
             }
-            case DICTIONARY_PAGE, INDEX_PAGE -> null;
+            case DICTIONARY_PAGE, INDEX_PAGE, UNKNOWN -> null;
         };
     }
 
-    private static String shortType(PageHeader.PageType type) {
+    private static String shortType(PageType type) {
         return switch (type) {
             case DATA_PAGE -> "DATA";
             case DATA_PAGE_V2 -> "DATA_V2";
             case DICTIONARY_PAGE -> "DICT";
             case INDEX_PAGE -> "INDEX";
+            case UNKNOWN -> "UNKNOWN";
         };
     }
 
@@ -467,7 +469,7 @@ public class InspectPagesCommand implements Command<CommandInvocation> {
             case DATA_PAGE -> shortEncoding(header.dataPageHeader().encoding().name());
             case DATA_PAGE_V2 -> shortEncoding(header.dataPageHeaderV2().encoding().name());
             case DICTIONARY_PAGE -> shortEncoding(header.dictionaryPageHeader().encoding().name());
-            case INDEX_PAGE -> "N/A";
+            case INDEX_PAGE, UNKNOWN -> "N/A";
         };
     }
 
@@ -484,7 +486,7 @@ public class InspectPagesCommand implements Command<CommandInvocation> {
             case DATA_PAGE -> header.dataPageHeader().numValues();
             case DATA_PAGE_V2 -> header.dataPageHeaderV2().numValues();
             case DICTIONARY_PAGE -> header.dictionaryPageHeader().numValues();
-            case INDEX_PAGE -> 0;
+            case INDEX_PAGE, UNKNOWN -> 0;
         };
     }
 }

--- a/cli/src/main/java/dev/hardwood/cli/dive/internal/PagesScreen.java
+++ b/cli/src/main/java/dev/hardwood/cli/dive/internal/PagesScreen.java
@@ -23,6 +23,7 @@ import dev.hardwood.internal.metadata.PageHeader;
 import dev.hardwood.metadata.ColumnIndex;
 import dev.hardwood.metadata.OffsetIndex;
 import dev.hardwood.metadata.PageLocation;
+import dev.hardwood.metadata.PageType;
 import dev.hardwood.metadata.Statistics;
 import dev.hardwood.schema.ColumnSchema;
 import dev.tamboui.buffer.Buffer;
@@ -62,7 +63,7 @@ public final class PagesScreen {
         // on a data page.
         boolean onDataPage = !headers.isEmpty()
                 && state.selection() < headers.size()
-                && headers.get(state.selection()).type() != PageHeader.PageType.DICTIONARY_PAGE;
+                && headers.get(state.selection()).type() != PageType.DICTIONARY_PAGE;
         if (event.code() == dev.tamboui.tui.event.KeyCode.CHAR && event.character() == 't'
                 && !event.hasCtrl() && !event.hasAlt() && onDataPage) {
             stack.replaceTop(new ScreenState.Pages(
@@ -131,7 +132,7 @@ public final class PagesScreen {
         // anywhere (no ColumnIndex AND no inline statistics on any page). Every
         // row would be "—" otherwise, pure visual noise.
         boolean hasAnyStats = columnIndex != null || headers.stream()
-                .anyMatch(h -> h.type() != PageHeader.PageType.DICTIONARY_PAGE && inlineStats(h) != null);
+                .anyMatch(h -> h.type() != PageType.DICTIONARY_PAGE && inlineStats(h) != null);
         // Build Row objects only for the visible window — see RowWindow.
         RowWindow window = RowWindow.from(state.scrollTop(), state.selection(),
                 headers.size(), area.height() - 3);
@@ -140,7 +141,7 @@ public final class PagesScreen {
         // by counting non-dict pages in the skipped prefix.
         int dataPageIdx = 0;
         for (int i = 0; i < window.start(); i++) {
-            if (headers.get(i).type() != PageHeader.PageType.DICTIONARY_PAGE) {
+            if (headers.get(i).type() != PageType.DICTIONARY_PAGE) {
                 dataPageIdx++;
             }
         }
@@ -153,7 +154,7 @@ public final class PagesScreen {
             String nulls = "—";
             int values;
             String uncompressed = Sizes.format(h.uncompressedPageSize());
-            if (h.type() == PageHeader.PageType.DICTIONARY_PAGE) {
+            if (h.type() == PageType.DICTIONARY_PAGE) {
                 DictionaryPageHeader dph = h.dictionaryPageHeader();
                 values = dph != null ? dph.numValues() : 0;
             }
@@ -275,7 +276,7 @@ public final class PagesScreen {
         // DICTIONARY_PAGE row.
         boolean onDataPage = count > 0
                 && state.selection() < count
-                && headers.get(state.selection()).type() != PageHeader.PageType.DICTIONARY_PAGE;
+                && headers.get(state.selection()).type() != PageType.DICTIONARY_PAGE;
         boolean hasLogical = col.logicalType() != null && onDataPage;
         return new Keys.Hints()
                 .add(count > 1, "[↑↓] move")
@@ -391,7 +392,7 @@ public final class PagesScreen {
         lines.add(Line.empty());
         // Dictionary pages have no inline stats — `t` is a no-op even
         // when the column carries a logical type, so suppress the hint.
-        boolean onDataPage = header.type() != PageHeader.PageType.DICTIONARY_PAGE;
+        boolean onDataPage = header.type() != PageType.DICTIONARY_PAGE;
         boolean hasLogical = col.logicalType() != null && onDataPage;
         String hint = " Esc / Enter close" + (hasLogical ? " · t logical types" : "");
         lines.add(Line.from(new Span(hint, Theme.dim())));

--- a/core/src/main/java/dev/hardwood/internal/metadata/PageHeader.java
+++ b/core/src/main/java/dev/hardwood/internal/metadata/PageHeader.java
@@ -7,6 +7,8 @@
  */
 package dev.hardwood.internal.metadata;
 
+import dev.hardwood.metadata.PageType;
+
 /// Header for a page in Parquet.
 public record PageHeader(
         PageType type,
@@ -16,26 +18,4 @@ public record PageHeader(
         DataPageHeaderV2 dataPageHeaderV2,
         DictionaryPageHeader dictionaryPageHeader,
         Integer crc) {
-
-    public enum PageType {
-        DATA_PAGE(0),
-        INDEX_PAGE(1),
-        DICTIONARY_PAGE(2),
-        DATA_PAGE_V2(3);
-
-        private final int thriftValue;
-
-        PageType(int thriftValue) {
-            this.thriftValue = thriftValue;
-        }
-
-        public static PageType fromThriftValue(int value) {
-            for (PageType type : values()) {
-                if (type.thriftValue == value) {
-                    return type;
-                }
-            }
-            throw new IllegalArgumentException("Unknown page type: " + value);
-        }
-    }
 }

--- a/core/src/main/java/dev/hardwood/internal/reader/DictionaryParser.java
+++ b/core/src/main/java/dev/hardwood/internal/reader/DictionaryParser.java
@@ -16,6 +16,7 @@ import dev.hardwood.internal.thrift.PageHeaderReader;
 import dev.hardwood.internal.thrift.ThriftCompactReader;
 import dev.hardwood.metadata.ColumnMetaData;
 import dev.hardwood.metadata.CompressionCodec;
+import dev.hardwood.metadata.PageType;
 import dev.hardwood.schema.ColumnSchema;
 
 /// Parses dictionary pages from column chunk data.
@@ -39,7 +40,7 @@ public final class DictionaryParser {
         ThriftCompactReader probeReader = new ThriftCompactReader(dictRegion, 0);
         PageHeader header = PageHeaderReader.read(probeReader);
 
-        if (header.type() != PageHeader.PageType.DICTIONARY_PAGE) {
+        if (header.type() != PageType.DICTIONARY_PAGE) {
             return null;
         }
 

--- a/core/src/main/java/dev/hardwood/internal/reader/PageFormatProbe.java
+++ b/core/src/main/java/dev/hardwood/internal/reader/PageFormatProbe.java
@@ -51,7 +51,7 @@ final class PageFormatProbe {
     /// oversize headers). The dictionary page, if any, is skipped over by
     /// reading at the column's `dataPageOffset` directly.
     static PageType firstDataPageType(InputFile inputFile,
-                                                  ColumnChunk columnChunk) throws IOException {
+                                      ColumnChunk columnChunk) throws IOException {
         long offset = columnChunk.metaData().dataPageOffset();
         long maxLength = columnChunk.metaData().totalCompressedSize();
         int peek = (int) Math.min(INITIAL_PEEK_SIZE, maxLength);

--- a/core/src/main/java/dev/hardwood/internal/reader/PageFormatProbe.java
+++ b/core/src/main/java/dev/hardwood/internal/reader/PageFormatProbe.java
@@ -16,6 +16,7 @@ import dev.hardwood.internal.metadata.PageHeader;
 import dev.hardwood.internal.thrift.PageHeaderReader;
 import dev.hardwood.internal.thrift.ThriftCompactReader;
 import dev.hardwood.metadata.ColumnChunk;
+import dev.hardwood.metadata.PageType;
 
 /// Reads just enough of a column chunk to identify its first data page's
 /// format (v1 vs v2). Used by the per-page mask gate in [RowGroupIterator] to
@@ -49,7 +50,7 @@ final class PageFormatProbe {
     /// most one bounded `readRange` from `inputFile` (with growth on EOF for
     /// oversize headers). The dictionary page, if any, is skipped over by
     /// reading at the column's `dataPageOffset` directly.
-    static PageHeader.PageType firstDataPageType(InputFile inputFile,
+    static PageType firstDataPageType(InputFile inputFile,
                                                   ColumnChunk columnChunk) throws IOException {
         long offset = columnChunk.metaData().dataPageOffset();
         long maxLength = columnChunk.metaData().totalCompressedSize();

--- a/core/src/main/java/dev/hardwood/internal/reader/RowGroupIterator.java
+++ b/core/src/main/java/dev/hardwood/internal/reader/RowGroupIterator.java
@@ -22,7 +22,6 @@ import java.util.concurrent.atomic.AtomicIntegerArray;
 import dev.hardwood.InputFile;
 import dev.hardwood.internal.ExceptionContext;
 import dev.hardwood.internal.FetchReason;
-import dev.hardwood.internal.metadata.PageHeader;
 import dev.hardwood.internal.predicate.PageDropPredicates;
 import dev.hardwood.internal.predicate.PageFilterEvaluator;
 import dev.hardwood.internal.predicate.ResolvedPredicate;
@@ -39,6 +38,7 @@ import dev.hardwood.metadata.FileMetaData;
 import dev.hardwood.metadata.LogicalType;
 import dev.hardwood.metadata.OffsetIndex;
 import dev.hardwood.metadata.PageLocation;
+import dev.hardwood.metadata.PageType;
 import dev.hardwood.metadata.PhysicalType;
 import dev.hardwood.metadata.RepetitionType;
 import dev.hardwood.metadata.RowGroup;
@@ -855,7 +855,7 @@ public class RowGroupIterator {
                 continue;
             }
             if (PageFormatProbe.firstDataPageType(inputFile, columnChunk)
-                    == PageHeader.PageType.DATA_PAGE_V2) {
+                    == PageType.DATA_PAGE_V2) {
                 continue;
             }
             return false;

--- a/core/src/main/java/dev/hardwood/internal/reader/SequentialFetchPlan.java
+++ b/core/src/main/java/dev/hardwood/internal/reader/SequentialFetchPlan.java
@@ -26,6 +26,7 @@ import dev.hardwood.internal.thrift.ThriftCompactReader;
 import dev.hardwood.jfr.RowGroupScannedEvent;
 import dev.hardwood.metadata.ColumnChunk;
 import dev.hardwood.metadata.ColumnMetaData;
+import dev.hardwood.metadata.PageType;
 import dev.hardwood.metadata.Statistics;
 import dev.hardwood.schema.ColumnSchema;
 
@@ -433,7 +434,7 @@ public final class SequentialFetchPlan implements FetchPlan, RowGroupIterator.Co
             PageHeader header = parsed.header();
             int headerSize = parsed.headerSize();
 
-            if (header.type() == PageHeader.PageType.DICTIONARY_PAGE) {
+            if (header.type() == PageType.DICTIONARY_PAGE) {
                 int compressedSize = header.compressedPageSize();
                 int numValues = header.dictionaryPageHeader().numValues();
                 if (numValues < 0) {
@@ -489,8 +490,8 @@ public final class SequentialFetchPlan implements FetchPlan, RowGroupIterator.Co
                 int headerSize = parsed.headerSize();
                 int totalPageSize = headerSize + header.compressedPageSize();
 
-                if (header.type() != PageHeader.PageType.DATA_PAGE
-                        && header.type() != PageHeader.PageType.DATA_PAGE_V2) {
+                if (header.type() != PageType.DATA_PAGE
+                        && header.type() != PageType.DATA_PAGE_V2) {
                     // DICTIONARY_PAGE or INDEX_PAGE — skip without emitting.
                     position += totalPageSize;
                     continue;
@@ -584,7 +585,7 @@ public final class SequentialFetchPlan implements FetchPlan, RowGroupIterator.Co
             if (columnSchema.maxRepetitionLevel() == 0) {
                 return numValues;
             }
-            if (header.type() != PageHeader.PageType.DATA_PAGE_V2) {
+            if (header.type() != PageType.DATA_PAGE_V2) {
                 throw new IllegalStateException("Per-page row masking on a nested column requires "
                         + "DATA_PAGE_V2 pages; column '" + columnSchema.name()
                         + "' has a v1 data page. The row-group-wide mask gate should have "
@@ -627,7 +628,7 @@ public final class SequentialFetchPlan implements FetchPlan, RowGroupIterator.Co
             return switch (header.type()) {
                 case DATA_PAGE -> header.dataPageHeader().numValues();
                 case DATA_PAGE_V2 -> header.dataPageHeaderV2().numValues();
-                case DICTIONARY_PAGE, INDEX_PAGE -> 0;
+                case DICTIONARY_PAGE, INDEX_PAGE, UNKNOWN -> 0;
             };
         }
 

--- a/core/src/main/java/dev/hardwood/internal/thrift/ColumnMetaDataReader.java
+++ b/core/src/main/java/dev/hardwood/internal/thrift/ColumnMetaDataReader.java
@@ -18,6 +18,7 @@ import dev.hardwood.metadata.CompressionCodec;
 import dev.hardwood.metadata.Encoding;
 import dev.hardwood.metadata.FieldPath;
 import dev.hardwood.metadata.GeospatialStatistics;
+import dev.hardwood.metadata.PageEncodingStats;
 import dev.hardwood.metadata.PhysicalType;
 import dev.hardwood.metadata.Statistics;
 
@@ -49,6 +50,7 @@ public class ColumnMetaDataReader {
         GeospatialStatistics geospatialStatistics = null;
         Long bloomFilterOffset = null;
         Integer bloomFilterLength = null;
+        List<PageEncodingStats> encodingStats = List.of();
 
         while (true) {
             ThriftCompactReader.FieldHeader header = reader.readFieldHeader();
@@ -154,6 +156,14 @@ public class ColumnMetaDataReader {
                         reader.skipField(header.type());
                     }
                     break;
+                case 13: // encoding_stats (optional list<PageEncodingStats>)
+                    if (header.type() == 0x09) { // LIST
+                        encodingStats = PageEncodingStatsReader.read(reader);
+                    }
+                    else {
+                        reader.skipField(header.type());
+                    }
+                    break;
                 case 14: // bloom_filter_offset (optional i64)
                     if (header.type() == 0x06) {
                         bloomFilterOffset = reader.readI64();
@@ -186,6 +196,7 @@ public class ColumnMetaDataReader {
 
         return new ColumnMetaData(type, encodings, new FieldPath(List.copyOf(pathInSchema)), codec,
                 numValues, totalUncompressedSize, totalCompressedSize, keyValueMetadata, dataPageOffset,
-                dictionaryPageOffset, statistics, geospatialStatistics, bloomFilterOffset, bloomFilterLength);
+                dictionaryPageOffset, statistics, geospatialStatistics, bloomFilterOffset, bloomFilterLength,
+                encodingStats);
     }
 }

--- a/core/src/main/java/dev/hardwood/internal/thrift/PageEncodingStatsReader.java
+++ b/core/src/main/java/dev/hardwood/internal/thrift/PageEncodingStatsReader.java
@@ -19,28 +19,56 @@ import dev.hardwood.metadata.PageType;
 
 /// Reads a Thrift-encoded `list<PageEncodingStats>` into an unmodifiable list: one entry per
 /// (page type, encoding) pair written in a column chunk.
+///
+/// The field is optional and purely informational, so no shape of it fails the footer read: a
+/// list that cannot be decoded as written is reported as absent (an empty list) and logged at
+/// WARNING. An empty list carries no such claim, since callers already handle writers that omit
+/// the field entirely.
 class PageEncodingStatsReader {
+
+    private static final System.Logger LOG = System.getLogger(PageEncodingStatsReader.class.getName());
 
     /// Reads an encoding stats list from the given reader, which must be positioned right after
     /// the list field header has been consumed (i.e. ready to read the list header).
+    ///
+    /// The reader is always left positioned on the byte after the list, so the rest of the
+    /// footer parses regardless of what this field contained.
     static List<PageEncodingStats> read(ThriftCompactReader reader) throws IOException {
         ThriftCompactReader.CollectionHeader listHeader = reader.readListHeader();
         // Elements are read as structs, so a list declaring anything else would have its value
-        // bytes misread as field headers.
+        // bytes misread as field headers. Skipping by the declared element type consumes it
+        // without that risk.
         if (listHeader.elementType() != Codes.STRUCT) {
-            throw new IOException("ColumnMetaData.encoding_stats has wrong Thrift element type 0x"
-                    + Integer.toHexString(listHeader.elementType() & 0xFF) + " (expected struct)");
+            for (int i = 0; i < listHeader.size(); i++) {
+                reader.skipField(listHeader.elementType());
+            }
+            LOG.log(System.Logger.Level.WARNING,
+                    "Ignoring ColumnMetaData.encoding_stats: wrong Thrift element type 0x"
+                            + Integer.toHexString(listHeader.elementType() & 0xFF) + " (expected struct)");
+            return List.of();
         }
         List<PageEncodingStats> result = new ArrayList<>(listHeader.size());
         for (int i = 0; i < listHeader.size(); i++) {
-            result.add(readStats(reader));
+            PageEncodingStats stats = readStats(reader);
+            if (stats != null) {
+                result.add(stats);
+            }
+        }
+        if (result.size() != listHeader.size()) {
+            LOG.log(System.Logger.Level.WARNING,
+                    "Ignoring ColumnMetaData.encoding_stats: " + (listHeader.size() - result.size())
+                            + " of " + listHeader.size() + " entries are missing a required field");
+            return List.of();
         }
         return Collections.unmodifiableList(result);
     }
 
     /// Reads a single PageEncodingStats Thrift struct (field 1: page_type, field 2: encoding,
-    /// field 3: count). All three are required by the format; a struct missing any of them, or
-    /// carrying one at the wrong wire type, is a malformed footer rather than an entry to drop.
+    /// field 3: count), all three required by the format and all three `i32`.
+    ///
+    /// Returns `null` for a struct that does not carry all three at that wire type, or whose
+    /// count is negative. The struct is consumed either way, leaving the reader on the next
+    /// element.
     private static PageEncodingStats readStats(ThriftCompactReader reader) throws IOException {
         short saved = reader.pushFieldIdContext();
         try {
@@ -53,43 +81,27 @@ class PageEncodingStatsReader {
                 if (header == null) {
                     break;
                 }
-
+                // Every field defined on this struct is an i32, so one wire-type gate covers
+                // all three: anything else is a field this version cannot use.
+                if (header.type() != Codes.I32) {
+                    reader.skipField(header.type());
+                    continue;
+                }
                 switch (header.fieldId()) {
-                    case 1: // page_type (required PageType)
-                        requireI32(header.type(), "page_type");
-                        pageType = ThriftEnumLookup.pageType(reader.readI32());
-                        break;
-                    case 2: // encoding (required Encoding)
-                        requireI32(header.type(), "encoding");
-                        encoding = ThriftEnumLookup.encoding(reader.readI32());
-                        break;
-                    case 3: // count (required i32)
-                        requireI32(header.type(), "count");
-                        count = reader.readNonNegativeI32("PageEncodingStats.count");
-                        break;
-                    default:
-                        reader.skipField(header.type());
-                        break;
+                    case 1 -> pageType = ThriftEnumLookup.pageType(reader.readI32());
+                    case 2 -> encoding = ThriftEnumLookup.encoding(reader.readI32());
+                    case 3 -> count = reader.readI32();
+                    default -> reader.skipField(Codes.I32);
                 }
             }
 
             if (pageType == null || encoding == null || count < 0) {
-                throw new IOException("PageEncodingStats missing required field(s):"
-                        + (pageType == null ? " page_type" : "")
-                        + (encoding == null ? " encoding" : "")
-                        + (count < 0 ? " count" : ""));
+                return null;
             }
             return new PageEncodingStats(pageType, encoding, count);
         }
         finally {
             reader.popFieldIdContext(saved);
-        }
-    }
-
-    private static void requireI32(byte type, String fieldName) throws IOException {
-        if (type != Codes.I32) {
-            throw new IOException("PageEncodingStats." + fieldName + " has wrong Thrift type 0x"
-                    + Integer.toHexString(type & 0xFF) + " (expected i32)");
         }
     }
 }

--- a/core/src/main/java/dev/hardwood/internal/thrift/PageEncodingStatsReader.java
+++ b/core/src/main/java/dev/hardwood/internal/thrift/PageEncodingStatsReader.java
@@ -9,6 +9,7 @@ package dev.hardwood.internal.thrift;
 
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 
 import dev.hardwood.internal.thrift.ThriftCompactConstants.FieldType.Codes;
@@ -34,7 +35,7 @@ class PageEncodingStatsReader {
         for (int i = 0; i < listHeader.size(); i++) {
             result.add(readStats(reader));
         }
-        return List.copyOf(result);
+        return Collections.unmodifiableList(result);
     }
 
     /// Reads a single PageEncodingStats Thrift struct (field 1: page_type, field 2: encoding,

--- a/core/src/main/java/dev/hardwood/internal/thrift/PageEncodingStatsReader.java
+++ b/core/src/main/java/dev/hardwood/internal/thrift/PageEncodingStatsReader.java
@@ -11,6 +11,7 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 
+import dev.hardwood.internal.thrift.ThriftCompactConstants.FieldType.Codes;
 import dev.hardwood.metadata.Encoding;
 import dev.hardwood.metadata.PageEncodingStats;
 import dev.hardwood.metadata.PageType;
@@ -19,12 +20,16 @@ import dev.hardwood.metadata.PageType;
 /// (page type, encoding) pair written in a column chunk.
 class PageEncodingStatsReader {
 
-    private static final byte TYPE_I32 = 0x05;
-
     /// Reads an encoding stats list from the given reader, which must be positioned right after
     /// the list field header has been consumed (i.e. ready to read the list header).
     static List<PageEncodingStats> read(ThriftCompactReader reader) throws IOException {
         ThriftCompactReader.CollectionHeader listHeader = reader.readListHeader();
+        // Elements are read as structs, so a list declaring anything else would have its value
+        // bytes misread as field headers.
+        if (listHeader.elementType() != Codes.STRUCT) {
+            throw new IOException("ColumnMetaData.encoding_stats has wrong Thrift element type 0x"
+                    + Integer.toHexString(listHeader.elementType() & 0xFF) + " (expected struct)");
+        }
         List<PageEncodingStats> result = new ArrayList<>(listHeader.size());
         for (int i = 0; i < listHeader.size(); i++) {
             result.add(readStats(reader));
@@ -81,7 +86,7 @@ class PageEncodingStatsReader {
     }
 
     private static void requireI32(byte type, String fieldName) throws IOException {
-        if (type != TYPE_I32) {
+        if (type != Codes.I32) {
             throw new IOException("PageEncodingStats." + fieldName + " has wrong Thrift type 0x"
                     + Integer.toHexString(type & 0xFF) + " (expected i32)");
         }

--- a/core/src/main/java/dev/hardwood/internal/thrift/PageEncodingStatsReader.java
+++ b/core/src/main/java/dev/hardwood/internal/thrift/PageEncodingStatsReader.java
@@ -1,0 +1,89 @@
+/*
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Copyright The original authors
+ *
+ *  Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package dev.hardwood.internal.thrift;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+
+import dev.hardwood.metadata.Encoding;
+import dev.hardwood.metadata.PageEncodingStats;
+import dev.hardwood.metadata.PageType;
+
+/// Reads a Thrift-encoded `list<PageEncodingStats>` into an unmodifiable list: one entry per
+/// (page type, encoding) pair written in a column chunk.
+class PageEncodingStatsReader {
+
+    private static final byte TYPE_I32 = 0x05;
+
+    /// Reads an encoding stats list from the given reader, which must be positioned right after
+    /// the list field header has been consumed (i.e. ready to read the list header).
+    static List<PageEncodingStats> read(ThriftCompactReader reader) throws IOException {
+        ThriftCompactReader.CollectionHeader listHeader = reader.readListHeader();
+        List<PageEncodingStats> result = new ArrayList<>(listHeader.size());
+        for (int i = 0; i < listHeader.size(); i++) {
+            result.add(readStats(reader));
+        }
+        return List.copyOf(result);
+    }
+
+    /// Reads a single PageEncodingStats Thrift struct (field 1: page_type, field 2: encoding,
+    /// field 3: count). All three are required by the format; a struct missing any of them, or
+    /// carrying one at the wrong wire type, is a malformed footer rather than an entry to drop.
+    private static PageEncodingStats readStats(ThriftCompactReader reader) throws IOException {
+        short saved = reader.pushFieldIdContext();
+        try {
+            PageType pageType = null;
+            Encoding encoding = null;
+            int count = -1;
+
+            while (true) {
+                ThriftCompactReader.FieldHeader header = reader.readFieldHeader();
+                if (header == null) {
+                    break;
+                }
+
+                switch (header.fieldId()) {
+                    case 1: // page_type (required PageType)
+                        requireI32(header.type(), "page_type");
+                        pageType = ThriftEnumLookup.pageType(reader.readI32());
+                        break;
+                    case 2: // encoding (required Encoding)
+                        requireI32(header.type(), "encoding");
+                        encoding = ThriftEnumLookup.encoding(reader.readI32());
+                        break;
+                    case 3: // count (required i32)
+                        requireI32(header.type(), "count");
+                        count = reader.readNonNegativeI32("PageEncodingStats.count");
+                        break;
+                    default:
+                        reader.skipField(header.type());
+                        break;
+                }
+            }
+
+            if (pageType == null || encoding == null || count < 0) {
+                throw new IOException("PageEncodingStats missing required field(s):"
+                        + (pageType == null ? " page_type" : "")
+                        + (encoding == null ? " encoding" : "")
+                        + (count < 0 ? " count" : ""));
+            }
+            return new PageEncodingStats(pageType, encoding, count);
+        }
+        finally {
+            reader.popFieldIdContext(saved);
+        }
+    }
+
+    private static void requireI32(byte type, String fieldName) throws IOException {
+        if (type != TYPE_I32) {
+            throw new IOException("PageEncodingStats." + fieldName + " has wrong Thrift type 0x"
+                    + Integer.toHexString(type & 0xFF) + " (expected i32)");
+        }
+    }
+}

--- a/core/src/main/java/dev/hardwood/internal/thrift/PageHeaderReader.java
+++ b/core/src/main/java/dev/hardwood/internal/thrift/PageHeaderReader.java
@@ -13,6 +13,7 @@ import dev.hardwood.internal.metadata.DataPageHeader;
 import dev.hardwood.internal.metadata.DataPageHeaderV2;
 import dev.hardwood.internal.metadata.DictionaryPageHeader;
 import dev.hardwood.internal.metadata.PageHeader;
+import dev.hardwood.metadata.PageType;
 
 /// Reader for PageHeader from Thrift Compact Protocol.
 public class PageHeaderReader {
@@ -28,7 +29,7 @@ public class PageHeaderReader {
     }
 
     private static PageHeader readInternal(ThriftCompactReader reader) throws IOException {
-        PageHeader.PageType type = null;
+        PageType type = null;
         int uncompressedPageSize = 0;
         int compressedPageSize = 0;
         Integer crc = null;
@@ -45,7 +46,12 @@ public class PageHeaderReader {
             switch (header.fieldId()) {
                 case 1: // type
                     if (header.type() == 0x05) {
-                        type = PageHeader.PageType.fromThriftValue(reader.readI32());
+                        int rawType = reader.readI32();
+                        type = ThriftEnumLookup.pageType(rawType);
+                        // A page whose header declares a type we do not know cannot be decoded.
+                        if (type == PageType.UNKNOWN) {
+                            throw new IOException("PageHeader has unknown page type: " + rawType);
+                        }
                     }
                     else {
                         reader.skipField(header.type());

--- a/core/src/main/java/dev/hardwood/internal/thrift/ThriftCompactReader.java
+++ b/core/src/main/java/dev/hardwood/internal/thrift/ThriftCompactReader.java
@@ -217,6 +217,13 @@ public class ThriftCompactReader {
     }
 
     /// Read a list/set header.
+    ///
+    /// A long-form element count is validated against the bytes still in the buffer. Every Thrift
+    /// element occupies at least one byte on the wire, so a count larger than the remainder cannot
+    /// describe real data. Callers that pre-size a collection from the count would otherwise turn
+    /// a five-byte varint into a multi-gigabyte allocation, and a count past the `int` range would
+    /// wrap to a negative capacity (an unchecked exception) or to zero (a silently empty
+    /// collection) instead of a controlled error naming the file.
     public CollectionHeader readListHeader() throws IOException {
         byte sizeAndType = readByte();
         int size = (sizeAndType >> 4) & 0x0F;
@@ -224,7 +231,12 @@ public class ThriftCompactReader {
 
         if (size == 15) {
             // Size is encoded separately
-            size = (int) readVarint();
+            long declaredSize = readVarint();
+            if (declaredSize < 0 || declaredSize > buffer.remaining()) {
+                throw new IOException("Malformed Parquet metadata: collection declares "
+                        + declaredSize + " elements but only " + buffer.remaining() + " bytes remain");
+            }
+            size = (int) declaredSize;
         }
 
         return new CollectionHeader(elementType, size);

--- a/core/src/main/java/dev/hardwood/internal/thrift/ThriftEnumLookup.java
+++ b/core/src/main/java/dev/hardwood/internal/thrift/ThriftEnumLookup.java
@@ -10,6 +10,7 @@ package dev.hardwood.internal.thrift;
 import dev.hardwood.metadata.CompressionCodec;
 import dev.hardwood.metadata.ConvertedType;
 import dev.hardwood.metadata.Encoding;
+import dev.hardwood.metadata.PageType;
 import dev.hardwood.metadata.PhysicalType;
 import dev.hardwood.metadata.RepetitionType;
 
@@ -27,6 +28,14 @@ class ThriftEnumLookup {
             PhysicalType.DOUBLE,                 // 5
             PhysicalType.BYTE_ARRAY,             // 6
             PhysicalType.FIXED_LEN_BYTE_ARRAY    // 7
+    };
+
+    // Indexed by Thrift value (0-3)
+    private static final PageType[] PAGE_TYPES = {
+            PageType.DATA_PAGE,        // 0
+            PageType.INDEX_PAGE,       // 1
+            PageType.DICTIONARY_PAGE,  // 2
+            PageType.DATA_PAGE_V2      // 3
     };
 
     // Indexed by Thrift value (0-2)
@@ -119,6 +128,13 @@ class ThriftEnumLookup {
             }
         }
         return Encoding.UNKNOWN;
+    }
+
+    static PageType pageType(int value) {
+        if (value >= 0 && value < PAGE_TYPES.length) {
+            return PAGE_TYPES[value];
+        }
+        return PageType.UNKNOWN;
     }
 
     static CompressionCodec compressionCodec(int value) {

--- a/core/src/main/java/dev/hardwood/internal/writer/ColumnChunkBuffer.java
+++ b/core/src/main/java/dev/hardwood/internal/writer/ColumnChunkBuffer.java
@@ -204,7 +204,9 @@ final class ColumnChunkBuffer implements RecordShredder.LevelSink {
                 values.statistics(),
                 null,
                 null,
-                null);
+                null,
+                // The writer does not emit encoding_stats yet.
+                List.of());
     }
 
     /// Seals the current page as a dictionary-indexed page and switches the rest of the chunk

--- a/core/src/main/java/dev/hardwood/metadata/ColumnMetaData.java
+++ b/core/src/main/java/dev/hardwood/metadata/ColumnMetaData.java
@@ -26,7 +26,7 @@ import java.util.Map;
 /// @param geospatialStatistics column chunk geospatial statistics (bounding box, geospatial types), or `null` if absent
 /// @param bloomFilterOffset file offset of the bloom filter for this column chunk, or `null` if absent
 /// @param bloomFilterLength length of the bloom filter in bytes, or `null` if absent
-/// @param encodingStats number of pages written per (page type, encoding) pair in this column chunk, or an empty list if absent
+/// @param encodingStats number of pages written per (page type, encoding) pair in this column chunk, or an empty list if the file omits the field or does not encode it as the format defines
 /// @see <a href="https://parquet.apache.org/docs/file-format/data-pages/columnchunks/">File Format – Column Chunks</a>
 /// @see <a href="https://github.com/apache/parquet-format/blob/master/src/main/thrift/parquet.thrift">parquet.thrift</a>
 public record ColumnMetaData(

--- a/core/src/main/java/dev/hardwood/metadata/ColumnMetaData.java
+++ b/core/src/main/java/dev/hardwood/metadata/ColumnMetaData.java
@@ -26,6 +26,7 @@ import java.util.Map;
 /// @param geospatialStatistics column chunk geospatial statistics (bounding box, geospatial types), or `null` if absent
 /// @param bloomFilterOffset file offset of the bloom filter for this column chunk, or `null` if absent
 /// @param bloomFilterLength length of the bloom filter in bytes, or `null` if absent
+/// @param encodingStats number of pages written per (page type, encoding) pair in this column chunk, or an empty list if absent
 /// @see <a href="https://parquet.apache.org/docs/file-format/data-pages/columnchunks/">File Format – Column Chunks</a>
 /// @see <a href="https://github.com/apache/parquet-format/blob/master/src/main/thrift/parquet.thrift">parquet.thrift</a>
 public record ColumnMetaData(
@@ -42,5 +43,6 @@ public record ColumnMetaData(
         Statistics statistics,
         GeospatialStatistics geospatialStatistics,
         Long bloomFilterOffset,
-        Integer bloomFilterLength) {
+        Integer bloomFilterLength,
+        List<PageEncodingStats> encodingStats) {
 }

--- a/core/src/main/java/dev/hardwood/metadata/PageEncodingStats.java
+++ b/core/src/main/java/dev/hardwood/metadata/PageEncodingStats.java
@@ -11,7 +11,9 @@ package dev.hardwood.metadata;
 /// column chunk.
 ///
 /// A chunk's full set of these is available from [ColumnMetaData#encodingStats()]; the field is
-/// optional in the format, so it may be absent.
+/// optional in the format, so it may be absent. When present it is complete: the counts account
+/// for every page in the chunk. A file that encodes the field in some other way than the format
+/// defines reads as absent rather than as a partial list.
 ///
 /// @param pageType the kind of page counted
 /// @param encoding the encoding those pages were written with

--- a/core/src/main/java/dev/hardwood/metadata/PageEncodingStats.java
+++ b/core/src/main/java/dev/hardwood/metadata/PageEncodingStats.java
@@ -1,0 +1,21 @@
+/*
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Copyright The original authors
+ *
+ *  Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package dev.hardwood.metadata;
+
+/// The number of pages a writer produced for one combination of page type and encoding within a
+/// column chunk.
+///
+/// A chunk's full set of these is available from [ColumnMetaData#encodingStats()]; the field is
+/// optional in the format, so it may be absent.
+///
+/// @param pageType the kind of page counted
+/// @param encoding the encoding those pages were written with
+/// @param count the number of pages written with this page type and encoding
+/// @see <a href="https://github.com/apache/parquet-format/blob/master/src/main/thrift/parquet.thrift">parquet.thrift</a>
+public record PageEncodingStats(PageType pageType, Encoding encoding, int count) {
+}

--- a/core/src/main/java/dev/hardwood/metadata/PageType.java
+++ b/core/src/main/java/dev/hardwood/metadata/PageType.java
@@ -1,0 +1,23 @@
+/*
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Copyright The original authors
+ *
+ *  Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package dev.hardwood.metadata;
+
+/// The kind of page stored in a column chunk.
+///
+/// @see <a href="https://parquet.apache.org/docs/file-format/data-pages/">File Format – Data Pages</a>
+/// @see <a href="https://github.com/apache/parquet-format/blob/master/src/main/thrift/parquet.thrift">parquet.thrift</a>
+public enum PageType {
+    DATA_PAGE,
+    INDEX_PAGE,
+    DICTIONARY_PAGE,
+    DATA_PAGE_V2,
+    /// Placeholder for a page type found in metadata that is not recognized.
+    /// Reported only through [ColumnMetaData#encodingStats()], whose counts are informational; a page whose own header declares an unrecognized type is
+    /// rejected when read, since it cannot be decoded.
+    UNKNOWN
+}

--- a/core/src/main/java/dev/hardwood/metadata/PageType.java
+++ b/core/src/main/java/dev/hardwood/metadata/PageType.java
@@ -12,12 +12,21 @@ package dev.hardwood.metadata;
 /// @see <a href="https://parquet.apache.org/docs/file-format/data-pages/">File Format – Data Pages</a>
 /// @see <a href="https://github.com/apache/parquet-format/blob/master/src/main/thrift/parquet.thrift">parquet.thrift</a>
 public enum PageType {
+    /// A v1 data page: the repetition levels, definition levels and values are compressed
+    /// together as a single payload.
     DATA_PAGE,
+    /// A page holding an index into the column chunk. Defined by the format, but not written by
+    /// any known writer; the column index and offset index serve this purpose instead.
     INDEX_PAGE,
+    /// The dictionary for a column chunk. The chunk's dictionary-encoded data pages store
+    /// indexes into it rather than values.
     DICTIONARY_PAGE,
+    /// A v2 data page: the repetition and definition levels are stored uncompressed and
+    /// length-prefixed ahead of the compressed values, so they can be read without decompressing
+    /// the page.
     DATA_PAGE_V2,
-    /// Placeholder for a page type found in metadata that is not recognized.
-    /// Reported only through [ColumnMetaData#encodingStats()], whose counts are informational; a page whose own header declares an unrecognized type is
-    /// rejected when read, since it cannot be decoded.
+    /// Placeholder for a page type found in metadata that is not recognized. Reported only
+    /// through [ColumnMetaData#encodingStats()], whose counts are informational; a page whose own
+    /// header declares an unrecognized type is rejected when read, since it cannot be decoded.
     UNKNOWN
 }

--- a/core/src/test/java/dev/hardwood/FilterPredicateTest.java
+++ b/core/src/test/java/dev/hardwood/FilterPredicateTest.java
@@ -1307,7 +1307,7 @@ class FilterPredicateTest {
         Statistics stats = new Statistics(min, max, 0L, null, false);
         ColumnMetaData cmd = new ColumnMetaData(
                 type, List.of(Encoding.PLAIN), FieldPath.of("col"),
-                CompressionCodec.UNCOMPRESSED, 100, 1000, 1000, Map.of(), 0, null, stats, null, null, null);
+                CompressionCodec.UNCOMPRESSED, 100, 1000, 1000, Map.of(), 0, null, stats, null, null, null, List.of());
         ColumnChunk chunk = new ColumnChunk(cmd, null, null, null, null);
         return new RowGroup(List.of(chunk), 1000, 100);
     }
@@ -1316,7 +1316,7 @@ class FilterPredicateTest {
         Statistics stats = new Statistics(null, null, nullCount, null, false);
         ColumnMetaData cmd = new ColumnMetaData(
                 type, List.of(Encoding.PLAIN), FieldPath.of("col"),
-                CompressionCodec.UNCOMPRESSED, 100, 1000, 1000, Map.of(), 0, null, stats, null, null, null);
+                CompressionCodec.UNCOMPRESSED, 100, 1000, 1000, Map.of(), 0, null, stats, null, null, null, List.of());
         ColumnChunk chunk = new ColumnChunk(cmd, null, null, null, null);
         return new RowGroup(List.of(chunk), 1000, numRows);
     }
@@ -1324,7 +1324,7 @@ class FilterPredicateTest {
     private static RowGroup createRowGroupWithoutStatistics() {
         ColumnMetaData cmd = new ColumnMetaData(
                 PhysicalType.INT32, List.of(Encoding.PLAIN), FieldPath.of("col"),
-                CompressionCodec.UNCOMPRESSED, 100, 1000, 1000, Map.of(), 0, null, null, null, null, null);
+                CompressionCodec.UNCOMPRESSED, 100, 1000, 1000, Map.of(), 0, null, null, null, null, null, List.of());
         ColumnChunk chunk = new ColumnChunk(cmd, null, null, null, null);
         return new RowGroup(List.of(chunk), 1000, 100);
     }
@@ -1347,7 +1347,7 @@ class FilterPredicateTest {
     private static ColumnChunk createGeostatsColumnChunk(GeospatialStatistics geospatialStatistics) {
         ColumnMetaData cmd = new ColumnMetaData(
                 PhysicalType.BYTE_ARRAY, List.of(Encoding.PLAIN), FieldPath.of("col"),
-                CompressionCodec.UNCOMPRESSED, 100, 1000, 1000, Map.of(), 0, null, null, geospatialStatistics, null, null);
+                CompressionCodec.UNCOMPRESSED, 100, 1000, 1000, Map.of(), 0, null, null, geospatialStatistics, null, null, List.of());
         return new ColumnChunk(cmd, null, null, null, null);
     }
 

--- a/core/src/test/java/dev/hardwood/PageEncodingStatsMetadataTest.java
+++ b/core/src/test/java/dev/hardwood/PageEncodingStatsMetadataTest.java
@@ -1,0 +1,50 @@
+/*
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Copyright The original authors
+ *
+ *  Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package dev.hardwood;
+
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
+import org.junit.jupiter.api.Test;
+
+import dev.hardwood.metadata.ColumnChunk;
+import dev.hardwood.metadata.Encoding;
+import dev.hardwood.metadata.PageEncodingStats;
+import dev.hardwood.metadata.PageType;
+import dev.hardwood.metadata.RowGroup;
+import dev.hardwood.reader.ParquetFileReader;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/// Verifies that the `encoding_stats` field on Thrift `ColumnMetaData` (field 13) is surfaced on
+/// the public [dev.hardwood.metadata.ColumnMetaData] record. The fixture
+/// `dictionary_uncompressed.parquet` writes column `id` as plain data pages and column `category`
+/// with a dictionary, so a single footer parse covers both a chunk with only a data-page entry and
+/// one that also counts a dictionary page.
+class PageEncodingStatsMetadataTest {
+
+    @Test
+    void surfacesEncodingStatsFromFooter() throws Exception {
+        Path parquetFile = Paths.get("src/test/resources/dictionary_uncompressed.parquet");
+
+        try (ParquetFileReader reader = ParquetFileReader.open(InputFile.of(parquetFile))) {
+            RowGroup rowGroup = reader.getFileMetaData().rowGroups().getFirst();
+
+            ColumnChunk idChunk = rowGroup.columns().getFirst();
+            assertThat(idChunk.metaData().pathInSchema().toString()).isEqualTo("id");
+            assertThat(idChunk.metaData().encodingStats())
+                    .containsExactly(new PageEncodingStats(PageType.DATA_PAGE, Encoding.PLAIN, 1));
+
+            ColumnChunk categoryChunk = rowGroup.columns().get(1);
+            assertThat(categoryChunk.metaData().pathInSchema().toString()).isEqualTo("category");
+            assertThat(categoryChunk.metaData().encodingStats()).containsExactly(
+                    new PageEncodingStats(PageType.DICTIONARY_PAGE, Encoding.PLAIN, 1),
+                    new PageEncodingStats(PageType.DATA_PAGE, Encoding.RLE_DICTIONARY, 1));
+        }
+    }
+}

--- a/core/src/test/java/dev/hardwood/internal/predicate/BloomFilterPushDownTest.java
+++ b/core/src/test/java/dev/hardwood/internal/predicate/BloomFilterPushDownTest.java
@@ -239,7 +239,7 @@ class BloomFilterPushDownTest {
                 md.type(), md.encodings(), md.pathInSchema(), md.codec(),
                 md.numValues(), md.totalUncompressedSize(), md.totalCompressedSize(),
                 md.keyValueMetadata(), md.dataPageOffset(), md.dictionaryPageOffset(),
-                md.statistics(), md.geospatialStatistics(), md.bloomFilterOffset(), null);
+                md.statistics(), md.geospatialStatistics(), md.bloomFilterOffset(), null, md.encodingStats());
         ColumnChunk patched = new ColumnChunk(withoutLength, original.offsetIndexOffset(),
                 original.offsetIndexLength(), original.columnIndexOffset(), original.columnIndexLength());
 
@@ -337,7 +337,7 @@ class BloomFilterPushDownTest {
                 md.type(), md.encodings(), md.pathInSchema(), md.codec(),
                 md.numValues(), md.totalUncompressedSize(), md.totalCompressedSize(),
                 md.keyValueMetadata(), md.dataPageOffset(), md.dictionaryPageOffset(),
-                md.statistics(), md.geospatialStatistics(), bloomOffset, null);
+                md.statistics(), md.geospatialStatistics(), bloomOffset, null, md.encodingStats());
         ColumnChunk chunk = new ColumnChunk(withBloom, template.offsetIndexOffset(),
                 template.offsetIndexLength(), template.columnIndexOffset(), template.columnIndexLength());
         return new RowGroup(List.of(chunk), rowGroup.totalByteSize(), rowGroup.numRows());

--- a/core/src/test/java/dev/hardwood/internal/predicate/RowGroupDecideTest.java
+++ b/core/src/test/java/dev/hardwood/internal/predicate/RowGroupDecideTest.java
@@ -155,7 +155,7 @@ class RowGroupDecideTest {
         ColumnMetaData cmd = new ColumnMetaData(
                 type, List.of(Encoding.PLAIN), FieldPath.of("col"),
                 CompressionCodec.UNCOMPRESSED, 100, 1000, 1000, Map.of(), 0, null, stats,
-                null, null, null);
+                null, null, null, List.of());
         ColumnChunk chunk = new ColumnChunk(cmd, null, null, null, null);
         return new RowGroup(List.of(chunk), 1000, numRows);
     }

--- a/core/src/test/java/dev/hardwood/internal/reader/PageFormatProbeTest.java
+++ b/core/src/test/java/dev/hardwood/internal/reader/PageFormatProbeTest.java
@@ -41,8 +41,7 @@ class PageFormatProbeTest {
             FileMetaData meta = ParquetMetadataReader.readMetadata(file);
             RowGroup rg = meta.rowGroups().get(0);
             for (int c = 0; c < rg.columns().size(); c++) {
-                PageType type =
-                        PageFormatProbe.firstDataPageType(file, rg.columns().get(c));
+                PageType type = PageFormatProbe.firstDataPageType(file, rg.columns().get(c));
                 assertThat(type)
                         .as("column %d (path=%s)", c, rg.columns().get(c).metaData().pathInSchema())
                         .isEqualTo(PageType.DATA_PAGE);
@@ -57,8 +56,7 @@ class PageFormatProbeTest {
             FileMetaData meta = ParquetMetadataReader.readMetadata(file);
             RowGroup rg = meta.rowGroups().get(0);
             for (int c = 0; c < rg.columns().size(); c++) {
-                PageType type =
-                        PageFormatProbe.firstDataPageType(file, rg.columns().get(c));
+                PageType type = PageFormatProbe.firstDataPageType(file, rg.columns().get(c));
                 assertThat(type)
                         .as("column %d (path=%s)", c, rg.columns().get(c).metaData().pathInSchema())
                         .isEqualTo(PageType.DATA_PAGE_V2);

--- a/core/src/test/java/dev/hardwood/internal/reader/PageFormatProbeTest.java
+++ b/core/src/test/java/dev/hardwood/internal/reader/PageFormatProbeTest.java
@@ -13,8 +13,8 @@ import java.nio.file.Paths;
 import org.junit.jupiter.api.Test;
 
 import dev.hardwood.InputFile;
-import dev.hardwood.internal.metadata.PageHeader;
 import dev.hardwood.metadata.FileMetaData;
+import dev.hardwood.metadata.PageType;
 import dev.hardwood.metadata.RowGroup;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -41,11 +41,11 @@ class PageFormatProbeTest {
             FileMetaData meta = ParquetMetadataReader.readMetadata(file);
             RowGroup rg = meta.rowGroups().get(0);
             for (int c = 0; c < rg.columns().size(); c++) {
-                PageHeader.PageType type =
+                PageType type =
                         PageFormatProbe.firstDataPageType(file, rg.columns().get(c));
                 assertThat(type)
                         .as("column %d (path=%s)", c, rg.columns().get(c).metaData().pathInSchema())
-                        .isEqualTo(PageHeader.PageType.DATA_PAGE);
+                        .isEqualTo(PageType.DATA_PAGE);
             }
         }
     }
@@ -57,11 +57,11 @@ class PageFormatProbeTest {
             FileMetaData meta = ParquetMetadataReader.readMetadata(file);
             RowGroup rg = meta.rowGroups().get(0);
             for (int c = 0; c < rg.columns().size(); c++) {
-                PageHeader.PageType type =
+                PageType type =
                         PageFormatProbe.firstDataPageType(file, rg.columns().get(c));
                 assertThat(type)
                         .as("column %d (path=%s)", c, rg.columns().get(c).metaData().pathInSchema())
-                        .isEqualTo(PageHeader.PageType.DATA_PAGE_V2);
+                        .isEqualTo(PageType.DATA_PAGE_V2);
             }
         }
     }

--- a/core/src/test/java/dev/hardwood/internal/reader/SequentialFetchPlanChunkSizeTest.java
+++ b/core/src/test/java/dev/hardwood/internal/reader/SequentialFetchPlanChunkSizeTest.java
@@ -107,6 +107,7 @@ class SequentialFetchPlanChunkSizeTest {
                 null,
                 null,
                 null,
-                null);
+                null,
+                List.of());
     }
 }

--- a/core/src/test/java/dev/hardwood/internal/thrift/MalformedMetadataValidationTest.java
+++ b/core/src/test/java/dev/hardwood/internal/thrift/MalformedMetadataValidationTest.java
@@ -14,6 +14,7 @@ import java.nio.ByteOrder;
 import org.junit.jupiter.api.Test;
 
 import dev.hardwood.internal.metadata.PageHeader;
+import dev.hardwood.metadata.PageType;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -65,11 +66,21 @@ class MalformedMetadataValidationTest {
     }
 
     @Test
+    void unknownPageTypeRejected() {
+        // PageHeader: field1 type=4, which no released version of the format defines. Unlike
+        // encoding_stats, a page we cannot classify cannot be decoded either, so it must fail.
+        assertThatThrownBy(() -> PageHeaderReader.read(
+                reader(0x15, 0x08, 0x15, 0x14, 0x15, 0x10, 0x00)))
+                .isInstanceOf(IOException.class)
+                .hasMessageContaining("unknown page type: 4");
+    }
+
+    @Test
     void validPageHeaderStillParses() {
         // PageHeader: field1 type=DATA_PAGE(0), field2 uncompressed=10, field3 compressed=8
         PageHeader header = assertDoesNotThrow(() -> PageHeaderReader.read(
                 reader(0x15, 0x00, 0x15, 0x14, 0x15, 0x10, 0x00)));
-        assertThat(header.type()).isEqualTo(PageHeader.PageType.DATA_PAGE);
+        assertThat(header.type()).isEqualTo(PageType.DATA_PAGE);
         assertThat(header.uncompressedPageSize()).isEqualTo(10);
         assertThat(header.compressedPageSize()).isEqualTo(8);
     }

--- a/core/src/test/java/dev/hardwood/internal/thrift/PageEncodingStatsReaderTest.java
+++ b/core/src/test/java/dev/hardwood/internal/thrift/PageEncodingStatsReaderTest.java
@@ -19,6 +19,7 @@ import dev.hardwood.metadata.PageEncodingStats;
 import dev.hardwood.metadata.PageType;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 /// Verifies how `ColumnMetaData.encoding_stats` (field 13) is decoded, using hand-crafted Thrift
 /// Compact Protocol bytes so each shape can be isolated. Field header byte is
@@ -94,6 +95,19 @@ class PageEncodingStatsReaderTest {
         ColumnMetaData metaData = ColumnMetaDataReader.read(reader(0xD5, 0x02, 0x00));
 
         assertThat(metaData.encodingStats()).isEmpty();
+    }
+
+    @Test
+    void impossibleEntryCountIsRejectedAsMalformedMetadata() {
+        // Long-form list size 2^31, which casts to a negative capacity. Pre-sizing from it throws
+        // IllegalArgumentException, which escapes ParquetMetadataReader's catch (IOException) and
+        // reaches the caller unchecked and without the file name.
+        assertThatThrownBy(() -> ColumnMetaDataReader.read(reader(
+                ENCODING_STATS_FIELD, 0xFC,
+                0x80, 0x80, 0x80, 0x80, 0x08,
+                0x00)))
+                .isInstanceOf(IOException.class)
+                .hasMessageContaining("2147483648 elements");
     }
 
     @Test

--- a/core/src/test/java/dev/hardwood/internal/thrift/PageEncodingStatsReaderTest.java
+++ b/core/src/test/java/dev/hardwood/internal/thrift/PageEncodingStatsReaderTest.java
@@ -19,7 +19,6 @@ import dev.hardwood.metadata.PageEncodingStats;
 import dev.hardwood.metadata.PageType;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 /// Verifies how `ColumnMetaData.encoding_stats` (field 13) is decoded, using hand-crafted Thrift
 /// Compact Protocol bytes so each shape can be isolated. Field header byte is
@@ -110,46 +109,76 @@ class PageEncodingStatsReaderTest {
     }
 
     @Test
-    void missingCountRejected() {
-        // Entry carrying only page_type and encoding. All three fields are required.
-        assertThatThrownBy(() -> ColumnMetaDataReader.read(reader(
+    void missingCountDropsTheField() throws IOException {
+        // Entry carrying only page_type and encoding. All three fields are required, so the
+        // entry cannot be reconstructed — and since the counts only mean anything as a complete
+        // partition of the chunk's pages, the whole field is reported as absent.
+        ColumnMetaData metaData = ColumnMetaDataReader.read(reader(
                 ENCODING_STATS_FIELD, 0x1C,
                 0x15, 0x00, 0x15, 0x00, 0x00,
-                0x00)))
-                .isInstanceOf(IOException.class)
-                .hasMessageContaining("count");
+                0x00));
+
+        assertThat(metaData.encodingStats()).isEmpty();
     }
 
     @Test
-    void negativeCountRejected() {
-        assertThatThrownBy(() -> ColumnMetaDataReader.read(reader(
+    void negativeCountDropsTheField() throws IOException {
+        ColumnMetaData metaData = ColumnMetaDataReader.read(reader(
                 ENCODING_STATS_FIELD, 0x1C,
                 0x15, 0x00, 0x15, 0x00, 0x15, 0x01, 0x00,
-                0x00)))
-                .isInstanceOf(IOException.class)
-                .hasMessageContaining("PageEncodingStats.count");
+                0x00));
+
+        assertThat(metaData.encodingStats()).isEmpty();
     }
 
     @Test
-    void nonStructListElementTypeRejected() {
+    void oneMalformedEntryDropsTheWholeField() throws IOException {
+        // A well-formed (DATA_PAGE, PLAIN, 1) entry followed by one missing its count. Keeping
+        // the first would present 1 page as the chunk's full page inventory when it is not.
+        ColumnMetaData metaData = ColumnMetaDataReader.read(reader(
+                ENCODING_STATS_FIELD, 0x2C,
+                0x15, 0x00, 0x15, 0x00, 0x15, 0x02, 0x00,
+                0x15, 0x04, 0x15, 0x00, 0x00,
+                0x00));
+
+        assertThat(metaData.encodingStats()).isEmpty();
+    }
+
+    @Test
+    void nonStructListElementTypeDropsTheField() throws IOException {
         // Field 13 declared as list<i32> (element type 0x05) carrying the value 1. Elements are
-        // read as structs, so decoding it would misread value bytes as field headers.
-        assertThatThrownBy(() -> ColumnMetaDataReader.read(reader(
+        // read as structs, so decoding it would misread value bytes as field headers; skipping
+        // by the declared element type consumes it instead.
+        ColumnMetaData metaData = ColumnMetaDataReader.read(reader(
                 ENCODING_STATS_FIELD, 0x15,
                 0x02,
-                0x00)))
-                .isInstanceOf(IOException.class)
-                .hasMessageContaining("encoding_stats");
+                0x00));
+
+        assertThat(metaData.encodingStats()).isEmpty();
     }
 
     @Test
-    void wrongWireTypeOnRequiredFieldRejected() {
+    void wrongWireTypeOnRequiredFieldDropsTheField() throws IOException {
         // page_type declared as i64 (0x06) rather than i32.
-        assertThatThrownBy(() -> ColumnMetaDataReader.read(reader(
+        ColumnMetaData metaData = ColumnMetaDataReader.read(reader(
                 ENCODING_STATS_FIELD, 0x1C,
                 0x16, 0x00, 0x15, 0x00, 0x15, 0x02, 0x00,
-                0x00)))
-                .isInstanceOf(IOException.class)
-                .hasMessageContaining("page_type");
+                0x00));
+
+        assertThat(metaData.encodingStats()).isEmpty();
+    }
+
+    @Test
+    void malformedFieldDoesNotDisturbLaterFields() throws IOException {
+        // encoding_stats as list<i32>, then field 14 (bloom_filter_offset, i64) = 8. The skip
+        // has to leave the reader exactly on the next field header for this to decode.
+        ColumnMetaData metaData = ColumnMetaDataReader.read(reader(
+                ENCODING_STATS_FIELD, 0x15,
+                0x02,
+                0x16, 0x10,
+                0x00));
+
+        assertThat(metaData.encodingStats()).isEmpty();
+        assertThat(metaData.bloomFilterOffset()).isEqualTo(8L);
     }
 }

--- a/core/src/test/java/dev/hardwood/internal/thrift/PageEncodingStatsReaderTest.java
+++ b/core/src/test/java/dev/hardwood/internal/thrift/PageEncodingStatsReaderTest.java
@@ -1,0 +1,121 @@
+/*
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Copyright The original authors
+ *
+ *  Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package dev.hardwood.internal.thrift;
+
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
+
+import org.junit.jupiter.api.Test;
+
+import dev.hardwood.metadata.ColumnMetaData;
+import dev.hardwood.metadata.Encoding;
+import dev.hardwood.metadata.PageEncodingStats;
+import dev.hardwood.metadata.PageType;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/// Verifies how `ColumnMetaData.encoding_stats` (field 13) is decoded, using hand-crafted Thrift
+/// Compact Protocol bytes so each shape can be isolated. Field header byte is
+/// `(fieldIdDelta << 4) | type`; list header byte is `(size << 4) | elementType`; `i32` values are
+/// zigzag varints (`zigzag(-1) = 1`, `zigzag(1) = 2`, `zigzag(2) = 4`, `zigzag(8) = 16`); `0x00` is
+/// STOP.
+class PageEncodingStatsReaderTest {
+
+    /// Field 13 as a list of structs, i.e. the `encoding_stats` field header (`0xD9`) followed by
+    /// the list header for `count` elements. The trailing `0x00` closing the ColumnMetaData struct
+    /// is supplied by each test.
+    private static final int ENCODING_STATS_FIELD = 0xD9;
+
+    private static ThriftCompactReader reader(int... bytes) {
+        byte[] b = new byte[bytes.length];
+        for (int i = 0; i < bytes.length; i++) {
+            b[i] = (byte) bytes[i];
+        }
+        return new ThriftCompactReader(ByteBuffer.wrap(b).order(ByteOrder.LITTLE_ENDIAN));
+    }
+
+    @Test
+    void readsEntriesInWrittenOrder() throws IOException {
+        // Two entries: (DICTIONARY_PAGE, PLAIN, 1) then (DATA_PAGE, RLE_DICTIONARY, 2).
+        ColumnMetaData metaData = ColumnMetaDataReader.read(reader(
+                ENCODING_STATS_FIELD, 0x2C,
+                0x15, 0x04, 0x15, 0x00, 0x15, 0x02, 0x00,
+                0x15, 0x00, 0x15, 0x10, 0x15, 0x04, 0x00,
+                0x00));
+
+        assertThat(metaData.encodingStats()).containsExactly(
+                new PageEncodingStats(PageType.DICTIONARY_PAGE, Encoding.PLAIN, 1),
+                new PageEncodingStats(PageType.DATA_PAGE, Encoding.RLE_DICTIONARY, 2));
+    }
+
+    @Test
+    void absentFieldYieldsEmptyList() throws IOException {
+        ColumnMetaData metaData = ColumnMetaDataReader.read(reader(0x00));
+
+        assertThat(metaData.encodingStats()).isEmpty();
+    }
+
+    @Test
+    void unrecognizedPageTypeIsCarriedThroughAsUnknown() throws IOException {
+        // page_type = 7, which no released version of the format defines. The counts are
+        // informational, so this must not make the footer unreadable.
+        ColumnMetaData metaData = ColumnMetaDataReader.read(reader(
+                ENCODING_STATS_FIELD, 0x1C,
+                0x15, 0x0E, 0x15, 0x00, 0x15, 0x02, 0x00,
+                0x00));
+
+        assertThat(metaData.encodingStats())
+                .containsExactly(new PageEncodingStats(PageType.UNKNOWN, Encoding.PLAIN, 1));
+    }
+
+    @Test
+    void unknownStructFieldIsSkipped() throws IOException {
+        // A field 4 the format does not define today, appended after count.
+        ColumnMetaData metaData = ColumnMetaDataReader.read(reader(
+                ENCODING_STATS_FIELD, 0x1C,
+                0x15, 0x00, 0x15, 0x00, 0x15, 0x02, 0x15, 0x02, 0x00,
+                0x00));
+
+        assertThat(metaData.encodingStats())
+                .containsExactly(new PageEncodingStats(PageType.DATA_PAGE, Encoding.PLAIN, 1));
+    }
+
+    @Test
+    void missingCountRejected() {
+        // Entry carrying only page_type and encoding. All three fields are required.
+        assertThatThrownBy(() -> ColumnMetaDataReader.read(reader(
+                ENCODING_STATS_FIELD, 0x1C,
+                0x15, 0x00, 0x15, 0x00, 0x00,
+                0x00)))
+                .isInstanceOf(IOException.class)
+                .hasMessageContaining("count");
+    }
+
+    @Test
+    void negativeCountRejected() {
+        assertThatThrownBy(() -> ColumnMetaDataReader.read(reader(
+                ENCODING_STATS_FIELD, 0x1C,
+                0x15, 0x00, 0x15, 0x00, 0x15, 0x01, 0x00,
+                0x00)))
+                .isInstanceOf(IOException.class)
+                .hasMessageContaining("PageEncodingStats.count");
+    }
+
+    @Test
+    void wrongWireTypeOnRequiredFieldRejected() {
+        // page_type declared as i64 (0x06) rather than i32.
+        assertThatThrownBy(() -> ColumnMetaDataReader.read(reader(
+                ENCODING_STATS_FIELD, 0x1C,
+                0x16, 0x00, 0x15, 0x00, 0x15, 0x02, 0x00,
+                0x00)))
+                .isInstanceOf(IOException.class)
+                .hasMessageContaining("page_type");
+    }
+}

--- a/core/src/test/java/dev/hardwood/internal/thrift/PageEncodingStatsReaderTest.java
+++ b/core/src/test/java/dev/hardwood/internal/thrift/PageEncodingStatsReaderTest.java
@@ -76,6 +76,28 @@ class PageEncodingStatsReaderTest {
     }
 
     @Test
+    void unrecognizedEncodingIsCarriedThroughAsUnknown() throws IOException {
+        // encoding = 10, which no released version of the format defines. Like an unrecognized
+        // page type, it must not make the footer unreadable.
+        ColumnMetaData metaData = ColumnMetaDataReader.read(reader(
+                ENCODING_STATS_FIELD, 0x1C,
+                0x15, 0x00, 0x15, 0x14, 0x15, 0x02, 0x00,
+                0x00));
+
+        assertThat(metaData.encodingStats())
+                .containsExactly(new PageEncodingStats(PageType.DATA_PAGE, Encoding.UNKNOWN, 1));
+    }
+
+    @Test
+    void nonListFieldIsSkipped() throws IOException {
+        // Field 13 declared as an i32 rather than a list. The field is optional and informational,
+        // so it is skipped rather than failing the footer.
+        ColumnMetaData metaData = ColumnMetaDataReader.read(reader(0xD5, 0x02, 0x00));
+
+        assertThat(metaData.encodingStats()).isEmpty();
+    }
+
+    @Test
     void unknownStructFieldIsSkipped() throws IOException {
         // A field 4 the format does not define today, appended after count.
         ColumnMetaData metaData = ColumnMetaDataReader.read(reader(
@@ -106,6 +128,18 @@ class PageEncodingStatsReaderTest {
                 0x00)))
                 .isInstanceOf(IOException.class)
                 .hasMessageContaining("PageEncodingStats.count");
+    }
+
+    @Test
+    void nonStructListElementTypeRejected() {
+        // Field 13 declared as list<i32> (element type 0x05) carrying the value 1. Elements are
+        // read as structs, so decoding it would misread value bytes as field headers.
+        assertThatThrownBy(() -> ColumnMetaDataReader.read(reader(
+                ENCODING_STATS_FIELD, 0x15,
+                0x02,
+                0x00)))
+                .isInstanceOf(IOException.class)
+                .hasMessageContaining("encoding_stats");
     }
 
     @Test

--- a/core/src/test/java/dev/hardwood/internal/thrift/ThriftCompactReaderTest.java
+++ b/core/src/test/java/dev/hardwood/internal/thrift/ThriftCompactReaderTest.java
@@ -14,6 +14,7 @@ import java.nio.ByteOrder;
 import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 /// Tests for ThriftCompactReader, particularly field skipping for complex types.
 class ThriftCompactReaderTest {
@@ -161,5 +162,62 @@ class ThriftCompactReaderTest {
         // Should be at STOP
         ThriftCompactReader.FieldHeader stop = reader.readFieldHeader();
         assertThat(stop).isNull();
+    }
+
+    /// A long-form element count larger than the bytes left cannot describe real elements — the
+    /// cheapest of them still costs a byte — so it is rejected before any caller pre-sizes a
+    /// collection from it.
+    @Test
+    void listHeaderRejectsCountLargerThanRemainingBytes() {
+        // List header: size nibble 15 (long form), element type struct (0x0C), then varint(100).
+        ThriftCompactReader reader = reader(0xFC, 0x64, 0x00, 0x00);
+
+        assertThatThrownBy(reader::readListHeader)
+                .isInstanceOf(IOException.class)
+                .hasMessageContaining("declares 100 elements")
+                .hasMessageContaining("2 bytes remain");
+    }
+
+    /// A count past the `int` range would wrap to a negative capacity, which surfaces as an
+    /// unchecked `IllegalArgumentException` from the collection constructor rather than as the
+    /// controlled, file-attributed `IOException` the footer path contracts for.
+    @Test
+    void listHeaderRejectsCountOverflowingInt() {
+        // varint 0x80 0x80 0x80 0x80 0x08 encodes 2^31, which casts to Integer.MIN_VALUE.
+        ThriftCompactReader reader = reader(0xFC, 0x80, 0x80, 0x80, 0x80, 0x08, 0x00);
+
+        assertThatThrownBy(reader::readListHeader)
+                .isInstanceOf(IOException.class)
+                .hasMessageContaining("2147483648 elements");
+    }
+
+    /// The one success case among these tests: the others all assert a rejection, so a bound that
+    /// wrongly rejected every long-form list would still pass them — while breaking any file with
+    /// 15 or more columns, row groups or key-value pairs, since those all take this path.
+    ///
+    /// Sizing the list to fill the buffer exactly also pins the comparison at `>` rather than
+    /// `>=`: a collection is allowed to end where the buffer does.
+    @Test
+    void listHeaderAcceptsLongFormCountWithinRemainingBytes() throws IOException {
+        // 15 bool elements, each one byte, followed by exactly 15 payload bytes.
+        int[] bytes = new int[17];
+        bytes[0] = 0xF1;  // size nibble 15 (long form), element type bool
+        bytes[1] = 0x0F;  // varint(15)
+        for (int i = 0; i < 15; i++) {
+            bytes[i + 2] = 0x01;
+        }
+
+        ThriftCompactReader.CollectionHeader header = reader(bytes).readListHeader();
+
+        assertThat(header.size()).isEqualTo(15);
+        assertThat(header.elementType()).isEqualTo((byte) 0x01);
+    }
+
+    private static ThriftCompactReader reader(int... bytes) {
+        byte[] b = new byte[bytes.length];
+        for (int i = 0; i < bytes.length; i++) {
+            b[i] = (byte) bytes[i];
+        }
+        return new ThriftCompactReader(ByteBuffer.wrap(b).order(ByteOrder.LITTLE_ENDIAN));
     }
 }

--- a/docs/content/how-to/metadata.md
+++ b/docs/content/how-to/metadata.md
@@ -20,7 +20,7 @@ A Parquet file is organized as follows:
 
 - **FileMetaData** — top-level: row count, schema, key-value metadata (e.g. Spark schema, pandas metadata), the writer that produced the file (`createdBy`), and the per-column statistics ordering (`columnOrders`)
 - **RowGroup** — a horizontal partition of the data; each row group contains all columns for a subset of rows
-- **ColumnChunk** — one column within a row group; holds compression codec, byte sizes, and optional statistics (min/max values, null count) used for predicate pushdown. Per-chunk byte ranges for the column index and offset index (when present in the file) are exposed via `columnIndexOffset`/`columnIndexLength` and `offsetIndexOffset`/`offsetIndexLength` on `ColumnChunk`. The bloom-filter byte range (`bloomFilterOffset`/`bloomFilterLength`) is exposed on `ColumnMetaData`, matching its position in the Parquet Thrift schema.
+- **ColumnChunk** — one column within a row group; holds compression codec, byte sizes, and optional statistics (min/max values, null count) used for predicate pushdown. Per-chunk byte ranges for the column index and offset index (when present in the file) are exposed via `columnIndexOffset`/`columnIndexLength` and `offsetIndexOffset`/`offsetIndexLength` on `ColumnChunk`. The bloom-filter byte range (`bloomFilterOffset`/`bloomFilterLength`) is exposed on `ColumnMetaData`, matching its position in the Parquet Thrift schema. `ColumnMetaData.encodingStats()` returns the chunk's page counts per (page type, encoding) pair as a list of `PageEncodingStats`, empty when the file omits the field. A page type this version does not recognize is reported as `PageType.UNKNOWN`.
 
 ```java
 import dev.hardwood.metadata.ColumnChunk;

--- a/performance-testing/micro-benchmarks/src/main/java/dev/hardwood/benchmarks/FixedSizeListDecodeBenchmark.java
+++ b/performance-testing/micro-benchmarks/src/main/java/dev/hardwood/benchmarks/FixedSizeListDecodeBenchmark.java
@@ -41,6 +41,7 @@ import dev.hardwood.internal.reader.SequentialFetchPlan;
 import dev.hardwood.internal.thrift.PageHeaderReader;
 import dev.hardwood.internal.thrift.ThriftCompactReader;
 import dev.hardwood.metadata.ColumnChunk;
+import dev.hardwood.metadata.PageType;
 import dev.hardwood.metadata.RowGroup;
 import dev.hardwood.reader.ColumnReader;
 import dev.hardwood.reader.ParquetFileReader;
@@ -211,7 +212,7 @@ public class FixedSizeListDecodeBenchmark {
                         }
                         ThriftCompactReader headerReader = new ThriftCompactReader(pageBuffer, 0);
                         PageHeader header = PageHeaderReader.read(headerReader);
-                        if (header.type() != PageHeader.PageType.DATA_PAGE_V2) {
+                        if (header.type() != PageType.DATA_PAGE_V2) {
                             continue;
                         }
                         ByteBuffer body = pageBuffer.slice(headerReader.getBytesRead(), header.compressedPageSize());


### PR DESCRIPTION
Hello, this PR resolves #856, that can be shipped on its own, and make it possible to close #196

The footer parser skipped Thrift field 13, so callers had no way to see how many pages a writer produced per (page type, encoding) pair. Beyond mirroring the spec, it is the only metadata that proves a chunk's data pages are entirely dictionary-encoded, which a reader needs before it can trust a dictionary page as a complete inventory of the chunk's values.

Surfacing it means the page-type enum becomes public, so it moves out of the internal `PageHeader` into `dev.hardwood.metadata`. It gains an `UNKNOWN` constant: `encoding_stats` is optional and purely informational, so a page type from a future release (or invalid one) must not make an otherwise readable file unreadable. A page header declaring such a type is still rejected, because that page has to be decoded and cannot be.

The writer does not emit the field yet.

## Checklist

- [x] Build via `./mvnw clean verify` passes
- [x] The commit message is prefixed with the issue key ("#123 Adding support for...")
- [x] Code changes are covered by tests
- [x] If this PR adds or changes user-facing behaviour, `docs/` has been updated
