### PR TITLE
#863 Preserve empty rows in wrap mode

### DIFF
--- a/cli/src/main/java/dev/hardwood/cli/internal/table/StreamedTable.java
+++ b/cli/src/main/java/dev/hardwood/cli/internal/table/StreamedTable.java
@@ -148,6 +148,9 @@ public class StreamedTable {
                 cell = "";
             }
             List<String> lines = new ArrayList<>();
+            if (cell.isEmpty()) {
+                lines.add("");
+            }
             for (int start = 0; start < cell.length();) {
                 int end = displayPrefixEnd(cell, start, widths[i]);
                 if (end == start) {

--- a/cli/src/test/java/dev/hardwood/cli/internal/table/StreamedTableTest.java
+++ b/cli/src/test/java/dev/hardwood/cli/internal/table/StreamedTableTest.java
@@ -46,6 +46,41 @@ class StreamedTableTest {
     }
 
     @Test
+    void rendersAllEmptyRowsWhenWrapping() {
+        String output = render(
+                List.<String[]>of(new String[]{"", ""}),
+                new String[]{"left", "right"},
+                10,
+                false);
+
+        assertThat(output).isEqualTo("""
+                +------+-------+
+                | left | right |
+                +------+-------+
+                |      |       |
+                +------+-------+""");
+        assertEqualDisplayWidths(output);
+    }
+
+    @Test
+    void wrapsRowsWithEmptyAndNonEmptyCells() {
+        String output = render(
+                List.<String[]>of(new String[]{"", "abcdef"}),
+                new String[]{"empty", "value"},
+                5,
+                false);
+
+        assertThat(output).isEqualTo("""
+                +-------+-------+
+                | empty | value |
+                +-------+-------+
+                |       | abcde |
+                |       | f     |
+                +-------+-------+""");
+        assertEqualDisplayWidths(output);
+    }
+
+    @Test
     void doesNotTruncateSurrogatePairsThatFitTheDisplayWidth() {
         String output = render(List.<String[]>of(new String[]{"😀abcd"}), 5, true);
 
@@ -253,11 +288,19 @@ class StreamedTableTest {
         return render(rows, header, maxWidth, truncate, rows.size());
     }
 
+    private static String render(List<String[]> rows, String[] headers, int maxWidth, boolean truncate) {
+        return render(rows, headers, maxWidth, truncate, rows.size());
+    }
+
     private static String render(List<String[]> rows, String header, int maxWidth, boolean truncate, int sampleSize) {
+        return render(rows, new String[]{header}, maxWidth, truncate, sampleSize);
+    }
+
+    private static String render(List<String[]> rows, String[] headers, int maxWidth, boolean truncate, int sampleSize) {
         StringWriter output = new StringWriter();
         new StreamedTable().print(
                 new PrintWriter(output),
-                new String[]{header},
+                headers,
                 rows.stream()
                         .<IntFunction<String>>map(row -> column -> row[column])
                         .iterator(),


### PR DESCRIPTION
Fixes #863

In wrap mode, empty cells produced no rendered lines. When every cell in a row was empty, the row-wide line count therefore stayed at zero and the emitting loop skipped the row entirely.

This change represents an empty cell as one blank wrapped line. Non-empty wrapping is unchanged, while an all-empty row now produces the same single padded row block as truncate mode.

Regression coverage includes both an all-empty multi-column row and a mixed row whose non-empty cell wraps across multiple lines.

## Verification

- `StreamedTableTest`: 17 tests passed
- All non-S3, non-native CLI tests: 339 tests passed
- Full reactor compilation/package/license checks passed with tests skipped
- `./mvnw clean verify` reached the existing S3 Testcontainers suite; local completion is blocked only because this machine has no Docker daemon
- GitHub created the PR Build check suite, but it is currently awaiting the repository's first-time-contributor workflow approval (`action_required`)

## Checklist

- [ ] Build via `./mvnw clean verify` passes (awaiting maintainer approval of the fork workflow)
- [x] The commit message is prefixed with the issue key (`#863`)
- [x] Code changes are covered by tests
- [x] No documentation update is needed; this restores row preservation without changing CLI options or documented APIs
