### PR TITLE
#901 Write the run header of a zero-bit RLE stream

### DIFF
--- a/core/src/main/java/dev/hardwood/internal/encoding/RleBitPackingHybridEncoder.java
+++ b/core/src/main/java/dev/hardwood/internal/encoding/RleBitPackingHybridEncoder.java
@@ -11,7 +11,7 @@ import java.util.Arrays;
 
 /// Encoder for RLE/Bit-Packing Hybrid encoding, the inverse of
 /// [RleBitPackingHybridDecoder]. Used for definition/repetition levels (via
-/// [LevelEncoder]) and, later, dictionary indices.
+/// [LevelEncoder]) and for a data page's dictionary index stream.
 ///
 /// Values that repeat at least eight times in a row are emitted as an RLE run; shorter
 /// stretches are bit-packed in groups of eight. Emitting a single RLE run for a constant

--- a/core/src/main/java/dev/hardwood/internal/encoding/RleBitPackingHybridEncoder.java
+++ b/core/src/main/java/dev/hardwood/internal/encoding/RleBitPackingHybridEncoder.java
@@ -18,6 +18,11 @@ import java.util.Arrays;
 /// stream is what lets the reader take its all-present fast path on a fully-populated
 /// optional column. The bit-packed byte layout is little-endian bit order, matching the
 /// decoder: value `i` of a group occupies bits `[i·bitWidth, (i+1)·bitWidth)`.
+///
+/// A zero-bit stream — the dictionary indices of a chunk whose dictionary holds a single
+/// entry — is one RLE run whose values occupy no bytes, so only the run header is written.
+/// The header cannot be skipped even though it carries no value: a decoder reads the run
+/// length from the stream rather than from the page's value count.
 public final class RleBitPackingHybridEncoder {
 
     private final int bitWidth;
@@ -63,8 +68,11 @@ public final class RleBitPackingHybridEncoder {
             throw new IllegalStateException("Encoder already finished");
         }
         if (bitWidth == 0) {
-            // A 0-bit stream carries no information — the decoder reads nothing — so there
-            // is nothing to buffer or emit.
+            // Zero bits leave only one representable value, so the whole stream is one RLE
+            // run and the value itself needs no bytes. The run header is still required: a
+            // decoder takes the run length from the stream rather than from the page's value
+            // count, and reads past the end without it.
+            repeatCount++;
             return;
         }
         if (value == previousValue) {
@@ -92,7 +100,12 @@ public final class RleBitPackingHybridEncoder {
     /// to afterwards.
     public byte[] toByteArray() {
         if (!finished) {
-            if (repeatCount >= 8) {
+            if (bitWidth == 0) {
+                if (repeatCount > 0) {
+                    writeRleRun();
+                }
+            }
+            else if (repeatCount >= 8) {
                 writeRleRun();
             }
             else if (numBufferedValues > 0) {

--- a/core/src/test/java/dev/hardwood/internal/encoding/RleBitPackingHybridEncoderTest.java
+++ b/core/src/test/java/dev/hardwood/internal/encoding/RleBitPackingHybridEncoderTest.java
@@ -19,6 +19,26 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 /// share no code, so agreement pins the encoded byte layout to what the reader decodes.
 class RleBitPackingHybridEncoderTest {
 
+    /// A zero-bit stream still needs its RLE run header. Hardwood's own decoder short-circuits
+    /// on the bit width and never reads the bytes, but parquet-java and Arrow C++ drive the
+    /// decode from the stream itself and read past its end if the header is missing, so a
+    /// single-entry dictionary produced an index page they could not decode (#901).
+    ///
+    /// The run is `<varint (count << 1)>` with no value bytes, since a zero-bit value occupies
+    /// `ceil(0 / 8) == 0` bytes.
+    @Test
+    void encodesZeroBitStreamAsAnRleRunHeader() {
+        byte[] encoded = encode(new int[300], 0);
+
+        // 300 << 1 == 600, a two-byte unsigned varint.
+        assertThat(encoded).containsExactly(0xD8, 0x04);
+    }
+
+    @Test
+    void encodesEmptyZeroBitStreamAsNoBytes() {
+        assertThat(encode(new int[0], 0)).isEmpty();
+    }
+
     @Test
     void encodesConstantStreamAsSingleRleRun() {
         int[] values = new int[1000];
@@ -109,12 +129,6 @@ class RleBitPackingHybridEncoderTest {
             values[i] = random.nextInt(8);
         }
         assertRoundTrip(values, 3);
-    }
-
-    @Test
-    void bitWidthZeroEncodesNothing() {
-        byte[] encoded = encode(new int[] { 0, 0, 0 }, 0);
-        assertThat(encoded).isEmpty();
     }
 
     @Test

--- a/core/src/test/java/dev/hardwood/writer/WriterRoundTripTest.java
+++ b/core/src/test/java/dev/hardwood/writer/WriterRoundTripTest.java
@@ -568,8 +568,7 @@ class WriterRoundTripTest {
         Arrays.fill(values, -99);
 
         ByteBufferOutputFile out = new ByteBufferOutputFile();
-        try (ParquetFileWriter writer = ParquetFileWriter.create(out,
-                oneColumn(), WriterConfig.builder().codec(CompressionCodec.UNCOMPRESSED).build())) {
+        try (ParquetFileWriter writer = ParquetFileWriter.create(out, oneColumn())) {
             writer.writeBatch(batch -> batch.ints(0, values));
         }
 
@@ -587,8 +586,8 @@ class WriterRoundTripTest {
     }
 
     /// Length in bytes of the RLE index stream of the first data page at `dataPageOffset`,
-    /// which for an unlevelled, uncompressed `RLE_DICTIONARY` page is the body past its
-    /// leading bit-width byte.
+    /// which for an unlevelled `RLE_DICTIONARY` page is the uncompressed body past its leading
+    /// bit-width byte. Taken from the page header, so the chunk's codec does not matter.
     private static int indexStreamLength(byte[] file, long dataPageOffset) throws Exception {
         ThriftCompactReader reader = new ThriftCompactReader(ByteBuffer.wrap(file),
                 Math.toIntExact(dataPageOffset));

--- a/core/src/test/java/dev/hardwood/writer/WriterRoundTripTest.java
+++ b/core/src/test/java/dev/hardwood/writer/WriterRoundTripTest.java
@@ -568,14 +568,33 @@ class WriterRoundTripTest {
         Arrays.fill(values, -99);
 
         ByteBufferOutputFile out = new ByteBufferOutputFile();
-        try (ParquetFileWriter writer = ParquetFileWriter.create(out, oneColumn())) {
+        try (ParquetFileWriter writer = ParquetFileWriter.create(out,
+                oneColumn(), WriterConfig.builder().codec(CompressionCodec.UNCOMPRESSED).build())) {
             writer.writeBatch(batch -> batch.ints(0, values));
         }
 
-        try (ParquetFileReader reader = ParquetFileReader.open(InputFile.of(ByteBuffer.wrap(out.toByteArray())))) {
+        byte[] file = out.toByteArray();
+        try (ParquetFileReader reader = ParquetFileReader.open(InputFile.of(ByteBuffer.wrap(file)))) {
             assertThat(columnMeta(reader, 0).dictionaryPageOffset()).isNotNull();
             assertThat(Arrays.equals(readInts(reader, 0), values)).isTrue();
+
+            // The index stream is more than its bit-width byte: a zero-bit run still carries
+            // its header, without which parquet-java and Arrow C++ read past the end (#901).
+            // Hardwood's own decoder short-circuits on the bit width, so the round trip above
+            // passes either way.
+            assertThat(indexStreamLength(file, columnMeta(reader, 0).dataPageOffset())).isPositive();
         }
+    }
+
+    /// Length in bytes of the RLE index stream of the first data page at `dataPageOffset`,
+    /// which for an unlevelled, uncompressed `RLE_DICTIONARY` page is the body past its
+    /// leading bit-width byte.
+    private static int indexStreamLength(byte[] file, long dataPageOffset) throws Exception {
+        ThriftCompactReader reader = new ThriftCompactReader(ByteBuffer.wrap(file),
+                Math.toIntExact(dataPageOffset));
+        PageHeader header = PageHeaderReader.read(reader);
+        assertThat(header.dataPageHeader().encoding()).isEqualTo(Encoding.RLE_DICTIONARY);
+        return header.uncompressedPageSize() - 1;
     }
 
     @Test


### PR DESCRIPTION
Fixes #901.

A column chunk whose dictionary holds a single entry indexes it with a zero-bit stream, and `RleBitPackingHybridEncoder` emitted nothing at all for one — leaving the `RLE_DICTIONARY` data page body as just its bit-width byte `0x00`. Zero bits leave one representable value, so the stream is one RLE run whose values occupy no bytes, but the run header is still required: a decoder takes the run length from the stream rather than from the page's `num_values`.

Consequence: any file Hardwood wrote with a constant column — or one whose distinct values happened to collapse to a single entry within a chunk — was unreadable by parquet-java (`IllegalArgumentException: Reading past RLE/BitPacking stream`) and PyArrow (`Dict decoding failed` / `Invalid number of indices: 0` / `Unexpected end of stream`, depending on physical type). Any physical type is affected.

The comment the early return carried was right about level streams — `ColumnChunkBuffer` only writes definition and repetition levels when `maxLevel > 0`, so those never reach bit width 0 — but not about dictionary indices.

## Why the existing tests missed it

`WriterRoundTripTest.dictionaryEncodesSingleDistinctValue` already covered this exact shape, and passed: Hardwood's decoder short-circuits on the bit width and fills zeros without reading the stream. The DuckDB differential passes too, because DuckDB is lenient here as well.

So the regression test pins the encoded bytes directly — a 300-value zero-bit stream must be exactly `D8 04`, the varint `300 << 1` — and the writer test now asserts the index stream is more than its bit-width byte, rather than only that the values survive. The old `bitWidthZeroEncodesNothing` case is removed; it pinned the defect.

## Verification

Full `./mvnw verify` green. Beyond the suite, files written before and after the change were read with **parquet-java 1.15.2** and **PyArrow 24.0.0**: both fail on the pre-fix files and read the post-fix ones correctly, for `INT32`, `BYTE_ARRAY` (required and optional), and `FIXED_LEN_BYTE_ARRAY`.

Worth considering separately: nothing in CI reads a Hardwood-written file with a non-lenient external implementation. A parquet-java interop test on the write path would have caught this at the time it was introduced.
