### PR TITLE
Fix streamed table bottom border for zero sample size

### DIFF
--- a/cli/src/main/java/dev/hardwood/cli/internal/table/StreamedTable.java
+++ b/cli/src/main/java/dev/hardwood/cli/internal/table/StreamedTable.java
@@ -60,9 +60,12 @@ public class StreamedTable {
         printRow(out, i -> headers[i], widths, truncate);
         out.println(sep);
 
+        boolean emittedDataRow = false;
+
         // catch up the sampled rows
         for (String[] rowFunc : sampleRows) {
             printRow(out, i -> rowFunc[i], widths, truncate);
+            emittedDataRow = true;
             if (rowDelimiter) {
                 out.println(sep);
             }
@@ -72,12 +75,13 @@ public class StreamedTable {
         while (iterator.hasNext()) {
             IntFunction<String> rowFunc = iterator.next();
             printRow(out, rowFunc, widths, truncate);
+            emittedDataRow = true;
             if (rowDelimiter) {
                 out.println(sep);
             }
         }
 
-        if (!rowDelimiter && !sampleRows.isEmpty()) {
+        if (!rowDelimiter && emittedDataRow) {
             out.println(sep);
         }
 

--- a/cli/src/test/java/dev/hardwood/cli/internal/table/StreamedTableTest.java
+++ b/cli/src/test/java/dev/hardwood/cli/internal/table/StreamedTableTest.java
@@ -220,6 +220,31 @@ class StreamedTableTest {
                 +---+""");
     }
 
+    @Test
+    void closesTableWhenRowsArePrintedWithZeroSampleSize() {
+        String output = render(List.<String[]>of(new String[]{"a"}, new String[]{"b"}), "s", 10, true, 0);
+
+        assertThat(output).isEqualTo("""
+                +---+
+                | s |
+                +---+
+                | a |
+                | b |
+                +---+""");
+        assertEqualDisplayWidths(output);
+    }
+
+    @Test
+    void doesNotAddExtraSeparatorForZeroRowsWithZeroSampleSize() {
+        String output = render(List.of(), "s", 10, true, 0);
+
+        assertThat(output).isEqualTo("""
+                +---+
+                | s |
+                +---+""");
+        assertEqualDisplayWidths(output);
+    }
+
     private static String render(List<String[]> rows, int maxWidth, boolean truncate) {
         return render(rows, "name", maxWidth, truncate);
     }


### PR DESCRIPTION
## Checklist

- [ ] Build via `./mvnw clean verify` passes
- [ ] The commit message is prefixed with the issue key ("#123 Adding support for...")
- [ ] Code changes are covered by tests
- [ ] If this PR adds or changes user-facing behaviour, `docs/` has been updated
