### PR TITLE
#851 Match upstream's HadoopInputFile API

### DIFF
--- a/docs/content/how-to/compat.md
+++ b/docs/content/how-to/compat.md
@@ -48,6 +48,36 @@ try (ParquetReader<Group> reader = ParquetReader.builder(new GroupReadSupport(),
 }
 ```
 
+## Building the Input File Yourself
+
+Instead of passing a `Path` to the builder, create the input file with `HadoopInputFile.fromPath()` and pass that. This works for local and S3 paths alike.
+
+```java
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.Path;
+import org.apache.parquet.hadoop.util.HadoopInputFile;
+
+Configuration conf = new Configuration();
+HadoopInputFile file = HadoopInputFile.fromPath(new Path("data.parquet"), conf);
+
+try (ParquetReader<Group> reader = ParquetReader.builder(new GroupReadSupport(), file).build()) {
+    // read as usual
+}
+```
+
+`fromPath()` returns `HadoopInputFile` and throws `IOException`. The file length is read during the call, so a path that does not exist fails there rather than on the first read. For an S3 path this is where the client first connects. `fromPathUnchecked()` is the same call with the exception wrapped in an `UncheckedIOException`.
+
+The instance exposes `getPath()`, `getConfiguration()` and `getLength()`. `getLength()` declares no checked exception — the length is read when the file is created:
+
+```java
+HadoopInputFile file = HadoopInputFile.fromPathUnchecked(new Path("data.parquet"), conf);
+
+long bytes = file.getLength();
+Path resolved = file.getPath();
+```
+
+`fromStatus()` and `newStream()` are not provided; they take Hadoop `FileStatus` and parquet-java `SeekableInputStream`, neither of which this module shims.
+
 ## Reading from S3
 
 ```java

--- a/parquet-java-compat/src/main/java/org/apache/parquet/hadoop/ParquetReader.java
+++ b/parquet-java-compat/src/main/java/org/apache/parquet/hadoop/ParquetReader.java
@@ -142,7 +142,7 @@ public class ParquetReader<T> implements AutoCloseable {
             return new ParquetReader<>(resolveHardwoodInputFile(), resolveFilter());
         }
 
-        private dev.hardwood.InputFile resolveHardwoodInputFile() {
+        private dev.hardwood.InputFile resolveHardwoodInputFile() throws IOException {
             if (inputFile != null) {
                 return InputFiles.unwrap(inputFile);
             }

--- a/parquet-java-compat/src/main/java/org/apache/parquet/hadoop/util/HadoopInputFile.java
+++ b/parquet-java-compat/src/main/java/org/apache/parquet/hadoop/util/HadoopInputFile.java
@@ -53,10 +53,6 @@ public final class HadoopInputFile implements InputFile {
     /// - `fs.s3a.endpoint` — endpoint override (e.g. LocalStack, MinIO)
     /// - `fs.s3a.path.style.access` — force path-style access
     ///
-    /// The length is read before this method returns, so a path that does not exist fails
-    /// here rather than on the first read. For S3 paths that means the client connects
-    /// during this call.
-    ///
     /// @param path the Hadoop path
     /// @param conf the Hadoop configuration
     /// @return an input file backed by the given path
@@ -65,8 +61,6 @@ public final class HadoopInputFile implements InputFile {
         URI uri = path.toUri();
 
         if (!isS3(uri)) {
-            // Read the length without opening: no mapping and no descriptor is held by an
-            // instance the caller never passes to a reader.
             java.nio.file.Path localPath = java.nio.file.Path.of(uri);
             long length = Files.size(localPath);
             return new HadoopInputFile(dev.hardwood.InputFile.of(localPath), path, conf, length);
@@ -103,16 +97,10 @@ public final class HadoopInputFile implements InputFile {
         }
     }
 
-    /// The path this file was created from.
-    ///
-    /// @return the Hadoop path
     public Path getPath() {
         return path;
     }
 
-    /// The configuration this file was created with.
-    ///
-    /// @return the Hadoop configuration
     public Configuration getConfiguration() {
         return conf;
     }
@@ -124,12 +112,6 @@ public final class HadoopInputFile implements InputFile {
 
     // --- org.apache.parquet.io.InputFile ---
 
-    /// The file length in bytes, read when this instance was created.
-    ///
-    /// Declares no checked exception, so the length of a file held in the concrete
-    /// type can be read without handling [IOException].
-    ///
-    /// @return the file length in bytes
     @Override
     public long getLength() {
         return length;

--- a/parquet-java-compat/src/main/java/org/apache/parquet/hadoop/util/HadoopInputFile.java
+++ b/parquet-java-compat/src/main/java/org/apache/parquet/hadoop/util/HadoopInputFile.java
@@ -9,8 +9,10 @@ package org.apache.parquet.hadoop.util;
 
 import java.io.Closeable;
 import java.io.IOException;
+import java.io.UncheckedIOException;
 import java.lang.reflect.Method;
 import java.net.URI;
+import java.nio.file.Files;
 import java.util.Locale;
 import java.util.Set;
 
@@ -31,12 +33,18 @@ public final class HadoopInputFile implements InputFile {
     private static final Set<String> S3_SCHEMES = Set.of("s3", "s3a", "s3n");
 
     private final dev.hardwood.InputFile delegate;
+    private final Path path;
+    private final Configuration conf;
+    private final long length;
 
-    private HadoopInputFile(dev.hardwood.InputFile delegate) {
+    private HadoopInputFile(dev.hardwood.InputFile delegate, Path path, Configuration conf, long length) {
         this.delegate = delegate;
+        this.path = path;
+        this.conf = conf;
+        this.length = length;
     }
 
-    /// Create an [InputFile] from a Hadoop-style Path and Configuration.
+    /// Create a [HadoopInputFile] from a Hadoop-style Path and Configuration.
     ///
     /// For local paths, the Configuration is ignored and a local file is returned.
     /// For S3 paths, the Configuration is used to construct an S3 client with properties:
@@ -45,29 +53,86 @@ public final class HadoopInputFile implements InputFile {
     /// - `fs.s3a.endpoint` — endpoint override (e.g. LocalStack, MinIO)
     /// - `fs.s3a.path.style.access` — force path-style access
     ///
+    /// The length is read before this method returns, so a path that does not exist fails
+    /// here rather than on the first read. For S3 paths that means the client connects
+    /// during this call.
+    ///
     /// @param path the Hadoop path
     /// @param conf the Hadoop configuration
-    /// @return an InputFile backed by the given path
-    public static InputFile fromPath(Path path, Configuration conf) {
+    /// @return an input file backed by the given path
+    /// @throws IOException if the file does not exist or its length cannot be read
+    public static HadoopInputFile fromPath(Path path, Configuration conf) throws IOException {
         URI uri = path.toUri();
 
-        dev.hardwood.InputFile hardwoodFile;
-        if (isS3(uri)) {
-            hardwoodFile = createS3InputFile(uri, conf);
-        }
-        else {
-            hardwoodFile = dev.hardwood.InputFile.of(java.nio.file.Path.of(uri));
+        if (!isS3(uri)) {
+            // Read the length without opening: no mapping and no descriptor is held by an
+            // instance the caller never passes to a reader.
+            java.nio.file.Path localPath = java.nio.file.Path.of(uri);
+            long length = Files.size(localPath);
+            return new HadoopInputFile(dev.hardwood.InputFile.of(localPath), path, conf, length);
         }
 
-        return new HadoopInputFile(hardwoodFile);
+        // S3 has no equivalent: the length comes from the response to the initial fetch.
+        dev.hardwood.InputFile hardwoodFile = createS3InputFile(uri, conf);
+        try {
+            hardwoodFile.open();
+            long length = hardwoodFile.length();
+            return new HadoopInputFile(hardwoodFile, path, conf, length);
+        }
+        catch (IOException | RuntimeException e) {
+            closeQuietly(hardwoodFile, e);
+            throw e;
+        }
+    }
+
+    /// Same as [#fromPath(Path, Configuration)], but wraps an [IOException] in an
+    /// unchecked exception.
+    ///
+    /// The wrapper is an [UncheckedIOException], which preserves the cause as an
+    /// [IOException]. Upstream parquet-java wraps in a plain `RuntimeException`.
+    ///
+    /// @param path the Hadoop path
+    /// @param conf the Hadoop configuration
+    /// @return an input file backed by the given path
+    public static HadoopInputFile fromPathUnchecked(Path path, Configuration conf) {
+        try {
+            return fromPath(path, conf);
+        }
+        catch (IOException e) {
+            throw new UncheckedIOException(e);
+        }
+    }
+
+    /// The path this file was created from.
+    ///
+    /// @return the Hadoop path
+    public Path getPath() {
+        return path;
+    }
+
+    /// The configuration this file was created with.
+    ///
+    /// @return the Hadoop configuration
+    public Configuration getConfiguration() {
+        return conf;
+    }
+
+    @Override
+    public String toString() {
+        return path.toString();
     }
 
     // --- org.apache.parquet.io.InputFile ---
 
+    /// The file length in bytes, read when this instance was created.
+    ///
+    /// Declares no checked exception, so the length of a file held in the concrete
+    /// type can be read without handling [IOException].
+    ///
+    /// @return the file length in bytes
     @Override
-    public long getLength() throws IOException {
-        delegate.open();
-        return delegate.length();
+    public long getLength() {
+        return length;
     }
 
     // --- package-private access for InputFiles bridge ---
@@ -77,6 +142,17 @@ public final class HadoopInputFile implements InputFile {
     }
 
     // --- internal helpers ---
+
+    /// Releases a file that failed to open, attaching any close failure to the original
+    /// exception so the cause of the failure is not lost.
+    private static void closeQuietly(dev.hardwood.InputFile file, Exception failure) {
+        try {
+            file.close();
+        }
+        catch (IOException | RuntimeException e) {
+            failure.addSuppressed(e);
+        }
+    }
 
     private static boolean isS3(URI uri) {
         String scheme = uri.getScheme();

--- a/parquet-java-compat/src/main/java/org/apache/parquet/io/InputFile.java
+++ b/parquet-java-compat/src/main/java/org/apache/parquet/io/InputFile.java
@@ -14,7 +14,6 @@ import java.io.IOException;
 /// In real parquet-java this interface also declares `newStream()`, but
 /// Hardwood does not use seekable input streams — it uses range reads via
 /// [dev.hardwood.InputFile]. This shim exists purely so that
-/// `HadoopInputFile.fromPath()` returns the correct upstream type and
 /// `ParquetReader.builder(ReadSupport, InputFile)` compiles.
 public interface InputFile {
 

--- a/parquet-java-compat/src/test/java/org/apache/parquet/compat/HadoopInputFileCompatTest.java
+++ b/parquet-java-compat/src/test/java/org/apache/parquet/compat/HadoopInputFileCompatTest.java
@@ -1,0 +1,89 @@
+/*
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Copyright The original authors
+ *
+ *  Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package org.apache.parquet.compat;
+
+import java.io.IOException;
+import java.io.UncheckedIOException;
+
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.Path;
+import org.apache.parquet.hadoop.util.HadoopInputFile;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/// Tests that `HadoopInputFile`'s factory methods and accessors match their upstream counterparts.
+class HadoopInputFileCompatTest {
+
+    private static final String PATH = "../core/src/test/resources/plain_uncompressed.parquet";
+    private static final String MISSING_PATH = "../core/src/test/resources/does_not_exist.parquet";
+
+    @Test
+    void fromPathReturnsConcreteType() throws IOException {
+        // must compile against the concrete type, as upstream code does
+        HadoopInputFile file = HadoopInputFile.fromPath(new Path(PATH), new Configuration());
+
+        assertThat(file.getLength()).isPositive();
+        assertThat(file.getPath().toUri().getPath()).endsWith("plain_uncompressed.parquet");
+    }
+
+    @Test
+    void fromPathUncheckedReturnsConcreteType() {
+        HadoopInputFile file = HadoopInputFile.fromPathUnchecked(new Path(PATH), new Configuration());
+
+        // getLength() declares no checked exception, as upstream's does not: this method
+        // compiles without a throws clause only because that signature matches
+        assertThat(file.getLength()).isPositive();
+    }
+
+    @Test
+    void exposesTheConfigurationItWasCreatedWith() throws IOException {
+        Configuration conf = new Configuration();
+
+        HadoopInputFile file = HadoopInputFile.fromPath(new Path(PATH), conf);
+
+        assertThat(file.getConfiguration()).isSameAs(conf);
+    }
+
+    @Test
+    void toStringNamesThePath() throws IOException {
+        Path path = new Path(PATH);
+
+        HadoopInputFile file = HadoopInputFile.fromPath(path, new Configuration());
+
+        assertThat(file.toString()).isEqualTo(path.toString());
+    }
+
+    /// The `throws` clauses are part of the signature this shim has to match, but a caller
+    /// that handles the exception compiles either way. Asserting them reflectively is what
+    /// makes a regression fail the build.
+    @Test
+    void factoryAndAccessorSignaturesMatchUpstream() throws NoSuchMethodException {
+        assertThat(HadoopInputFile.class.getMethod("fromPath", Path.class, Configuration.class)
+                .getReturnType()).isEqualTo(HadoopInputFile.class);
+        assertThat(HadoopInputFile.class.getMethod("fromPath", Path.class, Configuration.class)
+                .getExceptionTypes()).containsExactly(IOException.class);
+        assertThat(HadoopInputFile.class.getMethod("fromPathUnchecked", Path.class, Configuration.class)
+                .getExceptionTypes()).isEmpty();
+        assertThat(HadoopInputFile.class.getMethod("getLength").getExceptionTypes()).isEmpty();
+    }
+
+    @Test
+    void fromPathFailsOnMissingFile() {
+        assertThatThrownBy(() -> HadoopInputFile.fromPath(new Path(MISSING_PATH), new Configuration()))
+                .isInstanceOf(IOException.class);
+    }
+
+    @Test
+    void fromPathUncheckedWrapsFailureOnMissingFile() {
+        assertThatThrownBy(() -> HadoopInputFile.fromPathUnchecked(new Path(MISSING_PATH), new Configuration()))
+                .isInstanceOf(UncheckedIOException.class)
+                .hasCauseInstanceOf(IOException.class);
+    }
+}

--- a/parquet-java-compat/src/test/java/org/apache/parquet/compat/HadoopInputFileCompatTest.java
+++ b/parquet-java-compat/src/test/java/org/apache/parquet/compat/HadoopInputFileCompatTest.java
@@ -9,6 +9,7 @@ package org.apache.parquet.compat;
 
 import java.io.IOException;
 import java.io.UncheckedIOException;
+import java.nio.file.FileSystemNotFoundException;
 
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.Path;
@@ -85,5 +86,25 @@ class HadoopInputFileCompatTest {
         assertThatThrownBy(() -> HadoopInputFile.fromPathUnchecked(new Path(MISSING_PATH), new Configuration()))
                 .isInstanceOf(UncheckedIOException.class)
                 .hasCauseInstanceOf(IOException.class);
+    }
+
+    /// A scheme that is neither S3 nor a local path takes the local branch, where
+    /// `java.nio.file.Path.of` has no provider for it. Upstream reports the same condition as
+    /// an `IOException` from `path.getFileSystem(conf)`, so the type here is a divergence: a
+    /// caller's `catch (IOException)` around `fromPath` does not cover it.
+    @Test
+    void unsupportedSchemeThrowsFileSystemNotFound() {
+        assertThatThrownBy(() -> HadoopInputFile.fromPath(new Path("hdfs://nn/x.parquet"), new Configuration()))
+                .isInstanceOf(FileSystemNotFoundException.class)
+                .hasMessageContaining("hdfs");
+    }
+
+    /// [FileSystemNotFoundException] is not an [IOException], so it passes straight through
+    /// `fromPathUnchecked`'s catch rather than being wrapped like every other failure.
+    @Test
+    void unsupportedSchemeIsNotWrappedByFromPathUnchecked() {
+        assertThatThrownBy(() -> HadoopInputFile.fromPathUnchecked(new Path("gs://bucket/k.parquet"), new Configuration()))
+                .isInstanceOf(FileSystemNotFoundException.class)
+                .isNotInstanceOf(UncheckedIOException.class);
     }
 }


### PR DESCRIPTION
Fixes #851.

Comparing upstream (`javap` against the parquet-java 1.16.0) with shim: 

```
=== upstream ===                                                                                                        === shim ===
                                                                                                                        //     vvvvv
public class org.apache.parquet.hadoop.util.HadoopInputFile implements org.apache.parquet.io.InputFile {                public final class org.apache.parquet.hadoop.util.HadoopInputFile implements org.apache.parquet.io.InputFile {
  public static ...HadoopInputFile fromPath(...Path, ...Configuration) throws java.io.IOException;                        public static ...HadoopInputFile fromPath(...Path, ...Configuration) throws java.io.IOException;
  public static ...HadoopInputFile fromPathUnchecked(...Path, ...Configuration);                                          public static ...HadoopInputFile fromPathUnchecked(...Path, ...Configuration);
  public static ...HadoopInputFile fromStatus(...FileStatus, ...Configuration) throws java.io.IOException;
  public org.apache.hadoop.conf.Configuration getConfiguration();                                                         public org.apache.hadoop.conf.Configuration getConfiguration();
  public org.apache.hadoop.fs.Path getPath();                                                                             public org.apache.hadoop.fs.Path getPath();
  public long getLength();                                                                                                public long getLength();
  public org.apache.parquet.io.SeekableInputStream newStream() throws java.io.IOException;
  public java.lang.String toString();                                                                                     public java.lang.String toString();
}
                                                                                                                          dev.hardwood.InputFile delegate();
                                                                                                                        }
```

Following are missing from shim: 
- `fromStatus(FileStatus, Configuration)`: this would require Hadoop `FileSystem` API
- `org.apache.parquet.io.SeekableInputStream newStream()`: `InputFile` works on range reads; we could support this signature, but is it required?


## Checklist

- [x] Build via `./mvnw clean verify` passes
- [x] The commit message is prefixed with the issue key ("#123 Adding support for...")
- [x] Code changes are covered by tests
- [x] If this PR adds or changes user-facing behaviour, `docs/` has been updated — `docs/content/how-to/compat.md`
