### PR TITLE
#388 Skip non-actionable data preview modal fields

### DIFF
--- a/_designs/INTERACTIVE_DIVE_TUI.md
+++ b/_designs/INTERACTIVE_DIVE_TUI.md
@@ -222,12 +222,13 @@ Projected rows read via `RowReader`. Per-frame the screen knows the viewport hei
 and shows that many rows. `←` / `→` scrolls the visible column window with the row
 number column pinned; `PgDn` / `PgUp` flips pages forward (and backward via cursor
 re-creation). The title shows `rows X-Y of T · cols A-B of C · physical|logical`.
-`Enter` opens a row-detail modal with one line per field. When the modal body fits,
-`↑` / `↓` move between actionable fields; when it overflows, they move one rendered
-line at a time so all content remains reachable. `Enter` toggles inline expansion
-of the focused field's full value, and `▶` marks actionable field headers rather
-than scalar lines selected only for scrolling (the cursor is hidden when no field
-is expandable and content fits).
+`Enter` opens a row-detail modal with one line per field. `↑` / `↓` step between the
+fields `Enter` can expand — a field is expandable when its full value does not
+already fit the collapsed line, measured in display cells — and `PgDn` / `PgUp`
+scroll the body, so fields the cursor skips over are still readable. The modal opens
+with the cursor on the first expandable field, scrolled into view, and `▶` marks it;
+a record with nothing to expand shows no cursor at all. `Enter` toggles inline
+expansion of the focused field's full value.
 `e` / `c` expand / collapse all fields. `t` toggles logical types both in-table
 and in the modal. Long cell values get `…` indicators sized to the actual rendered
 column width.

--- a/_designs/INTERACTIVE_DIVE_TUI.md
+++ b/_designs/INTERACTIVE_DIVE_TUI.md
@@ -222,9 +222,12 @@ Projected rows read via `RowReader`. Per-frame the screen knows the viewport hei
 and shows that many rows. `←` / `→` scrolls the visible column window with the row
 number column pinned; `PgDn` / `PgUp` flips pages forward (and backward via cursor
 re-creation). The title shows `rows X-Y of T · cols A-B of C · physical|logical`.
-`Enter` opens a row-detail modal with one line per field; in the modal `↑` / `↓`
-moves the cursor across fields, `Enter` toggles inline expansion of the focused
-field's full value (cursor is hidden when no field is expandable and content fits).
+`Enter` opens a row-detail modal with one line per field. When the modal body fits,
+`↑` / `↓` move between actionable fields; when it overflows, they move one rendered
+line at a time so all content remains reachable. `Enter` toggles inline expansion
+of the focused field's full value, and `▶` marks actionable field headers rather
+than scalar lines selected only for scrolling (the cursor is hidden when no field
+is expandable and content fits).
 `e` / `c` expand / collapse all fields. `t` toggles logical types both in-table
 and in the modal. Long cell values get `…` indicators sized to the actual rendered
 column width.

--- a/cli/src/main/java/dev/hardwood/cli/dive/ScreenState.java
+++ b/cli/src/main/java/dev/hardwood/cli/dive/ScreenState.java
@@ -216,8 +216,10 @@ public sealed interface ScreenState {
     /// modal is currently open (-1 when closed). `logicalTypes` controls
     /// whether values render via their logical type (default) or the raw
     /// physical-type form — toggled with `t`. Inside the record modal,
-    /// `modalCursorLine` is the per-line cursor (collapsed fields = 1 line,
-    /// expanded fields = N lines); `expandedColumns` is the set of fields
+    /// `modalCursorLine` is the line of the field the cursor sits on and
+    /// `modalScroll` is the first body line the modal shows; the two move
+    /// independently because `↑`/`↓` step between expandable fields while
+    /// `PgDn`/`PgUp` scroll the body. `expandedColumns` is the set of fields
     /// whose pretty-printed value is rendered inline (multi-line, no
     /// element caps). `expandedRows` is parallel to `rows` and holds the
     /// multi-line pretty-printed form of each cell, populated by
@@ -233,13 +235,23 @@ public sealed interface ScreenState {
             int modalRow,
             boolean logicalTypes,
             java.util.Set<Integer> expandedColumns,
-            int modalCursorLine)
+            int modalCursorLine,
+            int modalScroll)
             implements ScreenState {
         public DataPreview {
             columnNames = java.util.List.copyOf(columnNames);
             rows = java.util.List.copyOf(rows);
             expandedRows = java.util.List.copyOf(expandedRows);
             expandedColumns = java.util.Set.copyOf(expandedColumns);
+        }
+
+        public DataPreview(long firstRow, int pageSize, java.util.List<String> columnNames,
+                           java.util.List<java.util.List<String>> rows,
+                           java.util.List<java.util.List<String>> expandedRows,
+                           int columnScroll, int selectedRow, int modalRow, boolean logicalTypes,
+                           java.util.Set<Integer> expandedColumns, int modalCursorLine) {
+            this(firstRow, pageSize, columnNames, rows, expandedRows, columnScroll, selectedRow,
+                    modalRow, logicalTypes, expandedColumns, modalCursorLine, 0);
         }
     }
 }

--- a/cli/src/main/java/dev/hardwood/cli/dive/internal/DataPreviewScreen.java
+++ b/cli/src/main/java/dev/hardwood/cli/dive/internal/DataPreviewScreen.java
@@ -293,6 +293,7 @@ public final class DataPreviewScreen {
             String name = names.get(fieldIdx);
             String pad = " ".repeat(maxKeyWidth - name.length());
             boolean isExpanded = state.expandedColumns().contains(fieldIdx);
+            boolean isExpandable = isExpandableField(state, fieldIdx, geometry);
             String value = fieldIdx < values.size() ? values.get(fieldIdx) : "";
             Style selectionStyle = Theme.selection();
             if (cursorLine == fieldFirstLine) {
@@ -305,7 +306,8 @@ public final class DataPreviewScreen {
                     shown = truncate(value, valueBudget);
                 }
                 all.set(cursorLine, Line.from(
-                        new Span("▶" + name + pad + " : ", selectionStyle),
+                        new Span((isExpandable ? "▶" : " ") + name + pad + " : ",
+                                selectionStyle),
                         new Span(shown, selectionStyle)));
             }
             else if (isExpanded) {

--- a/cli/src/main/java/dev/hardwood/cli/dive/internal/DataPreviewScreen.java
+++ b/cli/src/main/java/dev/hardwood/cli/dive/internal/DataPreviewScreen.java
@@ -237,7 +237,6 @@ public final class DataPreviewScreen {
     private static void renderRecordModal(Buffer buffer, Rect screenArea, ParquetModel model,
                                           ScreenState.DataPreview state) {
         List<String> values = state.rows().get(state.modalRow());
-        List<String> expanded = state.expandedRows().get(state.modalRow());
         List<String> names = state.columnNames();
         ModalGeometry geometry = modalGeometry(
                 screenArea.width(), screenArea.height(), names);
@@ -265,11 +264,7 @@ public final class DataPreviewScreen {
             String value = i < values.size() ? values.get(i) : "";
             ownership[i] = all.size();
             if (isExpanded) {
-                String fullValue = i < expanded.size() ? expanded.get(i) : value;
-                List<String> wrapped = Strings.hardWrap(fullValue, valueBudget);
-                if (wrapped.isEmpty()) {
-                    wrapped.add("");
-                }
+                List<String> wrapped = expandedValueLines(state, i, geometry);
                 all.add(Line.from(
                         new Span(" " + name + pad + " : ", Theme.primary()),
                         Span.raw(wrapped.get(0))));
@@ -289,17 +284,11 @@ public final class DataPreviewScreen {
         // Cursor is purely decorative when there's nothing to do with it:
         // no field can expand AND content fits the viewport. In that case
         // the modal becomes a static info display.
-        boolean canExpandAny = false;
-        for (String e : expanded) {
-            if (e.indexOf('\n') >= 0) {
-                canExpandAny = true;
-                break;
-            }
-        }
+        boolean canExpandAny = hasExpandableField(state, geometry);
         boolean overflows = totalLines > viewport;
         boolean showCursor = canExpandAny || overflows;
         if (showCursor && cursorLine < all.size()) {
-            int fieldIdx = fieldForLine(state, cursorLine);
+            int fieldIdx = fieldForLine(state, cursorLine, geometry);
             int fieldFirstLine = ownership[fieldIdx];
             String name = names.get(fieldIdx);
             String pad = " ".repeat(maxKeyWidth - name.length());
@@ -309,8 +298,7 @@ public final class DataPreviewScreen {
             if (cursorLine == fieldFirstLine) {
                 String shown;
                 if (isExpanded) {
-                    String fullValue = fieldIdx < expanded.size() ? expanded.get(fieldIdx) : value;
-                    List<String> wrapped = Strings.hardWrap(fullValue, valueBudget);
+                    List<String> wrapped = expandedValueLines(state, fieldIdx, geometry);
                     shown = wrapped.isEmpty() ? "" : wrapped.get(0);
                 }
                 else {
@@ -321,8 +309,7 @@ public final class DataPreviewScreen {
                         new Span(shown, selectionStyle)));
             }
             else if (isExpanded) {
-                String fullValue = fieldIdx < expanded.size() ? expanded.get(fieldIdx) : value;
-                List<String> wrapped = Strings.hardWrap(fullValue, valueBudget);
+                List<String> wrapped = expandedValueLines(state, fieldIdx, geometry);
                 int contIdx = cursorLine - fieldFirstLine;
                 String text = contIdx < wrapped.size() ? wrapped.get(contIdx) : "";
                 all.set(cursorLine, Line.from(new Span(continuationIndent + text, selectionStyle)));
@@ -335,13 +322,14 @@ public final class DataPreviewScreen {
 
         List<Line> lines = new ArrayList<>(all.subList(scroll, end));
         lines.add(Line.empty());
-        // Hint is tiered: drop "↑↓ navigate" when navigation has no effect
-        // (cursor is hidden because content fits AND nothing is expandable,
-        // or content fits with only one line); drop "Enter expand" +
+        // Hint is tiered: drop "↑↓ navigate" when neither direction can move;
+        // drop "Enter expand" +
         // "e/c all" when no field has a multi-line expanded form;
         // include "t logical types" only when at least one column has a
         // logical type.
-        boolean canNavigate = showCursor && totalLines > 1;
+        boolean canNavigate = overflows
+                || previousNavigableLine(state, cursorLine, totalLines, geometry) >= 0
+                || nextNavigableLine(state, cursorLine, totalLines, geometry) >= 0;
         boolean canExpand = canExpandAny;
         boolean anyLogical = false;
         for (SchemaNode child : model.schema().getRootNode().children()) {
@@ -401,6 +389,31 @@ public final class DataPreviewScreen {
         return new ModalGeometry(width, height, maxKeyWidth, valueBudget, viewportLines);
     }
 
+    private static ModalGeometry observedModalGeometry(ScreenState.DataPreview state) {
+        if (!Keys.hasObservedArea()) {
+            return null;
+        }
+        return modalGeometry(
+                Keys.observedAreaWidth(), Keys.observedAreaHeight(), state.columnNames());
+    }
+
+    private static List<String> expandedValueLines(
+            ScreenState.DataPreview state, int field, ModalGeometry geometry) {
+        return expandedValueLines(state, state.modalRow(), field, geometry);
+    }
+
+    private static List<String> expandedValueLines(
+            ScreenState.DataPreview state, int modalRow, int field, ModalGeometry geometry) {
+        List<String> values = state.rows().get(modalRow);
+        List<String> expanded = state.expandedRows().get(modalRow);
+        String value = field < values.size() ? values.get(field) : "";
+        String fullValue = field < expanded.size() ? expanded.get(field) : value;
+        List<String> lines = geometry == null
+                ? List.of(fullValue.split("\n", -1))
+                : Strings.hardWrap(fullValue, geometry.valueBudget());
+        return lines.isEmpty() ? List.of("") : lines;
+    }
+
     private record ModalGeometry(
             int width,
             int height,
@@ -439,45 +452,48 @@ public final class DataPreviewScreen {
     private static boolean handleModal(KeyEvent event, ScreenState.DataPreview state,
                                        dev.hardwood.cli.dive.NavigationStack stack,
                                        ParquetModel model) {
-        // Inside the modal, ↑/↓ navigate the modal's content one line at a
-        // time (collapsed field = 1 line, expanded field = N lines), so a
-        // long expansion can be scrolled and the next field below it
-        // reached without closing. Enter toggles expansion for the field
-        // owning the current line; e / c expand / collapse all fields. Esc
-        // closes the modal. Row stepping is intentionally absent — the
-        // user picks another row from the table after closing.
+        // Inside an overflowing modal, ↑/↓ move one rendered line at a time
+        // so every field remains reachable. When the body fits, they skip to
+        // fields whose expanded rendering reveals something new. Enter
+        // toggles that field; e / c expand / collapse all fields. Esc closes
+        // the modal. Row stepping is intentionally absent — the user picks
+        // another row from the table after closing.
         if (event.isCancel()) {
             stack.replaceTop(withModalRow(state, -1));
             return true;
         }
-        int totalLines = totalModalLines(state);
+        ModalGeometry geometry = observedModalGeometry(state);
+        int totalLines = totalModalLines(state, geometry);
         if (event.isConfirm()) {
-            int field = fieldForLine(state, state.modalCursorLine());
+            int field = fieldForLine(state, state.modalCursorLine(), geometry);
+            if (geometry != null && !isExpandableField(state, field, geometry)) {
+                return false;
+            }
             Set<Integer> next = new HashSet<>(state.expandedColumns());
             if (!next.remove(field)) {
                 next.add(field);
             }
             // Keep the cursor on the same field after toggling so the user
             // doesn't lose their place.
-            int newCursor = firstLineForField(state, next, field);
+            int newCursor = firstLineForField(state, next, field, geometry);
             stack.replaceTop(withExpansion(state, next, newCursor));
             return true;
         }
         if (event.code() == KeyCode.CHAR && event.character() == 'e'
                 && !event.hasCtrl() && !event.hasAlt()) {
-            int field = fieldForLine(state, state.modalCursorLine());
+            int field = fieldForLine(state, state.modalCursorLine(), geometry);
             Set<Integer> all = new HashSet<>();
             for (int i = 0; i < state.columnNames().size(); i++) {
                 all.add(i);
             }
-            int newCursor = firstLineForField(state, all, field);
+            int newCursor = firstLineForField(state, all, field, geometry);
             stack.replaceTop(withExpansion(state, all, newCursor));
             return true;
         }
         if (event.code() == KeyCode.CHAR && event.character() == 'c'
                 && !event.hasCtrl() && !event.hasAlt()) {
-            int field = fieldForLine(state, state.modalCursorLine());
-            int newCursor = firstLineForField(state, Set.of(), field);
+            int field = fieldForLine(state, state.modalCursorLine(), geometry);
+            int newCursor = firstLineForField(state, Set.of(), field, geometry);
             stack.replaceTop(withExpansion(state, Set.of(), newCursor));
             return true;
         }
@@ -501,14 +517,24 @@ public final class DataPreviewScreen {
             if (state.modalCursorLine() == 0) {
                 return false;
             }
-            stack.replaceTop(withCursorLine(state, state.modalCursorLine() - 1));
+            int previous = previousNavigableLine(
+                    state, state.modalCursorLine(), totalLines, geometry);
+            if (previous < 0) {
+                return false;
+            }
+            stack.replaceTop(withCursorLine(state, previous));
             return true;
         }
         if (event.isDown()) {
             if (state.modalCursorLine() >= totalLines - 1) {
                 return false;
             }
-            stack.replaceTop(withCursorLine(state, state.modalCursorLine() + 1));
+            int next = nextNavigableLine(
+                    state, state.modalCursorLine(), totalLines, geometry);
+            if (next < 0) {
+                return false;
+            }
+            stack.replaceTop(withCursorLine(state, next));
             return true;
         }
         return false;
@@ -517,14 +543,13 @@ public final class DataPreviewScreen {
     /// Total displayable lines in the modal body — one per field for
     /// collapsed fields, plus extra continuation lines for each expanded
     /// field's pretty-printed value.
-    private static int totalModalLines(ScreenState.DataPreview state) {
+    private static int totalModalLines(ScreenState.DataPreview state, ModalGeometry geometry) {
         int total = state.columnNames().size();
-        List<String> expanded = state.expandedRows().get(state.modalRow());
         for (int i : state.expandedColumns()) {
-            if (i < 0 || i >= expanded.size()) {
+            if (i < 0 || i >= state.columnNames().size()) {
                 continue;
             }
-            int continuationLines = expanded.get(i).split("\n", -1).length;
+            int continuationLines = expandedValueLines(state, i, geometry).size();
             total += Math.max(0, continuationLines - 1);
         }
         return total;
@@ -532,17 +557,17 @@ public final class DataPreviewScreen {
 
     /// Field index that owns the given cursor line in the flattened modal
     /// body. Continuation lines of an expanded field map to that field.
-    private static int fieldForLine(ScreenState.DataPreview state, int line) {
+    private static int fieldForLine(
+            ScreenState.DataPreview state, int line, ModalGeometry geometry) {
         int names = state.columnNames().size();
         if (names == 0) {
             return 0;
         }
-        List<String> expanded = state.expandedRows().get(state.modalRow());
         int cursor = 0;
         for (int field = 0; field < names; field++) {
             int linesForField = 1;
-            if (state.expandedColumns().contains(field) && field < expanded.size()) {
-                linesForField = expanded.get(field).split("\n", -1).length;
+            if (state.expandedColumns().contains(field)) {
+                linesForField = expandedValueLines(state, field, geometry).size();
             }
             if (line < cursor + linesForField) {
                 return field;
@@ -554,17 +579,99 @@ public final class DataPreviewScreen {
 
     /// Line index of the key line for `field` given the new expanded set.
     private static int firstLineForField(ScreenState.DataPreview state,
-                                          Set<Integer> expandedColumns, int field) {
-        List<String> expanded = state.expandedRows().get(state.modalRow());
+                                          Set<Integer> expandedColumns, int field,
+                                          ModalGeometry geometry) {
+        return firstLineForField(
+                state, state.modalRow(), expandedColumns, field, geometry);
+    }
+
+    private static int firstLineForField(ScreenState.DataPreview state, int modalRow,
+                                          Set<Integer> expandedColumns, int field,
+                                          ModalGeometry geometry) {
         int line = 0;
         for (int i = 0; i < field; i++) {
             int linesForField = 1;
-            if (expandedColumns.contains(i) && i < expanded.size()) {
-                linesForField = expanded.get(i).split("\n", -1).length;
+            if (expandedColumns.contains(i)) {
+                linesForField = expandedValueLines(state, modalRow, i, geometry).size();
             }
             line += linesForField;
         }
         return line;
+    }
+
+    private static boolean hasExpandableField(
+            ScreenState.DataPreview state, ModalGeometry geometry) {
+        for (int field = 0; field < state.columnNames().size(); field++) {
+            if (isExpandableField(state, field, geometry)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private static boolean isExpandableField(
+            ScreenState.DataPreview state, int field, ModalGeometry geometry) {
+        return isExpandableField(state, state.modalRow(), field, geometry);
+    }
+
+    private static boolean isExpandableField(
+            ScreenState.DataPreview state, int modalRow, int field, ModalGeometry geometry) {
+        List<String> expanded = state.expandedRows().get(modalRow);
+        if (field < 0 || field >= expanded.size()) {
+            return false;
+        }
+        if (geometry == null) {
+            return expanded.get(field).indexOf('\n') >= 0;
+        }
+        List<String> wrapped = expandedValueLines(state, modalRow, field, geometry);
+        List<String> values = state.rows().get(modalRow);
+        String collapsed = truncate(field < values.size() ? values.get(field) : "",
+                geometry.valueBudget());
+        return wrapped.size() > 1 || !wrapped.get(0).equals(collapsed);
+    }
+
+    /// Finds the previous reachable line: one physical line when scrolling is
+    /// required, otherwise the first line of the previous actionable field.
+    private static int previousNavigableLine(
+            ScreenState.DataPreview state, int from, int totalLines,
+            ModalGeometry geometry) {
+        if (usesLineNavigation(state, totalLines, geometry)) {
+            return from - 1;
+        }
+        int currentField = fieldForLine(state, from, geometry);
+        for (int field = currentField - 1; field >= 0; field--) {
+            if (isExpandableField(state, field, geometry)) {
+                return firstLineForField(state, state.expandedColumns(), field, geometry);
+            }
+        }
+        return -1;
+    }
+
+    /// Finds the next reachable line: one physical line when scrolling is
+    /// required, otherwise the first line of the next actionable field.
+    private static int nextNavigableLine(
+            ScreenState.DataPreview state, int from, int totalLines,
+            ModalGeometry geometry) {
+        if (usesLineNavigation(state, totalLines, geometry)) {
+            return from + 1;
+        }
+        int currentField = fieldForLine(state, from, geometry);
+        for (int field = currentField + 1; field < state.columnNames().size(); field++) {
+            if (isExpandableField(state, field, geometry)) {
+                return firstLineForField(state, state.expandedColumns(), field, geometry);
+            }
+        }
+        return -1;
+    }
+
+    private static boolean usesLineNavigation(
+            ScreenState.DataPreview state, int totalLines, ModalGeometry geometry) {
+        if (geometry != null) {
+            return totalLines > geometry.viewportLines();
+        }
+        // Handler-only tests and the first event before a render retain the
+        // previous scalar fallback because no viewport is available yet.
+        return !hasExpandableField(state, null);
     }
 
     private static ScreenState.DataPreview withSelectedRow(ScreenState.DataPreview s, int sel) {
@@ -574,10 +681,29 @@ public final class DataPreviewScreen {
     }
 
     private static ScreenState.DataPreview withModalRow(ScreenState.DataPreview s, int modalRow) {
+        ModalGeometry geometry = observedModalGeometry(s);
+        int cursorLine = 0;
+        if (modalRow >= 0
+                && (geometry == null || s.columnNames().size() <= geometry.viewportLines())) {
+            int field = firstExpandableField(s, modalRow, geometry);
+            cursorLine = firstLineForField(
+                    s, modalRow, s.expandedColumns(), field, geometry);
+        }
         return new ScreenState.DataPreview(s.firstRow(), s.pageSize(), s.columnNames(), s.rows(),
                 s.expandedRows(), s.columnScroll(), s.selectedRow(), modalRow, s.logicalTypes(),
                 modalRow < 0 ? Set.of() : s.expandedColumns(),
-                modalRow < 0 ? 0 : s.modalCursorLine());
+                cursorLine);
+    }
+
+    /// Returns the first expandable field, or field 0 when the record has none.
+    private static int firstExpandableField(
+            ScreenState.DataPreview state, int modalRow, ModalGeometry geometry) {
+        for (int field = 0; field < state.columnNames().size(); field++) {
+            if (isExpandableField(state, modalRow, field, geometry)) {
+                return field;
+            }
+        }
+        return 0;
     }
 
     private static ScreenState.DataPreview withColumnScroll(ScreenState.DataPreview s, int scroll) {

--- a/cli/src/main/java/dev/hardwood/cli/dive/internal/DataPreviewScreen.java
+++ b/cli/src/main/java/dev/hardwood/cli/dive/internal/DataPreviewScreen.java
@@ -177,6 +177,7 @@ public final class DataPreviewScreen {
     }
 
     public static void render(Buffer buffer, Rect area, ParquetModel model, ScreenState.DataPreview state) {
+        Keys.observeArea(area.width(), area.height());
         // Block borders (top + bottom) + header row = 3 cells of chrome
         // around the data rows.
         Keys.observeViewport(area.height() - 3);
@@ -238,18 +239,18 @@ public final class DataPreviewScreen {
         List<String> values = state.rows().get(state.modalRow());
         List<String> expanded = state.expandedRows().get(state.modalRow());
         List<String> names = state.columnNames();
-        int width = Math.max(40, screenArea.width() - 4);
-        int height = Math.max(8, screenArea.height() - 2);
+        ModalGeometry geometry = modalGeometry(
+                screenArea.width(), screenArea.height(), names);
+        int width = geometry.width();
+        int height = geometry.height();
         int x = screenArea.left() + (screenArea.width() - width) / 2;
         int y = screenArea.top() + (screenArea.height() - height) / 2;
         Rect area = new Rect(x, y, width, height);
         Clear.INSTANCE.render(area, buffer);
 
-        int maxKeyWidth = 0;
-        for (String name : names) {
-            maxKeyWidth = Math.max(maxKeyWidth, name.length());
-        }
-        int valueBudget = Math.max(8, width - 2 - 1 - maxKeyWidth - 3 - 1);
+        int maxKeyWidth = geometry.maxKeyWidth();
+        int valueBudget = geometry.valueBudget();
+        int viewport = geometry.viewportLines();
         String continuationIndent = " ".repeat(1 + maxKeyWidth + 3);
 
         // Build the full body as a flat line list. ownership[i] = the line
@@ -295,8 +296,7 @@ public final class DataPreviewScreen {
                 break;
             }
         }
-        int viewportForCursor = Math.max(1, height - 4);
-        boolean overflows = totalLines > viewportForCursor;
+        boolean overflows = totalLines > viewport;
         boolean showCursor = canExpandAny || overflows;
         if (showCursor && cursorLine < all.size()) {
             int fieldIdx = fieldForLine(state, cursorLine);
@@ -329,7 +329,6 @@ public final class DataPreviewScreen {
             }
         }
 
-        int viewport = Math.max(1, height - 4);
         int scroll = Math.max(0, Math.min(totalLines - viewport,
                 Math.max(0, cursorLine - viewport / 2)));
         int end = Math.min(totalLines, scroll + viewport);
@@ -387,6 +386,27 @@ public final class DataPreviewScreen {
                 .left()
                 .build()
                 .render(area, buffer);
+    }
+
+    private static ModalGeometry modalGeometry(
+            int screenWidth, int screenHeight, List<String> names) {
+        int width = Math.max(40, screenWidth - 4);
+        int height = Math.max(8, screenHeight - 2);
+        int maxKeyWidth = 0;
+        for (String name : names) {
+            maxKeyWidth = Math.max(maxKeyWidth, name.length());
+        }
+        int valueBudget = Math.max(8, width - 2 - 1 - maxKeyWidth - 3 - 1);
+        int viewportLines = Math.max(1, height - 4);
+        return new ModalGeometry(width, height, maxKeyWidth, valueBudget, viewportLines);
+    }
+
+    private record ModalGeometry(
+            int width,
+            int height,
+            int maxKeyWidth,
+            int valueBudget,
+            int viewportLines) {
     }
 
     public static String keybarKeys(ScreenState.DataPreview state, ParquetModel model) {

--- a/cli/src/main/java/dev/hardwood/cli/dive/internal/DataPreviewScreen.java
+++ b/cli/src/main/java/dev/hardwood/cli/dive/internal/DataPreviewScreen.java
@@ -177,7 +177,7 @@ public final class DataPreviewScreen {
     }
 
     public static void render(Buffer buffer, Rect area, ParquetModel model, ScreenState.DataPreview state) {
-        Keys.observeArea(area.width(), area.height());
+        Keys.observeDataPreviewArea(area.width(), area.height());
         // Block borders (top + bottom) + header row = 3 cells of chrome
         // around the data rows.
         Keys.observeViewport(area.height() - 3);
@@ -281,19 +281,17 @@ public final class DataPreviewScreen {
 
         int totalLines = all.size();
         int cursorLine = Math.max(0, Math.min(state.modalCursorLine(), totalLines - 1));
-        // Cursor is purely decorative when there's nothing to do with it:
-        // no field can expand AND content fits the viewport. In that case
-        // the modal becomes a static info display.
+        // The cursor exists to point at something Enter can act on. With no
+        // expandable field there is nothing to point at, so the modal becomes
+        // a static info display that PgDn/PgUp scrolls.
         boolean canExpandAny = hasExpandableField(state, geometry);
-        boolean overflows = totalLines > viewport;
-        boolean showCursor = canExpandAny || overflows;
-        if (showCursor && cursorLine < all.size()) {
-            int fieldIdx = fieldForLine(state, cursorLine, geometry);
+        int fieldIdx = fieldForLine(state, cursorLine, geometry);
+        boolean focusExpandable = canExpandAny && isExpandableField(state, fieldIdx, geometry);
+        if (canExpandAny && cursorLine < all.size()) {
             int fieldFirstLine = ownership[fieldIdx];
             String name = names.get(fieldIdx);
             String pad = " ".repeat(maxKeyWidth - name.length());
             boolean isExpanded = state.expandedColumns().contains(fieldIdx);
-            boolean isExpandable = isExpandableField(state, fieldIdx, geometry);
             String value = fieldIdx < values.size() ? values.get(fieldIdx) : "";
             Style selectionStyle = Theme.selection();
             if (cursorLine == fieldFirstLine) {
@@ -306,7 +304,7 @@ public final class DataPreviewScreen {
                     shown = truncate(value, valueBudget);
                 }
                 all.set(cursorLine, Line.from(
-                        new Span((isExpandable ? "▶" : " ") + name + pad + " : ",
+                        new Span((focusExpandable ? "▶" : " ") + name + pad + " : ",
                                 selectionStyle),
                         new Span(shown, selectionStyle)));
             }
@@ -318,21 +316,21 @@ public final class DataPreviewScreen {
             }
         }
 
-        int scroll = Math.max(0, Math.min(totalLines - viewport,
-                Math.max(0, cursorLine - viewport / 2)));
+        // The handlers keep `modalScroll` pointed at the cursor; render only
+        // clamps it, so a PgDn that scrolled away from the cursor stays put.
+        int scroll = Math.max(0, Math.min(state.modalScroll(), maxScroll(totalLines, geometry)));
         int end = Math.min(totalLines, scroll + viewport);
 
         List<Line> lines = new ArrayList<>(all.subList(scroll, end));
         lines.add(Line.empty());
-        // Hint is tiered: drop "↑↓ navigate" when neither direction can move;
-        // drop "Enter expand" +
-        // "e/c all" when no field has a multi-line expanded form;
-        // include "t logical types" only when at least one column has a
-        // logical type.
-        boolean canNavigate = overflows
-                || previousNavigableLine(state, cursorLine, totalLines, geometry) >= 0
-                || nextNavigableLine(state, cursorLine, totalLines, geometry) >= 0;
-        boolean canExpand = canExpandAny;
+        // Hint is tiered: drop "↑↓ field" when no other expandable field can
+        // be reached; drop "PgDn/PgUp scroll" when the body already fits;
+        // drop "Enter expand" when the focused field has nothing more to
+        // show and "e/c all" when no field does; include "t logical types"
+        // only when at least one column has a logical type.
+        boolean canNavigate = previousExpandableLine(state, cursorLine, geometry) >= 0
+                || nextExpandableLine(state, cursorLine, geometry) >= 0;
+        boolean canScroll = totalLines > viewport;
         boolean anyLogical = false;
         for (SchemaNode child : model.schema().getRootNode().children()) {
             if (child instanceof SchemaNode.PrimitiveNode p && p.logicalType() != null) {
@@ -348,10 +346,15 @@ public final class DataPreviewScreen {
             segments.add(" ↑ " + scroll + " lines above");
         }
         if (canNavigate) {
-            segments.add("↑↓ navigate");
+            segments.add("↑↓ field");
         }
-        if (canExpand) {
+        if (canScroll) {
+            segments.add("PgDn/PgUp scroll");
+        }
+        if (focusExpandable) {
             segments.add("Enter expand");
+        }
+        if (canExpandAny) {
             segments.add("e/c all");
         }
         if (anyLogical) {
@@ -391,12 +394,13 @@ public final class DataPreviewScreen {
         return new ModalGeometry(width, height, maxKeyWidth, valueBudget, viewportLines);
     }
 
+    /// The geometry the modal was last drawn with. Key handlers run between
+    /// frames and must reach the same answers as the drawing code, so they
+    /// rebuild it from the area `render` recorded — falling back to a default
+    /// terminal size before the first frame, never to a second rulebook.
     private static ModalGeometry observedModalGeometry(ScreenState.DataPreview state) {
-        if (!Keys.hasObservedArea()) {
-            return null;
-        }
         return modalGeometry(
-                Keys.observedAreaWidth(), Keys.observedAreaHeight(), state.columnNames());
+                Keys.dataPreviewAreaWidth(), Keys.dataPreviewAreaHeight(), state.columnNames());
     }
 
     private static List<String> expandedValueLines(
@@ -410,9 +414,7 @@ public final class DataPreviewScreen {
         List<String> expanded = state.expandedRows().get(modalRow);
         String value = field < values.size() ? values.get(field) : "";
         String fullValue = field < expanded.size() ? expanded.get(field) : value;
-        List<String> lines = geometry == null
-                ? List.of(fullValue.split("\n", -1))
-                : Strings.hardWrap(fullValue, geometry.valueBudget());
+        List<String> lines = Strings.hardWrap(fullValue, geometry.valueBudget());
         return lines.isEmpty() ? List.of("") : lines;
     }
 
@@ -454,31 +456,28 @@ public final class DataPreviewScreen {
     private static boolean handleModal(KeyEvent event, ScreenState.DataPreview state,
                                        dev.hardwood.cli.dive.NavigationStack stack,
                                        ParquetModel model) {
-        // Inside an overflowing modal, ↑/↓ move one rendered line at a time
-        // so every field remains reachable. When the body fits, they skip to
-        // fields whose expanded rendering reveals something new. Enter
-        // toggles that field; e / c expand / collapse all fields. Esc closes
-        // the modal. Row stepping is intentionally absent — the user picks
-        // another row from the table after closing.
+        // ↑/↓ step between the fields Enter can expand, skipping the ones it
+        // can't at every terminal size; PgDn/PgUp scroll the body so content
+        // the cursor never stops on is still readable. Enter toggles the
+        // field under the cursor; e / c expand / collapse all fields. Esc
+        // closes the modal. Row stepping is intentionally absent — the user
+        // picks another row from the table after closing.
         if (event.isCancel()) {
             stack.replaceTop(withModalRow(state, -1));
             return true;
         }
         ModalGeometry geometry = observedModalGeometry(state);
-        int totalLines = totalModalLines(state, geometry);
+        int totalLines = totalModalLines(state, state.expandedColumns(), geometry);
         if (event.isConfirm()) {
             int field = fieldForLine(state, state.modalCursorLine(), geometry);
-            if (geometry != null && !isExpandableField(state, field, geometry)) {
+            if (!isExpandableField(state, field, geometry)) {
                 return false;
             }
             Set<Integer> next = new HashSet<>(state.expandedColumns());
             if (!next.remove(field)) {
                 next.add(field);
             }
-            // Keep the cursor on the same field after toggling so the user
-            // doesn't lose their place.
-            int newCursor = firstLineForField(state, next, field, geometry);
-            stack.replaceTop(withExpansion(state, next, newCursor));
+            stack.replaceTop(withExpansion(state, next, field, geometry));
             return true;
         }
         if (event.code() == KeyCode.CHAR && event.character() == 'e'
@@ -488,21 +487,19 @@ public final class DataPreviewScreen {
             for (int i = 0; i < state.columnNames().size(); i++) {
                 all.add(i);
             }
-            int newCursor = firstLineForField(state, all, field, geometry);
-            stack.replaceTop(withExpansion(state, all, newCursor));
+            stack.replaceTop(withExpansion(state, all, field, geometry));
             return true;
         }
         if (event.code() == KeyCode.CHAR && event.character() == 'c'
                 && !event.hasCtrl() && !event.hasAlt()) {
             int field = fieldForLine(state, state.modalCursorLine(), geometry);
-            int newCursor = firstLineForField(state, Set.of(), field, geometry);
-            stack.replaceTop(withExpansion(state, Set.of(), newCursor));
+            stack.replaceTop(withExpansion(state, Set.of(), field, geometry));
             return true;
         }
         // `t` toggles logical-type rendering. Re-loads the current page
         // with the new flag and preserves the modal-state fields
-        // (selectedRow, modalRow, expandedColumns, cursorLine) so the
-        // user stays put.
+        // (selectedRow, modalRow, expandedColumns, cursorLine, scroll) so
+        // the user stays put.
         if (event.code() == KeyCode.CHAR && event.character() == 't'
                 && !event.hasCtrl() && !event.hasAlt()) {
             boolean nextLogical = !state.logicalTypes();
@@ -512,42 +509,61 @@ public final class DataPreviewScreen {
                     reloaded.firstRow(), reloaded.pageSize(), reloaded.columnNames(),
                     reloaded.rows(), reloaded.expandedRows(), reloaded.columnScroll(),
                     state.selectedRow(), state.modalRow(), nextLogical,
-                    state.expandedColumns(), state.modalCursorLine()));
+                    state.expandedColumns(), state.modalCursorLine(), state.modalScroll()));
             return true;
         }
-        if (event.isUp()) {
-            if (state.modalCursorLine() == 0) {
-                return false;
-            }
-            int previous = previousNavigableLine(
-                    state, state.modalCursorLine(), totalLines, geometry);
+        // Paging is checked before stepping because `isPageDown` / `isPageUp`
+        // also match Shift+↓/↑, which `event.isDown()` / `isUp()` would claim.
+        if (Keys.isPageDown(event)) {
+            return scrollModal(state, stack, totalLines, geometry, geometry.viewportLines());
+        }
+        if (Keys.isPageUp(event)) {
+            return scrollModal(state, stack, totalLines, geometry, -geometry.viewportLines());
+        }
+        if (Keys.isStepUp(event)) {
+            int previous = previousExpandableLine(state, state.modalCursorLine(), geometry);
             if (previous < 0) {
                 return false;
             }
-            stack.replaceTop(withCursorLine(state, previous));
+            stack.replaceTop(withCursorLine(state, previous, totalLines, geometry));
             return true;
         }
-        if (event.isDown()) {
-            if (state.modalCursorLine() >= totalLines - 1) {
-                return false;
-            }
-            int next = nextNavigableLine(
-                    state, state.modalCursorLine(), totalLines, geometry);
+        if (Keys.isStepDown(event)) {
+            int next = nextExpandableLine(state, state.modalCursorLine(), geometry);
             if (next < 0) {
                 return false;
             }
-            stack.replaceTop(withCursorLine(state, next));
+            stack.replaceTop(withCursorLine(state, next, totalLines, geometry));
             return true;
         }
         return false;
     }
 
-    /// Total displayable lines in the modal body — one per field for
-    /// collapsed fields, plus extra continuation lines for each expanded
-    /// field's pretty-printed value.
-    private static int totalModalLines(ScreenState.DataPreview state, ModalGeometry geometry) {
+    /// Scrolls the modal body by `delta` lines without moving the cursor.
+    /// Returns `false` when the body is already against that end, so the
+    /// keypress reads as unhandled rather than as a no-op redraw.
+    private static boolean scrollModal(ScreenState.DataPreview state,
+                                       dev.hardwood.cli.dive.NavigationStack stack,
+                                       int totalLines, ModalGeometry geometry, int delta) {
+        int max = maxScroll(totalLines, geometry);
+        int current = Math.max(0, Math.min(state.modalScroll(), max));
+        int next = Math.max(0, Math.min(max, current + delta));
+        if (next == current) {
+            return false;
+        }
+        stack.replaceTop(withModalScroll(state, next));
+        return true;
+    }
+
+    /// Total displayable lines in the modal body given `expandedColumns` —
+    /// one per collapsed field, plus extra continuation lines for each
+    /// expanded field's pretty-printed value. Takes the set as a parameter so
+    /// callers can size the body a toggle is about to produce, not just the
+    /// one currently on screen.
+    private static int totalModalLines(ScreenState.DataPreview state,
+                                       Set<Integer> expandedColumns, ModalGeometry geometry) {
         int total = state.columnNames().size();
-        for (int i : state.expandedColumns()) {
+        for (int i : expandedColumns) {
             if (i < 0 || i >= state.columnNames().size()) {
                 continue;
             }
@@ -616,14 +632,17 @@ public final class DataPreviewScreen {
         return isExpandableField(state, state.modalRow(), field, geometry);
     }
 
+    /// A field is expandable when expanding it puts something on screen that
+    /// the collapsed line doesn't already show — either because its value
+    /// wraps onto more than one line, or because the collapsed line had to
+    /// truncate it. Both sides measure display cells, so a value that fits
+    /// the budget is never reported as expandable however many `char`s it
+    /// happens to occupy.
     private static boolean isExpandableField(
             ScreenState.DataPreview state, int modalRow, int field, ModalGeometry geometry) {
         List<String> expanded = state.expandedRows().get(modalRow);
         if (field < 0 || field >= expanded.size()) {
             return false;
-        }
-        if (geometry == null) {
-            return expanded.get(field).indexOf('\n') >= 0;
         }
         List<String> wrapped = expandedValueLines(state, modalRow, field, geometry);
         List<String> values = state.rows().get(modalRow);
@@ -632,14 +651,11 @@ public final class DataPreviewScreen {
         return wrapped.size() > 1 || !wrapped.get(0).equals(collapsed);
     }
 
-    /// Finds the previous reachable line: one physical line when scrolling is
-    /// required, otherwise the first line of the previous actionable field.
-    private static int previousNavigableLine(
-            ScreenState.DataPreview state, int from, int totalLines,
-            ModalGeometry geometry) {
-        if (usesLineNavigation(state, totalLines, geometry)) {
-            return from - 1;
-        }
+    /// First line of the nearest expandable field before `from`, or `-1` when
+    /// there is none. `↑` skips over fields Enter can do nothing with at every
+    /// terminal size; reading past them is `PgUp`'s job, not the cursor's.
+    private static int previousExpandableLine(
+            ScreenState.DataPreview state, int from, ModalGeometry geometry) {
         int currentField = fieldForLine(state, from, geometry);
         for (int field = currentField - 1; field >= 0; field--) {
             if (isExpandableField(state, field, geometry)) {
@@ -649,14 +665,10 @@ public final class DataPreviewScreen {
         return -1;
     }
 
-    /// Finds the next reachable line: one physical line when scrolling is
-    /// required, otherwise the first line of the next actionable field.
-    private static int nextNavigableLine(
-            ScreenState.DataPreview state, int from, int totalLines,
-            ModalGeometry geometry) {
-        if (usesLineNavigation(state, totalLines, geometry)) {
-            return from + 1;
-        }
+    /// First line of the nearest expandable field after `from`, or `-1` when
+    /// there is none. See [#previousExpandableLine].
+    private static int nextExpandableLine(
+            ScreenState.DataPreview state, int from, ModalGeometry geometry) {
         int currentField = fieldForLine(state, from, geometry);
         for (int field = currentField + 1; field < state.columnNames().size(); field++) {
             if (isExpandableField(state, field, geometry)) {
@@ -666,35 +678,61 @@ public final class DataPreviewScreen {
         return -1;
     }
 
-    private static boolean usesLineNavigation(
-            ScreenState.DataPreview state, int totalLines, ModalGeometry geometry) {
-        if (geometry != null) {
-            return totalLines > geometry.viewportLines();
+    /// Largest first-visible-line the body can scroll to.
+    private static int maxScroll(int totalLines, ModalGeometry geometry) {
+        return Math.max(0, totalLines - geometry.viewportLines());
+    }
+
+    /// Clamps `scroll` into range and then pulls it just far enough for
+    /// `cursorLine` to be on screen. Used when stepping between fields, so the
+    /// view moves as little as possible; `PgDn`/`PgUp` bypass it, which is
+    /// what lets the body scroll away from the cursor.
+    private static int scrollToReveal(int scroll, int cursorLine, int totalLines,
+                                      ModalGeometry geometry) {
+        int viewport = geometry.viewportLines();
+        int max = maxScroll(totalLines, geometry);
+        int clamped = Math.max(0, Math.min(scroll, max));
+        if (cursorLine < clamped) {
+            return cursorLine;
         }
-        // Handler-only tests and the first event before a render retain the
-        // previous scalar fallback because no viewport is available yet.
-        return !hasExpandableField(state, null);
+        if (cursorLine >= clamped + viewport) {
+            return Math.min(max, cursorLine - viewport + 1);
+        }
+        return clamped;
+    }
+
+    /// Puts `cursorLine` at the top of the viewport. Used after an expansion
+    /// toggle: the point of expanding is to read what appeared underneath, so
+    /// the field goes to the top and takes as much of its value with it as
+    /// fits, rather than staying put and revealing only its key line.
+    private static int scrollToTop(int cursorLine, int totalLines, ModalGeometry geometry) {
+        return Math.max(0, Math.min(cursorLine, maxScroll(totalLines, geometry)));
     }
 
     private static ScreenState.DataPreview withSelectedRow(ScreenState.DataPreview s, int sel) {
         return new ScreenState.DataPreview(s.firstRow(), s.pageSize(), s.columnNames(), s.rows(),
                 s.expandedRows(), s.columnScroll(), sel, s.modalRow(), s.logicalTypes(),
-                s.expandedColumns(), s.modalCursorLine());
+                s.expandedColumns(), s.modalCursorLine(), s.modalScroll());
     }
 
+    /// Opens (`modalRow >= 0`) or closes (`-1`) the record modal. Opening puts
+    /// the cursor on the first expandable field and scrolls it into view, so
+    /// the modal starts on something Enter can act on even when that field
+    /// sits below the fold.
     private static ScreenState.DataPreview withModalRow(ScreenState.DataPreview s, int modalRow) {
-        ModalGeometry geometry = observedModalGeometry(s);
-        int cursorLine = 0;
-        if (modalRow >= 0
-                && (geometry == null || s.columnNames().size() <= geometry.viewportLines())) {
-            int field = firstExpandableField(s, modalRow, geometry);
-            cursorLine = firstLineForField(
-                    s, modalRow, s.expandedColumns(), field, geometry);
+        if (modalRow < 0) {
+            return new ScreenState.DataPreview(s.firstRow(), s.pageSize(), s.columnNames(),
+                    s.rows(), s.expandedRows(), s.columnScroll(), s.selectedRow(), modalRow,
+                    s.logicalTypes(), Set.of(), 0, 0);
         }
+        ModalGeometry geometry = observedModalGeometry(s);
+        int field = firstExpandableField(s, modalRow, geometry);
+        int cursorLine = firstLineForField(s, modalRow, s.expandedColumns(), field, geometry);
+        int totalLines = totalModalLines(s, s.expandedColumns(), geometry);
         return new ScreenState.DataPreview(s.firstRow(), s.pageSize(), s.columnNames(), s.rows(),
                 s.expandedRows(), s.columnScroll(), s.selectedRow(), modalRow, s.logicalTypes(),
-                modalRow < 0 ? Set.of() : s.expandedColumns(),
-                cursorLine);
+                s.expandedColumns(), cursorLine,
+                scrollToReveal(0, cursorLine, totalLines, geometry));
     }
 
     /// Returns the first expandable field, or field 0 when the record has none.
@@ -711,20 +749,37 @@ public final class DataPreviewScreen {
     private static ScreenState.DataPreview withColumnScroll(ScreenState.DataPreview s, int scroll) {
         return new ScreenState.DataPreview(s.firstRow(), s.pageSize(), s.columnNames(), s.rows(),
                 s.expandedRows(), scroll, s.selectedRow(), s.modalRow(), s.logicalTypes(),
-                s.expandedColumns(), s.modalCursorLine());
+                s.expandedColumns(), s.modalCursorLine(), s.modalScroll());
     }
 
-    private static ScreenState.DataPreview withCursorLine(ScreenState.DataPreview s, int line) {
+    /// Moves the modal cursor to `line`, scrolling only as far as needed to
+    /// bring it on screen.
+    private static ScreenState.DataPreview withCursorLine(ScreenState.DataPreview s, int line,
+                                                          int totalLines, ModalGeometry geometry) {
         return new ScreenState.DataPreview(s.firstRow(), s.pageSize(), s.columnNames(), s.rows(),
                 s.expandedRows(), s.columnScroll(), s.selectedRow(), s.modalRow(), s.logicalTypes(),
-                s.expandedColumns(), line);
+                s.expandedColumns(), line,
+                scrollToReveal(s.modalScroll(), line, totalLines, geometry));
     }
 
+    private static ScreenState.DataPreview withModalScroll(ScreenState.DataPreview s, int scroll) {
+        return new ScreenState.DataPreview(s.firstRow(), s.pageSize(), s.columnNames(), s.rows(),
+                s.expandedRows(), s.columnScroll(), s.selectedRow(), s.modalRow(), s.logicalTypes(),
+                s.expandedColumns(), s.modalCursorLine(), scroll);
+    }
+
+    /// Applies a new expanded set, keeping the cursor on `field` so the user
+    /// doesn't lose their place, and scrolling that field to the top so its
+    /// newly revealed lines are on screen.
     private static ScreenState.DataPreview withExpansion(ScreenState.DataPreview s,
-                                                          Set<Integer> expanded, int cursorLine) {
+                                                          Set<Integer> expanded, int field,
+                                                          ModalGeometry geometry) {
+        int cursorLine = firstLineForField(s, expanded, field, geometry);
+        int totalLines = totalModalLines(s, expanded, geometry);
         return new ScreenState.DataPreview(s.firstRow(), s.pageSize(), s.columnNames(), s.rows(),
                 s.expandedRows(), s.columnScroll(), s.selectedRow(), s.modalRow(), s.logicalTypes(),
-                expanded, cursorLine);
+                expanded, cursorLine,
+                scrollToTop(cursorLine, totalLines, geometry));
     }
 
     private static ScreenState.DataPreview loadPage(ParquetModel model, long firstRow, int pageSize,

--- a/cli/src/main/java/dev/hardwood/cli/dive/internal/Keys.java
+++ b/cli/src/main/java/dev/hardwood/cli/dive/internal/Keys.java
@@ -66,6 +66,9 @@ public final class Keys {
     /// Fallback terminal width before the first frame renders.
     private static final int DEFAULT_VIEWPORT_COLUMNS = 120;
 
+    /// Fallback terminal height before the first frame renders.
+    private static final int DEFAULT_VIEWPORT_ROWS = 40;
+
     /// Side channel from a list screen's render → its handle: the visible
     /// row count the screen settled on. Used to size PgDn/PgUp jumps so
     /// they advance by exactly one viewport instead of a hard-coded 20.
@@ -75,11 +78,14 @@ public final class Keys {
     /// handling consistent with the most recently rendered column window.
     private static int observedViewportColumns = -1;
 
-    /// Side channel for geometry-dependent handlers. Renderers record the
-    /// area they actually received so the next key event can make the same
-    /// width- and height-dependent decisions as the drawing code.
-    private static int observedAreaWidth = -1;
-    private static int observedAreaHeight = -1;
+    /// Side channel from Data preview's render → its handle. The record modal
+    /// derives its wrapping budget and viewport height from the area it is
+    /// drawn into, and the key handler has to reach the same answers as the
+    /// drawing code — which field is expandable, how far a page scrolls.
+    /// Scoped to the one screen that owns it: a second writer would silently
+    /// change how the modal navigates.
+    private static int observedDataPreviewWidth = -1;
+    private static int observedDataPreviewHeight = -1;
 
     /// Called by a list screen's `render` to record the body row count it
     /// can show. The next `handle` will use this as the PgDn/PgUp stride.
@@ -110,35 +116,32 @@ public final class Keys {
         return observedViewportRows > 0;
     }
 
-    /// Records the area available to a screen's renderer.
-    public static void observeArea(int width, int height) {
-        observedAreaWidth = Math.max(1, width);
-        observedAreaHeight = Math.max(1, height);
+    /// Called by Data preview's `render` to record the area it was drawn into.
+    public static void observeDataPreviewArea(int width, int height) {
+        observedDataPreviewWidth = Math.max(1, width);
+        observedDataPreviewHeight = Math.max(1, height);
     }
 
-    /// True iff a renderer has recorded its available width and height.
-    public static boolean hasObservedArea() {
-        return observedAreaWidth > 0 && observedAreaHeight > 0;
+    /// Width of the area Data preview last rendered into, or a pre-render
+    /// fallback.
+    public static int dataPreviewAreaWidth() {
+        return observedDataPreviewWidth > 0 ? observedDataPreviewWidth : DEFAULT_VIEWPORT_COLUMNS;
     }
 
-    /// Width of the most recently observed screen area, or `-1` before render.
-    public static int observedAreaWidth() {
-        return observedAreaWidth;
+    /// Height of the area Data preview last rendered into, or a pre-render
+    /// fallback.
+    public static int dataPreviewAreaHeight() {
+        return observedDataPreviewHeight > 0 ? observedDataPreviewHeight : DEFAULT_VIEWPORT_ROWS;
     }
 
-    /// Height of the most recently observed screen area, or `-1` before render.
-    public static int observedAreaHeight() {
-        return observedAreaHeight;
-    }
-
-    /// Test hook — clears the observed viewport so handler-only tests
-    /// that ran after a render-path test don't see a viewport seeded
-    /// by that render and trigger unwanted auto-resize.
-    public static void resetObservedViewport() {
+    /// Test hook — clears every observed geometry so handler-only tests that
+    /// ran after a render-path test don't see a viewport or area seeded by
+    /// that render and trigger unwanted auto-resize.
+    public static void resetObservedGeometry() {
         observedViewportRows = -1;
         observedViewportColumns = -1;
-        observedAreaWidth = -1;
-        observedAreaHeight = -1;
+        observedDataPreviewWidth = -1;
+        observedDataPreviewHeight = -1;
     }
 
     /// Conditional-keybar builder. Each `add(enabled, binding)` appends the

--- a/cli/src/main/java/dev/hardwood/cli/dive/internal/Keys.java
+++ b/cli/src/main/java/dev/hardwood/cli/dive/internal/Keys.java
@@ -75,6 +75,12 @@ public final class Keys {
     /// handling consistent with the most recently rendered column window.
     private static int observedViewportColumns = -1;
 
+    /// Side channel for geometry-dependent handlers. Renderers record the
+    /// area they actually received so the next key event can make the same
+    /// width- and height-dependent decisions as the drawing code.
+    private static int observedAreaWidth = -1;
+    private static int observedAreaHeight = -1;
+
     /// Called by a list screen's `render` to record the body row count it
     /// can show. The next `handle` will use this as the PgDn/PgUp stride.
     public static void observeViewport(int rows) {
@@ -104,12 +110,35 @@ public final class Keys {
         return observedViewportRows > 0;
     }
 
+    /// Records the area available to a screen's renderer.
+    public static void observeArea(int width, int height) {
+        observedAreaWidth = Math.max(1, width);
+        observedAreaHeight = Math.max(1, height);
+    }
+
+    /// True iff a renderer has recorded its available width and height.
+    public static boolean hasObservedArea() {
+        return observedAreaWidth > 0 && observedAreaHeight > 0;
+    }
+
+    /// Width of the most recently observed screen area, or `-1` before render.
+    public static int observedAreaWidth() {
+        return observedAreaWidth;
+    }
+
+    /// Height of the most recently observed screen area, or `-1` before render.
+    public static int observedAreaHeight() {
+        return observedAreaHeight;
+    }
+
     /// Test hook — clears the observed viewport so handler-only tests
     /// that ran after a render-path test don't see a viewport seeded
     /// by that render and trigger unwanted auto-resize.
     public static void resetObservedViewport() {
         observedViewportRows = -1;
         observedViewportColumns = -1;
+        observedAreaWidth = -1;
+        observedAreaHeight = -1;
     }
 
     /// Conditional-keybar builder. Each `add(enabled, binding)` appends the

--- a/cli/src/main/java/dev/hardwood/cli/dive/internal/Strings.java
+++ b/cli/src/main/java/dev/hardwood/cli/dive/internal/Strings.java
@@ -10,6 +10,8 @@ package dev.hardwood.cli.dive.internal;
 import java.util.ArrayList;
 import java.util.List;
 
+import dev.tamboui.text.CharWidth;
+
 /// Small string helpers shared by `dive` screens. Kept here so the
 /// truncation/padding behavior — including the ellipsis character — stays
 /// consistent across every screen that draws columnar content.
@@ -86,6 +88,10 @@ public final class Strings {
     /// Splits `value` into display lines of at most `width` cells without
     /// respecting word boundaries. Hard line breaks in the source are
     /// preserved; each segment is then chunked at `width` if it's longer.
+    ///
+    /// Chunking measures display cells, not `char`s, so that a line's rendered
+    /// width matches what callers budgeted for: wide glyphs (CJK, emoji) count
+    /// double and combining marks count zero.
     public static List<String> hardWrap(String value, int width) {
         List<String> out = new ArrayList<>();
         if (width <= 0) {
@@ -97,11 +103,17 @@ public final class Strings {
                 out.add("");
                 continue;
             }
-            int i = 0;
-            while (i < line.length()) {
-                int end = Math.min(line.length(), i + width);
-                out.add(line.substring(i, end));
-                i = end;
+            String rest = line;
+            while (!rest.isEmpty()) {
+                String chunk = CharWidth.substringByWidth(rest, width);
+                if (chunk.isEmpty()) {
+                    // A single glyph wider than the whole budget: emit it on
+                    // its own line and overflow by one cell rather than loop
+                    // forever making no progress.
+                    chunk = rest.substring(0, rest.offsetByCodePoints(0, 1));
+                }
+                out.add(chunk);
+                rest = rest.substring(chunk.length());
             }
         }
         return out;

--- a/cli/src/test/java/dev/hardwood/cli/dive/DiveAppTest.java
+++ b/cli/src/test/java/dev/hardwood/cli/dive/DiveAppTest.java
@@ -31,7 +31,7 @@ class DiveAppTest {
 
     @BeforeEach
     void openFixture() throws Exception {
-        dev.hardwood.cli.dive.internal.Keys.resetObservedViewport();
+        dev.hardwood.cli.dive.internal.Keys.resetObservedGeometry();
         Path path = Path.of(getClass().getResource("/column_index_pushdown.parquet").getPath());
         model = ParquetModel.open(InputFile.of(path), path.toString());
         app = new DiveApp(model);

--- a/cli/src/test/java/dev/hardwood/cli/dive/DiveRenderTest.java
+++ b/cli/src/test/java/dev/hardwood/cli/dive/DiveRenderTest.java
@@ -265,6 +265,147 @@ class DiveRenderTest {
         assertThat(RenderHarness.keybarFor(state, model)).contains("[←→] columns");
     }
 
+    @Test
+    void dataPreviewScalarOnlyOverflowRemainsReachable() {
+        List<String> names = numberedValues("f", 30);
+        List<String> values = numberedValues("v", 30);
+        ScreenState.DataPreview state = openModal(names, values, values);
+        NavigationStack stack = rooted(state);
+        Rect area = new Rect(0, 0, 100, 24);
+        RenderHarness.RenderedFrame first = RenderHarness.render(area, state, model);
+        assertThat(first.contains("▶f0"))
+                .as("a selected scalar field has no action marker")
+                .isFalse();
+
+        for (int line = 1; line < names.size(); line++) {
+            assertThat(DataPreviewScreen.handle(key(KeyCode.DOWN), model, stack))
+                    .as("move to scalar line %s", line)
+                    .isTrue();
+            assertThat(((ScreenState.DataPreview) stack.top()).modalCursorLine())
+                    .isEqualTo(line);
+        }
+
+        ScreenState.DataPreview atLast = (ScreenState.DataPreview) stack.top();
+        RenderHarness.RenderedFrame rendered = RenderHarness.render(area, atLast, model);
+        assertThat(rendered.contains("f29")).isTrue();
+        assertThat(rendered.contains("▶f29"))
+                .as("a selected scalar field is highlighted without an expand marker")
+                .isFalse();
+        assertThat(DataPreviewScreen.handle(key(KeyCode.UP), model, stack)).isTrue();
+        assertThat(((ScreenState.DataPreview) stack.top()).modalCursorLine()).isEqualTo(28);
+    }
+
+    @Test
+    void dataPreviewMixedOverflowRemainsReachablePastLastExpandableField() {
+        List<String> names = new java.util.ArrayList<>(numberedValues("f", 30));
+        List<String> values = new java.util.ArrayList<>(numberedValues("v", 30));
+        List<String> expanded = new java.util.ArrayList<>(values);
+        names.set(0, "items");
+        values.set(0, "[1, 2]");
+        expanded.set(0, "[\n  1,\n  2\n]");
+        ScreenState.DataPreview state = openModal(names, values, expanded);
+        NavigationStack stack = rooted(state);
+        Rect area = new Rect(0, 0, 100, 24);
+        RenderHarness.RenderedFrame first = RenderHarness.render(area, state, model);
+        assertThat(first.contains("▶items"))
+                .as("the expandable field shows an action marker")
+                .isTrue();
+
+        for (int line = 1; line < names.size(); line++) {
+            assertThat(DataPreviewScreen.handle(key(KeyCode.DOWN), model, stack))
+                    .as("move to line %s after the expandable field", line)
+                    .isTrue();
+        }
+
+        ScreenState.DataPreview atLast = (ScreenState.DataPreview) stack.top();
+        assertThat(atLast.modalCursorLine()).isEqualTo(29);
+        RenderHarness.RenderedFrame rendered = RenderHarness.render(area, atLast, model);
+        assertThat(rendered.contains("f29")).isTrue();
+        assertThat(rendered.contains("▶f29"))
+                .as("a scalar remains selectable for scrolling without an action marker")
+                .isFalse();
+    }
+
+    @Test
+    void dataPreviewLongSingleLineScalarIsActionableWhenTruncated() {
+        String longNote = "x".repeat(100) + "TAIL";
+        ScreenState.DataPreview state = openModal(
+                List.of("tags", "note"),
+                List.of("[a, b]", longNote),
+                List.of("[\n  a,\n  b\n]", longNote));
+        NavigationStack stack = rooted(state);
+        Rect area = new Rect(0, 0, 60, 24);
+        RenderHarness.render(area, state, model);
+
+        assertThat(DataPreviewScreen.handle(key(KeyCode.DOWN), model, stack)).isTrue();
+        ScreenState.DataPreview selectedNote = (ScreenState.DataPreview) stack.top();
+        assertThat(selectedNote.modalCursorLine()).isEqualTo(1);
+        assertThat(RenderHarness.render(area, selectedNote, model).contains("▶note"))
+                .as("a truncated single-line value shows an action marker")
+                .isTrue();
+
+        assertThat(DataPreviewScreen.handle(key(KeyCode.ENTER), model, stack)).isTrue();
+        ScreenState.DataPreview expanded = (ScreenState.DataPreview) stack.top();
+        assertThat(expanded.expandedColumns()).containsExactly(1);
+        assertThat(RenderHarness.render(area, expanded, model).contains("TAIL")).isTrue();
+    }
+
+    @Test
+    void dataPreviewFittedSingleExpandableFieldOmitsNavigationHint() {
+        ScreenState.DataPreview state = openModal(
+                List.of("items", "id", "status"),
+                List.of("[a, b]", "1", "ready"),
+                List.of("[\n  a,\n  b\n]", "1", "ready"));
+        NavigationStack stack = rooted(state);
+        Rect area = new Rect(0, 0, 100, 24);
+
+        RenderHarness.RenderedFrame rendered = RenderHarness.render(area, state, model);
+
+        assertThat(DataPreviewScreen.handle(key(KeyCode.UP), model, stack))
+                .as("there is no previous actionable field")
+                .isFalse();
+        assertThat(DataPreviewScreen.handle(key(KeyCode.DOWN), model, stack))
+                .as("there is no next actionable field")
+                .isFalse();
+        assertThat(rendered.contains("↑↓ navigate"))
+                .as("the hint omits navigation when neither direction can move")
+                .isFalse();
+        assertThat(rendered.contains("Enter expand"))
+                .as("the selected field remains expandable")
+                .isTrue();
+    }
+
+    @Test
+    void dataPreviewFittedScalarCursorShowsNavigationHintWhenFieldIsReachable() {
+        ScreenState.DataPreview state = openModal(
+                List.of("items", "id", "status"),
+                List.of("[a, b, c, d]", "1", "ready"),
+                List.of("[\n  a,\n  b,\n  c,\n  d\n]", "1", "ready"));
+        NavigationStack stack = rooted(state);
+        Rect area = new Rect(0, 0, 100, 10);
+        RenderHarness.render(area, state, model);
+
+        assertThat(DataPreviewScreen.handle(key(KeyCode.ENTER), model, stack)).isTrue();
+        for (int line = 1; line <= 6; line++) {
+            assertThat(DataPreviewScreen.handle(key(KeyCode.DOWN), model, stack))
+                    .as("move through overflowing content to scalar line %s", line)
+                    .isTrue();
+        }
+        assertThat(DataPreviewScreen.handle(
+                new KeyEvent(KeyCode.CHAR, KeyModifiers.NONE, 'c'), model, stack)).isTrue();
+
+        ScreenState.DataPreview collapsed = (ScreenState.DataPreview) stack.top();
+        assertThat(collapsed.modalCursorLine()).isEqualTo(1);
+        RenderHarness.RenderedFrame rendered = RenderHarness.render(area, collapsed, model);
+
+        assertThat(DataPreviewScreen.handle(key(KeyCode.UP), model, stack))
+                .as("the expandable field above the scalar remains reachable")
+                .isTrue();
+        assertThat(rendered.contains("↑↓ navigate"))
+                .as("the hint reflects that navigation can move from the scalar")
+                .isTrue();
+    }
+
     /// Cross-product smoke render: every screen × every fixture renders
     /// without throwing. Catches data-shape edge cases (no CI, no dict,
     /// nested types, all-null pages) that the handler tests don't
@@ -323,6 +464,25 @@ class DiveRenderTest {
         // The "Press ? or Esc to close" sentinel is the very last line of the
         // overlay; if it renders, no content above it can have been clipped.
         assertThat(renderToString(buffer, screenArea)).contains("Press ? or Esc to close");
+    }
+
+    private static ScreenState.DataPreview openModal(
+            List<String> names, List<String> values, List<String> expandedValues) {
+        return new ScreenState.DataPreview(
+                0, 1, names, List.of(values), List.of(expandedValues),
+                0, 0, 0, true, java.util.Set.of(), 0);
+    }
+
+    private static List<String> numberedValues(String prefix, int count) {
+        return java.util.stream.IntStream.range(0, count)
+                .mapToObj(i -> prefix + i)
+                .toList();
+    }
+
+    private static NavigationStack rooted(ScreenState child) {
+        NavigationStack stack = new NavigationStack(ScreenState.Overview.initial());
+        stack.push(child);
+        return stack;
     }
 
     private static String renderToString(Buffer buffer, Rect screenArea) {

--- a/cli/src/test/java/dev/hardwood/cli/dive/DiveRenderTest.java
+++ b/cli/src/test/java/dev/hardwood/cli/dive/DiveRenderTest.java
@@ -8,10 +8,12 @@
 package dev.hardwood.cli.dive;
 
 import java.nio.file.Path;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
 import java.util.function.Function;
 import java.util.regex.Pattern;
+import java.util.stream.IntStream;
 import java.util.stream.Stream;
 
 import org.junit.jupiter.api.AfterEach;
@@ -48,7 +50,7 @@ class DiveRenderTest {
 
     @BeforeEach
     void setUp() throws Exception {
-        Keys.resetObservedViewport();
+        Keys.resetObservedGeometry();
         Path path = Path.of(getClass().getResource("/column_index_pushdown.parquet").getPath());
         model = ParquetModel.open(InputFile.of(path), path.toString());
     }
@@ -266,64 +268,125 @@ class DiveRenderTest {
     }
 
     @Test
-    void dataPreviewScalarOnlyOverflowRemainsReachable() {
+    void dataPreviewScalarOnlyRecordIsCursorlessAndScrollsWithPageKeys() {
         List<String> names = numberedValues("f", 30);
         List<String> values = numberedValues("v", 30);
         ScreenState.DataPreview state = openModal(names, values, values);
         NavigationStack stack = rooted(state);
         Rect area = new Rect(0, 0, 100, 24);
+
         RenderHarness.RenderedFrame first = RenderHarness.render(area, state, model);
-        assertThat(first.contains("▶f0"))
-                .as("a selected scalar field has no action marker")
+        assertThat(first.contains("▶f"))
+                .as("nothing in the record can be expanded, so no cursor is drawn")
                 .isFalse();
-
-        for (int line = 1; line < names.size(); line++) {
-            assertThat(DataPreviewScreen.handle(key(KeyCode.DOWN), model, stack))
-                    .as("move to scalar line %s", line)
-                    .isTrue();
-            assertThat(((ScreenState.DataPreview) stack.top()).modalCursorLine())
-                    .isEqualTo(line);
-        }
-
-        ScreenState.DataPreview atLast = (ScreenState.DataPreview) stack.top();
-        RenderHarness.RenderedFrame rendered = RenderHarness.render(area, atLast, model);
-        assertThat(rendered.contains("f29")).isTrue();
-        assertThat(rendered.contains("▶f29"))
-                .as("a selected scalar field is highlighted without an expand marker")
+        assertThat(first.contains("Enter expand"))
+                .as("the hint does not offer an expansion that cannot happen")
                 .isFalse();
-        assertThat(DataPreviewScreen.handle(key(KeyCode.UP), model, stack)).isTrue();
-        assertThat(((ScreenState.DataPreview) stack.top()).modalCursorLine()).isEqualTo(28);
+        assertThat(first.contains("e/c all")).isFalse();
+        assertThat(first.contains("↑↓ field"))
+                .as("there is no expandable field to step to")
+                .isFalse();
+        assertThat(first.contains("PgDn/PgUp scroll"))
+                .as("the body overflows, so paging is what reaches the rest")
+                .isTrue();
+
+        assertThat(DataPreviewScreen.handle(key(KeyCode.UP), model, stack)).isFalse();
+        assertThat(DataPreviewScreen.handle(key(KeyCode.DOWN), model, stack)).isFalse();
+
+        assertThat(DataPreviewScreen.handle(key(KeyCode.PAGE_DOWN), model, stack)).isTrue();
+        ScreenState.DataPreview scrolled = (ScreenState.DataPreview) stack.top();
+        assertThat(RenderHarness.render(area, scrolled, model).contains("f29"))
+                .as("PgDn reaches the tail of a record no cursor can walk")
+                .isTrue();
+        assertThat(DataPreviewScreen.handle(key(KeyCode.PAGE_DOWN), model, stack))
+                .as("already against the bottom")
+                .isFalse();
+        assertThat(DataPreviewScreen.handle(key(KeyCode.PAGE_UP), model, stack)).isTrue();
+        assertThat(((ScreenState.DataPreview) stack.top()).modalScroll()).isZero();
     }
 
     @Test
-    void dataPreviewMixedOverflowRemainsReachablePastLastExpandableField() {
-        List<String> names = new java.util.ArrayList<>(numberedValues("f", 30));
-        List<String> values = new java.util.ArrayList<>(numberedValues("v", 30));
-        List<String> expanded = new java.util.ArrayList<>(values);
+    void dataPreviewOverflowStillStepsBetweenExpandableFieldsOnly() {
+        List<String> names = new ArrayList<>(numberedValues("f", 30));
+        List<String> values = new ArrayList<>(numberedValues("v", 30));
+        List<String> expanded = new ArrayList<>(values);
+        names.set(0, "items");
+        values.set(0, "[1, 2]");
+        expanded.set(0, "[\n  1,\n  2\n]");
+        names.set(20, "more");
+        values.set(20, "[3, 4]");
+        expanded.set(20, "[\n  3,\n  4\n]");
+        ScreenState.DataPreview state = openModal(names, values, expanded);
+        NavigationStack stack = rooted(state);
+        Rect area = new Rect(0, 0, 100, 24);
+        RenderHarness.RenderedFrame first = RenderHarness.render(area, state, model);
+        assertThat(first.contains("▶items")).isTrue();
+
+        assertThat(DataPreviewScreen.handle(key(KeyCode.DOWN), model, stack)).isTrue();
+        ScreenState.DataPreview atMore = (ScreenState.DataPreview) stack.top();
+        assertThat(atMore.modalCursorLine())
+                .as("↓ skips the 19 scalars between the two expandable fields "
+                        + "even though the body overflows")
+                .isEqualTo(20);
+        RenderHarness.RenderedFrame second = RenderHarness.render(area, atMore, model);
+        assertThat(second.contains("▶more"))
+                .as("the body scrolled far enough to show the newly selected field")
+                .isTrue();
+
+        assertThat(DataPreviewScreen.handle(key(KeyCode.DOWN), model, stack))
+                .as("no expandable field after the last one")
+                .isFalse();
+        assertThat(DataPreviewScreen.handle(key(KeyCode.UP), model, stack)).isTrue();
+        assertThat(((ScreenState.DataPreview) stack.top()).modalCursorLine()).isZero();
+    }
+
+    @Test
+    void dataPreviewExpandingAFieldScrollsItsNewLinesIntoView() {
+        List<String> names = new ArrayList<>(numberedValues("f", 30));
+        List<String> values = new ArrayList<>(numberedValues("v", 30));
+        List<String> expanded = new ArrayList<>(values);
+        names.set(20, "items");
+        values.set(20, "[alpha, beta, gamma]");
+        expanded.set(20, "[\n  alpha,\n  beta,\n  gamma\n]");
+        ScreenState.DataPreview state = openModal(names, values, expanded);
+        NavigationStack stack = rooted(state);
+        Rect area = new Rect(0, 0, 100, 24);
+        RenderHarness.render(area, state, model);
+
+        // ↓ lands on `items`, leaving it on the last visible line.
+        assertThat(DataPreviewScreen.handle(key(KeyCode.DOWN), model, stack)).isTrue();
+        assertThat(DataPreviewScreen.handle(key(KeyCode.ENTER), model, stack)).isTrue();
+
+        ScreenState.DataPreview opened = (ScreenState.DataPreview) stack.top();
+        assertThat(opened.expandedColumns()).containsExactly(20);
+        RenderHarness.RenderedFrame rendered = RenderHarness.render(area, opened, model);
+        assertThat(rendered.contains("▶items")).isTrue();
+        assertThat(rendered.contains("gamma"))
+                .as("expanding scrolls so the revealed lines are on screen, "
+                        + "not just the field's key line")
+                .isTrue();
+    }
+
+    @Test
+    void dataPreviewPageKeysScrollTheBodyWithoutMovingTheCursor() {
+        List<String> names = new ArrayList<>(numberedValues("f", 30));
+        List<String> values = new ArrayList<>(numberedValues("v", 30));
+        List<String> expanded = new ArrayList<>(values);
         names.set(0, "items");
         values.set(0, "[1, 2]");
         expanded.set(0, "[\n  1,\n  2\n]");
         ScreenState.DataPreview state = openModal(names, values, expanded);
         NavigationStack stack = rooted(state);
         Rect area = new Rect(0, 0, 100, 24);
-        RenderHarness.RenderedFrame first = RenderHarness.render(area, state, model);
-        assertThat(first.contains("▶items"))
-                .as("the expandable field shows an action marker")
-                .isTrue();
+        RenderHarness.render(area, state, model);
 
-        for (int line = 1; line < names.size(); line++) {
-            assertThat(DataPreviewScreen.handle(key(KeyCode.DOWN), model, stack))
-                    .as("move to line %s after the expandable field", line)
-                    .isTrue();
-        }
-
-        ScreenState.DataPreview atLast = (ScreenState.DataPreview) stack.top();
-        assertThat(atLast.modalCursorLine()).isEqualTo(29);
-        RenderHarness.RenderedFrame rendered = RenderHarness.render(area, atLast, model);
-        assertThat(rendered.contains("f29")).isTrue();
-        assertThat(rendered.contains("▶f29"))
-                .as("a scalar remains selectable for scrolling without an action marker")
-                .isFalse();
+        assertThat(DataPreviewScreen.handle(key(KeyCode.PAGE_DOWN), model, stack)).isTrue();
+        ScreenState.DataPreview scrolled = (ScreenState.DataPreview) stack.top();
+        assertThat(scrolled.modalCursorLine())
+                .as("paging reads ahead; it does not drag the selection along")
+                .isZero();
+        assertThat(scrolled.modalScroll()).isPositive();
+        assertThat(RenderHarness.render(area, scrolled, model).contains("f29")).isTrue();
     }
 
     @Test
@@ -367,8 +430,11 @@ class DiveRenderTest {
         assertThat(DataPreviewScreen.handle(key(KeyCode.DOWN), model, stack))
                 .as("there is no next actionable field")
                 .isFalse();
-        assertThat(rendered.contains("↑↓ navigate"))
+        assertThat(rendered.contains("↑↓ field"))
                 .as("the hint omits navigation when neither direction can move")
+                .isFalse();
+        assertThat(rendered.contains("PgDn/PgUp scroll"))
+                .as("the body fits, so there is nothing to scroll to")
                 .isFalse();
         assertThat(rendered.contains("Enter expand"))
                 .as("the selected field remains expandable")
@@ -376,33 +442,91 @@ class DiveRenderTest {
     }
 
     @Test
-    void dataPreviewFittedScalarCursorShowsNavigationHintWhenFieldIsReachable() {
+    void dataPreviewValueFillingTheBudgetExactlyIsNotActionable() {
+        // maxKeyWidth 4 ("note") at width 100 leaves an 85-cell value budget.
+        int budget = 85;
+        ScreenState.DataPreview fits = openModal(
+                List.of("note"), List.of("x".repeat(budget)), List.of("x".repeat(budget)));
+        NavigationStack stack = rooted(fits);
+        Rect area = new Rect(0, 0, 100, 24);
+
+        assertThat(RenderHarness.render(area, fits, model).contains("▶note"))
+                .as("a value the collapsed line shows in full is not actionable")
+                .isFalse();
+        assertThat(DataPreviewScreen.handle(key(KeyCode.ENTER), model, stack)).isFalse();
+
+        ScreenState.DataPreview overflows = openModal(
+                List.of("note"), List.of("x".repeat(budget + 1)), List.of("x".repeat(budget + 1)));
+        assertThat(RenderHarness.render(area, overflows, model).contains("▶note"))
+                .as("one cell over the budget and expanding reveals something")
+                .isTrue();
+    }
+
+    @Test
+    void dataPreviewActionabilityMeasuresDisplayCellsNotChars() {
+        // 100 chars but only 50 display cells: each 'e' carries a zero-width
+        // combining accent. The collapsed line shows all of it, so Enter has
+        // nothing to reveal.
+        String accented = "e\u0301".repeat(50);
         ScreenState.DataPreview state = openModal(
-                List.of("items", "id", "status"),
-                List.of("[a, b, c, d]", "1", "ready"),
-                List.of("[\n  a,\n  b,\n  c,\n  d\n]", "1", "ready"));
+                List.of("note"), List.of(accented), List.of(accented));
         NavigationStack stack = rooted(state);
-        Rect area = new Rect(0, 0, 100, 10);
-        RenderHarness.render(area, state, model);
+        Rect area = new Rect(0, 0, 100, 24);
+
+        RenderHarness.RenderedFrame rendered = RenderHarness.render(area, state, model);
+        assertThat(rendered.contains("…"))
+                .as("the value fits the budget in cells, so it is not truncated")
+                .isFalse();
+        assertThat(rendered.contains("▶note"))
+                .as("a fully visible value must not be offered as expandable")
+                .isFalse();
+        assertThat(DataPreviewScreen.handle(key(KeyCode.ENTER), model, stack)).isFalse();
+    }
+
+    @Test
+    void dataPreviewModalOpensOnTheFirstExpandableField() {
+        List<String> names = List.of("id", "name", "tags");
+        List<String> values = List.of("1", "bob", "[a, b]");
+        List<String> expanded = List.of("1", "bob", "[\n  a,\n  b\n]");
+        Rect area = new Rect(0, 0, 100, 24);
+        ScreenState.DataPreview closed = closedPreview(names, values, expanded, area);
+        NavigationStack stack = rooted(closed);
+        RenderHarness.render(area, closed, model);
 
         assertThat(DataPreviewScreen.handle(key(KeyCode.ENTER), model, stack)).isTrue();
-        for (int line = 1; line <= 6; line++) {
-            assertThat(DataPreviewScreen.handle(key(KeyCode.DOWN), model, stack))
-                    .as("move through overflowing content to scalar line %s", line)
-                    .isTrue();
-        }
-        assertThat(DataPreviewScreen.handle(
-                new KeyEvent(KeyCode.CHAR, KeyModifiers.NONE, 'c'), model, stack)).isTrue();
 
-        ScreenState.DataPreview collapsed = (ScreenState.DataPreview) stack.top();
-        assertThat(collapsed.modalCursorLine()).isEqualTo(1);
-        RenderHarness.RenderedFrame rendered = RenderHarness.render(area, collapsed, model);
+        ScreenState.DataPreview opened = (ScreenState.DataPreview) stack.top();
+        assertThat(opened.columnNames())
+                .as("the synthetic state must survive the open, not be re-paged")
+                .isEqualTo(names);
+        assertThat(opened.modalCursorLine())
+                .as("id and name are scalars; the cursor opens on tags")
+                .isEqualTo(2);
+        assertThat(RenderHarness.render(area, opened, model).contains("▶tags")).isTrue();
+    }
 
-        assertThat(DataPreviewScreen.handle(key(KeyCode.UP), model, stack))
-                .as("the expandable field above the scalar remains reachable")
-                .isTrue();
-        assertThat(rendered.contains("↑↓ navigate"))
-                .as("the hint reflects that navigation can move from the scalar")
+    @Test
+    void dataPreviewModalOpensScrolledToAnExpandableFieldBelowTheFold() {
+        List<String> names = new ArrayList<>(numberedValues("f", 30));
+        List<String> values = new ArrayList<>(numberedValues("v", 30));
+        List<String> expanded = new ArrayList<>(values);
+        names.set(25, "items");
+        values.set(25, "[1, 2]");
+        expanded.set(25, "[\n  1,\n  2\n]");
+        Rect area = new Rect(0, 0, 100, 24);
+        ScreenState.DataPreview closed = closedPreview(names, values, expanded, area);
+        NavigationStack stack = rooted(closed);
+        RenderHarness.render(area, closed, model);
+
+        assertThat(DataPreviewScreen.handle(key(KeyCode.ENTER), model, stack)).isTrue();
+
+        ScreenState.DataPreview opened = (ScreenState.DataPreview) stack.top();
+        assertThat(opened.modalCursorLine()).isEqualTo(25);
+        assertThat(opened.modalScroll())
+                .as("the only expandable field sits past the first screenful")
+                .isPositive();
+        assertThat(RenderHarness.render(area, opened, model).contains("▶items"))
+                .as("opening scrolls the field it selected into view")
                 .isTrue();
     }
 
@@ -466,15 +590,29 @@ class DiveRenderTest {
         assertThat(renderToString(buffer, screenArea)).contains("Press ? or Esc to close");
     }
 
+    /// A Data preview state with the record modal already open on row 0 and
+    /// the cursor at line 0 — the shape render assertions want, without
+    /// going through the open path.
     private static ScreenState.DataPreview openModal(
             List<String> names, List<String> values, List<String> expandedValues) {
         return new ScreenState.DataPreview(
                 0, 1, names, List.of(values), List.of(expandedValues),
-                0, 0, 0, true, java.util.Set.of(), 0);
+                0, 0, 0, true, Set.of(), 0);
+    }
+
+    /// A Data preview state with the modal closed, for tests that open it
+    /// with `Enter` and assert on where the cursor lands. `pageSize` matches
+    /// the stride `area` will make `handle` observe, so opening doesn't
+    /// re-page the synthetic rows away.
+    private static ScreenState.DataPreview closedPreview(
+            List<String> names, List<String> values, List<String> expandedValues, Rect area) {
+        return new ScreenState.DataPreview(
+                0, area.height() - 3, names, List.of(values), List.of(expandedValues),
+                0, 0, -1, true, Set.of(), 0);
     }
 
     private static List<String> numberedValues(String prefix, int count) {
-        return java.util.stream.IntStream.range(0, count)
+        return IntStream.range(0, count)
                 .mapToObj(i -> prefix + i)
                 .toList();
     }

--- a/cli/src/test/java/dev/hardwood/cli/dive/DiveStateTest.java
+++ b/cli/src/test/java/dev/hardwood/cli/dive/DiveStateTest.java
@@ -747,6 +747,37 @@ class DiveStateTest {
     }
 
     @Test
+    void dataPreviewRowModalNavigationSkipsScalarFields() throws Exception {
+        // First row: scalar id, followed by two non-empty expandable lists.
+        Path file = Path.of(getClass().getResource("/list_basic_test.parquet").getPath());
+        try (ParquetModel listModel = ParquetModel.open(InputFile.of(file), file.toString())) {
+            ScreenState.DataPreview initial = DataPreviewScreen.initialState(listModel, 5);
+            NavigationStack stack = rooted(initial);
+
+            // Opening skips id (line 0) and selects tags (line 1).
+            DataPreviewScreen.handle(key(KeyCode.ENTER), listModel, stack);
+            assertThat(((ScreenState.DataPreview) stack.top()).modalCursorLine()).isEqualTo(1);
+
+            boolean handledAtFirst = DataPreviewScreen.handle(key(KeyCode.UP), listModel, stack);
+            assertThat(handledAtFirst).isFalse();
+            assertThat(((ScreenState.DataPreview) stack.top()).modalCursorLine()).isEqualTo(1);
+
+            boolean handledDown = DataPreviewScreen.handle(key(KeyCode.DOWN), listModel, stack);
+            assertThat(handledDown).isTrue();
+            // The next actionable field is scores (line 2).
+            assertThat(((ScreenState.DataPreview) stack.top()).modalCursorLine()).isEqualTo(2);
+
+            boolean handledAtLast = DataPreviewScreen.handle(key(KeyCode.DOWN), listModel, stack);
+            assertThat(handledAtLast).isFalse();
+            assertThat(((ScreenState.DataPreview) stack.top()).modalCursorLine()).isEqualTo(2);
+
+            boolean handledUp = DataPreviewScreen.handle(key(KeyCode.UP), listModel, stack);
+            assertThat(handledUp).isTrue();
+            assertThat(((ScreenState.DataPreview) stack.top()).modalCursorLine()).isEqualTo(1);
+        }
+    }
+
+    @Test
     void dataPreviewRowModalEnterTogglesInlineExpansion() {
         ScreenState.DataPreview initial = DataPreviewScreen.initialState(model, 5);
         NavigationStack stack = rooted(initial);

--- a/cli/src/test/java/dev/hardwood/cli/dive/DiveStateTest.java
+++ b/cli/src/test/java/dev/hardwood/cli/dive/DiveStateTest.java
@@ -29,6 +29,7 @@ import dev.hardwood.cli.dive.internal.PagesScreen;
 import dev.hardwood.cli.dive.internal.RowGroupDetailScreen;
 import dev.hardwood.cli.dive.internal.RowGroupsScreen;
 import dev.hardwood.cli.dive.internal.SchemaScreen;
+import dev.tamboui.layout.Rect;
 import dev.tamboui.tui.event.KeyCode;
 import dev.tamboui.tui.event.KeyEvent;
 import dev.tamboui.tui.event.KeyModifiers;
@@ -48,7 +49,7 @@ class DiveStateTest {
         // behind. Data preview's auto-resize keys off Keys.viewportStride
         // so a stale observation would force a re-load and break the
         // explicit page-size assertions in this suite.
-        Keys.resetObservedViewport();
+        Keys.resetObservedGeometry();
         // 10 000 rows × 2 columns (id, value) in 1 RG / ~10 pages; has a Column Index.
         // Covers pagination, schema navigation, and column-index drills without
         // needing multiple fixtures.
@@ -733,13 +734,15 @@ class DiveStateTest {
         ScreenState.DataPreview opened = (ScreenState.DataPreview) stack.top();
         assertThat(opened.modalRow()).isEqualTo(2);
 
-        // ↑/↓ inside the modal navigate the per-line cursor — the modalRow
-        // stays put (row stepping is intentionally not available inside the
-        // modal; users close it and pick another row from the table).
-        DataPreviewScreen.handle(key(KeyCode.DOWN), model, stack);
+        // ↑/↓ inside the modal move the field cursor — the modalRow stays put
+        // (row stepping is intentionally not available inside the modal; users
+        // close it and pick another row from the table). This fixture is two
+        // scalar columns, so there is no expandable field to step to and the
+        // cursor has nowhere to go.
+        assertThat(DataPreviewScreen.handle(key(KeyCode.DOWN), model, stack)).isFalse();
         ScreenState.DataPreview moved = (ScreenState.DataPreview) stack.top();
         assertThat(moved.modalRow()).isEqualTo(2);
-        assertThat(moved.modalCursorLine()).isEqualTo(1);
+        assertThat(moved.modalCursorLine()).isZero();
 
         // Esc closes the modal.
         DataPreviewScreen.handle(key(KeyCode.ESCAPE), model, stack);
@@ -753,6 +756,11 @@ class DiveStateTest {
         try (ParquetModel listModel = ParquetModel.open(InputFile.of(file), file.toString())) {
             ScreenState.DataPreview initial = DataPreviewScreen.initialState(listModel, 5);
             NavigationStack stack = rooted(initial);
+            // Render first, as the runtime loop does: which fields are
+            // expandable depends on the width the modal is drawn at, so a
+            // handler-only run would answer from a default terminal size
+            // rather than the one under test.
+            RenderHarness.render(new Rect(0, 0, 100, 24), initial, listModel);
 
             // Opening skips id (line 0) and selects tags (line 1).
             DataPreviewScreen.handle(key(KeyCode.ENTER), listModel, stack);
@@ -778,31 +786,36 @@ class DiveStateTest {
     }
 
     @Test
-    void dataPreviewRowModalEnterTogglesInlineExpansion() {
-        ScreenState.DataPreview initial = DataPreviewScreen.initialState(model, 5);
-        NavigationStack stack = rooted(initial);
+    void dataPreviewRowModalEnterTogglesInlineExpansion() throws Exception {
+        // Needs a record with an expandable field: id is scalar, tags and
+        // scores are lists whose full value doesn't fit the collapsed line.
+        Path file = Path.of(getClass().getResource("/list_basic_test.parquet").getPath());
+        try (ParquetModel listModel = ParquetModel.open(InputFile.of(file), file.toString())) {
+            ScreenState.DataPreview initial = DataPreviewScreen.initialState(listModel, 5);
+            NavigationStack stack = rooted(initial);
+            RenderHarness.render(new Rect(0, 0, 100, 24), initial, listModel);
 
-        DataPreviewScreen.handle(key(KeyCode.ENTER), model, stack);
-        ScreenState.DataPreview opened = (ScreenState.DataPreview) stack.top();
-        assertThat(opened.modalRow()).isEqualTo(0);
-        assertThat(opened.modalCursorLine()).isEqualTo(0);
-        assertThat(opened.expandedColumns()).isEmpty();
+            DataPreviewScreen.handle(key(KeyCode.ENTER), listModel, stack);
+            ScreenState.DataPreview opened = (ScreenState.DataPreview) stack.top();
+            assertThat(opened.modalRow()).isZero();
+            assertThat(opened.modalCursorLine())
+                    .as("the cursor opens on tags, the first expandable field")
+                    .isEqualTo(1);
+            assertThat(opened.expandedColumns()).isEmpty();
 
-        // ↓ moves the per-line cursor within the modal.
-        DataPreviewScreen.handle(key(KeyCode.DOWN), model, stack);
-        assertThat(((ScreenState.DataPreview) stack.top()).modalCursorLine()).isEqualTo(1);
+            // Enter expands the field at the cursor (column 1).
+            DataPreviewScreen.handle(key(KeyCode.ENTER), listModel, stack);
+            assertThat(((ScreenState.DataPreview) stack.top()).expandedColumns())
+                    .containsExactly(1);
 
-        // Enter expands the field at the cursor (column 1).
-        DataPreviewScreen.handle(key(KeyCode.ENTER), model, stack);
-        assertThat(((ScreenState.DataPreview) stack.top()).expandedColumns()).containsExactly(1);
+            // Enter again on the same field collapses it.
+            DataPreviewScreen.handle(key(KeyCode.ENTER), listModel, stack);
+            assertThat(((ScreenState.DataPreview) stack.top()).expandedColumns()).isEmpty();
 
-        // Enter again on the same field collapses it.
-        DataPreviewScreen.handle(key(KeyCode.ENTER), model, stack);
-        assertThat(((ScreenState.DataPreview) stack.top()).expandedColumns()).isEmpty();
-
-        // Esc closes the row modal entirely.
-        DataPreviewScreen.handle(key(KeyCode.ESCAPE), model, stack);
-        assertThat(((ScreenState.DataPreview) stack.top()).modalRow()).isEqualTo(-1);
+            // Esc closes the row modal entirely.
+            DataPreviewScreen.handle(key(KeyCode.ESCAPE), listModel, stack);
+            assertThat(((ScreenState.DataPreview) stack.top()).modalRow()).isEqualTo(-1);
+        }
     }
 
     @Test

--- a/cli/src/test/java/dev/hardwood/cli/dive/internal/StringsTest.java
+++ b/cli/src/test/java/dev/hardwood/cli/dive/internal/StringsTest.java
@@ -1,0 +1,57 @@
+/*
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Copyright The original authors
+ *
+ *  Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package dev.hardwood.cli.dive.internal;
+
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+
+import dev.tamboui.text.CharWidth;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class StringsTest {
+
+    @Test
+    void hardWrapChunksAsciiAtTheWidthBoundary() {
+        assertThat(Strings.hardWrap("abcdefgh", 3)).containsExactly("abc", "def", "gh");
+        assertThat(Strings.hardWrap("abc", 3)).containsExactly("abc");
+    }
+
+    @Test
+    void hardWrapPreservesHardLineBreaks() {
+        assertThat(Strings.hardWrap("ab\n\ncd", 4)).containsExactly("ab", "", "cd");
+    }
+
+    @Test
+    void hardWrapCountsWideGlyphsAsTwoCells() {
+        // Each CJK ideograph occupies two cells, so only two fit in five.
+        List<String> lines = Strings.hardWrap("日本語テキスト", 5);
+        assertThat(lines).containsExactly("日本", "語テ", "キス", "ト");
+        for (String line : lines) {
+            assertThat(CharWidth.of(line)).isLessThanOrEqualTo(5);
+        }
+    }
+
+    @Test
+    void hardWrapCountsCombiningMarksAsZeroCells() {
+        // 10 chars, 5 cells: every 'e' carries a zero-width combining accent.
+        String accented = "e\u0301".repeat(5);
+        assertThat(accented).hasSize(10);
+        assertThat(Strings.hardWrap(accented, 5))
+                .as("the string already fits five cells, so it must not be split")
+                .containsExactly(accented);
+    }
+
+    @Test
+    void hardWrapEmitsAGlyphWiderThanTheBudgetOnItsOwnLine() {
+        assertThat(Strings.hardWrap("日本", 1))
+                .as("overflowing by one cell beats looping forever making no progress")
+                .containsExactly("日", "本");
+    }
+}

--- a/docs/content/reference/cli.md
+++ b/docs/content/reference/cli.md
@@ -155,9 +155,9 @@ navigable session. Typical things to reach for it for:
   the highlighted entry.
 - **Preview a few rows** without exporting — Data preview paginates with
   `PgDn`/`PgUp` (`g`/`G` for first/last); `Enter` opens a per-row modal.
-  When the modal fits, `↑`/`↓` skip fields whose full value is already
-  visible; when it overflows, they scroll one rendered line at a time.
-  `Enter` expands the focused field when it reveals additional content.
+  In the modal `↑`/`↓` step between the fields whose full value isn't
+  already on screen, `Enter` expands the focused one inline, and
+  `PgDn`/`PgUp` scroll the body.
 - **Decode key/value metadata** — Spark JSON schemas pretty-print, Arrow
   IPC schemas decode to a hex dump.
 - **Compare a column across row groups** — from Schema, `Enter` on a
@@ -173,7 +173,7 @@ navigable session. Typical things to reach for it for:
 | Key | Action |
 |-----|--------|
 | `↑` / `↓` | Move selection |
-| `PgDn` / `PgUp` (or `Shift-↓` / `Shift-↑`) | Page down / up |
+| `PgDn` / `PgUp` (or `Shift-↓` / `Shift-↑`) | Page down / up; scroll the body of the Data preview row modal |
 | `g` / `G` | Jump to first / last row |
 | `Enter` | Drill into the selected item |
 | `Esc` / `Backspace` | Go back one level |

--- a/docs/content/reference/cli.md
+++ b/docs/content/reference/cli.md
@@ -154,8 +154,10 @@ navigable session. Typical things to reach for it for:
   `/` substring filter; `Enter` reveals the full untruncated value of
   the highlighted entry.
 - **Preview a few rows** without exporting — Data preview paginates with
-  `PgDn`/`PgUp` (`g`/`G` for first/last); `Enter` opens a per-row modal
-  where each field can be expanded inline.
+  `PgDn`/`PgUp` (`g`/`G` for first/last); `Enter` opens a per-row modal.
+  When the modal fits, `↑`/`↓` skip fields whose full value is already
+  visible; when it overflows, they scroll one rendered line at a time.
+  `Enter` expands the focused field when it reveals additional content.
 - **Decode key/value metadata** — Spark JSON schemas pretty-print, Arrow
   IPC schemas decode to a hex dump.
 - **Compare a column across row groups** — from Schema, `Enter` on a


### PR DESCRIPTION
Hello, this PR resolves #388 by making the cursor in the data preview row modal represent only actionable fields.

Previously, scalar fields displayed a selection cursor even though pressing
Enter on them had no effect. The modal now places the cursor on the first
expandable field and Up/Down navigation skips fields that cannot be expanded.

A regression test using `list_basic_test.parquet` verifies the initial cursor
position, navigation between expandable fields, and behavior at the navigation
boundaries.

Closes #388.

## Checklist

- [x] Build via `./mvnw clean verify` passes
- [x] The commit message is prefixed with the issue key ("#388")
- [x] Code changes are covered by tests
- [x] If this PR adds or changes user-facing behaviour, `docs/` has been updated
