### PR TITLE
#890 Cover mass-submitted pull requests in the contribution guidelines

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -74,8 +74,13 @@ project's standards for correctness, completeness and performance.
 
 In addition, pull requests opened by autonomous agents, with no person submitting them, are closed without review,
 whether or not the change itself is correct.
-Review here is also how the project gets to know the people it works with,
-and that only works when there is someone on the other side of the conversation.
+The same applies to unsolicited pull requests from accounts submitting at scale across many unrelated projects,
+whether or not a person is behind them: the project has no review capacity for them,
+and that holds regardless of how good an individual change may be.
+
+Code reviews are also how we get to know the people we're working with,
+and that only works when there is an actual human being on the other side of the conversation,
+who has an interest in this project.
 Contributing under your real name is encouraged for the same reason, though it is not a requirement.
 
 The PR template asks you to confirm that the change comes from a human


### PR DESCRIPTION
The AI-contribution rules added in #887 all turn on facts that cannot be established from outside a submission: whether an autonomous agent opened the PR, whether its author considered the LLM's output, whether the template box was ticked honestly. The pattern that actually triggers most closes — an account firing unsolicited PRs at dozens of unrelated projects — was the one criterion missing from the text, and it is the one thing that is plainly visible.

Without it, closing such a PR meant citing rules that did not describe the reason for closing it.

The new sentence sits alongside the autonomous-agent rule so the rationale that follows covers both cases, and it is deliberately worded to hold "whether or not a person is behind them" — bot-ness never has to be established. The stated reason is review capacity rather than suspicion of automation.

Fixes #890