### PR TITLE
#874 Pad all five footer labels to a common width so the values line up

### DIFF
--- a/cli/src/main/java/dev/hardwood/cli/command/FooterCommand.java
+++ b/cli/src/main/java/dev/hardwood/cli/command/FooterCommand.java
@@ -69,11 +69,11 @@ public class FooterCommand implements Command<CommandInvocation> {
 
             long footerOffset = fileSize - TRAILER_SIZE - footerLength;
 
-            System.out.println("File Size:     " + fileSize + " bytes");
-            System.out.println("Footer Offset: " + footerOffset + " bytes");
-            System.out.println("Footer Length: " + footerLength + " bytes");
-            System.out.println("Leading Magic:  " + new String(leadingMagic, StandardCharsets.US_ASCII));
-            System.out.println("Trailing Magic: " + new String(trailingMagic, StandardCharsets.US_ASCII));
+            System.out.printf("%-16s%s bytes%n", "File Size:", fileSize);
+            System.out.printf("%-16s%s bytes%n", "Footer Offset:", footerOffset);
+            System.out.printf("%-16s%s bytes%n", "Footer Length:", footerLength);
+            System.out.printf("%-16s%s%n", "Leading Magic:", new String(leadingMagic, StandardCharsets.US_ASCII));
+            System.out.printf("%-16s%s%n", "Trailing Magic:", new String(trailingMagic, StandardCharsets.US_ASCII));
         }
         catch (IOException e) {
             System.err.println("Error reading file: " + e.getMessage());

--- a/cli/src/test/java/dev/hardwood/cli/command/FooterCommandContract.java
+++ b/cli/src/test/java/dev/hardwood/cli/command/FooterCommandContract.java
@@ -24,9 +24,9 @@ interface FooterCommandContract {
 
         assertThat(result.exitCode()).isZero();
         assertThat(result.output()).isEqualTo("""
-                File Size:     722 bytes
-                Footer Offset: 178 bytes
-                Footer Length: 536 bytes
+                File Size:      722 bytes
+                Footer Offset:  178 bytes
+                Footer Length:  536 bytes
                 Leading Magic:  PAR1
                 Trailing Magic: PAR1""");
     }


### PR DESCRIPTION
## Checklist

- [x] Build via `./mvnw clean verify` passes
- [x] The commit message is prefixed with the issue key ("#874 Pad all five footer labels to a common width so the values line up")
- [x] Code changes are covered by tests
- [ ] If this PR adds or changes user-facing behaviour, `docs/` has been updated

## Summary

Fix the output alignment issue described in #874. The `hardwood footer` command padded its label column inconsistently: the first three values started at column 16, the two magic values started at column 17.

### Changes
- Replaced manual `println` with hardcoded spacing with `printf` using `%-16s` format specifier in `FooterCommand.java`
- Updated the test assertion in `FooterCommandContract.java` to match the corrected output alignment

All five labels now pad to a common width of 16 characters (set by `Trailing Magic:`, the longest label). The values are aligned at column 17.

If this helped, RawNuke welcomes sponsorship: https://github.com/sponsors/RawNuke
