### PR TITLE
#912 Widening the Thrift type-code table so every module can reach it

### DIFF
--- a/core/src/main/java/dev/hardwood/internal/thrift/ThriftCompactConstants.java
+++ b/core/src/main/java/dev/hardwood/internal/thrift/ThriftCompactConstants.java
@@ -7,10 +7,11 @@
  */
 package dev.hardwood.internal.thrift;
 
-/// Thrift Compact Protocol type codes, defined once and shared by the reader and
-/// writer so the wire constants are not duplicated.
+/// Thrift Compact Protocol type codes, defined once and shared by every reader,
+/// writer and test fixture that encodes or decodes the wire format, so the
+/// constants are not duplicated.
 /// Reference: https://github.com/apache/thrift/blob/master/doc/specs/thrift-compact-protocol.md
-final class ThriftCompactConstants {
+public final class ThriftCompactConstants {
 
     /// Type codes for struct field headers.
     public enum FieldType {
@@ -36,7 +37,7 @@ final class ThriftCompactConstants {
         }
 
         /// The Thrift Compact Protocol wire code for this type.
-        byte code() {
+        public byte code() {
             return code;
         }
 
@@ -44,21 +45,24 @@ final class ThriftCompactConstants {
         /// `switch` on the raw wire byte — notably [ThriftCompactReader] — reference
         /// these so the codes are defined once, without re-declaring the literals.
         /// The [FieldType] and [ElementType] enums are built from them too.
-        static final class Codes {
+        public static final class Codes {
 
-            static final byte BOOLEAN_TRUE = 0x01;
-            static final byte BOOLEAN_FALSE = 0x02;
-            static final byte BYTE = 0x03;
-            static final byte I16 = 0x04;
-            static final byte I32 = 0x05;
-            static final byte I64 = 0x06;
-            static final byte DOUBLE = 0x07;
-            static final byte BINARY = 0x08;
-            static final byte LIST = 0x09;
-            static final byte SET = 0x0A;
-            static final byte MAP = 0x0B;
-            static final byte STRUCT = 0x0C;
-            static final byte UUID = 0x0D;
+            /// Not a type: the field header a struct terminates with.
+            public static final byte STOP = 0x00;
+
+            public static final byte BOOLEAN_TRUE = 0x01;
+            public static final byte BOOLEAN_FALSE = 0x02;
+            public static final byte BYTE = 0x03;
+            public static final byte I16 = 0x04;
+            public static final byte I32 = 0x05;
+            public static final byte I64 = 0x06;
+            public static final byte DOUBLE = 0x07;
+            public static final byte BINARY = 0x08;
+            public static final byte LIST = 0x09;
+            public static final byte SET = 0x0A;
+            public static final byte MAP = 0x0B;
+            public static final byte STRUCT = 0x0C;
+            public static final byte UUID = 0x0D;
 
             private Codes() {
             }
@@ -91,7 +95,7 @@ final class ThriftCompactConstants {
         }
 
         /// The Thrift Compact Protocol wire code for this element type.
-        byte code() {
+        public byte code() {
             return code;
         }
     }

--- a/core/src/main/java/dev/hardwood/internal/thrift/ThriftCompactConstants.java
+++ b/core/src/main/java/dev/hardwood/internal/thrift/ThriftCompactConstants.java
@@ -17,6 +17,10 @@ public final class ThriftCompactConstants {
     /// not a type code, so it belongs to neither [FieldType] nor [ElementType].
     public static final byte STOP = 0x00;
 
+    /// The list-header size nibble that saturates, meaning the real element count follows the
+    /// header as a varint rather than fitting in the nibble.
+    public static final int LONG_FORM_SIZE = 15;
+
     /// Type codes for struct field headers.
     public enum FieldType {
 
@@ -49,21 +53,21 @@ public final class ThriftCompactConstants {
         /// `switch` on the raw wire byte — notably [ThriftCompactReader] — reference
         /// these so the codes are defined once, without re-declaring the literals.
         /// The [FieldType] and [ElementType] enums are built from them too.
-        public static final class Codes {
+        static final class Codes {
 
-            public static final byte BOOLEAN_TRUE = 0x01;
-            public static final byte BOOLEAN_FALSE = 0x02;
-            public static final byte BYTE = 0x03;
-            public static final byte I16 = 0x04;
-            public static final byte I32 = 0x05;
-            public static final byte I64 = 0x06;
-            public static final byte DOUBLE = 0x07;
-            public static final byte BINARY = 0x08;
-            public static final byte LIST = 0x09;
-            public static final byte SET = 0x0A;
-            public static final byte MAP = 0x0B;
-            public static final byte STRUCT = 0x0C;
-            public static final byte UUID = 0x0D;
+            static final byte BOOLEAN_TRUE = 0x01;
+            static final byte BOOLEAN_FALSE = 0x02;
+            static final byte BYTE = 0x03;
+            static final byte I16 = 0x04;
+            static final byte I32 = 0x05;
+            static final byte I64 = 0x06;
+            static final byte DOUBLE = 0x07;
+            static final byte BINARY = 0x08;
+            static final byte LIST = 0x09;
+            static final byte SET = 0x0A;
+            static final byte MAP = 0x0B;
+            static final byte STRUCT = 0x0C;
+            static final byte UUID = 0x0D;
 
             private Codes() {
             }
@@ -72,12 +76,11 @@ public final class ThriftCompactConstants {
 
     /// Type codes for list/set/map elements. These mirror [FieldType] except boolean:
     /// a collection has a single element type for `bool`, whereas a field packs
-    /// true/false into the type. [#BOOL] is written as `1` — the de-facto standard;
-    /// [#BOOL_LEGACY] is the spec's original `2`, and readers accept either.
+    /// true/false into the type. [#BOOL] is written as `1` — the de-facto standard; the spec's
+    /// original code is `2`, which readers accept as well.
     public enum ElementType {
 
         BOOL(FieldType.Codes.BOOLEAN_TRUE),
-        BOOL_LEGACY(FieldType.Codes.BOOLEAN_FALSE),
         BYTE(FieldType.Codes.BYTE),
         I16(FieldType.Codes.I16),
         I32(FieldType.Codes.I32),

--- a/core/src/main/java/dev/hardwood/internal/thrift/ThriftCompactConstants.java
+++ b/core/src/main/java/dev/hardwood/internal/thrift/ThriftCompactConstants.java
@@ -13,6 +13,10 @@ package dev.hardwood.internal.thrift;
 /// Reference: https://github.com/apache/thrift/blob/master/doc/specs/thrift-compact-protocol.md
 public final class ThriftCompactConstants {
 
+    /// The byte a struct terminates with, where a field header would otherwise start. It is
+    /// not a type code, so it belongs to neither [FieldType] nor [ElementType].
+    public static final byte STOP = 0x00;
+
     /// Type codes for struct field headers.
     public enum FieldType {
 
@@ -47,9 +51,6 @@ public final class ThriftCompactConstants {
         /// The [FieldType] and [ElementType] enums are built from them too.
         public static final class Codes {
 
-            /// Not a type: the field header a struct terminates with.
-            public static final byte STOP = 0x00;
-
             public static final byte BOOLEAN_TRUE = 0x01;
             public static final byte BOOLEAN_FALSE = 0x02;
             public static final byte BYTE = 0x03;
@@ -70,12 +71,13 @@ public final class ThriftCompactConstants {
     }
 
     /// Type codes for list/set/map elements. These mirror [FieldType] except boolean:
-    /// a collection has a single [#BOOL] element type, whereas a field packs
-    /// true/false into the type. `BOOL` is written as `1` — the de-facto standard;
-    /// the spec's original code was `2` and readers should accept either.
+    /// a collection has a single element type for `bool`, whereas a field packs
+    /// true/false into the type. [#BOOL] is written as `1` — the de-facto standard;
+    /// [#BOOL_LEGACY] is the spec's original `2`, and readers accept either.
     public enum ElementType {
 
         BOOL(FieldType.Codes.BOOLEAN_TRUE),
+        BOOL_LEGACY(FieldType.Codes.BOOLEAN_FALSE),
         BYTE(FieldType.Codes.BYTE),
         I16(FieldType.Codes.I16),
         I32(FieldType.Codes.I32),

--- a/core/src/main/java/dev/hardwood/internal/thrift/ThriftCompactReader.java
+++ b/core/src/main/java/dev/hardwood/internal/thrift/ThriftCompactReader.java
@@ -32,7 +32,6 @@ public class ThriftCompactReader {
     // The reader dispatches on the raw wire byte in a switch, whose case labels must
     // be compile-time constants, so it references the shared byte codes in
     // [ThriftCompactConstants.FieldType.Codes] rather than the enum values.
-    private static final byte TYPE_STOP = Codes.STOP;
     private static final byte TYPE_BOOLEAN_TRUE = Codes.BOOLEAN_TRUE;
     private static final byte TYPE_BOOLEAN_FALSE = Codes.BOOLEAN_FALSE;
     private static final byte TYPE_BYTE = Codes.BYTE;
@@ -207,7 +206,7 @@ public class ThriftCompactReader {
     public FieldHeader readFieldHeader() throws IOException {
         byte b = readByte();
 
-        if (b == TYPE_STOP) {
+        if (b == ThriftCompactConstants.STOP) {
             lastFieldId = 0;
             return null;
         }

--- a/core/src/main/java/dev/hardwood/internal/thrift/ThriftCompactReader.java
+++ b/core/src/main/java/dev/hardwood/internal/thrift/ThriftCompactReader.java
@@ -32,6 +32,7 @@ public class ThriftCompactReader {
     // The reader dispatches on the raw wire byte in a switch, whose case labels must
     // be compile-time constants, so it references the shared byte codes in
     // [ThriftCompactConstants.FieldType.Codes] rather than the enum values.
+    private static final byte TYPE_STOP = Codes.STOP;
     private static final byte TYPE_BOOLEAN_TRUE = Codes.BOOLEAN_TRUE;
     private static final byte TYPE_BOOLEAN_FALSE = Codes.BOOLEAN_FALSE;
     private static final byte TYPE_BYTE = Codes.BYTE;
@@ -206,8 +207,7 @@ public class ThriftCompactReader {
     public FieldHeader readFieldHeader() throws IOException {
         byte b = readByte();
 
-        if (b == 0) {
-            // STOP field
+        if (b == TYPE_STOP) {
             lastFieldId = 0;
             return null;
         }

--- a/core/src/main/java/dev/hardwood/internal/thrift/ThriftCompactWriter.java
+++ b/core/src/main/java/dev/hardwood/internal/thrift/ThriftCompactWriter.java
@@ -45,11 +45,11 @@ public class ThriftCompactWriter {
     /// @param size number of elements
     /// @param elementType the element type
     public void writeListBegin(int size, ThriftCompactConstants.ElementType elementType) {
-        if (size < 15) {
+        if (size < ThriftCompactConstants.LONG_FORM_SIZE) {
             out.write((size << 4) | elementType.code());
         }
         else {
-            out.write(0xF0 | elementType.code());
+            out.write((ThriftCompactConstants.LONG_FORM_SIZE << 4) | elementType.code());
             writeVarint(size);
         }
     }

--- a/core/src/main/java/dev/hardwood/internal/thrift/ThriftCompactWriter.java
+++ b/core/src/main/java/dev/hardwood/internal/thrift/ThriftCompactWriter.java
@@ -37,7 +37,7 @@ public class ThriftCompactWriter {
 
     /// Write the STOP marker that terminates a struct's fields.
     public void writeFieldStop() {
-        out.write(0);
+        out.write(ThriftCompactConstants.FieldType.Codes.STOP);
     }
 
     /// Write a list header.

--- a/core/src/main/java/dev/hardwood/internal/thrift/ThriftCompactWriter.java
+++ b/core/src/main/java/dev/hardwood/internal/thrift/ThriftCompactWriter.java
@@ -37,7 +37,7 @@ public class ThriftCompactWriter {
 
     /// Write the STOP marker that terminates a struct's fields.
     public void writeFieldStop() {
-        out.write(ThriftCompactConstants.FieldType.Codes.STOP);
+        out.write(ThriftCompactConstants.STOP);
     }
 
     /// Write a list header.

--- a/core/src/test/java/dev/hardwood/internal/predicate/PageFilterEvaluatorTest.java
+++ b/core/src/test/java/dev/hardwood/internal/predicate/PageFilterEvaluatorTest.java
@@ -26,6 +26,7 @@ import dev.hardwood.InputFile;
 import dev.hardwood.internal.reader.ParquetMetadataReader;
 import dev.hardwood.internal.reader.RowGroupIndexBuffers;
 import dev.hardwood.internal.reader.RowRanges;
+import dev.hardwood.internal.thrift.ThriftCompactConstants.FieldType;
 import dev.hardwood.internal.thrift.ThriftStructBuilder;
 import dev.hardwood.metadata.ColumnChunk;
 import dev.hardwood.metadata.ColumnIndex;
@@ -604,14 +605,14 @@ class PageFilterEvaluatorTest {
         // walks them with a single index, so this has to fail before it does — naming the file,
         // the row group and the column, none of which the page index itself carries.
         byte[] columnIndex = new ThriftStructBuilder()
-                .field(1, ThriftStructBuilder.TYPE_LIST).boolList(false, false, false)
-                .field(2, ThriftStructBuilder.TYPE_LIST)
+                .field(1, FieldType.LIST).boolList(false, false, false)
+                .field(2, FieldType.LIST)
                 .binaryList(intBytes(1), intBytes(11), intBytes(21))
-                .field(3, ThriftStructBuilder.TYPE_LIST)
+                .field(3, FieldType.LIST)
                 .binaryList(intBytes(10), intBytes(20), intBytes(30))
                 .stop().build();
         byte[] offsetIndex = new ThriftStructBuilder()
-                .field(1, ThriftStructBuilder.TYPE_LIST)
+                .field(1, FieldType.LIST)
                 .structList(pageLocation(0, 0), pageLocation(100, 30))
                 .stop().build();
 
@@ -637,9 +638,9 @@ class PageFilterEvaluatorTest {
     /// A PageLocation struct body: offset, compressed_page_size, first_row_index.
     private static byte[] pageLocation(long offset, long firstRowIndex) {
         return new ThriftStructBuilder()
-                .field(1, ThriftStructBuilder.TYPE_I64).i64(offset)
-                .field(2, ThriftStructBuilder.TYPE_I32).i32(100)
-                .field(3, ThriftStructBuilder.TYPE_I64).i64(firstRowIndex)
+                .field(1, FieldType.I64).i64(offset)
+                .field(2, FieldType.I32).i32(100)
+                .field(3, FieldType.I64).i64(firstRowIndex)
                 .stop().build();
     }
 

--- a/core/src/test/java/dev/hardwood/internal/thrift/BoundingBoxReaderTest.java
+++ b/core/src/test/java/dev/hardwood/internal/thrift/BoundingBoxReaderTest.java
@@ -13,6 +13,7 @@ import java.nio.ByteOrder;
 
 import org.junit.jupiter.api.Test;
 
+import dev.hardwood.internal.thrift.ThriftCompactConstants.FieldType;
 import dev.hardwood.metadata.BoundingBox;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -20,17 +21,15 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 class BoundingBoxReaderTest {
 
-    private static final byte TYPE_DOUBLE = 0x07;
-
     @Test
     void readsAllFieldsWhenPresent() throws IOException {
         byte[] thrift = bbox()
-                .field(1, TYPE_DOUBLE).doubleValue(-4.0)
-                .field(2, TYPE_DOUBLE).doubleValue(7.5)
-                .field(3, TYPE_DOUBLE).doubleValue(20.96)
-                .field(4, TYPE_DOUBLE).doubleValue(77.08)
-                .field(5, TYPE_DOUBLE).doubleValue(10.5)
-                .field(6, TYPE_DOUBLE).doubleValue(90.0)
+                .field(1, FieldType.DOUBLE).doubleValue(-4.0)
+                .field(2, FieldType.DOUBLE).doubleValue(7.5)
+                .field(3, FieldType.DOUBLE).doubleValue(20.96)
+                .field(4, FieldType.DOUBLE).doubleValue(77.08)
+                .field(5, FieldType.DOUBLE).doubleValue(10.5)
+                .field(6, FieldType.DOUBLE).doubleValue(90.0)
                 .stop().build();
 
         BoundingBox box = BoundingBoxReader.read(new ThriftCompactReader(ByteBuffer.wrap(thrift)));
@@ -49,9 +48,9 @@ class BoundingBoxReaderTest {
     void throwsWhenRequiredFieldMissing() {
         // Missing field 4 (ymax)
         byte[] thrift = bbox()
-                .field(1, TYPE_DOUBLE).doubleValue(0.0)
-                .field(2, TYPE_DOUBLE).doubleValue(1.0)
-                .field(3, TYPE_DOUBLE).doubleValue(0.0)
+                .field(1, FieldType.DOUBLE).doubleValue(0.0)
+                .field(2, FieldType.DOUBLE).doubleValue(1.0)
+                .field(3, FieldType.DOUBLE).doubleValue(0.0)
                 .stop().build();
 
         assertThatThrownBy(() -> BoundingBoxReader.read(new ThriftCompactReader(ByteBuffer.wrap(thrift))))
@@ -61,9 +60,9 @@ class BoundingBoxReaderTest {
 
     @Test
     void throwsOnWrongWireTypeForRequiredField() {
-        // Field 1 (xmin) declared as I32 (0x05) instead of DOUBLE (0x07)
+        // Field 1 (xmin) declared as I32 instead of DOUBLE
         byte[] thrift = bbox()
-                .field(1, (byte) 0x05).i32(0)
+                .field(1, FieldType.I32).i32(0)
                 .stop().build();
 
         assertThatThrownBy(() -> BoundingBoxReader.read(new ThriftCompactReader(ByteBuffer.wrap(thrift))))
@@ -81,17 +80,17 @@ class BoundingBoxReaderTest {
         private short lastFieldId;
         private byte pendingFieldType;
 
-        ThriftBuilder field(int id, byte type) {
+        ThriftBuilder field(int id, FieldType type) {
             short delta = (short) (id - lastFieldId);
             if (delta > 0 && delta <= 15) {
-                buffer.put((byte) ((delta << 4) | (type & 0x0F)));
+                buffer.put((byte) ((delta << 4) | (type.code() & 0x0F)));
             }
             else {
-                buffer.put(type);
+                buffer.put(type.code());
                 writeZigzag(id);
             }
             lastFieldId = (short) id;
-            pendingFieldType = type;
+            pendingFieldType = type.code();
             return this;
         }
 

--- a/core/src/test/java/dev/hardwood/internal/thrift/BoundingBoxReaderTest.java
+++ b/core/src/test/java/dev/hardwood/internal/thrift/BoundingBoxReaderTest.java
@@ -9,7 +9,6 @@ package dev.hardwood.internal.thrift;
 
 import java.io.IOException;
 import java.nio.ByteBuffer;
-import java.nio.ByteOrder;
 
 import org.junit.jupiter.api.Test;
 
@@ -70,61 +69,7 @@ class BoundingBoxReaderTest {
                 .hasMessageContaining("xmin");
     }
 
-    private static ThriftBuilder bbox() {
-        return new ThriftBuilder();
-    }
-
-    /// Hand-rolled Thrift Compact Protocol struct builder for tests.
-    private static final class ThriftBuilder {
-        private final ByteBuffer buffer = ByteBuffer.allocate(256).order(ByteOrder.LITTLE_ENDIAN);
-        private short lastFieldId;
-        private byte pendingFieldType;
-
-        ThriftBuilder field(int id, FieldType type) {
-            short delta = (short) (id - lastFieldId);
-            if (delta > 0 && delta <= 15) {
-                buffer.put((byte) ((delta << 4) | (type.code() & 0x0F)));
-            }
-            else {
-                buffer.put(type.code());
-                writeZigzag(id);
-            }
-            lastFieldId = (short) id;
-            pendingFieldType = type.code();
-            return this;
-        }
-
-        ThriftBuilder doubleValue(double v) {
-            buffer.putDouble(v);
-            pendingFieldType = 0;
-            return this;
-        }
-
-        ThriftBuilder i32(int v) {
-            writeZigzag(v);
-            pendingFieldType = 0;
-            return this;
-        }
-
-        ThriftBuilder stop() {
-            buffer.put((byte) 0);
-            return this;
-        }
-
-        byte[] build() {
-            byte[] out = new byte[buffer.position()];
-            buffer.flip();
-            buffer.get(out);
-            return out;
-        }
-
-        private void writeZigzag(long v) {
-            long zz = (v << 1) ^ (v >> 63);
-            while ((zz & ~0x7FL) != 0) {
-                buffer.put((byte) ((zz & 0x7F) | 0x80));
-                zz >>>= 7;
-            }
-            buffer.put((byte) (zz & 0x7F));
-        }
+    private static ThriftStructBuilder bbox() {
+        return new ThriftStructBuilder();
     }
 }

--- a/core/src/test/java/dev/hardwood/internal/thrift/ColumnIndexReaderTest.java
+++ b/core/src/test/java/dev/hardwood/internal/thrift/ColumnIndexReaderTest.java
@@ -12,10 +12,9 @@ import java.nio.ByteBuffer;
 
 import org.junit.jupiter.api.Test;
 
+import dev.hardwood.internal.thrift.ThriftCompactConstants.FieldType;
 import dev.hardwood.metadata.ColumnIndex;
 
-import static dev.hardwood.internal.thrift.ThriftStructBuilder.TYPE_I32;
-import static dev.hardwood.internal.thrift.ThriftStructBuilder.TYPE_LIST;
 import static org.assertj.core.api.Assertions.assertThat;
 
 class ColumnIndexReaderTest {
@@ -25,14 +24,14 @@ class ColumnIndexReaderTest {
         // Three pages of a maxDef 1 / maxRep 0 column: the definition-level histogram
         // contributes two entries per page, the repetition-level histogram one.
         byte[] thrift = struct()
-                .field(1, TYPE_LIST).boolList(false, true, false)
-                .field(2, TYPE_LIST).binaryList(bytes(1), bytes(0), bytes(21))
-                .field(3, TYPE_LIST).binaryList(bytes(10), bytes(0), bytes(30))
-                .field(4, TYPE_I32).i32(1) // ASCENDING
-                .field(5, TYPE_LIST).i64List(0, 3, 0)
-                .field(6, TYPE_LIST).i64List(4, 3, 4)
-                .field(7, TYPE_LIST).i64List(0, 4, 3, 0, 0, 4)
-                .field(8, TYPE_LIST).i64List(0, 0, 1)
+                .field(1, FieldType.LIST).boolList(false, true, false)
+                .field(2, FieldType.LIST).binaryList(bytes(1), bytes(0), bytes(21))
+                .field(3, FieldType.LIST).binaryList(bytes(10), bytes(0), bytes(30))
+                .field(4, FieldType.I32).i32(1) // ASCENDING
+                .field(5, FieldType.LIST).i64List(0, 3, 0)
+                .field(6, FieldType.LIST).i64List(4, 3, 4)
+                .field(7, FieldType.LIST).i64List(0, 4, 3, 0, 0, 4)
+                .field(8, FieldType.LIST).i64List(0, 0, 1)
                 .stop().build();
 
         ColumnIndex index = ColumnIndexReader.read(new ThriftCompactReader(ByteBuffer.wrap(thrift)));
@@ -54,10 +53,10 @@ class ColumnIndexReaderTest {
         // Only fields 1-4 are required. A writer predating the histograms leaves every
         // optional list absent, which stays distinct from a present but empty one.
         byte[] thrift = struct()
-                .field(1, TYPE_LIST).boolList(false, false)
-                .field(2, TYPE_LIST).binaryList(bytes(1), bytes(2))
-                .field(3, TYPE_LIST).binaryList(bytes(9), bytes(9))
-                .field(4, TYPE_I32).i32(0)
+                .field(1, FieldType.LIST).boolList(false, false)
+                .field(2, FieldType.LIST).binaryList(bytes(1), bytes(2))
+                .field(3, FieldType.LIST).binaryList(bytes(9), bytes(9))
+                .field(4, FieldType.I32).i32(0)
                 .stop().build();
 
         ColumnIndex index = ColumnIndexReader.read(new ThriftCompactReader(ByteBuffer.wrap(thrift)));
@@ -75,13 +74,13 @@ class ColumnIndexReaderTest {
         // list<i64> belongs. The reader must skip them cleanly and still parse the
         // surrounding fields — including field 8, which follows the malformed one.
         byte[] thrift = struct()
-                .field(1, TYPE_LIST).boolList(false, false)
-                .field(2, TYPE_LIST).binaryList(bytes(1), bytes(2))
-                .field(3, TYPE_LIST).binaryList(bytes(9), bytes(9))
-                .field(4, TYPE_I32).i32(0)
-                .field(5, TYPE_LIST).i64List(2, 5)
-                .field(7, TYPE_LIST).emptyStructList(2)
-                .field(8, TYPE_LIST).i64List(0, 0)
+                .field(1, FieldType.LIST).boolList(false, false)
+                .field(2, FieldType.LIST).binaryList(bytes(1), bytes(2))
+                .field(3, FieldType.LIST).binaryList(bytes(9), bytes(9))
+                .field(4, FieldType.I32).i32(0)
+                .field(5, FieldType.LIST).i64List(2, 5)
+                .field(7, FieldType.LIST).emptyStructList(2)
+                .field(8, FieldType.LIST).i64List(0, 0)
                 .stop().build();
 
         ColumnIndex index = ColumnIndexReader.read(new ThriftCompactReader(ByteBuffer.wrap(thrift)));
@@ -99,17 +98,17 @@ class ColumnIndexReaderTest {
         // bytes as varints would leave the cursor mid-struct and shift every later field,
         // so the element type — not just the field type — has to drive the skip.
         byte[] payload = struct()
-                .field(1, TYPE_I32).i32(1234567)
-                .field(2, TYPE_I32).i32(7654321)
+                .field(1, FieldType.I32).i32(1234567)
+                .field(2, FieldType.I32).i32(7654321)
                 .stop().build();
         byte[] thrift = struct()
-                .field(1, TYPE_LIST).boolList(true)
-                .field(2, TYPE_LIST).binaryList(bytes(1))
-                .field(3, TYPE_LIST).binaryList(bytes(2))
-                .field(4, TYPE_I32).i32(0)
-                .field(6, TYPE_LIST).structList(payload, payload)
-                .field(7, TYPE_LIST).i64List(3, 9)
-                .field(8, TYPE_LIST).i64List(11)
+                .field(1, FieldType.LIST).boolList(true)
+                .field(2, FieldType.LIST).binaryList(bytes(1))
+                .field(3, FieldType.LIST).binaryList(bytes(2))
+                .field(4, FieldType.I32).i32(0)
+                .field(6, FieldType.LIST).structList(payload, payload)
+                .field(7, FieldType.LIST).i64List(3, 9)
+                .field(8, FieldType.LIST).i64List(11)
                 .stop().build();
 
         ColumnIndex index = ColumnIndexReader.read(new ThriftCompactReader(ByteBuffer.wrap(thrift)));
@@ -125,13 +124,13 @@ class ColumnIndexReaderTest {
         // its header's type nibble. Skipping these by field rules would consume nothing and
         // leave the cursor on the first element, losing fields 7 and 8 as well.
         byte[] thrift = struct()
-                .field(1, TYPE_LIST).boolList(false, false)
-                .field(2, TYPE_LIST).binaryList(bytes(1), bytes(2))
-                .field(3, TYPE_LIST).binaryList(bytes(9), bytes(9))
-                .field(4, TYPE_I32).i32(0)
-                .field(6, TYPE_LIST).boolList(true, false, true)
-                .field(7, TYPE_LIST).i64List(3, 9)
-                .field(8, TYPE_LIST).i64List(11, 12)
+                .field(1, FieldType.LIST).boolList(false, false)
+                .field(2, FieldType.LIST).binaryList(bytes(1), bytes(2))
+                .field(3, FieldType.LIST).binaryList(bytes(9), bytes(9))
+                .field(4, FieldType.I32).i32(0)
+                .field(6, FieldType.LIST).boolList(true, false, true)
+                .field(7, FieldType.LIST).i64List(3, 9)
+                .field(8, FieldType.LIST).i64List(11, 12)
                 .stop().build();
 
         ColumnIndex index = ColumnIndexReader.read(new ThriftCompactReader(ByteBuffer.wrap(thrift)));
@@ -146,14 +145,14 @@ class ColumnIndexReaderTest {
         // The same shape one field earlier, where the desync reaches three later fields
         // rather than two.
         byte[] thrift = struct()
-                .field(1, TYPE_LIST).boolList(false, false)
-                .field(2, TYPE_LIST).binaryList(bytes(1), bytes(2))
-                .field(3, TYPE_LIST).binaryList(bytes(9), bytes(9))
-                .field(4, TYPE_I32).i32(0)
-                .field(5, TYPE_LIST).boolList(true, false)
-                .field(6, TYPE_LIST).i64List(2, 2)
-                .field(7, TYPE_LIST).i64List(1, 3)
-                .field(8, TYPE_LIST).i64List(0, 0)
+                .field(1, FieldType.LIST).boolList(false, false)
+                .field(2, FieldType.LIST).binaryList(bytes(1), bytes(2))
+                .field(3, FieldType.LIST).binaryList(bytes(9), bytes(9))
+                .field(4, FieldType.I32).i32(0)
+                .field(5, FieldType.LIST).boolList(true, false)
+                .field(6, FieldType.LIST).i64List(2, 2)
+                .field(7, FieldType.LIST).i64List(1, 3)
+                .field(8, FieldType.LIST).i64List(0, 0)
                 .stop().build();
 
         ColumnIndex index = ColumnIndexReader.read(new ThriftCompactReader(ByteBuffer.wrap(thrift)));

--- a/core/src/test/java/dev/hardwood/internal/thrift/ColumnMetaDataReaderTest.java
+++ b/core/src/test/java/dev/hardwood/internal/thrift/ColumnMetaDataReaderTest.java
@@ -13,12 +13,9 @@ import java.nio.charset.StandardCharsets;
 
 import org.junit.jupiter.api.Test;
 
+import dev.hardwood.internal.thrift.ThriftCompactConstants.FieldType;
 import dev.hardwood.metadata.ColumnMetaData;
 
-import static dev.hardwood.internal.thrift.ThriftStructBuilder.TYPE_I32;
-import static dev.hardwood.internal.thrift.ThriftStructBuilder.TYPE_I64;
-import static dev.hardwood.internal.thrift.ThriftStructBuilder.TYPE_LIST;
-import static dev.hardwood.internal.thrift.ThriftStructBuilder.TYPE_STRUCT;
 import static org.assertj.core.api.Assertions.assertThat;
 
 class ColumnMetaDataReaderTest {
@@ -26,13 +23,13 @@ class ColumnMetaDataReaderTest {
     @Test
     void readsSizeStatisticsAtFieldSixteen() throws IOException {
         byte[] sizeStatistics = struct()
-                .field(1, TYPE_I64).i64(2048)
-                .field(2, TYPE_LIST).i64List(6, 3)
-                .field(3, TYPE_LIST).i64List(1, 8)
+                .field(1, FieldType.I64).i64(2048)
+                .field(2, FieldType.LIST).i64List(6, 3)
+                .field(3, FieldType.LIST).i64List(1, 8)
                 .stop().build();
 
         ColumnMetaData metaData = read(baseColumn()
-                .field(16, TYPE_STRUCT).nested(sizeStatistics)
+                .field(16, FieldType.STRUCT).nested(sizeStatistics)
                 .stop().build());
 
         assertThat(metaData.sizeStatistics()).isNotNull();
@@ -46,15 +43,15 @@ class ColumnMetaDataReaderTest {
         // Field ids restart inside a nested struct. If the size-statistics decode leaked its
         // field-id context, the following field 17 would be misread.
         byte[] sizeStatistics = struct()
-                .field(1, TYPE_I64).i64(512)
+                .field(1, FieldType.I64).i64(512)
                 .stop().build();
         byte[] geospatialStatistics = struct()
-                .field(2, TYPE_LIST).i32List(3)
+                .field(2, FieldType.LIST).i32List(3)
                 .stop().build();
 
         ColumnMetaData metaData = read(baseColumn()
-                .field(16, TYPE_STRUCT).nested(sizeStatistics)
-                .field(17, TYPE_STRUCT).nested(geospatialStatistics)
+                .field(16, FieldType.STRUCT).nested(sizeStatistics)
+                .field(17, FieldType.STRUCT).nested(geospatialStatistics)
                 .stop().build());
 
         assertThat(metaData.sizeStatistics().unencodedByteArrayDataBytes()).isEqualTo(512L);
@@ -74,8 +71,8 @@ class ColumnMetaDataReaderTest {
     void skipsWrongTypedSizeStatisticsField() throws IOException {
         // A malformed file types field 16 as an i64 rather than a struct.
         ColumnMetaData metaData = read(baseColumn()
-                .field(16, TYPE_I64).i64(7)
-                .field(17, TYPE_STRUCT).nested(struct().field(2, TYPE_LIST).i32List(1).stop().build())
+                .field(16, FieldType.I64).i64(7)
+                .field(17, FieldType.STRUCT).nested(struct().field(2, FieldType.LIST).i32List(1).stop().build())
                 .stop().build());
 
         assertThat(metaData.sizeStatistics()).isNull();
@@ -87,14 +84,14 @@ class ColumnMetaDataReaderTest {
     /// terminate the struct themselves.
     private static ThriftStructBuilder baseColumn() {
         return struct()
-                .field(1, TYPE_I32).i32(1) // INT32
-                .field(2, TYPE_LIST).i32List(0) // PLAIN
-                .field(3, TYPE_LIST).binaryList("col".getBytes(StandardCharsets.UTF_8))
-                .field(4, TYPE_I32).i32(0) // UNCOMPRESSED
-                .field(5, TYPE_I64).i64(100)
-                .field(6, TYPE_I64).i64(1000)
-                .field(7, TYPE_I64).i64(900)
-                .field(9, TYPE_I64).i64(4);
+                .field(1, FieldType.I32).i32(1) // INT32
+                .field(2, FieldType.LIST).i32List(0) // PLAIN
+                .field(3, FieldType.LIST).binaryList("col".getBytes(StandardCharsets.UTF_8))
+                .field(4, FieldType.I32).i32(0) // UNCOMPRESSED
+                .field(5, FieldType.I64).i64(100)
+                .field(6, FieldType.I64).i64(1000)
+                .field(7, FieldType.I64).i64(900)
+                .field(9, FieldType.I64).i64(4);
     }
 
     private static ColumnMetaData read(byte[] thrift) throws IOException {

--- a/core/src/test/java/dev/hardwood/internal/thrift/ColumnOrderReaderTest.java
+++ b/core/src/test/java/dev/hardwood/internal/thrift/ColumnOrderReaderTest.java
@@ -23,7 +23,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 class ColumnOrderReaderTest {
 
     /// Struct terminator.
-    private static final byte STOP = FieldType.Codes.STOP;
+    private static final byte STOP = ThriftCompactConstants.STOP;
 
     /// The header byte of a union member: the field-id delta in the high nibble, and STRUCT in
     /// the low nibble because every member is an empty marker struct.

--- a/core/src/test/java/dev/hardwood/internal/thrift/ColumnOrderReaderTest.java
+++ b/core/src/test/java/dev/hardwood/internal/thrift/ColumnOrderReaderTest.java
@@ -14,6 +14,8 @@ import org.junit.jupiter.api.Test;
 import dev.hardwood.internal.thrift.ThriftCompactConstants.FieldType;
 import dev.hardwood.metadata.ColumnOrder;
 
+import static dev.hardwood.internal.thrift.ThriftCompactConstants.STOP;
+import static dev.hardwood.internal.thrift.ThriftStructBuilder.fieldHeader;
 import static org.assertj.core.api.Assertions.assertThat;
 
 /// Unit tests for [ColumnOrderReader], decoding the `ColumnOrder` Thrift union.
@@ -22,13 +24,10 @@ import static org.assertj.core.api.Assertions.assertThat;
 /// STOP byte.
 class ColumnOrderReaderTest {
 
-    /// Struct terminator.
-    private static final byte STOP = ThriftCompactConstants.STOP;
-
-    /// The header byte of a union member: the field-id delta in the high nibble, and STRUCT in
-    /// the low nibble because every member is an empty marker struct.
+    /// The header byte of a union member. Every member is an empty marker struct, so the wire
+    /// type is always STRUCT and only the field id tells the members apart.
     private static byte member(int fieldId) {
-        return (byte) ((fieldId << 4) | FieldType.Codes.STRUCT);
+        return fieldHeader(fieldId, FieldType.STRUCT);
     }
 
     private static ColumnOrder decode(byte... bytes) throws Exception {

--- a/core/src/test/java/dev/hardwood/internal/thrift/ColumnOrderReaderTest.java
+++ b/core/src/test/java/dev/hardwood/internal/thrift/ColumnOrderReaderTest.java
@@ -11,6 +11,7 @@ import java.nio.ByteBuffer;
 
 import org.junit.jupiter.api.Test;
 
+import dev.hardwood.internal.thrift.ThriftCompactConstants.FieldType;
 import dev.hardwood.metadata.ColumnOrder;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -18,9 +19,17 @@ import static org.assertj.core.api.Assertions.assertThat;
 /// Unit tests for [ColumnOrderReader], decoding the `ColumnOrder` Thrift union.
 ///
 /// Each union entry is a struct holding one member field (an empty marker struct) followed by a
-/// STOP byte. The field header byte packs the field-id delta in the high nibble and the Thrift
-/// type (0x0C = STRUCT) in the low nibble.
+/// STOP byte.
 class ColumnOrderReaderTest {
+
+    /// Struct terminator.
+    private static final byte STOP = FieldType.Codes.STOP;
+
+    /// The header byte of a union member: the field-id delta in the high nibble, and STRUCT in
+    /// the low nibble because every member is an empty marker struct.
+    private static byte member(int fieldId) {
+        return (byte) ((fieldId << 4) | FieldType.Codes.STRUCT);
+    }
 
     private static ColumnOrder decode(byte... bytes) throws Exception {
         return ColumnOrderReader.read(new ThriftCompactReader(ByteBuffer.wrap(bytes)));
@@ -28,28 +37,28 @@ class ColumnOrderReaderTest {
 
     @Test
     void decodesTypeDefinedOrder() throws Exception {
-        // field id 1 (TYPE_ORDER), STRUCT type → header 0x1C; empty marker struct STOP; union STOP
-        assertThat(decode((byte) 0x1C, (byte) 0x00, (byte) 0x00))
+        // field id 1 (TYPE_ORDER); empty marker struct STOP; union STOP
+        assertThat(decode(member(1), STOP, STOP))
                 .isEqualTo(ColumnOrder.TYPE_DEFINED_ORDER);
     }
 
     @Test
     void decodesIeee754TotalOrder() throws Exception {
-        // field id 2 (IEEE_754_TOTAL_ORDER) → header 0x2C
-        assertThat(decode((byte) 0x2C, (byte) 0x00, (byte) 0x00))
+        // field id 2 (IEEE_754_TOTAL_ORDER)
+        assertThat(decode(member(2), STOP, STOP))
                 .isEqualTo(ColumnOrder.IEEE754_TOTAL_ORDER);
     }
 
     @Test
     void decodesUnknownUnionMemberAsUnknown() throws Exception {
-        // field id 3 — a future union member Hardwood does not recognize → header 0x3C
-        assertThat(decode((byte) 0x3C, (byte) 0x00, (byte) 0x00))
+        // field id 3 — a future union member Hardwood does not recognize
+        assertThat(decode(member(3), STOP, STOP))
                 .isEqualTo(ColumnOrder.UNKNOWN);
     }
 
     @Test
     void decodesEmptyUnionAsUnknown() throws Exception {
         // An empty union (immediate STOP) carries no member; treat leniently as UNKNOWN.
-        assertThat(decode((byte) 0x00)).isEqualTo(ColumnOrder.UNKNOWN);
+        assertThat(decode(STOP)).isEqualTo(ColumnOrder.UNKNOWN);
     }
 }

--- a/core/src/test/java/dev/hardwood/internal/thrift/MalformedMetadataValidationTest.java
+++ b/core/src/test/java/dev/hardwood/internal/thrift/MalformedMetadataValidationTest.java
@@ -38,7 +38,7 @@ import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 class MalformedMetadataValidationTest {
 
     /// Struct terminator.
-    private static final int STOP = FieldType.Codes.STOP;
+    private static final int STOP = ThriftCompactConstants.STOP;
 
     /// Field header byte: field-id delta in the high nibble, wire type in the low nibble.
     private static int field(int fieldIdDelta, FieldType type) {

--- a/core/src/test/java/dev/hardwood/internal/thrift/MalformedMetadataValidationTest.java
+++ b/core/src/test/java/dev/hardwood/internal/thrift/MalformedMetadataValidationTest.java
@@ -14,6 +14,7 @@ import java.nio.ByteOrder;
 import org.junit.jupiter.api.Test;
 
 import dev.hardwood.internal.metadata.PageHeader;
+import dev.hardwood.internal.thrift.ThriftCompactConstants.FieldType;
 import dev.hardwood.metadata.ColumnChunk;
 import dev.hardwood.metadata.ColumnIndex;
 import dev.hardwood.metadata.LogicalType;
@@ -31,10 +32,18 @@ import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 /// negative value reach a buffer allocation or slice downstream (see the
 /// cross-reader compatibility matrix discussed on dev@parquet, May 2026).
 ///
-/// Inputs are hand-crafted Thrift Compact Protocol bytes. Field header byte is
-/// `(fieldIdDelta << 4) | type`; `i32`/`i64` values are zigzag varints
-/// (`zigzag(-1) = 1`, `zigzag(10) = 20`, `zigzag(8) = 16`); `0x00` is STOP.
+/// Inputs are hand-crafted Thrift Compact Protocol bytes. Field headers are composed by
+/// [#field]; `i32`/`i64` values are zigzag varints (`zigzag(-1) = 1`, `zigzag(10) = 20`,
+/// `zigzag(8) = 16`).
 class MalformedMetadataValidationTest {
+
+    /// Struct terminator.
+    private static final int STOP = FieldType.Codes.STOP;
+
+    /// Field header byte: field-id delta in the high nibble, wire type in the low nibble.
+    private static int field(int fieldIdDelta, FieldType type) {
+        return (fieldIdDelta << 4) | type.code();
+    }
 
     private static ThriftCompactReader reader(int... bytes) {
         byte[] b = new byte[bytes.length];
@@ -52,7 +61,8 @@ class MalformedMetadataValidationTest {
     void negativeCompressedPageSizeRejected() {
         // PageHeader: field1 type=DATA_PAGE(0), field2 uncompressed=10, field3 compressed=-1
         assertThatThrownBy(() -> PageHeaderReader.read(
-                reader(0x15, 0x00, 0x15, 0x14, 0x15, 0x01, 0x00)))
+                reader(field(1, FieldType.I32), 0x00, field(1, FieldType.I32), 0x14,
+                        field(1, FieldType.I32), 0x01, STOP)))
                 .isInstanceOf(IOException.class)
                 .hasMessageContaining("compressed_page_size");
     }
@@ -61,7 +71,7 @@ class MalformedMetadataValidationTest {
     void negativeUncompressedPageSizeRejected() {
         // PageHeader: field1 type=DATA_PAGE(0), field2 uncompressed=-1
         assertThatThrownBy(() -> PageHeaderReader.read(
-                reader(0x15, 0x00, 0x15, 0x01, 0x00)))
+                reader(field(1, FieldType.I32), 0x00, field(1, FieldType.I32), 0x01, STOP)))
                 .isInstanceOf(IOException.class)
                 .hasMessageContaining("uncompressed_page_size");
     }
@@ -70,7 +80,7 @@ class MalformedMetadataValidationTest {
     void negativeDataPageOffsetRejected() {
         // ColumnMetaData: field9 data_page_offset (i64) = -1
         assertThatThrownBy(() -> ColumnMetaDataReader.read(
-                reader(0x96, 0x01, 0x00)))
+                reader(field(9, FieldType.I64), 0x01, STOP)))
                 .isInstanceOf(IOException.class)
                 .hasMessageContaining("data_page_offset");
     }
@@ -80,7 +90,8 @@ class MalformedMetadataValidationTest {
         // PageHeader: field1 type=4, which no released version of the format defines. Unlike
         // encoding_stats, a page we cannot classify cannot be decoded either, so it must fail.
         assertThatThrownBy(() -> PageHeaderReader.read(
-                reader(0x15, 0x08, 0x15, 0x14, 0x15, 0x10, 0x00)))
+                reader(field(1, FieldType.I32), 0x08, field(1, FieldType.I32), 0x14,
+                        field(1, FieldType.I32), 0x10, STOP)))
                 .isInstanceOf(IOException.class)
                 .hasMessageContaining("unknown page type: 4");
     }
@@ -90,7 +101,7 @@ class MalformedMetadataValidationTest {
         // ColumnChunk: field5 offset_index_length (i32) = -1, which RowGroupIndexBuffers would
         // otherwise pass straight to ByteBuffer.slice().
         byte[] chunk = new ThriftStructBuilder()
-                .field(5, ThriftStructBuilder.TYPE_I32).i32(-1)
+                .field(5, FieldType.I32).i32(-1)
                 .stop().build();
         assertThatThrownBy(() -> ColumnChunkReader.read(reader(chunk)))
                 .isInstanceOf(IOException.class)
@@ -103,7 +114,7 @@ class MalformedMetadataValidationTest {
         // read would hand back a two-byte name and leave the cursor inside the field, taking the
         // rest of it for the headers of the fields behind it.
         byte[] element = new ThriftStructBuilder()
-                .field(4, ThriftStructBuilder.TYPE_BINARY).raw(0x82, 0x80, 0x80, 0x80, 0x10)
+                .field(4, FieldType.BINARY).raw(0x82, 0x80, 0x80, 0x80, 0x10)
                 .stop().build();
         assertThatThrownBy(() -> SchemaElementReader.read(reader(element)))
                 .isInstanceOf(IOException.class)
@@ -116,7 +127,7 @@ class MalformedMetadataValidationTest {
         // so it reaches `new byte[length]` intact — this bound is all that stands between a
         // five-byte varint and the allocation.
         byte[] element = new ThriftStructBuilder()
-                .field(4, ThriftStructBuilder.TYPE_BINARY).raw(0x80, 0x80, 0x80, 0x04)
+                .field(4, FieldType.BINARY).raw(0x80, 0x80, 0x80, 0x04)
                 .stop().build();
         assertThatThrownBy(() -> SchemaElementReader.read(reader(element)))
                 .isInstanceOf(IOException.class)
@@ -130,7 +141,7 @@ class MalformedMetadataValidationTest {
         // the metadata of such a file stays inspectable — and the refusal lands where the data
         // would be read.
         byte[] chunk = new ThriftStructBuilder()
-                .field(1, ThriftStructBuilder.TYPE_BINARY).binary("data-2.parquet".getBytes(UTF_8))
+                .field(1, FieldType.BINARY).binary("data-2.parquet".getBytes(UTF_8))
                 .stop().build();
         ColumnChunk columnChunk = assertDoesNotThrow(() -> ColumnChunkReader.read(reader(chunk)));
         assertThat(columnChunk.filePath()).isEqualTo("data-2.parquet");
@@ -144,8 +155,8 @@ class MalformedMetadataValidationTest {
     void emptyFilePathIsThisFile() {
         // An empty file_path is the writer naming the file it is writing, not a split layout.
         byte[] chunk = new ThriftStructBuilder()
-                .field(1, ThriftStructBuilder.TYPE_BINARY).binary(new byte[0])
-                .field(5, ThriftStructBuilder.TYPE_I32).i32(64)
+                .field(1, FieldType.BINARY).binary(new byte[0])
+                .field(5, FieldType.I32).i32(64)
                 .stop().build();
         ColumnChunk columnChunk = assertDoesNotThrow(() -> ColumnChunkReader.read(reader(chunk)));
         assertThat(columnChunk.offsetIndexLength()).isEqualTo(64);
@@ -156,7 +167,7 @@ class MalformedMetadataValidationTest {
     void absentFilePathIsThisFile() {
         // The field is optional; a chunk that omits it makes no claim about another file.
         byte[] chunk = new ThriftStructBuilder()
-                .field(5, ThriftStructBuilder.TYPE_I32).i32(64)
+                .field(5, FieldType.I32).i32(64)
                 .stop().build();
         ColumnChunk columnChunk = assertDoesNotThrow(() -> ColumnChunkReader.read(reader(chunk)));
         assertThat(columnChunk.filePath()).isEmpty();
@@ -169,7 +180,7 @@ class MalformedMetadataValidationTest {
         // SchemaElement structs would take value bytes for field headers and misparse the
         // rest of the footer, so the whole read fails instead.
         byte[] footer = new ThriftStructBuilder()
-                .field(2, ThriftStructBuilder.TYPE_LIST).i32List(1, 2, 3)
+                .field(2, FieldType.LIST).i32List(1, 2, 3)
                 .stop().build();
         assertThatThrownBy(() -> FileMetaDataReader.read(reader(footer)))
                 .isInstanceOf(IOException.class)
@@ -182,8 +193,8 @@ class MalformedMetadataValidationTest {
         // optional, so it is reported absent — and field3 behind it still parses, which is what
         // skipping the elements by their declared type buys.
         byte[] stats = new ThriftStructBuilder()
-                .field(2, ThriftStructBuilder.TYPE_LIST).i32List(1, 2)
-                .field(3, ThriftStructBuilder.TYPE_LIST).i64List(7L, 8L)
+                .field(2, FieldType.LIST).i32List(1, 2)
+                .field(3, FieldType.LIST).i64List(7L, 8L)
                 .stop().build();
         SizeStatistics sizeStatistics = assertDoesNotThrow(() -> SizeStatisticsReader.read(reader(stats)));
         assertThat(sizeStatistics.repetitionLevelHistogram()).isNull();
@@ -195,7 +206,7 @@ class MalformedMetadataValidationTest {
         // An unknown field of type map declaring 2^32 + 2 entries: truncated to int that is 2,
         // so the skip would stop early and read the remaining entries as fields of this struct.
         byte[] metaData = new ThriftStructBuilder()
-                .field(100, ThriftStructBuilder.TYPE_MAP).raw(0x82, 0x80, 0x80, 0x80, 0x10)
+                .field(100, FieldType.MAP).raw(0x82, 0x80, 0x80, 0x80, 0x10)
                 .stop().build();
         assertThatThrownBy(() -> ColumnMetaDataReader.read(reader(metaData)))
                 .isInstanceOf(IOException.class)
@@ -207,10 +218,10 @@ class MalformedMetadataValidationTest {
         // ColumnIndex: two pages, but only one null count. PageFilterEvaluator indexes
         // null_counts with a page count that comes from elsewhere.
         byte[] index = new ThriftStructBuilder()
-                .field(1, ThriftStructBuilder.TYPE_LIST).boolList(false, false)
-                .field(2, ThriftStructBuilder.TYPE_LIST).binaryList(new byte[]{ 1 }, new byte[]{ 2 })
-                .field(3, ThriftStructBuilder.TYPE_LIST).binaryList(new byte[]{ 3 }, new byte[]{ 4 })
-                .field(5, ThriftStructBuilder.TYPE_LIST).i64List(0L)
+                .field(1, FieldType.LIST).boolList(false, false)
+                .field(2, FieldType.LIST).binaryList(new byte[]{ 1 }, new byte[]{ 2 })
+                .field(3, FieldType.LIST).binaryList(new byte[]{ 3 }, new byte[]{ 4 })
+                .field(5, FieldType.LIST).i64List(0L)
                 .stop().build();
         assertThatThrownBy(() -> ColumnIndexReader.read(reader(index)))
                 .isInstanceOf(IOException.class)
@@ -221,10 +232,10 @@ class MalformedMetadataValidationTest {
     @Test
     void columnIndexWithConsistentPerPageArraysParses() {
         byte[] index = new ThriftStructBuilder()
-                .field(1, ThriftStructBuilder.TYPE_LIST).boolList(false, true)
-                .field(2, ThriftStructBuilder.TYPE_LIST).binaryList(new byte[]{ 1 }, new byte[]{ 2 })
-                .field(3, ThriftStructBuilder.TYPE_LIST).binaryList(new byte[]{ 3 }, new byte[]{ 4 })
-                .field(5, ThriftStructBuilder.TYPE_LIST).i64List(0L, 5L)
+                .field(1, FieldType.LIST).boolList(false, true)
+                .field(2, FieldType.LIST).binaryList(new byte[]{ 1 }, new byte[]{ 2 })
+                .field(3, FieldType.LIST).binaryList(new byte[]{ 3 }, new byte[]{ 4 })
+                .field(5, FieldType.LIST).i64List(0L, 5L)
                 .stop().build();
         ColumnIndex columnIndex = assertDoesNotThrow(() -> ColumnIndexReader.read(reader(index)));
         assertThat(columnIndex.nullPages()).containsExactly(false, true);
@@ -237,8 +248,8 @@ class MalformedMetadataValidationTest {
         // carries in its own type nibble. Declared as binary it has a body, and leaving that
         // body unread would take it for the next field header.
         byte[] statistics = new ThriftStructBuilder()
-                .field(7, ThriftStructBuilder.TYPE_BINARY).binary(new byte[]{ 9 })
-                .field(9, ThriftStructBuilder.TYPE_I64).i64(3)
+                .field(7, FieldType.BINARY).binary(new byte[]{ 9 })
+                .field(9, FieldType.I64).i64(3)
                 .stop().build();
         Statistics parsed = assertDoesNotThrow(() -> StatisticsReader.read(reader(statistics)));
         assertThat(parsed.nanCount()).isEqualTo(3L);
@@ -251,10 +262,10 @@ class MalformedMetadataValidationTest {
         // has no default, so there is nothing to report but a failure.
         byte[] unit = new ThriftStructBuilder().stop().build();
         byte[] timeType = new ThriftStructBuilder()
-                .field(2, ThriftStructBuilder.TYPE_STRUCT).nested(unit)
+                .field(2, FieldType.STRUCT).nested(unit)
                 .stop().build();
         byte[] logicalType = new ThriftStructBuilder()
-                .field(7, ThriftStructBuilder.TYPE_STRUCT).nested(timeType)
+                .field(7, FieldType.STRUCT).nested(timeType)
                 .stop().build();
         assertThatThrownBy(() -> LogicalTypeReader.read(reader(logicalType)))
                 .isInstanceOf(IOException.class)
@@ -269,14 +280,14 @@ class MalformedMetadataValidationTest {
         // TimeType and misparse the rest of the schema element.
         byte[] emptyStruct = new ThriftStructBuilder().stop().build();
         byte[] unit = new ThriftStructBuilder()
-                .field(1, ThriftStructBuilder.TYPE_STRUCT).nested(emptyStruct)
-                .field(2, ThriftStructBuilder.TYPE_STRUCT).nested(emptyStruct)
+                .field(1, FieldType.STRUCT).nested(emptyStruct)
+                .field(2, FieldType.STRUCT).nested(emptyStruct)
                 .stop().build();
         byte[] timeType = new ThriftStructBuilder()
-                .field(2, ThriftStructBuilder.TYPE_STRUCT).nested(unit)
+                .field(2, FieldType.STRUCT).nested(unit)
                 .stop().build();
         byte[] logicalType = new ThriftStructBuilder()
-                .field(7, ThriftStructBuilder.TYPE_STRUCT).nested(timeType)
+                .field(7, FieldType.STRUCT).nested(timeType)
                 .stop().build();
         assertThatThrownBy(() -> LogicalTypeReader.read(reader(logicalType)))
                 .isInstanceOf(IOException.class)
@@ -290,10 +301,10 @@ class MalformedMetadataValidationTest {
         // (SPHERICAL=0 .. KARNEY=4), so it is an i32 on the wire. Reading it as a struct made
         // every non-default algorithm fall through to the SPHERICAL default in silence.
         byte[] geography = new ThriftStructBuilder()
-                .field(2, ThriftStructBuilder.TYPE_I32).i32(2)
+                .field(2, FieldType.I32).i32(2)
                 .stop().build();
         byte[] logicalType = new ThriftStructBuilder()
-                .field(18, ThriftStructBuilder.TYPE_STRUCT).nested(geography)
+                .field(18, FieldType.STRUCT).nested(geography)
                 .stop().build();
         LogicalType parsed = assertDoesNotThrow(() -> LogicalTypeReader.read(reader(logicalType)));
         assertThat(parsed).isInstanceOf(LogicalType.GeographyType.class);
@@ -305,10 +316,10 @@ class MalformedMetadataValidationTest {
     void geographyWithoutAlgorithmDefaultsToSpherical() {
         // The field is optional and the spec names SPHERICAL as its default.
         byte[] geography = new ThriftStructBuilder()
-                .field(1, ThriftStructBuilder.TYPE_BINARY).binary("OGC:CRS84".getBytes(UTF_8))
+                .field(1, FieldType.BINARY).binary("OGC:CRS84".getBytes(UTF_8))
                 .stop().build();
         byte[] logicalType = new ThriftStructBuilder()
-                .field(18, ThriftStructBuilder.TYPE_STRUCT).nested(geography)
+                .field(18, FieldType.STRUCT).nested(geography)
                 .stop().build();
         LogicalType parsed = assertDoesNotThrow(() -> LogicalTypeReader.read(reader(logicalType)));
         assertThat(((LogicalType.GeographyType) parsed).edgeInterpolation())
@@ -320,10 +331,10 @@ class MalformedMetadataValidationTest {
         // An algorithm the format adds after this release. It says how to interpolate between
         // the column's values, not how to decode them, so the file stays readable.
         byte[] geography = new ThriftStructBuilder()
-                .field(2, ThriftStructBuilder.TYPE_I32).i32(5)
+                .field(2, FieldType.I32).i32(5)
                 .stop().build();
         byte[] logicalType = new ThriftStructBuilder()
-                .field(18, ThriftStructBuilder.TYPE_STRUCT).nested(geography)
+                .field(18, FieldType.STRUCT).nested(geography)
                 .stop().build();
         LogicalType parsed = assertDoesNotThrow(() -> LogicalTypeReader.read(reader(logicalType)));
         assertThat(((LogicalType.GeographyType) parsed).edgeInterpolation())
@@ -335,10 +346,10 @@ class MalformedMetadataValidationTest {
         // Two pages and five histogram entries: no per-page stride divides that, so
         // ColumnIndex.repetitionLevelHistogram(page) has no slice it could return.
         byte[] index = new ThriftStructBuilder()
-                .field(1, ThriftStructBuilder.TYPE_LIST).boolList(false, false)
-                .field(2, ThriftStructBuilder.TYPE_LIST).binaryList(new byte[]{ 1 }, new byte[]{ 2 })
-                .field(3, ThriftStructBuilder.TYPE_LIST).binaryList(new byte[]{ 3 }, new byte[]{ 4 })
-                .field(6, ThriftStructBuilder.TYPE_LIST).i64List(0L, 1L, 2L, 3L, 4L)
+                .field(1, FieldType.LIST).boolList(false, false)
+                .field(2, FieldType.LIST).binaryList(new byte[]{ 1 }, new byte[]{ 2 })
+                .field(3, FieldType.LIST).binaryList(new byte[]{ 3 }, new byte[]{ 4 })
+                .field(6, FieldType.LIST).i64List(0L, 1L, 2L, 3L, 4L)
                 .stop().build();
         assertThatThrownBy(() -> ColumnIndexReader.read(reader(index)))
                 .isInstanceOf(IOException.class)
@@ -353,7 +364,7 @@ class MalformedMetadataValidationTest {
         // back to — and its elements are four bytes where bools are one, which would desync
         // the rest of the struct if decoded anyway.
         byte[] index = new ThriftStructBuilder()
-                .field(1, ThriftStructBuilder.TYPE_LIST).i32List(0, 1)
+                .field(1, FieldType.LIST).i32List(0, 1)
                 .stop().build();
         assertThatThrownBy(() -> ColumnIndexReader.read(reader(index)))
                 .isInstanceOf(IOException.class)
@@ -365,7 +376,8 @@ class MalformedMetadataValidationTest {
     void validPageHeaderStillParses() {
         // PageHeader: field1 type=DATA_PAGE(0), field2 uncompressed=10, field3 compressed=8
         PageHeader header = assertDoesNotThrow(() -> PageHeaderReader.read(
-                reader(0x15, 0x00, 0x15, 0x14, 0x15, 0x10, 0x00)));
+                reader(field(1, FieldType.I32), 0x00, field(1, FieldType.I32), 0x14,
+                        field(1, FieldType.I32), 0x10, STOP)));
         assertThat(header.type()).isEqualTo(PageType.DATA_PAGE);
         assertThat(header.uncompressedPageSize()).isEqualTo(10);
         assertThat(header.compressedPageSize()).isEqualTo(8);

--- a/core/src/test/java/dev/hardwood/internal/thrift/MalformedMetadataValidationTest.java
+++ b/core/src/test/java/dev/hardwood/internal/thrift/MalformedMetadataValidationTest.java
@@ -22,6 +22,8 @@ import dev.hardwood.metadata.PageType;
 import dev.hardwood.metadata.SizeStatistics;
 import dev.hardwood.metadata.Statistics;
 
+import static dev.hardwood.internal.thrift.ThriftCompactConstants.STOP;
+import static dev.hardwood.internal.thrift.ThriftStructBuilder.fieldHeader;
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -33,17 +35,12 @@ import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 /// cross-reader compatibility matrix discussed on dev@parquet, May 2026).
 ///
 /// Inputs are hand-crafted Thrift Compact Protocol bytes. Field headers are composed by
-/// [#field]; `i32`/`i64` values are zigzag varints (`zigzag(-1) = 1`, `zigzag(10) = 20`,
-/// `zigzag(8) = 16`).
+/// [ThriftStructBuilder#fieldHeader]; `i32`/`i64` values are zigzag varints (`zigzag(-1) = 1`,
+/// `zigzag(10) = 20`, `zigzag(8) = 16`).
 class MalformedMetadataValidationTest {
 
-    /// Struct terminator.
-    private static final int STOP = ThriftCompactConstants.STOP;
-
-    /// Field header byte: field-id delta in the high nibble, wire type in the low nibble.
-    private static int field(int fieldIdDelta, FieldType type) {
-        return (fieldIdDelta << 4) | type.code();
-    }
+    /// The header of the next `i32` field, which every `PageHeader` shape below steps through.
+    private static final byte NEXT_I32 = fieldHeader(1, FieldType.I32);
 
     private static ThriftCompactReader reader(int... bytes) {
         byte[] b = new byte[bytes.length];
@@ -61,8 +58,8 @@ class MalformedMetadataValidationTest {
     void negativeCompressedPageSizeRejected() {
         // PageHeader: field1 type=DATA_PAGE(0), field2 uncompressed=10, field3 compressed=-1
         assertThatThrownBy(() -> PageHeaderReader.read(
-                reader(field(1, FieldType.I32), 0x00, field(1, FieldType.I32), 0x14,
-                        field(1, FieldType.I32), 0x01, STOP)))
+                reader(NEXT_I32, 0x00, NEXT_I32, 0x14,
+                        NEXT_I32, 0x01, STOP)))
                 .isInstanceOf(IOException.class)
                 .hasMessageContaining("compressed_page_size");
     }
@@ -71,7 +68,7 @@ class MalformedMetadataValidationTest {
     void negativeUncompressedPageSizeRejected() {
         // PageHeader: field1 type=DATA_PAGE(0), field2 uncompressed=-1
         assertThatThrownBy(() -> PageHeaderReader.read(
-                reader(field(1, FieldType.I32), 0x00, field(1, FieldType.I32), 0x01, STOP)))
+                reader(NEXT_I32, 0x00, NEXT_I32, 0x01, STOP)))
                 .isInstanceOf(IOException.class)
                 .hasMessageContaining("uncompressed_page_size");
     }
@@ -80,7 +77,7 @@ class MalformedMetadataValidationTest {
     void negativeDataPageOffsetRejected() {
         // ColumnMetaData: field9 data_page_offset (i64) = -1
         assertThatThrownBy(() -> ColumnMetaDataReader.read(
-                reader(field(9, FieldType.I64), 0x01, STOP)))
+                reader(fieldHeader(9, FieldType.I64), 0x01, STOP)))
                 .isInstanceOf(IOException.class)
                 .hasMessageContaining("data_page_offset");
     }
@@ -90,8 +87,8 @@ class MalformedMetadataValidationTest {
         // PageHeader: field1 type=4, which no released version of the format defines. Unlike
         // encoding_stats, a page we cannot classify cannot be decoded either, so it must fail.
         assertThatThrownBy(() -> PageHeaderReader.read(
-                reader(field(1, FieldType.I32), 0x08, field(1, FieldType.I32), 0x14,
-                        field(1, FieldType.I32), 0x10, STOP)))
+                reader(NEXT_I32, 0x08, NEXT_I32, 0x14,
+                        NEXT_I32, 0x10, STOP)))
                 .isInstanceOf(IOException.class)
                 .hasMessageContaining("unknown page type: 4");
     }
@@ -376,8 +373,8 @@ class MalformedMetadataValidationTest {
     void validPageHeaderStillParses() {
         // PageHeader: field1 type=DATA_PAGE(0), field2 uncompressed=10, field3 compressed=8
         PageHeader header = assertDoesNotThrow(() -> PageHeaderReader.read(
-                reader(field(1, FieldType.I32), 0x00, field(1, FieldType.I32), 0x14,
-                        field(1, FieldType.I32), 0x10, STOP)));
+                reader(NEXT_I32, 0x00, NEXT_I32, 0x14,
+                        NEXT_I32, 0x10, STOP)));
         assertThat(header.type()).isEqualTo(PageType.DATA_PAGE);
         assertThat(header.uncompressedPageSize()).isEqualTo(10);
         assertThat(header.compressedPageSize()).isEqualTo(8);

--- a/core/src/test/java/dev/hardwood/internal/thrift/OffsetIndexReaderTest.java
+++ b/core/src/test/java/dev/hardwood/internal/thrift/OffsetIndexReaderTest.java
@@ -12,11 +12,9 @@ import java.nio.ByteBuffer;
 
 import org.junit.jupiter.api.Test;
 
+import dev.hardwood.internal.thrift.ThriftCompactConstants.FieldType;
 import dev.hardwood.metadata.OffsetIndex;
 
-import static dev.hardwood.internal.thrift.ThriftStructBuilder.TYPE_I32;
-import static dev.hardwood.internal.thrift.ThriftStructBuilder.TYPE_I64;
-import static dev.hardwood.internal.thrift.ThriftStructBuilder.TYPE_LIST;
 import static org.assertj.core.api.Assertions.assertThat;
 
 class OffsetIndexReaderTest {
@@ -24,8 +22,8 @@ class OffsetIndexReaderTest {
     @Test
     void readsPageLocationsAndUnencodedSizes() throws IOException {
         byte[] thrift = struct()
-                .field(1, TYPE_LIST).structList(pageLocation(100, 40, 0), pageLocation(140, 60, 8))
-                .field(2, TYPE_LIST).i64List(512, 768)
+                .field(1, FieldType.LIST).structList(pageLocation(100, 40, 0), pageLocation(140, 60, 8))
+                .field(2, FieldType.LIST).i64List(512, 768)
                 .stop().build();
 
         OffsetIndex index = read(thrift);
@@ -42,7 +40,7 @@ class OffsetIndexReaderTest {
         // Field 2 is optional and only defined for BYTE_ARRAY data, so a writer leaves it
         // unset on every other column. That must not read back as a zero-length list.
         byte[] thrift = struct()
-                .field(1, TYPE_LIST).structList(pageLocation(100, 40, 0))
+                .field(1, FieldType.LIST).structList(pageLocation(100, 40, 0))
                 .stop().build();
 
         assertThat(read(thrift).unencodedByteArrayDataBytes()).isNull();
@@ -51,8 +49,8 @@ class OffsetIndexReaderTest {
     @Test
     void readsPresentButEmptyUnencodedSizes() throws IOException {
         byte[] thrift = struct()
-                .field(1, TYPE_LIST).structList(pageLocation(100, 40, 0))
-                .field(2, TYPE_LIST).i64List()
+                .field(1, FieldType.LIST).structList(pageLocation(100, 40, 0))
+                .field(2, FieldType.LIST).i64List()
                 .stop().build();
 
         assertThat(read(thrift).unencodedByteArrayDataBytes()).isEmpty();
@@ -62,9 +60,9 @@ class OffsetIndexReaderTest {
     void skipsWrongTypedUnencodedSizesField() throws IOException {
         // A malformed file types field 2 as an i64 rather than a list.
         byte[] thrift = struct()
-                .field(1, TYPE_LIST).structList(pageLocation(100, 40, 0))
-                .field(2, TYPE_I64).i64(4096)
-                .field(3, TYPE_I64).i64(7)
+                .field(1, FieldType.LIST).structList(pageLocation(100, 40, 0))
+                .field(2, FieldType.I64).i64(4096)
+                .field(3, FieldType.I64).i64(7)
                 .stop().build();
 
         OffsetIndex index = read(thrift);
@@ -78,9 +76,9 @@ class OffsetIndexReaderTest {
         // Field 2 typed list<struct>. Decoding those bytes as varints would leave the
         // cursor mid-struct, so the element type has to drive the skip.
         byte[] thrift = struct()
-                .field(1, TYPE_LIST).structList(pageLocation(100, 40, 0))
-                .field(2, TYPE_LIST).structList(pageLocation(1, 2, 3), pageLocation(4, 5, 6))
-                .field(3, TYPE_I64).i64(7)
+                .field(1, FieldType.LIST).structList(pageLocation(100, 40, 0))
+                .field(2, FieldType.LIST).structList(pageLocation(1, 2, 3), pageLocation(4, 5, 6))
+                .field(3, FieldType.I64).i64(7)
                 .stop().build();
 
         OffsetIndex index = read(thrift);
@@ -95,9 +93,9 @@ class OffsetIndexReaderTest {
         // header's type nibble. Skipping these by field rules would consume none of them
         // and read the first element byte as the next field header.
         byte[] thrift = struct()
-                .field(1, TYPE_LIST).structList(pageLocation(100, 40, 0))
-                .field(2, TYPE_LIST).boolList(true, false, true)
-                .field(3, TYPE_I64).i64(7)
+                .field(1, FieldType.LIST).structList(pageLocation(100, 40, 0))
+                .field(2, FieldType.LIST).boolList(true, false, true)
+                .field(3, FieldType.I64).i64(7)
                 .stop().build();
 
         OffsetIndex index = read(thrift);
@@ -110,9 +108,9 @@ class OffsetIndexReaderTest {
     /// A `PageLocation` struct body: offset, compressed_page_size, first_row_index.
     private static byte[] pageLocation(long offset, int compressedPageSize, long firstRowIndex) {
         return struct()
-                .field(1, TYPE_I64).i64(offset)
-                .field(2, TYPE_I32).i32(compressedPageSize)
-                .field(3, TYPE_I64).i64(firstRowIndex)
+                .field(1, FieldType.I64).i64(offset)
+                .field(2, FieldType.I32).i32(compressedPageSize)
+                .field(3, FieldType.I64).i64(firstRowIndex)
                 .stop().build();
     }
 

--- a/core/src/test/java/dev/hardwood/internal/thrift/PageEncodingStatsReaderTest.java
+++ b/core/src/test/java/dev/hardwood/internal/thrift/PageEncodingStatsReaderTest.java
@@ -13,6 +13,8 @@ import java.nio.ByteOrder;
 
 import org.junit.jupiter.api.Test;
 
+import dev.hardwood.internal.thrift.ThriftCompactConstants.ElementType;
+import dev.hardwood.internal.thrift.ThriftCompactConstants.FieldType;
 import dev.hardwood.metadata.ColumnMetaData;
 import dev.hardwood.metadata.Encoding;
 import dev.hardwood.metadata.PageEncodingStats;
@@ -22,16 +24,30 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 /// Verifies how `ColumnMetaData.encoding_stats` (field 13) is decoded, using hand-crafted Thrift
-/// Compact Protocol bytes so each shape can be isolated. Field header byte is
-/// `(fieldIdDelta << 4) | type`; list header byte is `(size << 4) | elementType`; `i32` values are
-/// zigzag varints (`zigzag(-1) = 1`, `zigzag(1) = 2`, `zigzag(2) = 4`, `zigzag(8) = 16`); `0x00` is
-/// STOP.
+/// Compact Protocol bytes so each shape can be isolated. Headers are composed by [#field] and
+/// [#list]; `i32` values are zigzag varints (`zigzag(-1) = 1`, `zigzag(1) = 2`, `zigzag(2) = 4`,
+/// `zigzag(8) = 16`).
 class PageEncodingStatsReaderTest {
 
-    /// Field 13 as a list of structs, i.e. the `encoding_stats` field header (`0xD9`) followed by
-    /// the list header for `count` elements. The trailing `0x00` closing the ColumnMetaData struct
-    /// is supplied by each test.
-    private static final int ENCODING_STATS_FIELD = 0xD9;
+    /// Struct terminator.
+    private static final int STOP = FieldType.Codes.STOP;
+
+    /// A list header whose size nibble is saturated, meaning the real size follows as a varint.
+    private static final int LONG_FORM_SIZE = 15;
+
+    /// The `encoding_stats` field header: field 13 as a list. The trailing [#STOP] closing the
+    /// ColumnMetaData struct is supplied by each test.
+    private static final int ENCODING_STATS_FIELD = field(13, FieldType.LIST);
+
+    /// Field header byte: field-id delta in the high nibble, wire type in the low nibble.
+    private static int field(int fieldIdDelta, FieldType type) {
+        return (fieldIdDelta << 4) | type.code();
+    }
+
+    /// Short-form list header byte: element count in the high nibble, element type in the low.
+    private static int list(int size, ElementType elementType) {
+        return (size << 4) | elementType.code();
+    }
 
     private static ThriftCompactReader reader(int... bytes) {
         byte[] b = new byte[bytes.length];
@@ -45,10 +61,10 @@ class PageEncodingStatsReaderTest {
     void readsEntriesInWrittenOrder() throws IOException {
         // Two entries: (DICTIONARY_PAGE, PLAIN, 1) then (DATA_PAGE, RLE_DICTIONARY, 2).
         ColumnMetaData metaData = ColumnMetaDataReader.read(reader(
-                ENCODING_STATS_FIELD, 0x2C,
-                0x15, 0x04, 0x15, 0x00, 0x15, 0x02, 0x00,
-                0x15, 0x00, 0x15, 0x10, 0x15, 0x04, 0x00,
-                0x00));
+                ENCODING_STATS_FIELD, list(2, ElementType.STRUCT),
+                field(1, FieldType.I32), 0x04, field(1, FieldType.I32), 0x00, field(1, FieldType.I32), 0x02, STOP,
+                field(1, FieldType.I32), 0x00, field(1, FieldType.I32), 0x10, field(1, FieldType.I32), 0x04, STOP,
+                STOP));
 
         assertThat(metaData.encodingStats()).containsExactly(
                 new PageEncodingStats(PageType.DICTIONARY_PAGE, Encoding.PLAIN, 1),
@@ -57,7 +73,7 @@ class PageEncodingStatsReaderTest {
 
     @Test
     void absentFieldYieldsEmptyList() throws IOException {
-        ColumnMetaData metaData = ColumnMetaDataReader.read(reader(0x00));
+        ColumnMetaData metaData = ColumnMetaDataReader.read(reader(STOP));
 
         assertThat(metaData.encodingStats()).isEmpty();
     }
@@ -67,9 +83,9 @@ class PageEncodingStatsReaderTest {
         // page_type = 7, which no released version of the format defines. The counts are
         // informational, so this must not make the footer unreadable.
         ColumnMetaData metaData = ColumnMetaDataReader.read(reader(
-                ENCODING_STATS_FIELD, 0x1C,
-                0x15, 0x0E, 0x15, 0x00, 0x15, 0x02, 0x00,
-                0x00));
+                ENCODING_STATS_FIELD, list(1, ElementType.STRUCT),
+                field(1, FieldType.I32), 0x0E, field(1, FieldType.I32), 0x00, field(1, FieldType.I32), 0x02, STOP,
+                STOP));
 
         assertThat(metaData.encodingStats())
                 .containsExactly(new PageEncodingStats(PageType.UNKNOWN, Encoding.PLAIN, 1));
@@ -80,9 +96,9 @@ class PageEncodingStatsReaderTest {
         // encoding = 10, which no released version of the format defines. Like an unrecognized
         // page type, it must not make the footer unreadable.
         ColumnMetaData metaData = ColumnMetaDataReader.read(reader(
-                ENCODING_STATS_FIELD, 0x1C,
-                0x15, 0x00, 0x15, 0x14, 0x15, 0x02, 0x00,
-                0x00));
+                ENCODING_STATS_FIELD, list(1, ElementType.STRUCT),
+                field(1, FieldType.I32), 0x00, field(1, FieldType.I32), 0x14, field(1, FieldType.I32), 0x02, STOP,
+                STOP));
 
         assertThat(metaData.encodingStats())
                 .containsExactly(new PageEncodingStats(PageType.DATA_PAGE, Encoding.UNKNOWN, 1));
@@ -92,7 +108,7 @@ class PageEncodingStatsReaderTest {
     void nonListFieldIsSkipped() throws IOException {
         // Field 13 declared as an i32 rather than a list. The field is optional and informational,
         // so it is skipped rather than failing the footer.
-        ColumnMetaData metaData = ColumnMetaDataReader.read(reader(0xD5, 0x02, 0x00));
+        ColumnMetaData metaData = ColumnMetaDataReader.read(reader(field(13, FieldType.I32), 0x02, STOP));
 
         assertThat(metaData.encodingStats()).isEmpty();
     }
@@ -103,9 +119,9 @@ class PageEncodingStatsReaderTest {
         // IllegalArgumentException, which escapes ParquetMetadataReader's catch (IOException) and
         // reaches the caller unchecked and without the file name.
         assertThatThrownBy(() -> ColumnMetaDataReader.read(reader(
-                ENCODING_STATS_FIELD, 0xFC,
+                ENCODING_STATS_FIELD, list(LONG_FORM_SIZE, ElementType.STRUCT),
                 0x80, 0x80, 0x80, 0x80, 0x08,
-                0x00)))
+                STOP)))
                 .isInstanceOf(IOException.class)
                 .hasMessageContaining("2147483648 elements");
     }
@@ -114,9 +130,10 @@ class PageEncodingStatsReaderTest {
     void unknownStructFieldIsSkipped() throws IOException {
         // A field 4 the format does not define today, appended after count.
         ColumnMetaData metaData = ColumnMetaDataReader.read(reader(
-                ENCODING_STATS_FIELD, 0x1C,
-                0x15, 0x00, 0x15, 0x00, 0x15, 0x02, 0x15, 0x02, 0x00,
-                0x00));
+                ENCODING_STATS_FIELD, list(1, ElementType.STRUCT),
+                field(1, FieldType.I32), 0x00, field(1, FieldType.I32), 0x00, field(1, FieldType.I32), 0x02,
+                field(1, FieldType.I32), 0x02, STOP,
+                STOP));
 
         assertThat(metaData.encodingStats())
                 .containsExactly(new PageEncodingStats(PageType.DATA_PAGE, Encoding.PLAIN, 1));
@@ -128,9 +145,9 @@ class PageEncodingStatsReaderTest {
         // entry cannot be reconstructed — and since the counts only mean anything as a complete
         // partition of the chunk's pages, the whole field is reported as absent.
         ColumnMetaData metaData = ColumnMetaDataReader.read(reader(
-                ENCODING_STATS_FIELD, 0x1C,
-                0x15, 0x00, 0x15, 0x00, 0x00,
-                0x00));
+                ENCODING_STATS_FIELD, list(1, ElementType.STRUCT),
+                field(1, FieldType.I32), 0x00, field(1, FieldType.I32), 0x00, STOP,
+                STOP));
 
         assertThat(metaData.encodingStats()).isEmpty();
     }
@@ -138,9 +155,9 @@ class PageEncodingStatsReaderTest {
     @Test
     void negativeCountDropsTheField() throws IOException {
         ColumnMetaData metaData = ColumnMetaDataReader.read(reader(
-                ENCODING_STATS_FIELD, 0x1C,
-                0x15, 0x00, 0x15, 0x00, 0x15, 0x01, 0x00,
-                0x00));
+                ENCODING_STATS_FIELD, list(1, ElementType.STRUCT),
+                field(1, FieldType.I32), 0x00, field(1, FieldType.I32), 0x00, field(1, FieldType.I32), 0x01, STOP,
+                STOP));
 
         assertThat(metaData.encodingStats()).isEmpty();
     }
@@ -150,34 +167,34 @@ class PageEncodingStatsReaderTest {
         // A well-formed (DATA_PAGE, PLAIN, 1) entry followed by one missing its count. Keeping
         // the first would present 1 page as the chunk's full page inventory when it is not.
         ColumnMetaData metaData = ColumnMetaDataReader.read(reader(
-                ENCODING_STATS_FIELD, 0x2C,
-                0x15, 0x00, 0x15, 0x00, 0x15, 0x02, 0x00,
-                0x15, 0x04, 0x15, 0x00, 0x00,
-                0x00));
+                ENCODING_STATS_FIELD, list(2, ElementType.STRUCT),
+                field(1, FieldType.I32), 0x00, field(1, FieldType.I32), 0x00, field(1, FieldType.I32), 0x02, STOP,
+                field(1, FieldType.I32), 0x04, field(1, FieldType.I32), 0x00, STOP,
+                STOP));
 
         assertThat(metaData.encodingStats()).isEmpty();
     }
 
     @Test
     void nonStructListElementTypeDropsTheField() throws IOException {
-        // Field 13 declared as list<i32> (element type 0x05) carrying the value 1. Elements are
-        // read as structs, so decoding it would misread value bytes as field headers; skipping
-        // by the declared element type consumes it instead.
+        // Field 13 declared as list<i32> carrying the value 1. Elements are read as structs, so
+        // decoding it would misread value bytes as field headers; skipping by the declared
+        // element type consumes it instead.
         ColumnMetaData metaData = ColumnMetaDataReader.read(reader(
-                ENCODING_STATS_FIELD, 0x15,
+                ENCODING_STATS_FIELD, list(1, ElementType.I32),
                 0x02,
-                0x00));
+                STOP));
 
         assertThat(metaData.encodingStats()).isEmpty();
     }
 
     @Test
     void wrongWireTypeOnRequiredFieldDropsTheField() throws IOException {
-        // page_type declared as i64 (0x06) rather than i32.
+        // page_type declared as i64 rather than i32.
         ColumnMetaData metaData = ColumnMetaDataReader.read(reader(
-                ENCODING_STATS_FIELD, 0x1C,
-                0x16, 0x00, 0x15, 0x00, 0x15, 0x02, 0x00,
-                0x00));
+                ENCODING_STATS_FIELD, list(1, ElementType.STRUCT),
+                field(1, FieldType.I64), 0x00, field(1, FieldType.I32), 0x00, field(1, FieldType.I32), 0x02, STOP,
+                STOP));
 
         assertThat(metaData.encodingStats()).isEmpty();
     }
@@ -187,10 +204,10 @@ class PageEncodingStatsReaderTest {
         // encoding_stats as list<i32>, then field 14 (bloom_filter_offset, i64) = 8. The skip
         // has to leave the reader exactly on the next field header for this to decode.
         ColumnMetaData metaData = ColumnMetaDataReader.read(reader(
-                ENCODING_STATS_FIELD, 0x15,
+                ENCODING_STATS_FIELD, list(1, ElementType.I32),
                 0x02,
-                0x16, 0x10,
-                0x00));
+                field(1, FieldType.I64), 0x10,
+                STOP));
 
         assertThat(metaData.encodingStats()).isEmpty();
         assertThat(metaData.bloomFilterOffset()).isEqualTo(8L);
@@ -198,14 +215,14 @@ class PageEncodingStatsReaderTest {
 
     @Test
     void boolListElementTypeDoesNotDisturbLaterFields() throws IOException {
-        // The same shape with element type bool (0x01), whose elements are a bare byte each
-        // rather than a value carried in a field header. Skipping them by field rules would
-        // consume none of the two element bytes and read them as the next field header.
+        // The same shape with element type bool, whose elements are a bare byte each rather than
+        // a value carried in a field header. Skipping them by field rules would consume none of
+        // the two element bytes and read them as the next field header.
         ColumnMetaData metaData = ColumnMetaDataReader.read(reader(
-                ENCODING_STATS_FIELD, 0x21,
+                ENCODING_STATS_FIELD, list(2, ElementType.BOOL),
                 0x01, 0x02,
-                0x16, 0x10,
-                0x00));
+                field(1, FieldType.I64), 0x10,
+                STOP));
 
         assertThat(metaData.encodingStats()).isEmpty();
         assertThat(metaData.bloomFilterOffset()).isEqualTo(8L);

--- a/core/src/test/java/dev/hardwood/internal/thrift/PageEncodingStatsReaderTest.java
+++ b/core/src/test/java/dev/hardwood/internal/thrift/PageEncodingStatsReaderTest.java
@@ -20,44 +20,30 @@ import dev.hardwood.metadata.Encoding;
 import dev.hardwood.metadata.PageEncodingStats;
 import dev.hardwood.metadata.PageType;
 
+import static dev.hardwood.internal.thrift.ThriftCompactConstants.STOP;
+import static dev.hardwood.internal.thrift.ThriftStructBuilder.fieldHeader;
+import static dev.hardwood.internal.thrift.ThriftStructBuilder.listHeader;
+import static dev.hardwood.internal.thrift.ThriftStructBuilder.longFormListHeader;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 /// Verifies how `ColumnMetaData.encoding_stats` (field 13) is decoded, using hand-crafted Thrift
-/// Compact Protocol bytes so each shape can be isolated. Headers are composed by [#field] and
-/// [#list]; `i32` values are zigzag varints (`zigzag(-1) = 1`, `zigzag(1) = 2`, `zigzag(2) = 4`,
-/// `zigzag(8) = 16`).
+/// Compact Protocol bytes so each shape can be isolated. Headers are composed by
+/// [ThriftStructBuilder#fieldHeader] and [ThriftStructBuilder#listHeader]; `i32` values are
+/// zigzag varints (`zigzag(-1) = 1`, `zigzag(1) = 2`, `zigzag(2) = 4`, `zigzag(8) = 16`).
 class PageEncodingStatsReaderTest {
 
-    /// Struct terminator.
-    private static final int STOP = ThriftCompactConstants.STOP;
-
-    /// The size nibble that saturates, at which point the count no longer fits the header.
-    private static final int LONG_FORM_SIZE = 15;
-
-    /// The `encoding_stats` field header: field 13 as a list. The trailing [#STOP] closing the
+    /// The `encoding_stats` field header: field 13 as a list. The trailing STOP closing the
     /// ColumnMetaData struct is supplied by each test.
-    private static final int ENCODING_STATS_FIELD = field(13, FieldType.LIST);
+    private static final byte ENCODING_STATS_FIELD = fieldHeader(13, FieldType.LIST);
 
-    /// Field header byte: field-id delta in the high nibble, wire type in the low nibble.
-    private static int field(int fieldIdDelta, FieldType type) {
-        return (fieldIdDelta << 4) | type.code();
-    }
+    /// The header of the next field within a `PageEncodingStats` entry, whose three fields —
+    /// `page_type`, `encoding` and `count` — are consecutive `i32`s.
+    private static final byte NEXT_I32 = fieldHeader(1, FieldType.I32);
 
-    /// Short-form list header byte: element count in the high nibble, element type in the low.
-    /// A count of [#LONG_FORM_SIZE] or more does not fit the nibble — see [#longFormList].
-    private static int list(int size, ElementType elementType) {
-        if (size >= LONG_FORM_SIZE) {
-            throw new IllegalArgumentException(size + " elements need the long form, not the size nibble");
-        }
-        return (size << 4) | elementType.code();
-    }
-
-    /// Long-form list header byte: the size nibble saturated, so the count follows as a varint
-    /// the caller writes itself.
-    private static int longFormList(ElementType elementType) {
-        return (LONG_FORM_SIZE << 4) | elementType.code();
-    }
+    /// The same one field along as an `i64`, for the shapes that mistype a field or step past
+    /// `encoding_stats` into `bloom_filter_offset`.
+    private static final byte NEXT_I64 = fieldHeader(1, FieldType.I64);
 
     private static ThriftCompactReader reader(int... bytes) {
         byte[] b = new byte[bytes.length];
@@ -71,9 +57,9 @@ class PageEncodingStatsReaderTest {
     void readsEntriesInWrittenOrder() throws IOException {
         // Two entries: (DICTIONARY_PAGE, PLAIN, 1) then (DATA_PAGE, RLE_DICTIONARY, 2).
         ColumnMetaData metaData = ColumnMetaDataReader.read(reader(
-                ENCODING_STATS_FIELD, list(2, ElementType.STRUCT),
-                field(1, FieldType.I32), 0x04, field(1, FieldType.I32), 0x00, field(1, FieldType.I32), 0x02, STOP,
-                field(1, FieldType.I32), 0x00, field(1, FieldType.I32), 0x10, field(1, FieldType.I32), 0x04, STOP,
+                ENCODING_STATS_FIELD, listHeader(2, ElementType.STRUCT),
+                NEXT_I32, 0x04, NEXT_I32, 0x00, NEXT_I32, 0x02, STOP,
+                NEXT_I32, 0x00, NEXT_I32, 0x10, NEXT_I32, 0x04, STOP,
                 STOP));
 
         assertThat(metaData.encodingStats()).containsExactly(
@@ -93,8 +79,8 @@ class PageEncodingStatsReaderTest {
         // page_type = 7, which no released version of the format defines. The counts are
         // informational, so this must not make the footer unreadable.
         ColumnMetaData metaData = ColumnMetaDataReader.read(reader(
-                ENCODING_STATS_FIELD, list(1, ElementType.STRUCT),
-                field(1, FieldType.I32), 0x0E, field(1, FieldType.I32), 0x00, field(1, FieldType.I32), 0x02, STOP,
+                ENCODING_STATS_FIELD, listHeader(1, ElementType.STRUCT),
+                NEXT_I32, 0x0E, NEXT_I32, 0x00, NEXT_I32, 0x02, STOP,
                 STOP));
 
         assertThat(metaData.encodingStats())
@@ -106,8 +92,8 @@ class PageEncodingStatsReaderTest {
         // encoding = 10, which no released version of the format defines. Like an unrecognized
         // page type, it must not make the footer unreadable.
         ColumnMetaData metaData = ColumnMetaDataReader.read(reader(
-                ENCODING_STATS_FIELD, list(1, ElementType.STRUCT),
-                field(1, FieldType.I32), 0x00, field(1, FieldType.I32), 0x14, field(1, FieldType.I32), 0x02, STOP,
+                ENCODING_STATS_FIELD, listHeader(1, ElementType.STRUCT),
+                NEXT_I32, 0x00, NEXT_I32, 0x14, NEXT_I32, 0x02, STOP,
                 STOP));
 
         assertThat(metaData.encodingStats())
@@ -118,7 +104,7 @@ class PageEncodingStatsReaderTest {
     void nonListFieldIsSkipped() throws IOException {
         // Field 13 declared as an i32 rather than a list. The field is optional and informational,
         // so it is skipped rather than failing the footer.
-        ColumnMetaData metaData = ColumnMetaDataReader.read(reader(field(13, FieldType.I32), 0x02, STOP));
+        ColumnMetaData metaData = ColumnMetaDataReader.read(reader(fieldHeader(13, FieldType.I32), 0x02, STOP));
 
         assertThat(metaData.encodingStats()).isEmpty();
     }
@@ -129,7 +115,7 @@ class PageEncodingStatsReaderTest {
         // IllegalArgumentException, which escapes ParquetMetadataReader's catch (IOException) and
         // reaches the caller unchecked and without the file name.
         assertThatThrownBy(() -> ColumnMetaDataReader.read(reader(
-                ENCODING_STATS_FIELD, longFormList(ElementType.STRUCT),
+                ENCODING_STATS_FIELD, longFormListHeader(ElementType.STRUCT),
                 0x80, 0x80, 0x80, 0x80, 0x08,
                 STOP)))
                 .isInstanceOf(IOException.class)
@@ -140,9 +126,9 @@ class PageEncodingStatsReaderTest {
     void unknownStructFieldIsSkipped() throws IOException {
         // A field 4 the format does not define today, appended after count.
         ColumnMetaData metaData = ColumnMetaDataReader.read(reader(
-                ENCODING_STATS_FIELD, list(1, ElementType.STRUCT),
-                field(1, FieldType.I32), 0x00, field(1, FieldType.I32), 0x00, field(1, FieldType.I32), 0x02,
-                field(1, FieldType.I32), 0x02, STOP,
+                ENCODING_STATS_FIELD, listHeader(1, ElementType.STRUCT),
+                NEXT_I32, 0x00, NEXT_I32, 0x00, NEXT_I32, 0x02,
+                NEXT_I32, 0x02, STOP,
                 STOP));
 
         assertThat(metaData.encodingStats())
@@ -155,8 +141,8 @@ class PageEncodingStatsReaderTest {
         // entry cannot be reconstructed — and since the counts only mean anything as a complete
         // partition of the chunk's pages, the whole field is reported as absent.
         ColumnMetaData metaData = ColumnMetaDataReader.read(reader(
-                ENCODING_STATS_FIELD, list(1, ElementType.STRUCT),
-                field(1, FieldType.I32), 0x00, field(1, FieldType.I32), 0x00, STOP,
+                ENCODING_STATS_FIELD, listHeader(1, ElementType.STRUCT),
+                NEXT_I32, 0x00, NEXT_I32, 0x00, STOP,
                 STOP));
 
         assertThat(metaData.encodingStats()).isEmpty();
@@ -165,8 +151,8 @@ class PageEncodingStatsReaderTest {
     @Test
     void negativeCountDropsTheField() throws IOException {
         ColumnMetaData metaData = ColumnMetaDataReader.read(reader(
-                ENCODING_STATS_FIELD, list(1, ElementType.STRUCT),
-                field(1, FieldType.I32), 0x00, field(1, FieldType.I32), 0x00, field(1, FieldType.I32), 0x01, STOP,
+                ENCODING_STATS_FIELD, listHeader(1, ElementType.STRUCT),
+                NEXT_I32, 0x00, NEXT_I32, 0x00, NEXT_I32, 0x01, STOP,
                 STOP));
 
         assertThat(metaData.encodingStats()).isEmpty();
@@ -177,9 +163,9 @@ class PageEncodingStatsReaderTest {
         // A well-formed (DATA_PAGE, PLAIN, 1) entry followed by one missing its count. Keeping
         // the first would present 1 page as the chunk's full page inventory when it is not.
         ColumnMetaData metaData = ColumnMetaDataReader.read(reader(
-                ENCODING_STATS_FIELD, list(2, ElementType.STRUCT),
-                field(1, FieldType.I32), 0x00, field(1, FieldType.I32), 0x00, field(1, FieldType.I32), 0x02, STOP,
-                field(1, FieldType.I32), 0x04, field(1, FieldType.I32), 0x00, STOP,
+                ENCODING_STATS_FIELD, listHeader(2, ElementType.STRUCT),
+                NEXT_I32, 0x00, NEXT_I32, 0x00, NEXT_I32, 0x02, STOP,
+                NEXT_I32, 0x04, NEXT_I32, 0x00, STOP,
                 STOP));
 
         assertThat(metaData.encodingStats()).isEmpty();
@@ -191,7 +177,7 @@ class PageEncodingStatsReaderTest {
         // decoding it would misread value bytes as field headers; skipping by the declared
         // element type consumes it instead.
         ColumnMetaData metaData = ColumnMetaDataReader.read(reader(
-                ENCODING_STATS_FIELD, list(1, ElementType.I32),
+                ENCODING_STATS_FIELD, listHeader(1, ElementType.I32),
                 0x02,
                 STOP));
 
@@ -202,8 +188,8 @@ class PageEncodingStatsReaderTest {
     void wrongWireTypeOnRequiredFieldDropsTheField() throws IOException {
         // page_type declared as i64 rather than i32.
         ColumnMetaData metaData = ColumnMetaDataReader.read(reader(
-                ENCODING_STATS_FIELD, list(1, ElementType.STRUCT),
-                field(1, FieldType.I64), 0x00, field(1, FieldType.I32), 0x00, field(1, FieldType.I32), 0x02, STOP,
+                ENCODING_STATS_FIELD, listHeader(1, ElementType.STRUCT),
+                NEXT_I64, 0x00, NEXT_I32, 0x00, NEXT_I32, 0x02, STOP,
                 STOP));
 
         assertThat(metaData.encodingStats()).isEmpty();
@@ -214,9 +200,9 @@ class PageEncodingStatsReaderTest {
         // encoding_stats as list<i32>, then field 14 (bloom_filter_offset, i64) = 8. The skip
         // has to leave the reader exactly on the next field header for this to decode.
         ColumnMetaData metaData = ColumnMetaDataReader.read(reader(
-                ENCODING_STATS_FIELD, list(1, ElementType.I32),
+                ENCODING_STATS_FIELD, listHeader(1, ElementType.I32),
                 0x02,
-                field(1, FieldType.I64), 0x10,
+                NEXT_I64, 0x10,
                 STOP));
 
         assertThat(metaData.encodingStats()).isEmpty();
@@ -229,9 +215,9 @@ class PageEncodingStatsReaderTest {
         // a value carried in a field header. Skipping them by field rules would consume none of
         // the two element bytes and read them as the next field header.
         ColumnMetaData metaData = ColumnMetaDataReader.read(reader(
-                ENCODING_STATS_FIELD, list(2, ElementType.BOOL),
+                ENCODING_STATS_FIELD, listHeader(2, ElementType.BOOL),
                 0x01, 0x02,
-                field(1, FieldType.I64), 0x10,
+                NEXT_I64, 0x10,
                 STOP));
 
         assertThat(metaData.encodingStats()).isEmpty();

--- a/core/src/test/java/dev/hardwood/internal/thrift/PageEncodingStatsReaderTest.java
+++ b/core/src/test/java/dev/hardwood/internal/thrift/PageEncodingStatsReaderTest.java
@@ -30,9 +30,9 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 class PageEncodingStatsReaderTest {
 
     /// Struct terminator.
-    private static final int STOP = FieldType.Codes.STOP;
+    private static final int STOP = ThriftCompactConstants.STOP;
 
-    /// A list header whose size nibble is saturated, meaning the real size follows as a varint.
+    /// The size nibble that saturates, at which point the count no longer fits the header.
     private static final int LONG_FORM_SIZE = 15;
 
     /// The `encoding_stats` field header: field 13 as a list. The trailing [#STOP] closing the
@@ -45,8 +45,18 @@ class PageEncodingStatsReaderTest {
     }
 
     /// Short-form list header byte: element count in the high nibble, element type in the low.
+    /// A count of [#LONG_FORM_SIZE] or more does not fit the nibble — see [#longFormList].
     private static int list(int size, ElementType elementType) {
+        if (size >= LONG_FORM_SIZE) {
+            throw new IllegalArgumentException(size + " elements need the long form, not the size nibble");
+        }
         return (size << 4) | elementType.code();
+    }
+
+    /// Long-form list header byte: the size nibble saturated, so the count follows as a varint
+    /// the caller writes itself.
+    private static int longFormList(ElementType elementType) {
+        return (LONG_FORM_SIZE << 4) | elementType.code();
     }
 
     private static ThriftCompactReader reader(int... bytes) {
@@ -119,7 +129,7 @@ class PageEncodingStatsReaderTest {
         // IllegalArgumentException, which escapes ParquetMetadataReader's catch (IOException) and
         // reaches the caller unchecked and without the file name.
         assertThatThrownBy(() -> ColumnMetaDataReader.read(reader(
-                ENCODING_STATS_FIELD, list(LONG_FORM_SIZE, ElementType.STRUCT),
+                ENCODING_STATS_FIELD, longFormList(ElementType.STRUCT),
                 0x80, 0x80, 0x80, 0x80, 0x08,
                 STOP)))
                 .isInstanceOf(IOException.class)

--- a/core/src/test/java/dev/hardwood/internal/thrift/SizeStatisticsReaderTest.java
+++ b/core/src/test/java/dev/hardwood/internal/thrift/SizeStatisticsReaderTest.java
@@ -12,10 +12,9 @@ import java.nio.ByteBuffer;
 
 import org.junit.jupiter.api.Test;
 
+import dev.hardwood.internal.thrift.ThriftCompactConstants.FieldType;
 import dev.hardwood.metadata.SizeStatistics;
 
-import static dev.hardwood.internal.thrift.ThriftStructBuilder.TYPE_I64;
-import static dev.hardwood.internal.thrift.ThriftStructBuilder.TYPE_LIST;
 import static org.assertj.core.api.Assertions.assertThat;
 
 class SizeStatisticsReaderTest {
@@ -23,9 +22,9 @@ class SizeStatisticsReaderTest {
     @Test
     void readsAllFields() throws IOException {
         byte[] thrift = struct()
-                .field(1, TYPE_I64).i64(4096)
-                .field(2, TYPE_LIST).i64List(10, 4)
-                .field(3, TYPE_LIST).i64List(2, 12)
+                .field(1, FieldType.I64).i64(4096)
+                .field(2, FieldType.LIST).i64List(10, 4)
+                .field(3, FieldType.LIST).i64List(2, 12)
                 .stop().build();
 
         SizeStatistics stats = SizeStatisticsReader.read(new ThriftCompactReader(ByteBuffer.wrap(thrift)));
@@ -40,7 +39,7 @@ class SizeStatisticsReaderTest {
         // Every field is optional. A writer emitting only the definition-level histogram
         // must leave the other two distinguishable from a present-but-empty value.
         byte[] thrift = struct()
-                .field(3, TYPE_LIST).i64List(0, 7)
+                .field(3, FieldType.LIST).i64List(0, 7)
                 .stop().build();
 
         SizeStatistics stats = SizeStatisticsReader.read(new ThriftCompactReader(ByteBuffer.wrap(thrift)));
@@ -65,7 +64,7 @@ class SizeStatisticsReaderTest {
     void readsPresentButEmptyHistogram() throws IOException {
         // An empty histogram is a legal encoding and stays distinct from an absent one.
         byte[] thrift = struct()
-                .field(2, TYPE_LIST).i64List()
+                .field(2, FieldType.LIST).i64List()
                 .stop().build();
 
         SizeStatistics stats = SizeStatisticsReader.read(new ThriftCompactReader(ByteBuffer.wrap(thrift)));
@@ -79,9 +78,9 @@ class SizeStatisticsReaderTest {
         // A malformed file types field 1 as a list and field 2 as an i64. Both must be
         // skipped cleanly, leaving field 3 to parse.
         byte[] thrift = struct()
-                .field(1, TYPE_LIST).i64List(1, 2, 3)
-                .field(2, TYPE_I64).i64(99)
-                .field(3, TYPE_LIST).i64List(5, 6)
+                .field(1, FieldType.LIST).i64List(1, 2, 3)
+                .field(2, FieldType.I64).i64(99)
+                .field(3, FieldType.LIST).i64List(5, 6)
                 .stop().build();
 
         SizeStatistics stats = SizeStatisticsReader.read(new ThriftCompactReader(ByteBuffer.wrap(thrift)));
@@ -95,8 +94,8 @@ class SizeStatisticsReaderTest {
     void skipsUnknownTrailingField() throws IOException {
         // A field id beyond the struct's definition (a later format revision) is skipped.
         byte[] thrift = struct()
-                .field(1, TYPE_I64).i64(64)
-                .field(9, TYPE_I64).i64(123)
+                .field(1, FieldType.I64).i64(64)
+                .field(9, FieldType.I64).i64(123)
                 .stop().build();
 
         SizeStatistics stats = SizeStatisticsReader.read(new ThriftCompactReader(ByteBuffer.wrap(thrift)));

--- a/core/src/test/java/dev/hardwood/internal/thrift/StatisticsReaderTest.java
+++ b/core/src/test/java/dev/hardwood/internal/thrift/StatisticsReaderTest.java
@@ -12,11 +12,9 @@ import java.nio.ByteBuffer;
 
 import org.junit.jupiter.api.Test;
 
+import dev.hardwood.internal.thrift.ThriftCompactConstants.FieldType;
 import dev.hardwood.metadata.Statistics;
 
-import static dev.hardwood.internal.thrift.ThriftStructBuilder.TYPE_BINARY;
-import static dev.hardwood.internal.thrift.ThriftStructBuilder.TYPE_I64;
-import static dev.hardwood.internal.thrift.ThriftStructBuilder.TYPE_LIST;
 import static org.assertj.core.api.Assertions.assertThat;
 
 class StatisticsReaderTest {
@@ -24,10 +22,10 @@ class StatisticsReaderTest {
     @Test
     void readsNanCountAlongsidePreferredBounds() throws IOException {
         byte[] thrift = struct()
-                .field(3, TYPE_I64).i64(2)
-                .field(5, TYPE_BINARY).binary(bytes(9))
-                .field(6, TYPE_BINARY).binary(bytes(1))
-                .field(9, TYPE_I64).i64(5)
+                .field(3, FieldType.I64).i64(2)
+                .field(5, FieldType.BINARY).binary(bytes(9))
+                .field(6, FieldType.BINARY).binary(bytes(1))
+                .field(9, FieldType.I64).i64(5)
                 .stop().build();
 
         Statistics stats = read(thrift);
@@ -44,9 +42,9 @@ class StatisticsReaderTest {
         // A writer that predates nan_count, or a non-floating-point column, omits it.
         // That is distinct from a column known to hold no NaN values.
         byte[] thrift = struct()
-                .field(3, TYPE_I64).i64(0)
-                .field(5, TYPE_BINARY).binary(bytes(4))
-                .field(6, TYPE_BINARY).binary(bytes(0))
+                .field(3, FieldType.I64).i64(0)
+                .field(5, FieldType.BINARY).binary(bytes(4))
+                .field(6, FieldType.BINARY).binary(bytes(0))
                 .stop().build();
 
         assertThat(read(thrift).nanCount()).isNull();
@@ -56,7 +54,7 @@ class StatisticsReaderTest {
     void readsZeroNanCount() throws IOException {
         // Zero is the value that proves a floating-point chunk holds no NaN.
         byte[] thrift = struct()
-                .field(9, TYPE_I64).i64(0)
+                .field(9, FieldType.I64).i64(0)
                 .stop().build();
 
         assertThat(read(thrift).nanCount()).isEqualTo(0L);
@@ -67,8 +65,8 @@ class StatisticsReaderTest {
         // Field 9 typed as a list rather than an i64 must be skipped, leaving the
         // trailing field to parse.
         byte[] thrift = struct()
-                .field(9, TYPE_LIST).i64List(1, 2)
-                .field(10, TYPE_I64).i64(7)
+                .field(9, FieldType.LIST).i64List(1, 2)
+                .field(10, FieldType.I64).i64(7)
                 .stop().build();
 
         assertThat(read(thrift).nanCount()).isNull();
@@ -77,9 +75,9 @@ class StatisticsReaderTest {
     @Test
     void fallsBackToDeprecatedBoundsWithNanCountPresent() throws IOException {
         byte[] thrift = struct()
-                .field(1, TYPE_BINARY).binary(bytes(8))
-                .field(2, TYPE_BINARY).binary(bytes(2))
-                .field(9, TYPE_I64).i64(3)
+                .field(1, FieldType.BINARY).binary(bytes(8))
+                .field(2, FieldType.BINARY).binary(bytes(2))
+                .field(9, FieldType.I64).i64(3)
                 .stop().build();
 
         Statistics stats = read(thrift);

--- a/core/src/test/java/dev/hardwood/internal/thrift/ThriftCompactConstantsTest.java
+++ b/core/src/test/java/dev/hardwood/internal/thrift/ThriftCompactConstantsTest.java
@@ -1,0 +1,76 @@
+/*
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Copyright The original authors
+ *
+ *  Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package dev.hardwood.internal.thrift;
+
+import org.junit.jupiter.api.Test;
+
+import dev.hardwood.internal.thrift.ThriftCompactConstants.ElementType;
+import dev.hardwood.internal.thrift.ThriftCompactConstants.FieldType;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/// Pins the Thrift Compact Protocol wire table to the literals the spec names, so the codes stay
+/// anchored to the format rather than to themselves.
+///
+/// Every other test in this package composes its input bytes from [ThriftCompactConstants], the
+/// same table the readers dispatch on. A code that drifted would move both sides together and
+/// leave those tests green, so this is the one place the values are written out by hand.
+///
+/// Reference: https://github.com/apache/thrift/blob/master/doc/specs/thrift-compact-protocol.md
+class ThriftCompactConstantsTest {
+
+    @Test
+    void fieldTypesCarryTheSpecCodes() {
+        assertThat(FieldType.BOOLEAN_TRUE.code()).isEqualTo((byte) 0x01);
+        assertThat(FieldType.BOOLEAN_FALSE.code()).isEqualTo((byte) 0x02);
+        assertThat(FieldType.BYTE.code()).isEqualTo((byte) 0x03);
+        assertThat(FieldType.I16.code()).isEqualTo((byte) 0x04);
+        assertThat(FieldType.I32.code()).isEqualTo((byte) 0x05);
+        assertThat(FieldType.I64.code()).isEqualTo((byte) 0x06);
+        assertThat(FieldType.DOUBLE.code()).isEqualTo((byte) 0x07);
+        assertThat(FieldType.BINARY.code()).isEqualTo((byte) 0x08);
+        assertThat(FieldType.LIST.code()).isEqualTo((byte) 0x09);
+        assertThat(FieldType.SET.code()).isEqualTo((byte) 0x0A);
+        assertThat(FieldType.MAP.code()).isEqualTo((byte) 0x0B);
+        assertThat(FieldType.STRUCT.code()).isEqualTo((byte) 0x0C);
+        assertThat(FieldType.UUID.code()).isEqualTo((byte) 0x0D);
+    }
+
+    /// The element table mirrors the field table apart from `bool`: a collection declares one
+    /// element type where a field packs the value into its own type nibble.
+    @Test
+    void elementTypesCarryTheSpecCodes() {
+        assertThat(ElementType.BOOL.code()).isEqualTo((byte) 0x01);
+        assertThat(ElementType.BYTE.code()).isEqualTo((byte) 0x03);
+        assertThat(ElementType.I16.code()).isEqualTo((byte) 0x04);
+        assertThat(ElementType.I32.code()).isEqualTo((byte) 0x05);
+        assertThat(ElementType.I64.code()).isEqualTo((byte) 0x06);
+        assertThat(ElementType.DOUBLE.code()).isEqualTo((byte) 0x07);
+        assertThat(ElementType.BINARY.code()).isEqualTo((byte) 0x08);
+        assertThat(ElementType.LIST.code()).isEqualTo((byte) 0x09);
+        assertThat(ElementType.SET.code()).isEqualTo((byte) 0x0A);
+        assertThat(ElementType.MAP.code()).isEqualTo((byte) 0x0B);
+        assertThat(ElementType.STRUCT.code()).isEqualTo((byte) 0x0C);
+        assertThat(ElementType.UUID.code()).isEqualTo((byte) 0x0D);
+    }
+
+    /// No element type may collide with `bool`'s two codes: `0x02` is what a writer following the
+    /// spec's original numbering puts in the nibble, and readers accept it there.
+    @Test
+    void noElementTypeClaimsTheLegacyBoolCode() {
+        assertThat(ElementType.values())
+                .noneMatch(elementType -> elementType != ElementType.BOOL
+                        && elementType.code() == FieldType.Codes.BOOLEAN_FALSE);
+    }
+
+    @Test
+    void stopIsTheZeroByteAndListsSaturateAtFifteen() {
+        assertThat(ThriftCompactConstants.STOP).isEqualTo((byte) 0x00);
+        assertThat(ThriftCompactConstants.LONG_FORM_SIZE).isEqualTo(15);
+    }
+}

--- a/core/src/test/java/dev/hardwood/internal/thrift/ThriftCompactReaderTest.java
+++ b/core/src/test/java/dev/hardwood/internal/thrift/ThriftCompactReaderTest.java
@@ -13,11 +13,39 @@ import java.nio.ByteOrder;
 
 import org.junit.jupiter.api.Test;
 
+import dev.hardwood.internal.thrift.ThriftCompactConstants.ElementType;
+import dev.hardwood.internal.thrift.ThriftCompactConstants.FieldType;
+
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 /// Tests for ThriftCompactReader, particularly field skipping for complex types.
 class ThriftCompactReaderTest {
+
+    /// Struct terminator.
+    private static final byte STOP = FieldType.Codes.STOP;
+
+    /// Marks the end of the meaningful bytes, so a test can assert the reader stopped short of it.
+    private static final int SENTINEL = 0xFF;
+
+    /// A list header whose size nibble is saturated, meaning the real size follows as a varint.
+    private static final int LONG_FORM_SIZE = 15;
+
+    /// Field header byte: field-id delta in the high nibble, wire type in the low nibble.
+    private static byte field(int fieldIdDelta, FieldType type) {
+        return (byte) ((fieldIdDelta << 4) | type.code());
+    }
+
+    /// List header byte: element count in the high nibble, element type in the low nibble.
+    private static byte list(int size, ElementType elementType) {
+        return (byte) ((size << 4) | elementType.code());
+    }
+
+    /// The single byte a map writes after its size: key type in the high nibble, value type in
+    /// the low nibble.
+    private static byte mapTypes(ElementType key, ElementType value) {
+        return (byte) ((key.code() << 4) | value.code());
+    }
 
     /// Verifies that MAP fields are skipped correctly per the Thrift Compact Protocol spec.
     ///
@@ -35,8 +63,7 @@ class ThriftCompactReaderTest {
         // MAP size = 2 (varint)
         buffer.put((byte) 2);
 
-        // Key/value types packed: i32 (0x05) << 4 | i32 (0x05) = 0x55
-        buffer.put((byte) 0x55);
+        buffer.put(mapTypes(ElementType.I32, ElementType.I32));
 
         // Entry 1: key=10 (zigzag=20), value=20 (zigzag=40)
         buffer.put((byte) 20); // zigzag(10) = 20
@@ -47,12 +74,12 @@ class ThriftCompactReaderTest {
         buffer.put((byte) 80); // zigzag(40) = 80
 
         // Sentinel byte to verify we stopped at the right position
-        buffer.put((byte) 0xFF);
+        buffer.put((byte) SENTINEL);
 
         buffer.flip();
 
         ThriftCompactReader reader = new ThriftCompactReader(buffer);
-        reader.skipField((byte) 0x0B); // TYPE_MAP
+        reader.skipField(FieldType.MAP.code());
 
         // Should have consumed exactly 6 bytes: 1 (size) + 1 (types) + 4 (entries)
         assertThat(reader.getBytesRead()).isEqualTo(6);
@@ -68,12 +95,12 @@ class ThriftCompactReaderTest {
         buffer.put((byte) 0);
 
         // Sentinel
-        buffer.put((byte) 0xFF);
+        buffer.put((byte) SENTINEL);
 
         buffer.flip();
 
         ThriftCompactReader reader = new ThriftCompactReader(buffer);
-        reader.skipField((byte) 0x0B); // TYPE_MAP
+        reader.skipField(FieldType.MAP.code());
 
         // Should have consumed exactly 1 byte (the zero size varint)
         assertThat(reader.getBytesRead()).isEqualTo(1);
@@ -88,8 +115,7 @@ class ThriftCompactReaderTest {
         // MAP size = 1
         buffer.put((byte) 1);
 
-        // Key/value types packed: BINARY (0x08) << 4 | STRUCT (0x0C) = 0x8C
-        buffer.put((byte) 0x8C);
+        buffer.put(mapTypes(ElementType.BINARY, ElementType.STRUCT));
 
         // Entry 1 key: binary string "ab" (length=2, then 2 bytes)
         buffer.put((byte) 2); // length varint
@@ -97,18 +123,17 @@ class ThriftCompactReaderTest {
         buffer.put((byte) 'b');
 
         // Entry 1 value: struct with one i32 field (field id=1), then STOP
-        // Field header: delta=1, type=i32(0x05) -> byte = 0x15
-        buffer.put((byte) 0x15);
+        buffer.put(field(1, FieldType.I32));
         buffer.put((byte) 42); // zigzag(21) = 42
-        buffer.put((byte) 0x00); // STOP
+        buffer.put(STOP);
 
         // Sentinel
-        buffer.put((byte) 0xFF);
+        buffer.put((byte) SENTINEL);
 
         buffer.flip();
 
         ThriftCompactReader reader = new ThriftCompactReader(buffer);
-        reader.skipField((byte) 0x0B); // TYPE_MAP
+        reader.skipField(FieldType.MAP.code());
 
         // 1 (size) + 1 (types) + 3 (key) + 3 (struct) = 8 bytes
         assertThat(reader.getBytesRead()).isEqualTo(8);
@@ -120,23 +145,23 @@ class ThriftCompactReaderTest {
         // Build a struct with fields 1 (i32) and 2 (struct with field 1 (i32)) and 3 (i32)
         ByteBuffer buffer = ByteBuffer.allocate(64).order(ByteOrder.LITTLE_ENDIAN);
 
-        // Field 1: type i32 (0x05), delta 1 -> 0x15
-        buffer.put((byte) 0x15);
+        // Field 1
+        buffer.put(field(1, FieldType.I32));
         buffer.put((byte) 10); // zigzag(5) = 10
 
-        // Field 2: type struct (0x0C), delta 1 -> 0x1C
-        buffer.put((byte) 0x1C);
+        // Field 2, a nested struct
+        buffer.put(field(1, FieldType.STRUCT));
         // Nested struct: field 1 i32
-        buffer.put((byte) 0x15);
+        buffer.put(field(1, FieldType.I32));
         buffer.put((byte) 20); // zigzag(10) = 20
-        buffer.put((byte) 0x00); // STOP nested struct
+        buffer.put(STOP); // ends the nested struct
 
-        // Field 3: type i32 (0x05), delta 1 -> 0x15
-        buffer.put((byte) 0x15);
+        // Field 3
+        buffer.put(field(1, FieldType.I32));
         buffer.put((byte) 30); // zigzag(15) = 30
 
-        // STOP outer struct
-        buffer.put((byte) 0x00);
+        // ends the outer struct
+        buffer.put(STOP);
 
         buffer.flip();
 
@@ -169,8 +194,8 @@ class ThriftCompactReaderTest {
     /// collection from it.
     @Test
     void listHeaderRejectsCountLargerThanRemainingBytes() {
-        // List header: size nibble 15 (long form), element type struct (0x0C), then varint(100).
-        ThriftCompactReader reader = reader(0xFC, 0x64, 0x00, 0x00);
+        // Long-form list of structs, then varint(100).
+        ThriftCompactReader reader = reader(list(LONG_FORM_SIZE, ElementType.STRUCT), 0x64, STOP, STOP);
 
         assertThatThrownBy(reader::readListHeader)
                 .isInstanceOf(IOException.class)
@@ -184,7 +209,8 @@ class ThriftCompactReaderTest {
     @Test
     void listHeaderRejectsCountOverflowingInt() {
         // varint 0x80 0x80 0x80 0x80 0x08 encodes 2^31, which casts to Integer.MIN_VALUE.
-        ThriftCompactReader reader = reader(0xFC, 0x80, 0x80, 0x80, 0x80, 0x08, 0x00);
+        ThriftCompactReader reader = reader(
+                list(LONG_FORM_SIZE, ElementType.STRUCT), 0x80, 0x80, 0x80, 0x80, 0x08, STOP);
 
         assertThatThrownBy(reader::readListHeader)
                 .isInstanceOf(IOException.class)
@@ -201,16 +227,16 @@ class ThriftCompactReaderTest {
     void listHeaderAcceptsLongFormCountWithinRemainingBytes() throws IOException {
         // 15 bool elements, each one byte, followed by exactly 15 payload bytes.
         int[] bytes = new int[17];
-        bytes[0] = 0xF1;  // size nibble 15 (long form), element type bool
+        bytes[0] = list(LONG_FORM_SIZE, ElementType.BOOL);
         bytes[1] = 0x0F;  // varint(15)
         for (int i = 0; i < 15; i++) {
-            bytes[i + 2] = 0x01;
+            bytes[i + 2] = ElementType.BOOL.code();
         }
 
         ThriftCompactReader.CollectionHeader header = reader(bytes).readListHeader();
 
         assertThat(header.size()).isEqualTo(15);
-        assertThat(header.elementType()).isEqualTo((byte) 0x01);
+        assertThat(header.elementType()).isEqualTo(ElementType.BOOL.code());
     }
 
     /// A `bool` is the one type encoded differently as a collection element than as a struct
@@ -220,20 +246,26 @@ class ThriftCompactReaderTest {
     /// out of a shifted stream.
     @Test
     void skipFieldConsumesBooleanListElements() throws IOException {
-        // List header: 3 elements, element type bool (0x01), then three value bytes.
-        ThriftCompactReader reader = reader(0x31, 0x01, 0x02, 0x01, 0xFF);
+        // List header: 3 bool elements, then three value bytes.
+        ThriftCompactReader reader = reader(
+                list(3, ElementType.BOOL),
+                FieldType.Codes.BOOLEAN_TRUE, FieldType.Codes.BOOLEAN_FALSE, FieldType.Codes.BOOLEAN_TRUE,
+                SENTINEL);
 
-        reader.skipField((byte) 0x09); // TYPE_LIST
+        reader.skipField(FieldType.LIST.code());
 
         assertThat(reader.getBytesRead()).isEqualTo(4);
     }
 
-    /// `0x02` is the other type code a writer may put in the element nibble for `bool`.
+    /// `BOOLEAN_FALSE` is the other type code a writer may put in the element nibble for `bool`.
     @Test
     void skipFieldConsumesBooleanListElementsDeclaredAsFalse() throws IOException {
-        ThriftCompactReader reader = reader(0x22, 0x02, 0x02, 0xFF);
+        ThriftCompactReader reader = reader(
+                (2 << 4) | FieldType.Codes.BOOLEAN_FALSE,
+                FieldType.Codes.BOOLEAN_FALSE, FieldType.Codes.BOOLEAN_FALSE,
+                SENTINEL);
 
-        reader.skipField((byte) 0x09); // TYPE_LIST
+        reader.skipField(FieldType.LIST.code());
 
         assertThat(reader.getBytesRead()).isEqualTo(3);
     }
@@ -241,10 +273,14 @@ class ThriftCompactReaderTest {
     /// Map keys and values are elements too, so they follow the element encoding.
     @Test
     void skipFieldConsumesBooleanMapEntries() throws IOException {
-        // MAP size = 2, key/value types packed: bool (0x01) << 4 | bool (0x01) = 0x11.
-        ThriftCompactReader reader = reader(0x02, 0x11, 0x01, 0x02, 0x02, 0x01, 0xFF);
+        // MAP size = 2, then the packed bool/bool key-value type byte and the four element bytes.
+        ThriftCompactReader reader = reader(
+                0x02, mapTypes(ElementType.BOOL, ElementType.BOOL),
+                FieldType.Codes.BOOLEAN_TRUE, FieldType.Codes.BOOLEAN_FALSE,
+                FieldType.Codes.BOOLEAN_FALSE, FieldType.Codes.BOOLEAN_TRUE,
+                SENTINEL);
 
-        reader.skipField((byte) 0x0B); // TYPE_MAP
+        reader.skipField(FieldType.MAP.code());
 
         assertThat(reader.getBytesRead()).isEqualTo(6);
     }

--- a/core/src/test/java/dev/hardwood/internal/thrift/ThriftCompactReaderTest.java
+++ b/core/src/test/java/dev/hardwood/internal/thrift/ThriftCompactReaderTest.java
@@ -23,12 +23,12 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 class ThriftCompactReaderTest {
 
     /// Struct terminator.
-    private static final byte STOP = FieldType.Codes.STOP;
+    private static final byte STOP = ThriftCompactConstants.STOP;
 
     /// Marks the end of the meaningful bytes, so a test can assert the reader stopped short of it.
     private static final int SENTINEL = 0xFF;
 
-    /// A list header whose size nibble is saturated, meaning the real size follows as a varint.
+    /// The size nibble that saturates, at which point the count no longer fits the header.
     private static final int LONG_FORM_SIZE = 15;
 
     /// Field header byte: field-id delta in the high nibble, wire type in the low nibble.
@@ -36,9 +36,19 @@ class ThriftCompactReaderTest {
         return (byte) ((fieldIdDelta << 4) | type.code());
     }
 
-    /// List header byte: element count in the high nibble, element type in the low nibble.
+    /// Short-form list header byte: element count in the high nibble, element type in the low.
+    /// A count of [#LONG_FORM_SIZE] or more does not fit the nibble — see [#longFormList].
     private static byte list(int size, ElementType elementType) {
+        if (size >= LONG_FORM_SIZE) {
+            throw new IllegalArgumentException(size + " elements need the long form, not the size nibble");
+        }
         return (byte) ((size << 4) | elementType.code());
+    }
+
+    /// Long-form list header byte: the size nibble saturated, so the count follows as a varint
+    /// the caller writes itself.
+    private static byte longFormList(ElementType elementType) {
+        return (byte) ((LONG_FORM_SIZE << 4) | elementType.code());
     }
 
     /// The single byte a map writes after its size: key type in the high nibble, value type in
@@ -195,7 +205,7 @@ class ThriftCompactReaderTest {
     @Test
     void listHeaderRejectsCountLargerThanRemainingBytes() {
         // Long-form list of structs, then varint(100).
-        ThriftCompactReader reader = reader(list(LONG_FORM_SIZE, ElementType.STRUCT), 0x64, STOP, STOP);
+        ThriftCompactReader reader = reader(longFormList(ElementType.STRUCT), 0x64, STOP, STOP);
 
         assertThatThrownBy(reader::readListHeader)
                 .isInstanceOf(IOException.class)
@@ -210,7 +220,7 @@ class ThriftCompactReaderTest {
     void listHeaderRejectsCountOverflowingInt() {
         // varint 0x80 0x80 0x80 0x80 0x08 encodes 2^31, which casts to Integer.MIN_VALUE.
         ThriftCompactReader reader = reader(
-                list(LONG_FORM_SIZE, ElementType.STRUCT), 0x80, 0x80, 0x80, 0x80, 0x08, STOP);
+                longFormList(ElementType.STRUCT), 0x80, 0x80, 0x80, 0x80, 0x08, STOP);
 
         assertThatThrownBy(reader::readListHeader)
                 .isInstanceOf(IOException.class)
@@ -227,10 +237,10 @@ class ThriftCompactReaderTest {
     void listHeaderAcceptsLongFormCountWithinRemainingBytes() throws IOException {
         // 15 bool elements, each one byte, followed by exactly 15 payload bytes.
         int[] bytes = new int[17];
-        bytes[0] = list(LONG_FORM_SIZE, ElementType.BOOL);
+        bytes[0] = longFormList(ElementType.BOOL);
         bytes[1] = 0x0F;  // varint(15)
         for (int i = 0; i < 15; i++) {
-            bytes[i + 2] = ElementType.BOOL.code();
+            bytes[i + 2] = FieldType.Codes.BOOLEAN_TRUE;
         }
 
         ThriftCompactReader.CollectionHeader header = reader(bytes).readListHeader();
@@ -257,11 +267,12 @@ class ThriftCompactReaderTest {
         assertThat(reader.getBytesRead()).isEqualTo(4);
     }
 
-    /// `BOOLEAN_FALSE` is the other type code a writer may put in the element nibble for `bool`.
+    /// [ElementType#BOOL_LEGACY] is the other type code a writer may put in the element nibble
+    /// for `bool`.
     @Test
     void skipFieldConsumesBooleanListElementsDeclaredAsFalse() throws IOException {
         ThriftCompactReader reader = reader(
-                (2 << 4) | FieldType.Codes.BOOLEAN_FALSE,
+                list(2, ElementType.BOOL_LEGACY),
                 FieldType.Codes.BOOLEAN_FALSE, FieldType.Codes.BOOLEAN_FALSE,
                 SENTINEL);
 

--- a/core/src/test/java/dev/hardwood/internal/thrift/ThriftCompactReaderTest.java
+++ b/core/src/test/java/dev/hardwood/internal/thrift/ThriftCompactReaderTest.java
@@ -16,46 +16,19 @@ import org.junit.jupiter.api.Test;
 import dev.hardwood.internal.thrift.ThriftCompactConstants.ElementType;
 import dev.hardwood.internal.thrift.ThriftCompactConstants.FieldType;
 
+import static dev.hardwood.internal.thrift.ThriftCompactConstants.STOP;
+import static dev.hardwood.internal.thrift.ThriftStructBuilder.fieldHeader;
+import static dev.hardwood.internal.thrift.ThriftStructBuilder.listHeader;
+import static dev.hardwood.internal.thrift.ThriftStructBuilder.longFormListHeader;
+import static dev.hardwood.internal.thrift.ThriftStructBuilder.mapTypes;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 /// Tests for ThriftCompactReader, particularly field skipping for complex types.
 class ThriftCompactReaderTest {
 
-    /// Struct terminator.
-    private static final byte STOP = ThriftCompactConstants.STOP;
-
     /// Marks the end of the meaningful bytes, so a test can assert the reader stopped short of it.
     private static final int SENTINEL = 0xFF;
-
-    /// The size nibble that saturates, at which point the count no longer fits the header.
-    private static final int LONG_FORM_SIZE = 15;
-
-    /// Field header byte: field-id delta in the high nibble, wire type in the low nibble.
-    private static byte field(int fieldIdDelta, FieldType type) {
-        return (byte) ((fieldIdDelta << 4) | type.code());
-    }
-
-    /// Short-form list header byte: element count in the high nibble, element type in the low.
-    /// A count of [#LONG_FORM_SIZE] or more does not fit the nibble — see [#longFormList].
-    private static byte list(int size, ElementType elementType) {
-        if (size >= LONG_FORM_SIZE) {
-            throw new IllegalArgumentException(size + " elements need the long form, not the size nibble");
-        }
-        return (byte) ((size << 4) | elementType.code());
-    }
-
-    /// Long-form list header byte: the size nibble saturated, so the count follows as a varint
-    /// the caller writes itself.
-    private static byte longFormList(ElementType elementType) {
-        return (byte) ((LONG_FORM_SIZE << 4) | elementType.code());
-    }
-
-    /// The single byte a map writes after its size: key type in the high nibble, value type in
-    /// the low nibble.
-    private static byte mapTypes(ElementType key, ElementType value) {
-        return (byte) ((key.code() << 4) | value.code());
-    }
 
     /// Verifies that MAP fields are skipped correctly per the Thrift Compact Protocol spec.
     ///
@@ -133,7 +106,7 @@ class ThriftCompactReaderTest {
         buffer.put((byte) 'b');
 
         // Entry 1 value: struct with one i32 field (field id=1), then STOP
-        buffer.put(field(1, FieldType.I32));
+        buffer.put(fieldHeader(1, FieldType.I32));
         buffer.put((byte) 42); // zigzag(21) = 42
         buffer.put(STOP);
 
@@ -156,18 +129,18 @@ class ThriftCompactReaderTest {
         ByteBuffer buffer = ByteBuffer.allocate(64).order(ByteOrder.LITTLE_ENDIAN);
 
         // Field 1
-        buffer.put(field(1, FieldType.I32));
+        buffer.put(fieldHeader(1, FieldType.I32));
         buffer.put((byte) 10); // zigzag(5) = 10
 
         // Field 2, a nested struct
-        buffer.put(field(1, FieldType.STRUCT));
+        buffer.put(fieldHeader(1, FieldType.STRUCT));
         // Nested struct: field 1 i32
-        buffer.put(field(1, FieldType.I32));
+        buffer.put(fieldHeader(1, FieldType.I32));
         buffer.put((byte) 20); // zigzag(10) = 20
         buffer.put(STOP); // ends the nested struct
 
         // Field 3
-        buffer.put(field(1, FieldType.I32));
+        buffer.put(fieldHeader(1, FieldType.I32));
         buffer.put((byte) 30); // zigzag(15) = 30
 
         // ends the outer struct
@@ -205,7 +178,7 @@ class ThriftCompactReaderTest {
     @Test
     void listHeaderRejectsCountLargerThanRemainingBytes() {
         // Long-form list of structs, then varint(100).
-        ThriftCompactReader reader = reader(longFormList(ElementType.STRUCT), 0x64, STOP, STOP);
+        ThriftCompactReader reader = reader(longFormListHeader(ElementType.STRUCT), 0x64, STOP, STOP);
 
         assertThatThrownBy(reader::readListHeader)
                 .isInstanceOf(IOException.class)
@@ -220,7 +193,7 @@ class ThriftCompactReaderTest {
     void listHeaderRejectsCountOverflowingInt() {
         // varint 0x80 0x80 0x80 0x80 0x08 encodes 2^31, which casts to Integer.MIN_VALUE.
         ThriftCompactReader reader = reader(
-                longFormList(ElementType.STRUCT), 0x80, 0x80, 0x80, 0x80, 0x08, STOP);
+                longFormListHeader(ElementType.STRUCT), 0x80, 0x80, 0x80, 0x80, 0x08, STOP);
 
         assertThatThrownBy(reader::readListHeader)
                 .isInstanceOf(IOException.class)
@@ -237,7 +210,7 @@ class ThriftCompactReaderTest {
     void listHeaderAcceptsLongFormCountWithinRemainingBytes() throws IOException {
         // 15 bool elements, each one byte, followed by exactly 15 payload bytes.
         int[] bytes = new int[17];
-        bytes[0] = longFormList(ElementType.BOOL);
+        bytes[0] = longFormListHeader(ElementType.BOOL);
         bytes[1] = 0x0F;  // varint(15)
         for (int i = 0; i < 15; i++) {
             bytes[i + 2] = FieldType.Codes.BOOLEAN_TRUE;
@@ -258,7 +231,7 @@ class ThriftCompactReaderTest {
     void skipFieldConsumesBooleanListElements() throws IOException {
         // List header: 3 bool elements, then three value bytes.
         ThriftCompactReader reader = reader(
-                list(3, ElementType.BOOL),
+                listHeader(3, ElementType.BOOL),
                 FieldType.Codes.BOOLEAN_TRUE, FieldType.Codes.BOOLEAN_FALSE, FieldType.Codes.BOOLEAN_TRUE,
                 SENTINEL);
 
@@ -267,12 +240,12 @@ class ThriftCompactReaderTest {
         assertThat(reader.getBytesRead()).isEqualTo(4);
     }
 
-    /// [ElementType#BOOL_LEGACY] is the other type code a writer may put in the element nibble
-    /// for `bool`.
+    /// The spec's original `2` is the other type code a writer may put in the element nibble for
+    /// `bool`, so the element type is not enough to tell a bool list from a false-typed field.
     @Test
     void skipFieldConsumesBooleanListElementsDeclaredAsFalse() throws IOException {
         ThriftCompactReader reader = reader(
-                list(2, ElementType.BOOL_LEGACY),
+                listHeader(2, FieldType.Codes.BOOLEAN_FALSE),
                 FieldType.Codes.BOOLEAN_FALSE, FieldType.Codes.BOOLEAN_FALSE,
                 SENTINEL);
 

--- a/core/src/test/java/dev/hardwood/internal/thrift/ThriftStructBuilder.java
+++ b/core/src/test/java/dev/hardwood/internal/thrift/ThriftStructBuilder.java
@@ -18,19 +18,52 @@ import dev.hardwood.internal.thrift.ThriftCompactConstants.FieldType;
 /// Fields are written in ascending id order so the short-form field header
 /// (delta-encoded id) applies; a gap larger than 15 falls back to the long form.
 /// Every struct must be terminated with [#stop()] before [#build()].
+///
+/// The static header composers — [#fieldHeader], [#listHeader], [#longFormListHeader] and
+/// [#mapTypes] — are the same nibble packing exposed on its own, for tests that hand a reader
+/// a byte sequence rather than building a struct.
 public final class ThriftStructBuilder {
-
-    /// The list-header size nibble that saturates, meaning the real element count follows as a
-    /// varint rather than fitting in the nibble.
-    private static final int LONG_FORM_SIZE = 15;
 
     private final ByteBuffer buffer = ByteBuffer.allocate(512).order(ByteOrder.LITTLE_ENDIAN);
     private short lastFieldId;
 
+    /// Field header byte: the field-id delta in the high nibble, the wire type in the low nibble.
+    public static byte fieldHeader(int fieldIdDelta, FieldType type) {
+        return (byte) ((fieldIdDelta << 4) | type.code());
+    }
+
+    /// Short-form list header byte: the element count in the high nibble, the element type in the
+    /// low. A count of [ThriftCompactConstants#LONG_FORM_SIZE] or more does not fit the nibble —
+    /// see [#longFormListHeader].
+    public static byte listHeader(int size, ElementType elementType) {
+        return listHeader(size, elementType.code());
+    }
+
+    /// The same for an element type [ElementType] does not name, such as the `2` a writer may put
+    /// in the element nibble for `bool` instead of the de-facto standard `1`.
+    public static byte listHeader(int size, byte elementCode) {
+        if (size >= ThriftCompactConstants.LONG_FORM_SIZE) {
+            throw new IllegalArgumentException(size + " elements need the long form, not the size nibble");
+        }
+        return (byte) ((size << 4) | elementCode);
+    }
+
+    /// Long-form list header byte: the size nibble saturated, so the count follows as a varint the
+    /// caller writes itself.
+    public static byte longFormListHeader(ElementType elementType) {
+        return (byte) ((ThriftCompactConstants.LONG_FORM_SIZE << 4) | elementType.code());
+    }
+
+    /// The single byte a map writes after its size: the key type in the high nibble, the value
+    /// type in the low nibble.
+    public static byte mapTypes(ElementType key, ElementType value) {
+        return (byte) ((key.code() << 4) | value.code());
+    }
+
     public ThriftStructBuilder field(int id, FieldType type) {
         short delta = (short) (id - lastFieldId);
         if (delta > 0 && delta <= 15) {
-            buffer.put((byte) ((delta << 4) | type.code()));
+            buffer.put(fieldHeader(delta, type));
         }
         else {
             buffer.put(type.code());
@@ -41,7 +74,7 @@ public final class ThriftStructBuilder {
     }
 
     public ThriftStructBuilder boolList(boolean... values) {
-        listHeader(values.length, ElementType.BOOL);
+        putListHeader(values.length, ElementType.BOOL);
         for (boolean value : values) {
             buffer.put(value ? FieldType.Codes.BOOLEAN_TRUE : FieldType.Codes.BOOLEAN_FALSE);
         }
@@ -49,7 +82,7 @@ public final class ThriftStructBuilder {
     }
 
     public ThriftStructBuilder binaryList(byte[]... values) {
-        listHeader(values.length, ElementType.BINARY);
+        putListHeader(values.length, ElementType.BINARY);
         for (byte[] value : values) {
             writeVarint(value.length);
             buffer.put(value);
@@ -58,7 +91,7 @@ public final class ThriftStructBuilder {
     }
 
     public ThriftStructBuilder i32List(int... values) {
-        listHeader(values.length, ElementType.I32);
+        putListHeader(values.length, ElementType.I32);
         for (int value : values) {
             writeZigzag(value);
         }
@@ -66,7 +99,7 @@ public final class ThriftStructBuilder {
     }
 
     public ThriftStructBuilder i64List(long... values) {
-        listHeader(values.length, ElementType.I64);
+        putListHeader(values.length, ElementType.I64);
         for (long value : values) {
             writeZigzag(value);
         }
@@ -75,7 +108,7 @@ public final class ThriftStructBuilder {
 
     /// Writes a `list<struct>` of already-built struct bodies.
     public ThriftStructBuilder structList(byte[]... structs) {
-        listHeader(structs.length, ElementType.STRUCT);
+        putListHeader(structs.length, ElementType.STRUCT);
         for (byte[] struct : structs) {
             buffer.put(struct);
         }
@@ -130,7 +163,7 @@ public final class ThriftStructBuilder {
     /// Writes a list header without the elements, so a caller can follow it with [#raw] bytes
     /// or with fewer elements than it declares.
     public ThriftStructBuilder listHeaderOnly(int size, ElementType elementType) {
-        listHeader(size, elementType);
+        putListHeader(size, elementType);
         return this;
     }
 
@@ -146,12 +179,12 @@ public final class ThriftStructBuilder {
         return out;
     }
 
-    private void listHeader(int size, ElementType elementType) {
-        if (size < LONG_FORM_SIZE) {
-            buffer.put((byte) ((size << 4) | elementType.code()));
+    private void putListHeader(int size, ElementType elementType) {
+        if (size < ThriftCompactConstants.LONG_FORM_SIZE) {
+            buffer.put(listHeader(size, elementType));
         }
         else {
-            buffer.put((byte) ((LONG_FORM_SIZE << 4) | elementType.code()));
+            buffer.put(longFormListHeader(elementType));
             writeVarint(size);
         }
     }

--- a/core/src/test/java/dev/hardwood/internal/thrift/ThriftStructBuilder.java
+++ b/core/src/test/java/dev/hardwood/internal/thrift/ThriftStructBuilder.java
@@ -20,13 +20,17 @@ import dev.hardwood.internal.thrift.ThriftCompactConstants.FieldType;
 /// Every struct must be terminated with [#stop()] before [#build()].
 public final class ThriftStructBuilder {
 
+    /// The list-header size nibble that saturates, meaning the real element count follows as a
+    /// varint rather than fitting in the nibble.
+    private static final int LONG_FORM_SIZE = 15;
+
     private final ByteBuffer buffer = ByteBuffer.allocate(512).order(ByteOrder.LITTLE_ENDIAN);
     private short lastFieldId;
 
     public ThriftStructBuilder field(int id, FieldType type) {
         short delta = (short) (id - lastFieldId);
         if (delta > 0 && delta <= 15) {
-            buffer.put((byte) ((delta << 4) | (type.code() & 0x0F)));
+            buffer.put((byte) ((delta << 4) | type.code()));
         }
         else {
             buffer.put(type.code());
@@ -81,13 +85,18 @@ public final class ThriftStructBuilder {
     public ThriftStructBuilder emptyStructList(int count) {
         byte[][] structs = new byte[count][];
         for (int i = 0; i < count; i++) {
-            structs[i] = new byte[]{ 0 }; // empty struct: immediate STOP
+            structs[i] = new byte[]{ ThriftCompactConstants.STOP }; // empty struct: immediate STOP
         }
         return structList(structs);
     }
 
     public ThriftStructBuilder i32(int value) {
         writeZigzag(value);
+        return this;
+    }
+
+    public ThriftStructBuilder doubleValue(double value) {
+        buffer.putDouble(value);
         return this;
     }
 
@@ -126,7 +135,7 @@ public final class ThriftStructBuilder {
     }
 
     public ThriftStructBuilder stop() {
-        buffer.put((byte) 0);
+        buffer.put(ThriftCompactConstants.STOP);
         return this;
     }
 
@@ -138,11 +147,11 @@ public final class ThriftStructBuilder {
     }
 
     private void listHeader(int size, ElementType elementType) {
-        if (size < 15) {
-            buffer.put((byte) ((size << 4) | (elementType.code() & 0x0F)));
+        if (size < LONG_FORM_SIZE) {
+            buffer.put((byte) ((size << 4) | elementType.code()));
         }
         else {
-            buffer.put((byte) (0xF0 | (elementType.code() & 0x0F)));
+            buffer.put((byte) ((LONG_FORM_SIZE << 4) | elementType.code()));
             writeVarint(size);
         }
     }

--- a/core/src/test/java/dev/hardwood/internal/thrift/ThriftStructBuilder.java
+++ b/core/src/test/java/dev/hardwood/internal/thrift/ThriftStructBuilder.java
@@ -10,6 +10,9 @@ package dev.hardwood.internal.thrift;
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
 
+import dev.hardwood.internal.thrift.ThriftCompactConstants.ElementType;
+import dev.hardwood.internal.thrift.ThriftCompactConstants.FieldType;
+
 /// Hand-rolled Thrift Compact Protocol struct builder for reader tests.
 ///
 /// Fields are written in ascending id order so the short-form field header
@@ -17,31 +20,16 @@ import java.nio.ByteOrder;
 /// Every struct must be terminated with [#stop()] before [#build()].
 public final class ThriftStructBuilder {
 
-    // Thrift Compact Protocol field type codes.
-    public static final byte TYPE_I32 = 0x05;
-    public static final byte TYPE_I64 = 0x06;
-    public static final byte TYPE_BINARY = 0x08;
-    public static final byte TYPE_LIST = 0x09;
-    public static final byte TYPE_MAP = 0x0B;
-    public static final byte TYPE_STRUCT = 0x0C;
-
-    // Thrift Compact Protocol list element type codes.
-    public static final byte ELEM_BOOL = 0x01;
-    public static final byte ELEM_I32 = 0x05;
-    public static final byte ELEM_I64 = 0x06;
-    public static final byte ELEM_BINARY = 0x08;
-    public static final byte ELEM_STRUCT = 0x0C;
-
     private final ByteBuffer buffer = ByteBuffer.allocate(512).order(ByteOrder.LITTLE_ENDIAN);
     private short lastFieldId;
 
-    public ThriftStructBuilder field(int id, byte type) {
+    public ThriftStructBuilder field(int id, FieldType type) {
         short delta = (short) (id - lastFieldId);
         if (delta > 0 && delta <= 15) {
-            buffer.put((byte) ((delta << 4) | (type & 0x0F)));
+            buffer.put((byte) ((delta << 4) | (type.code() & 0x0F)));
         }
         else {
-            buffer.put(type);
+            buffer.put(type.code());
             writeZigzag(id);
         }
         lastFieldId = (short) id;
@@ -49,15 +37,15 @@ public final class ThriftStructBuilder {
     }
 
     public ThriftStructBuilder boolList(boolean... values) {
-        listHeader(values.length, ELEM_BOOL);
+        listHeader(values.length, ElementType.BOOL);
         for (boolean value : values) {
-            buffer.put((byte) (value ? 0x01 : 0x02));
+            buffer.put(value ? FieldType.Codes.BOOLEAN_TRUE : FieldType.Codes.BOOLEAN_FALSE);
         }
         return this;
     }
 
     public ThriftStructBuilder binaryList(byte[]... values) {
-        listHeader(values.length, ELEM_BINARY);
+        listHeader(values.length, ElementType.BINARY);
         for (byte[] value : values) {
             writeVarint(value.length);
             buffer.put(value);
@@ -66,7 +54,7 @@ public final class ThriftStructBuilder {
     }
 
     public ThriftStructBuilder i32List(int... values) {
-        listHeader(values.length, ELEM_I32);
+        listHeader(values.length, ElementType.I32);
         for (int value : values) {
             writeZigzag(value);
         }
@@ -74,7 +62,7 @@ public final class ThriftStructBuilder {
     }
 
     public ThriftStructBuilder i64List(long... values) {
-        listHeader(values.length, ELEM_I64);
+        listHeader(values.length, ElementType.I64);
         for (long value : values) {
             writeZigzag(value);
         }
@@ -83,7 +71,7 @@ public final class ThriftStructBuilder {
 
     /// Writes a `list<struct>` of already-built struct bodies.
     public ThriftStructBuilder structList(byte[]... structs) {
-        listHeader(structs.length, ELEM_STRUCT);
+        listHeader(structs.length, ElementType.STRUCT);
         for (byte[] struct : structs) {
             buffer.put(struct);
         }
@@ -132,7 +120,7 @@ public final class ThriftStructBuilder {
 
     /// Writes a list header without the elements, so a caller can follow it with [#raw] bytes
     /// or with fewer elements than it declares.
-    public ThriftStructBuilder listHeaderOnly(int size, byte elementType) {
+    public ThriftStructBuilder listHeaderOnly(int size, ElementType elementType) {
         listHeader(size, elementType);
         return this;
     }
@@ -149,12 +137,12 @@ public final class ThriftStructBuilder {
         return out;
     }
 
-    private void listHeader(int size, byte elementType) {
+    private void listHeader(int size, ElementType elementType) {
         if (size < 15) {
-            buffer.put((byte) ((size << 4) | (elementType & 0x0F)));
+            buffer.put((byte) ((size << 4) | (elementType.code() & 0x0F)));
         }
         else {
-            buffer.put((byte) (0xF0 | (elementType & 0x0F)));
+            buffer.put((byte) (0xF0 | (elementType.code() & 0x0F)));
             writeVarint(size);
         }
     }

--- a/s3/src/test/java/dev/hardwood/s3/TestParquetGenerator.java
+++ b/s3/src/test/java/dev/hardwood/s3/TestParquetGenerator.java
@@ -12,6 +12,9 @@ import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
 import java.nio.charset.StandardCharsets;
 
+import dev.hardwood.internal.thrift.ThriftCompactConstants.ElementType;
+import dev.hardwood.internal.thrift.ThriftCompactConstants.FieldType;
+
 /// Generates minimal valid Parquet files in pure Java for testing.
 ///
 /// Produces files with REQUIRED INT64 columns, PLAIN encoding, no compression,
@@ -105,14 +108,14 @@ final class TestParquetGenerator {
     /// }
     private static byte[] dataPageHeader(int numValues, int pageSize) {
         ThriftWriter w = new ThriftWriter();
-        w.field(1, T_I32).zigzagI32(0);
-        w.field(2, T_I32).zigzagI32(pageSize);
-        w.field(3, T_I32).zigzagI32(pageSize);
-        w.field(5, T_STRUCT).pushStruct();
-        w.field(1, T_I32).zigzagI32(numValues);
-        w.field(2, T_I32).zigzagI32(0);
-        w.field(3, T_I32).zigzagI32(0);
-        w.field(4, T_I32).zigzagI32(0);
+        w.field(1, FieldType.I32).zigzagI32(0);
+        w.field(2, FieldType.I32).zigzagI32(pageSize);
+        w.field(3, FieldType.I32).zigzagI32(pageSize);
+        w.field(5, FieldType.STRUCT).pushStruct();
+        w.field(1, FieldType.I32).zigzagI32(numValues);
+        w.field(2, FieldType.I32).zigzagI32(0);
+        w.field(3, FieldType.I32).zigzagI32(0);
+        w.field(4, FieldType.I32).zigzagI32(0);
         w.stop();
         w.stop();
         return w.toByteArray();
@@ -135,33 +138,33 @@ final class TestParquetGenerator {
         ThriftWriter w = new ThriftWriter();
 
         // version
-        w.field(1, T_I32).zigzagI32(2);
+        w.field(1, FieldType.I32).zigzagI32(2);
 
         // schema: list<SchemaElement>
-        w.field(2, T_LIST).listHeader(T_STRUCT, numColumns + 1);
+        w.field(2, FieldType.LIST).listHeader(ElementType.STRUCT, numColumns + 1);
         // Root element: name="schema", num_children=N
         w.pushStruct();
-        w.field(4, T_BINARY).binary("schema");
-        w.field(5, T_I32).zigzagI32(numColumns);
+        w.field(4, FieldType.BINARY).binary("schema");
+        w.field(5, FieldType.I32).zigzagI32(numColumns);
         w.stop();
         // Column elements: type=INT64, repetition_type=REQUIRED, name="cN"
         for (int col = 0; col < numColumns; col++) {
             w.pushStruct();
-            w.field(1, T_I32).zigzagI32(2);  // type = INT64
-            w.field(3, T_I32).zigzagI32(0);  // repetition_type = REQUIRED
-            w.field(4, T_BINARY).binary("c" + col);
+            w.field(1, FieldType.I32).zigzagI32(2);  // type = INT64
+            w.field(3, FieldType.I32).zigzagI32(0);  // repetition_type = REQUIRED
+            w.field(4, FieldType.BINARY).binary("c" + col);
             w.stop();
         }
 
         // num_rows
-        w.field(3, T_I64).zigzagI64((long) numRowGroups * rowsPerRowGroup);
+        w.field(3, FieldType.I64).zigzagI64((long) numRowGroups * rowsPerRowGroup);
 
         // row_groups: list<RowGroup>
-        w.field(4, T_LIST).listHeader(T_STRUCT, numRowGroups);
+        w.field(4, FieldType.LIST).listHeader(ElementType.STRUCT, numRowGroups);
         for (int rg = 0; rg < numRowGroups; rg++) {
             w.pushStruct();
             // columns: list<ColumnChunk>
-            w.field(1, T_LIST).listHeader(T_STRUCT, numColumns);
+            w.field(1, FieldType.LIST).listHeader(ElementType.STRUCT, numColumns);
             for (int col = 0; col < numColumns; col++) {
                 w.pushStruct();
                 columnChunk(w, col, chunkOffsets[rg][col], chunkSizes[rg][col], rowsPerRowGroup);
@@ -172,14 +175,14 @@ final class TestParquetGenerator {
             for (int col = 0; col < numColumns; col++) {
                 rgSize += chunkSizes[rg][col];
             }
-            w.field(2, T_I64).zigzagI64(rgSize);
+            w.field(2, FieldType.I64).zigzagI64(rgSize);
             // num_rows
-            w.field(3, T_I64).zigzagI64(rowsPerRowGroup);
+            w.field(3, FieldType.I64).zigzagI64(rowsPerRowGroup);
             w.stop();
         }
 
         // created_by
-        w.field(6, T_BINARY).binary("hardwood-test-generator");
+        w.field(6, FieldType.BINARY).binary("hardwood-test-generator");
         w.stop();
         return w.toByteArray();
     }
@@ -201,29 +204,23 @@ final class TestParquetGenerator {
     /// }
     private static void columnChunk(ThriftWriter w, int colIndex, long offset,
                                      int size, int numValues) {
-        w.field(2, T_I64).zigzagI64(offset);
-        w.field(3, T_STRUCT).pushStruct();
-        w.field(1, T_I32).zigzagI32(2);          // INT64
-        w.field(2, T_LIST).listHeader(T_I32, 1);
+        w.field(2, FieldType.I64).zigzagI64(offset);
+        w.field(3, FieldType.STRUCT).pushStruct();
+        w.field(1, FieldType.I32).zigzagI32(2);          // INT64
+        w.field(2, FieldType.LIST).listHeader(ElementType.I32, 1);
         w.zigzagI32(0);                           // PLAIN
-        w.field(3, T_LIST).listHeader(T_BINARY, 1);
+        w.field(3, FieldType.LIST).listHeader(ElementType.BINARY, 1);
         w.binary("c" + colIndex);
-        w.field(4, T_I32).zigzagI32(0);           // UNCOMPRESSED
-        w.field(5, T_I64).zigzagI64(numValues);
-        w.field(6, T_I64).zigzagI64(size);
-        w.field(7, T_I64).zigzagI64(size);
-        w.field(9, T_I64).zigzagI64(offset);
+        w.field(4, FieldType.I32).zigzagI32(0);           // UNCOMPRESSED
+        w.field(5, FieldType.I64).zigzagI64(numValues);
+        w.field(6, FieldType.I64).zigzagI64(size);
+        w.field(7, FieldType.I64).zigzagI64(size);
+        w.field(9, FieldType.I64).zigzagI64(offset);
         w.stop();
         w.stop();
     }
 
     // ==================== Thrift Compact Protocol ====================
-
-    private static final int T_I32 = 0x05;
-    private static final int T_I64 = 0x06;
-    private static final int T_BINARY = 0x08;
-    private static final int T_LIST = 0x09;
-    private static final int T_STRUCT = 0x0C;
 
     /// Minimal Thrift Compact Protocol writer.
     ///
@@ -233,13 +230,13 @@ final class TestParquetGenerator {
         private int lastFieldId = 0;
         private final java.util.ArrayDeque<Integer> fieldIdStack = new java.util.ArrayDeque<>();
 
-        ThriftWriter field(int fieldId, int typeId) {
+        ThriftWriter field(int fieldId, FieldType type) {
             int delta = fieldId - lastFieldId;
             if (delta > 0 && delta <= 15) {
-                buf.write((delta << 4) | typeId);
+                buf.write((delta << 4) | type.code());
             }
             else {
-                buf.write(typeId);
+                buf.write(type.code());
                 writeVarInt((fieldId << 1) ^ (fieldId >> 31));
             }
             lastFieldId = fieldId;
@@ -263,12 +260,12 @@ final class TestParquetGenerator {
             return this;
         }
 
-        ThriftWriter listHeader(int elementType, int size) {
+        ThriftWriter listHeader(ElementType elementType, int size) {
             if (size <= 14) {
-                buf.write((size << 4) | elementType);
+                buf.write((size << 4) | elementType.code());
             }
             else {
-                buf.write(0xF0 | elementType);
+                buf.write(0xF0 | elementType.code());
                 writeVarInt(size);
             }
             return this;
@@ -277,12 +274,12 @@ final class TestParquetGenerator {
         /// Ends the current struct (writes STOP byte) and restores the enclosing
         /// struct's field ID context from the stack.
         void stop() {
-            buf.write(0x00);
+            buf.write(FieldType.Codes.STOP);
             lastFieldId = fieldIdStack.isEmpty() ? 0 : fieldIdStack.pop();
         }
 
         /// Saves current field context and resets for a new struct scope.
-        /// Call before writing fields of a nested struct (either via `field(N, T_STRUCT)`
+        /// Call before writing fields of a nested struct (either via `field(N, FieldType.STRUCT)`
         /// or as a struct element in a list). The matching `stop()` restores the context.
         ThriftWriter pushStruct() {
             fieldIdStack.push(lastFieldId);

--- a/s3/src/test/java/dev/hardwood/s3/TestParquetGenerator.java
+++ b/s3/src/test/java/dev/hardwood/s3/TestParquetGenerator.java
@@ -262,11 +262,11 @@ final class TestParquetGenerator {
         }
 
         ThriftWriter listHeader(ElementType elementType, int size) {
-            if (size <= 14) {
+            if (size < ThriftCompactConstants.LONG_FORM_SIZE) {
                 buf.write((size << 4) | elementType.code());
             }
             else {
-                buf.write(0xF0 | elementType.code());
+                buf.write((ThriftCompactConstants.LONG_FORM_SIZE << 4) | elementType.code());
                 writeVarInt(size);
             }
             return this;

--- a/s3/src/test/java/dev/hardwood/s3/TestParquetGenerator.java
+++ b/s3/src/test/java/dev/hardwood/s3/TestParquetGenerator.java
@@ -12,6 +12,7 @@ import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
 import java.nio.charset.StandardCharsets;
 
+import dev.hardwood.internal.thrift.ThriftCompactConstants;
 import dev.hardwood.internal.thrift.ThriftCompactConstants.ElementType;
 import dev.hardwood.internal.thrift.ThriftCompactConstants.FieldType;
 
@@ -274,7 +275,7 @@ final class TestParquetGenerator {
         /// Ends the current struct (writes STOP byte) and restores the enclosing
         /// struct's field ID context from the stack.
         void stop() {
-            buf.write(FieldType.Codes.STOP);
+            buf.write(ThriftCompactConstants.STOP);
             lastFieldId = fieldIdStack.isEmpty() ? 0 : fieldIdStack.pop();
         }
 


### PR DESCRIPTION
Hello, this PR is a follow up on #668 that I wanted to do since a while, de-hardcoding all the bytes across the repo (I asked Claude to find them and utilize the constants), this makes the code easier to understand and more maintainable 


## Authorship

Hardwood is built with AI, not by AI. LLM assistance is welcome; submitting raw LLM output without understanding is not.
Neither are unattended agents opening pull requests.
See the [contribution guide](https://github.com/hardwood-hq/hardwood/blob/main/CONTRIBUTING.md) for more details.
Check this box to confirm:

- [x] This change is coming from a human who understands what it does and why, and can discuss it in review

## Checklist

- [x] Build via `./mvnw clean verify` passes
- [x] The commit message is prefixed with the issue key ("#123 Adding support for...")
- [x] Code changes are covered by tests
- [ ] If this PR adds or changes user-facing behaviour, `docs/` has been updated
