### PR TITLE
cli: align footer output columns

### DIFF
--- a/cli/src/main/java/dev/hardwood/cli/command/FooterCommand.java
+++ b/cli/src/main/java/dev/hardwood/cli/command/FooterCommand.java
@@ -69,9 +69,9 @@ public class FooterCommand implements Command<CommandInvocation> {
 
             long footerOffset = fileSize - TRAILER_SIZE - footerLength;
 
-            System.out.println("File Size:     " + fileSize + " bytes");
-            System.out.println("Footer Offset: " + footerOffset + " bytes");
-            System.out.println("Footer Length: " + footerLength + " bytes");
+            System.out.println("File Size:      " + fileSize + " bytes");
+            System.out.println("Footer Offset:  " + footerOffset + " bytes");
+            System.out.println("Footer Length:  " + footerLength + " bytes");
             System.out.println("Leading Magic:  " + new String(leadingMagic, StandardCharsets.US_ASCII));
             System.out.println("Trailing Magic: " + new String(trailingMagic, StandardCharsets.US_ASCII));
         }

--- a/cli/src/test/java/dev/hardwood/cli/command/FooterCommandContract.java
+++ b/cli/src/test/java/dev/hardwood/cli/command/FooterCommandContract.java
@@ -24,9 +24,9 @@ interface FooterCommandContract {
 
         assertThat(result.exitCode()).isZero();
         assertThat(result.output()).isEqualTo("""
-                File Size:     722 bytes
-                Footer Offset: 178 bytes
-                Footer Length: 536 bytes
+                File Size:      722 bytes
+                Footer Offset:  178 bytes
+                Footer Length:  536 bytes
                 Leading Magic:  PAR1
                 Trailing Magic: PAR1""");
     }

--- a/skills/hardwood-cli/SKILL.md
+++ b/skills/hardwood-cli/SKILL.md
@@ -221,9 +221,9 @@ hardwood footer -f FILE
 ```
 
 ```
-File Size:     722 bytes
-Footer Offset: 178 bytes
-Footer Length: 536 bytes
+File Size:      722 bytes
+Footer Offset:  178 bytes
+Footer Length:  536 bytes
 Leading Magic:  PAR1
 Trailing Magic: PAR1
 ```


### PR DESCRIPTION
## Summary

- pad the first three `hardwood footer` labels to the same value column as the magic-byte labels
- update the command contract test and CLI skill output example

Fixes #874

## Test results

- `./mvnw process-sources` — passed
- `./mvnw -pl cli -am -Dtest=FooterCommandTest -Dsurefire.failIfNoSpecifiedTests=false test` — 4 passed
- `./mvnw clean verify` — reached the S3 module; 124 S3 tests passed and 5 Testcontainers tests could not start because the local Docker daemon is unavailable
- `./mvnw -pl cli test` — 339 tests passed; 64 S3-backed tests could not start for the same Docker limitation

## Checklist

- [ ] Build via `./mvnw clean verify` passes (Docker daemon unavailable locally)
- [x] The commit message is prefixed with the issue key ("#123 Adding support for...")
- [x] Code changes are covered by tests
- [ ] If this PR adds or changes user-facing behaviour, `docs/` has been updated (no footer output example exists under `docs/`; `skills/hardwood-cli/SKILL.md` was updated)
