### PR TITLE
#655 Expose metadata for each input file

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -231,6 +231,7 @@ For field-level `parquet.thrift` metadata coverage (which spec fields are read/p
 - [x] Data page reading and decoding
 - [x] Page decompression
 - [x] Parallel column batch fetching
+- [x] Lazy per-file metadata access with a parent-owned footer cache (see [`_designs/PER_FILE_METADATA.md`](_designs/PER_FILE_METADATA.md))
 
 ### 7.3 Record Assembly (Inverse Dremel)
 - [x] Column reader synchronization (via RowReader)

--- a/_designs/PER_FILE_METADATA.md
+++ b/_designs/PER_FILE_METADATA.md
@@ -1,0 +1,68 @@
+# Per-File Metadata for Multi-File Readers
+
+**Status:** Completed
+
+## Context
+
+A multi-file `ParquetFileReader` exposed only the first file's `FileMetaData`. Consumers that
+need the total physical row count before allocating storage had to reopen every input and parse
+its footer independently, even though Hardwood would parse those same footers while reading.
+
+## Public contract
+
+- `getFileCount()` returns the number of physical inputs, in supplied order, without I/O.
+- The existing `getFileMetaData()` continues to return the eagerly parsed first footer.
+- `getFileMetaData(int)` returns one physical input's footer; index `0` returns that same first
+  `FileMetaData` instance.
+- Later footers remain lazy. Metadata access is synchronous and may join an asynchronous load
+  already started by a data reader.
+- Each in-progress, successful, or failed load is retained for the parent reader's lifetime.
+  Closing and reopening the parent is the retry boundary after failure and the refresh boundary
+  for files changed on the underlying storage.
+- Indexed metadata access after parent close fails. `getFileCount()` remains a pure property.
+- Inputs must remain unchanged while the parent is open.
+
+An indexed accessor was chosen over iterable or list metadata APIs because it preserves the
+checked `IOException` at the exact file access that can fail and does not suggest eager loading.
+
+## Ownership and cache boundary
+
+`ParquetFileReader` owns one `FileMetadataCache` and the input-file lifecycle. The cache keeps a
+single future per physical file. Its `PreparedFile` contains only reusable file-wide state:
+
+- the `InputFile`;
+- parsed `FileMetaData`;
+- derived `FileSchema`;
+- the footer's row groups.
+
+Both indexed metadata access and every `RowGroupIterator` use this cache, so neither direction
+of access reparses a footer. A failed future remains in the map, preventing an implicit retry in
+the same parent reader.
+
+Closing a child row or column reader releases only iterator-local workers and caches. It neither
+closes nor invalidates shared inputs. Parent close atomically prevents new cache admissions,
+waits for every admitted footer load without holding the lifecycle lock, clears the cached
+futures, then closes each owned input. Cache closure is idempotent and never closes inputs itself.
+
+## Per-reader schema state
+
+The cache deliberately does not store `FileColumnOrdinals`, touched-column validation, or other
+projection/filter state. For every child reader, `RowGroupIterator` validates its touched columns
+against each cached `FileSchema` and creates that iterator's own `FileColumnOrdinals` mapping.
+The mapping is by field path and is used consistently for pruning, masks, indexes, bloom filters,
+dictionaries, chunk-path checks, and fetch plans, preserving the cross-file ordering guarantees
+from #906.
+
+Consequently, `getFileMetaData(int)` can succeed for a file whose schema is incompatible with a
+later projection. The incompatibility is reported when the row or column reader is planned,
+because only then is the set of touched columns known.
+
+## Concurrency and failure behavior
+
+Reader cursors remain single-consumer objects. The cache's concurrency control exists to
+coordinate Hardwood's footer prefetch with synchronous indexed access: one lifecycle boundary
+serializes first-file seeding, load admission, and the start of cache closure, while atomic
+insertion of one future per index makes all requesters observe the same in-progress result.
+Existing exception translation is preserved: synchronous metadata access exposes the original
+footer `IOException`, while iterator paths retain their runtime wrapper behavior. Parent close
+ignores cached load failures while waiting so that every owned input can still be closed.

--- a/_designs/PER_FILE_METADATA.md
+++ b/_designs/PER_FILE_METADATA.md
@@ -4,17 +4,20 @@
 
 ## Context
 
-A multi-file `ParquetFileReader` exposed only the first file's `FileMetaData`. Consumers that
-need the total physical row count before allocating storage had to reopen every input and parse
-its footer independently, even though Hardwood would parse those same footers while reading.
+A multi-file `ParquetFileReader` reads every input's footer while it scans, but a consumer that
+needs whole-dataset facts — the total physical row count before allocating storage, per-file
+on-disk sizes — can reach only the first file's `FileMetaData`. Getting the rest means reopening
+every input and parsing footers Hardwood has already parsed.
 
 ## Public contract
 
 - `getFileCount()` returns the number of physical inputs, in supplied order, without I/O.
-- The existing `getFileMetaData()` continues to return the eagerly parsed first footer.
+- `getFileMetaData()` returns the eagerly parsed first footer.
 - `getFileMetaData(int)` returns one physical input's footer; index `0` returns that same first
-  `FileMetaData` instance.
-- Later footers remain lazy. Metadata access is synchronous and may join an asynchronous load
+  `FileMetaData` instance. The accessor is indexed rather than an iterable or list of all
+  footers: an index keeps the checked `IOException` on the single file access that can fail, and
+  carries no suggestion that the whole set is loaded.
+- Later footers are lazy. Metadata access is synchronous and may join an asynchronous load
   already started by a data reader.
 - Each in-progress, successful, or failed load is retained for the parent reader's lifetime.
   Closing and reopening the parent is the retry boundary after failure and the refresh boundary
@@ -22,22 +25,27 @@ its footer independently, even though Hardwood would parse those same footers wh
 - Indexed metadata access after parent close fails. `getFileCount()` remains a pure property.
 - Inputs must remain unchanged while the parent is open.
 
-An indexed accessor was chosen over iterable or list metadata APIs because it preserves the
-checked `IOException` at the exact file access that can fail and does not suggest eager loading.
-
 ## Ownership and cache boundary
 
 `ParquetFileReader` owns one `FileMetadataCache` and the input-file lifecycle. The cache keeps a
-single future per physical file. Its `PreparedFile` contains only reusable file-wide state:
+single future per physical file. Its `PreparedFile` contains only reusable file-wide state, every
+component of it parsed from that file's own footer and therefore always present:
 
 - the `InputFile`;
 - parsed `FileMetaData`;
 - derived `FileSchema`;
 - the footer's row groups.
 
-Both indexed metadata access and every `RowGroupIterator` use this cache, so neither direction
-of access reparses a footer. A failed future remains in the map, preventing an implicit retry in
-the same parent reader.
+The reader seeds index `0` with the footer it read at open, so opening the reader and inspecting
+that index never read the same footer twice. Both indexed metadata access and every
+`RowGroupIterator` use this cache, so neither direction of access reparses a footer. A failed
+future remains in the map, preventing an implicit retry in the same parent reader.
+
+The reader tracks the iterators it hands to child readers, so that closing the parent tears down
+an iterator whose child reader the caller never closed. An iterator drops itself from that list
+when it is closed, so a reader used for many sequential single-column reads does not accumulate
+the work lists of finished children. The row-reader and multi-column paths share one iterator
+across sibling readers, so no individual child owns it and it stays tracked until parent close.
 
 Closing a child row or column reader releases only iterator-local workers and caches. It neither
 closes nor invalidates shared inputs. Parent close atomically prevents new cache admissions,
@@ -46,8 +54,9 @@ futures, then closes each owned input. Cache closure is idempotent and never clo
 
 ## Per-reader schema state
 
-The cache deliberately does not store `FileColumnOrdinals`, touched-column validation, or other
-projection/filter state. For every child reader, `RowGroupIterator` validates its touched columns
+The cache deliberately does not store `FileColumnOrdinals`, touched-column validation, the
+row-group subset one reader's filters admit, or any other projection/filter state — those belong
+to a reader, not to a file. For every child reader, `RowGroupIterator` validates its touched columns
 against each cached `FileSchema` and creates that iterator's own `FileColumnOrdinals` mapping.
 The mapping is by field path and is used consistently for pruning, masks, indexes, bloom filters,
 dictionaries, chunk-path checks, and fetch plans, preserving the cross-file ordering guarantees
@@ -61,8 +70,8 @@ because only then is the set of touched columns known.
 
 Reader cursors remain single-consumer objects. The cache's concurrency control exists to
 coordinate Hardwood's footer prefetch with synchronous indexed access: one lifecycle boundary
-serializes first-file seeding, load admission, and the start of cache closure, while atomic
-insertion of one future per index makes all requesters observe the same in-progress result.
-Existing exception translation is preserved: synchronous metadata access exposes the original
-footer `IOException`, while iterator paths retain their runtime wrapper behavior. Parent close
-ignores cached load failures while waiting so that every owned input can still be closed.
+serializes load admission against the start of cache closure, while atomic insertion of one
+future per index makes all requesters observe the same in-progress result. Exception translation
+differs by entry point: synchronous metadata access exposes the original footer `IOException`,
+while iterator paths get the runtime wrapper. Parent close ignores cached load failures while
+waiting so that every owned input can still be closed.

--- a/core/src/main/java/dev/hardwood/internal/reader/FileMetadataCache.java
+++ b/core/src/main/java/dev/hardwood/internal/reader/FileMetadataCache.java
@@ -1,0 +1,220 @@
+/*
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Copyright The original authors
+ *
+ *  Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package dev.hardwood.internal.reader;
+
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionException;
+
+import dev.hardwood.InputFile;
+import dev.hardwood.internal.ExceptionContext;
+import dev.hardwood.jfr.FileOpenedEvent;
+import dev.hardwood.metadata.FileMetaData;
+import dev.hardwood.metadata.RowGroup;
+import dev.hardwood.schema.FileSchema;
+
+/// Lazily opens input files and caches each parsed footer for one
+/// [dev.hardwood.reader.ParquetFileReader].
+public final class FileMetadataCache {
+
+    private final List<InputFile> inputFiles;
+    private final Object lifecycleLock = new Object();
+    private final Map<Integer, CompletableFuture<PreparedFile>> fileFutures = new HashMap<>();
+    private final CompletableFuture<Void> closeCompletion = new CompletableFuture<>();
+    private boolean closeStarted;
+
+    FileMetadataCache(List<InputFile> inputFiles) {
+        if (inputFiles.isEmpty()) {
+            throw new IllegalArgumentException("At least one file must be provided");
+        }
+        this.inputFiles = List.copyOf(inputFiles);
+    }
+
+    public FileMetadataCache(List<InputFile> inputFiles, FileMetaData firstFileMetaData,
+                             FileSchema firstFileSchema) {
+        this(inputFiles);
+        InputFile first = this.inputFiles.getFirst();
+        PreparedFile prepared = new PreparedFile(first, firstFileMetaData, firstFileSchema,
+                firstFileMetaData.rowGroups());
+        seedFirstFile(prepared);
+    }
+
+    List<InputFile> inputFiles() {
+        return inputFiles;
+    }
+
+    /// Seeds metadata already read by a caller that owns this cache. Existing
+    /// complete metadata, such as the first footer read by ParquetFileReader,
+    /// is never replaced by an iterator-specific row-group subset.
+    void setFirstFile(FileSchema schema, List<RowGroup> rowGroups) {
+        InputFile first = inputFiles.getFirst();
+        PreparedFile prepared = new PreparedFile(first, null, schema, rowGroups);
+        seedFirstFile(prepared);
+    }
+
+    public FileMetaData getFileMetaData(int fileIndex) throws IOException {
+        PreparedFile prepared = getFileChecked(fileIndex);
+        if (prepared.metaData() == null) {
+            throw new IllegalStateException("File metadata is unavailable for index " + fileIndex);
+        }
+        return prepared.metaData();
+    }
+
+    /// Gets or loads a prepared file, blocking if necessary.
+    ///
+    /// Unwraps the [CompletionException] that [CompletableFuture#join] would
+    /// otherwise wrap around the load failure, so callers see the original
+    /// exception (e.g. [UncheckedIOException]) directly rather than as a
+    /// `CompletionException` cause.
+    PreparedFile getFile(int fileIndex) {
+        CompletableFuture<PreparedFile> future = registerLoad(fileIndex, true);
+        try {
+            return future.join();
+        }
+        catch (CompletionException e) {
+            Throwable cause = e.getCause();
+            if (cause instanceof RuntimeException runtimeException) {
+                throw runtimeException;
+            }
+            if (cause instanceof Error error) {
+                throw error;
+            }
+            throw e;
+        }
+    }
+
+    PreparedFile getFileChecked(int fileIndex) throws IOException {
+        try {
+            return getFile(fileIndex);
+        }
+        catch (UncheckedIOException e) {
+            throw e.getCause();
+        }
+    }
+
+    void prefetch(int fileIndex) {
+        registerLoad(fileIndex, false);
+    }
+
+    /// Prevents new loads, waits for every admitted load, and releases cached
+    /// results. Input-file ownership remains with the caller.
+    public void close() {
+        List<CompletableFuture<PreparedFile>> registeredLoads;
+        synchronized (lifecycleLock) {
+            if (closeStarted) {
+                registeredLoads = null;
+            }
+            else {
+                closeStarted = true;
+                registeredLoads = List.copyOf(fileFutures.values());
+            }
+        }
+
+        if (registeredLoads == null) {
+            closeCompletion.join();
+            return;
+        }
+
+        try {
+            for (CompletableFuture<PreparedFile> future : registeredLoads) {
+                try {
+                    future.join();
+                }
+                catch (RuntimeException ignored) {
+                }
+            }
+        }
+        finally {
+            synchronized (lifecycleLock) {
+                fileFutures.clear();
+            }
+            closeCompletion.complete(null);
+        }
+    }
+
+    private void seedFirstFile(PreparedFile prepared) {
+        synchronized (lifecycleLock) {
+            ensureOpen();
+            fileFutures.putIfAbsent(0, CompletableFuture.completedFuture(prepared));
+        }
+    }
+
+    private CompletableFuture<PreparedFile> registerLoad(int fileIndex, boolean required) {
+        synchronized (lifecycleLock) {
+            if (closeStarted) {
+                if (required) {
+                    throw new IllegalStateException("FileMetadataCache is closed");
+                }
+                return null;
+            }
+            if (fileIndex < 0 || fileIndex >= inputFiles.size()) {
+                if (required) {
+                    Objects.checkIndex(fileIndex, inputFiles.size());
+                }
+                return null;
+            }
+            return fileFutures.computeIfAbsent(fileIndex, this::loadFileAsync);
+        }
+    }
+
+    private void ensureOpen() {
+        if (closeStarted) {
+            throw new IllegalStateException("FileMetadataCache is closed");
+        }
+    }
+
+    private CompletableFuture<PreparedFile> loadFileAsync(int fileIndex) {
+        return CompletableFuture.supplyAsync(() -> loadFile(fileIndex));
+    }
+
+    private PreparedFile loadFile(int fileIndex) {
+        InputFile inputFile = inputFiles.get(fileIndex);
+        try {
+            inputFile.open();
+        }
+        catch (IOException e) {
+            throw new UncheckedIOException(
+                    ExceptionContext.filePrefix(inputFile.name()) + "Failed to open file", e);
+        }
+
+        FileOpenedEvent event = new FileOpenedEvent();
+        event.begin();
+
+        try {
+            FileMetaData metaData = ParquetMetadataReader.readMetadata(inputFile);
+            FileSchema schema = FileSchema.fromSchemaElements(metaData.schema());
+
+            event.file = inputFile.name();
+            event.fileSize = inputFile.length();
+            event.rowGroupCount = metaData.rowGroups().size();
+            event.columnCount = schema.getColumnCount();
+            event.commit();
+
+            return new PreparedFile(inputFile, metaData, schema, metaData.rowGroups());
+        }
+        catch (IOException e) {
+            throw new UncheckedIOException(
+                    ExceptionContext.filePrefix(inputFile.name()) + "Failed to read metadata", e);
+        }
+        catch (RuntimeException e) {
+            throw ExceptionContext.addFileContext(inputFile.name(), e);
+        }
+    }
+
+    record PreparedFile(
+            InputFile inputFile,
+            FileMetaData metaData,
+            FileSchema schema,
+            List<RowGroup> rowGroups
+    ) {}
+}

--- a/core/src/main/java/dev/hardwood/internal/reader/FileMetadataCache.java
+++ b/core/src/main/java/dev/hardwood/internal/reader/FileMetadataCache.java
@@ -40,34 +40,23 @@ public final class FileMetadataCache {
         this.inputFiles = List.copyOf(inputFiles);
     }
 
+    /// Seeds the first file's footer, already read by the owning
+    /// [dev.hardwood.reader.ParquetFileReader], so that opening the reader and
+    /// inspecting index `0` never read it twice.
     public FileMetadataCache(List<InputFile> inputFiles, FileMetaData firstFileMetaData,
                              FileSchema firstFileSchema) {
         this(inputFiles);
-        InputFile first = this.inputFiles.getFirst();
-        PreparedFile prepared = new PreparedFile(first, firstFileMetaData, firstFileSchema,
-                firstFileMetaData.rowGroups());
-        seedFirstFile(prepared);
+        PreparedFile prepared = new PreparedFile(this.inputFiles.getFirst(), firstFileMetaData,
+                firstFileSchema, firstFileMetaData.rowGroups());
+        fileFutures.put(0, CompletableFuture.completedFuture(prepared));
     }
 
     List<InputFile> inputFiles() {
         return inputFiles;
     }
 
-    /// Seeds metadata already read by a caller that owns this cache. Existing
-    /// complete metadata, such as the first footer read by ParquetFileReader,
-    /// is never replaced by an iterator-specific row-group subset.
-    void setFirstFile(FileSchema schema, List<RowGroup> rowGroups) {
-        InputFile first = inputFiles.getFirst();
-        PreparedFile prepared = new PreparedFile(first, null, schema, rowGroups);
-        seedFirstFile(prepared);
-    }
-
     public FileMetaData getFileMetaData(int fileIndex) throws IOException {
-        PreparedFile prepared = getFileChecked(fileIndex);
-        if (prepared.metaData() == null) {
-            throw new IllegalStateException("File metadata is unavailable for index " + fileIndex);
-        }
-        return prepared.metaData();
+        return getFileChecked(fileIndex).metaData();
     }
 
     /// Gets or loads a prepared file, blocking if necessary.
@@ -142,13 +131,6 @@ public final class FileMetadataCache {
         }
     }
 
-    private void seedFirstFile(PreparedFile prepared) {
-        synchronized (lifecycleLock) {
-            ensureOpen();
-            fileFutures.putIfAbsent(0, CompletableFuture.completedFuture(prepared));
-        }
-    }
-
     private CompletableFuture<PreparedFile> registerLoad(int fileIndex, boolean required) {
         synchronized (lifecycleLock) {
             if (closeStarted) {
@@ -164,12 +146,6 @@ public final class FileMetadataCache {
                 return null;
             }
             return fileFutures.computeIfAbsent(fileIndex, this::loadFileAsync);
-        }
-    }
-
-    private void ensureOpen() {
-        if (closeStarted) {
-            throw new IllegalStateException("FileMetadataCache is closed");
         }
     }
 
@@ -211,10 +187,19 @@ public final class FileMetadataCache {
         }
     }
 
+    /// One file's reusable, projection-independent state. Every component is
+    /// parsed from that file's own footer, so none of them is ever absent.
     record PreparedFile(
             InputFile inputFile,
             FileMetaData metaData,
             FileSchema schema,
             List<RowGroup> rowGroups
-    ) {}
+    ) {
+        PreparedFile {
+            Objects.requireNonNull(inputFile, "inputFile");
+            Objects.requireNonNull(metaData, "metaData");
+            Objects.requireNonNull(schema, "schema");
+            Objects.requireNonNull(rowGroups, "rowGroups");
+        }
+    }
 }

--- a/core/src/main/java/dev/hardwood/internal/reader/RowGroupIterator.java
+++ b/core/src/main/java/dev/hardwood/internal/reader/RowGroupIterator.java
@@ -17,7 +17,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.CompletionException;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicIntegerArray;
 
@@ -31,14 +30,13 @@ import dev.hardwood.internal.predicate.ResolvedPredicate;
 import dev.hardwood.internal.predicate.RowGroupBloomFilterSource;
 import dev.hardwood.internal.predicate.RowGroupFilterEvaluator;
 import dev.hardwood.internal.predicate.dictionary.RowGroupDictionaryFilterSource;
+import dev.hardwood.internal.reader.FileMetadataCache.PreparedFile;
 import dev.hardwood.internal.schema.ProjectedSchema;
 import dev.hardwood.internal.thrift.OffsetIndexReader;
 import dev.hardwood.internal.thrift.ThriftCompactReader;
-import dev.hardwood.jfr.FileOpenedEvent;
 import dev.hardwood.jfr.RowGroupFilterEvent;
 import dev.hardwood.metadata.ColumnChunk;
 import dev.hardwood.metadata.FieldPath;
-import dev.hardwood.metadata.FileMetaData;
 import dev.hardwood.metadata.LogicalType;
 import dev.hardwood.metadata.OffsetIndex;
 import dev.hardwood.metadata.PageLocation;
@@ -53,9 +51,8 @@ import dev.hardwood.schema.FileSchema;
 
 /// Shared iterator over `(InputFile, RowGroup)` pairs across one or more files.
 ///
-/// Handles file lifecycle (open, metadata read, schema validation, close),
-/// row-group filtering by statistics, `maxRows` limiting at the row-group level,
-/// and async prefetching of the next file.
+/// Handles schema validation, row-group filtering by statistics,
+/// `maxRows` limiting at the row-group level, and async prefetching of the next file.
 ///
 /// Each [PageSource] maintains its own cursor into the work list exposed by
 /// this iterator. Shared per-row-group metadata (index buffers, matching rows)
@@ -76,6 +73,8 @@ public class RowGroupIterator {
             Integer.getInteger("hardwood.internal.maxCoalescedBytes", 128 * 1024 * 1024);
 
     private final List<InputFile> inputFiles;
+    private final FileMetadataCache fileMetadataCache;
+    private final boolean ownsFileMetadataCache;
     private final HardwoodContextImpl context;
     private final long maxRows;
     private final long physicalSkip;
@@ -108,9 +107,6 @@ public class RowGroupIterator {
 
     // Work list: all (file, rowGroup) pairs to process, built during initialize()
     private final List<WorkItem> workItems = new ArrayList<>();
-
-    // Prefetch state
-    private final ConcurrentHashMap<Integer, CompletableFuture<PreparedFile>> fileFutures = new ConcurrentHashMap<>();
 
     // Per-row-group shared metadata cache (keyed by work item index)
     private final ConcurrentHashMap<Integer, SharedRowGroupMetadata> metadataCache = new ConcurrentHashMap<>();
@@ -159,21 +155,7 @@ public class RowGroupIterator {
             MaskCapability maskCapability
     ) {}
 
-    /// Result of opening and validating a file.
-    /// `columnOrdinals` is `null` for the first file, whose metadata is prepared
-    /// before the projection is known; it is the reference, so its mapping is the
-    /// identity and [#buildWorkList] substitutes that.
-    private record PreparedFile(
-            InputFile inputFile,
-            FileMetaData metaData,
-            FileSchema schema,
-            List<RowGroup> rowGroups,
-            FileColumnOrdinals columnOrdinals
-    ) {
-        PreparedFile withColumnOrdinals(FileColumnOrdinals ordinals) {
-            return new PreparedFile(inputFile, metaData, schema, rowGroups, ordinals);
-        }
-    }
+    private List<RowGroup> firstFileRowGroups;
 
     /// Creates a RowGroupIterator for the given files.
     ///
@@ -215,9 +197,18 @@ public class RowGroupIterator {
     ///        semantics.
     public RowGroupIterator(List<InputFile> inputFiles, HardwoodContextImpl context,
                             long maxRows, long tailSkip, long physicalSkip) {
-        if (inputFiles.isEmpty()) {
-            throw new IllegalArgumentException("At least one file must be provided");
-        }
+        this(new FileMetadataCache(inputFiles), true, context, maxRows, tailSkip, physicalSkip);
+    }
+
+    /// Creates a RowGroupIterator sharing file metadata with its parent reader.
+    public RowGroupIterator(FileMetadataCache fileMetadataCache, HardwoodContextImpl context,
+                            long maxRows, long tailSkip, long physicalSkip) {
+        this(fileMetadataCache, false, context, maxRows, tailSkip, physicalSkip);
+    }
+
+    private RowGroupIterator(FileMetadataCache fileMetadataCache, boolean ownsFileMetadataCache,
+                             HardwoodContextImpl context, long maxRows, long tailSkip,
+                             long physicalSkip) {
         if (tailSkip < 0) {
             throw new IllegalArgumentException("tailSkip must be non-negative, got " + tailSkip);
         }
@@ -229,7 +220,9 @@ public class RowGroupIterator {
                     "tailSkip and physicalSkip are mutually exclusive, got tailSkip=" + tailSkip
                             + ", physicalSkip=" + physicalSkip);
         }
-        this.inputFiles = new ArrayList<>(inputFiles);
+        this.fileMetadataCache = fileMetadataCache;
+        this.ownsFileMetadataCache = ownsFileMetadataCache;
+        this.inputFiles = fileMetadataCache.inputFiles();
         this.context = context;
         this.maxRows = maxRows;
         this.tailSkip = tailSkip;
@@ -255,18 +248,14 @@ public class RowGroupIterator {
     /// @param rowGroups the (already filtered) row groups from the first file
     public void setFirstFile(FileSchema schema, List<RowGroup> rowGroups) {
         this.referenceSchema = schema;
-        InputFile first = inputFiles.get(0);
-        PreparedFile prepared = new PreparedFile(first, null, schema, rowGroups, null);
-        fileFutures.put(0, CompletableFuture.completedFuture(prepared));
+        this.firstFileRowGroups = rowGroups;
+        fileMetadataCache.setFirstFile(schema, rowGroups);
     }
 
     /// Opens the first file and returns its schema.
     public FileSchema openFirst() throws IOException {
-        InputFile first = inputFiles.get(0);
-        first.open();
-        PreparedFile prepared = openAndReadMetadata(first);
-        referenceSchema = prepared.schema;
-        fileFutures.put(0, CompletableFuture.completedFuture(prepared));
+        PreparedFile prepared = fileMetadataCache.getFileChecked(0);
+        referenceSchema = prepared.schema();
         return referenceSchema;
     }
 
@@ -955,25 +944,22 @@ public class RowGroupIterator {
         return context;
     }
 
-    /// Waits for in-flight prefetches and closes all files.
+    /// Releases iterator-local caches. Standalone iterators also wait for
+    /// in-flight metadata loads and close their input files; iterators owned by
+    /// ParquetFileReader leave those shared resources to the parent.
     public void close() {
-        for (CompletableFuture<PreparedFile> future : fileFutures.values()) {
-            try {
-                future.join();
-            }
-            catch (Exception ignored) {
-            }
-        }
-        fileFutures.clear();
         metadataCache.clear();
         fetchPlanCache.clear();
 
-        for (InputFile file : inputFiles) {
-            try {
-                file.close();
-            }
-            catch (IOException e) {
-                LOG.log(System.Logger.Level.WARNING, "Failed to close file: " + file.name(), e);
+        if (ownsFileMetadataCache) {
+            fileMetadataCache.close();
+            for (InputFile file : inputFiles) {
+                try {
+                    file.close();
+                }
+                catch (IOException e) {
+                    LOG.log(System.Logger.Level.WARNING, "Failed to close file: " + file.name(), e);
+                }
             }
         }
     }
@@ -990,22 +976,26 @@ public class RowGroupIterator {
         boolean allKeptAlwaysMatch = true;
         for (int fileIndex = 0; fileIndex < inputFiles.size() && rowBudget > 0; fileIndex++) {
             PreparedFile prepared = getPreparedFile(fileIndex);
-            FileColumnOrdinals columnOrdinals = prepared.columnOrdinals() != null
-                    ? prepared.columnOrdinals()
-                    : FileColumnOrdinals.identity(referenceSchema.getColumnCount(), filterPredicate);
+            FileColumnOrdinals columnOrdinals = fileIndex == 0
+                    ? FileColumnOrdinals.identity(referenceSchema.getColumnCount(), filterPredicate)
+                    : FileColumnOrdinals.of(
+                            validateSchemaCompatibility(prepared.inputFile(), prepared.schema()),
+                            filterPredicate);
+            List<RowGroup> sourceRowGroups = fileIndex == 0 && firstFileRowGroups != null
+                    ? firstFileRowGroups : prepared.rowGroups();
             // Metadata pruning indexes every row group's chunk list by ordinal, so with
             // it active the cross-check has to cover the whole file before it runs.
             // Without it, the only row groups ever indexed are those that become work
             // items, and the ones physicalSkip / maxRows discard are never looked at.
-            ChunkPathCheck chunkPaths = chunkPathCheck(prepared.schema, columnOrdinals);
+            ChunkPathCheck chunkPaths = chunkPathCheck(prepared.schema(), columnOrdinals);
             boolean pruningIndexesChunks = filterPredicate != null && metadataFilteringEnabled;
             if (pruningIndexesChunks) {
-                for (int rgIndex = 0; rgIndex < prepared.rowGroups.size(); rgIndex++) {
-                    chunkPaths.verify(prepared.rowGroups.get(rgIndex), rgIndex, prepared.inputFile);
+                for (int rgIndex = 0; rgIndex < sourceRowGroups.size(); rgIndex++) {
+                    chunkPaths.verify(sourceRowGroups.get(rgIndex), rgIndex, prepared.inputFile());
                 }
             }
-            List<FilteredRowGroup> rowGroups = filterRowGroups(prepared.rowGroups, prepared.inputFile,
-                    prepared.schema, columnOrdinals);
+            List<FilteredRowGroup> rowGroups = filterRowGroups(
+                    sourceRowGroups, prepared.inputFile(), prepared.schema(), columnOrdinals);
 
             for (int rgIndex = 0; rgIndex < rowGroups.size() && rowBudget > 0; rgIndex++) {
                 FilteredRowGroup decided = rowGroups.get(rgIndex);
@@ -1025,14 +1015,14 @@ public class RowGroupIterator {
                 // Not yet cross-checked when pruning was skipped: filterRowGroups then
                 // returns every row group untouched, so rgIndex is the file's own index.
                 if (!pruningIndexesChunks) {
-                    chunkPaths.verify(rg, rgIndex, prepared.inputFile);
+                    chunkPaths.verify(rg, rgIndex, prepared.inputFile());
                 }
 
                 allKeptAlwaysMatch &= decided.alwaysMatches();
                 workItems.add(new WorkItem(
-                        prepared.inputFile,
+                        prepared.inputFile(),
                         rg,
-                        prepared.schema,
+                        prepared.schema(),
                         columnOrdinals,
                         fileIndex,
                         rgIndex,
@@ -1068,88 +1058,15 @@ public class RowGroupIterator {
         return filterSatisfiedByStatistics;
     }
 
-    /// Gets or loads a prepared file, blocking if necessary.
-    ///
-    /// Unwraps the [CompletionException] that [CompletableFuture#join] would
-    /// otherwise wrap around the load failure, so callers see the original
-    /// exception (e.g. [SchemaIncompatibleException], [UncheckedIOException])
-    /// directly rather than as a `CompletionException` cause.
+    /// Gets or loads file-wide metadata. Projection-specific validation remains
+    /// local to [#buildWorkList].
     private PreparedFile getPreparedFile(int fileIndex) {
-        CompletableFuture<PreparedFile> future = fileFutures.computeIfAbsent(
-                fileIndex, this::loadFileAsync);
-        try {
-            return future.join();
-        }
-        catch (CompletionException e) {
-            Throwable cause = e.getCause();
-            if (cause instanceof RuntimeException re) {
-                throw re;
-            }
-            if (cause instanceof Error err) {
-                throw err;
-            }
-            throw e;
-        }
+        return fileMetadataCache.getFile(fileIndex);
     }
 
     /// Triggers async loading of the file at the given index.
     private void triggerPrefetch(int fileIndex) {
-        if (fileIndex >= 0 && fileIndex < inputFiles.size()) {
-            fileFutures.computeIfAbsent(fileIndex, this::loadFileAsync);
-        }
-    }
-
-    private CompletableFuture<PreparedFile> loadFileAsync(int fileIndex) {
-        return CompletableFuture.supplyAsync(() -> loadFile(fileIndex));
-    }
-
-    private PreparedFile loadFile(int fileIndex) {
-        InputFile inputFile = inputFiles.get(fileIndex);
-        try {
-            inputFile.open();
-        }
-        catch (IOException e) {
-            throw new UncheckedIOException(
-                    ExceptionContext.filePrefix(inputFile.name()) + "Failed to open file", e);
-        }
-
-        PreparedFile prepared = openAndReadMetadata(inputFile);
-
-        // Validate schema compatibility (skip first file — it IS the reference)
-        if (fileIndex == 0) {
-            return prepared;
-        }
-        return prepared.withColumnOrdinals(FileColumnOrdinals.of(
-                validateSchemaCompatibility(inputFile, prepared.schema), filterPredicate));
-    }
-
-    private PreparedFile openAndReadMetadata(InputFile inputFile) {
-        FileOpenedEvent event = new FileOpenedEvent();
-        event.begin();
-
-        try {
-            FileMetaData metaData = ParquetMetadataReader.readMetadata(inputFile);
-            FileSchema schema = FileSchema.fromSchemaElements(metaData.schema());
-
-            event.file = inputFile.name();
-            event.fileSize = inputFile.length();
-            event.rowGroupCount = metaData.rowGroups().size();
-            event.columnCount = schema.getColumnCount();
-            event.commit();
-
-            // Row groups are stored unfiltered; filtering happens in buildWorkList()
-            return new PreparedFile(inputFile, metaData, schema, metaData.rowGroups(), null);
-        }
-        catch (IOException e) {
-            throw new UncheckedIOException(
-                    ExceptionContext.filePrefix(inputFile.name()) + "Failed to read metadata", e);
-        }
-        catch (RuntimeException e) {
-            // RuntimeExceptions thrown during Thrift parsing (e.g. ThriftEnumLookup
-            // for corrupt enum values) escape the IOException catch above — enrich
-            // them with file context so they're attributable.
-            throw ExceptionContext.addFileContext(inputFile.name(), e);
-        }
+        fileMetadataCache.prefetch(fileIndex);
     }
 
     /// Where each column this read touches sits in one file, and the path the chunk

--- a/core/src/main/java/dev/hardwood/internal/reader/RowGroupIterator.java
+++ b/core/src/main/java/dev/hardwood/internal/reader/RowGroupIterator.java
@@ -19,6 +19,7 @@ import java.util.Objects;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicIntegerArray;
+import java.util.function.Consumer;
 
 import dev.hardwood.InputFile;
 import dev.hardwood.internal.ExceptionContext;
@@ -72,9 +73,13 @@ public class RowGroupIterator {
     private static final int MAX_COALESCED_BYTES =
             Integer.getInteger("hardwood.internal.maxCoalescedBytes", 128 * 1024 * 1024);
 
+    private static final Consumer<RowGroupIterator> NO_CLOSE_LISTENER = iterator -> {
+    };
+
     private final List<InputFile> inputFiles;
     private final FileMetadataCache fileMetadataCache;
     private final boolean ownsFileMetadataCache;
+    private final Consumer<RowGroupIterator> closeListener;
     private final HardwoodContextImpl context;
     private final long maxRows;
     private final long physicalSkip;
@@ -197,16 +202,24 @@ public class RowGroupIterator {
     ///        semantics.
     public RowGroupIterator(List<InputFile> inputFiles, HardwoodContextImpl context,
                             long maxRows, long tailSkip, long physicalSkip) {
-        this(new FileMetadataCache(inputFiles), true, context, maxRows, tailSkip, physicalSkip);
+        this(new FileMetadataCache(inputFiles), true, NO_CLOSE_LISTENER, context,
+                maxRows, tailSkip, physicalSkip);
     }
 
     /// Creates a RowGroupIterator sharing file metadata with its parent reader.
-    public RowGroupIterator(FileMetadataCache fileMetadataCache, HardwoodContextImpl context,
+    ///
+    /// `closeListener` is invoked with this iterator once [#close()] has released
+    /// its caches, so the parent can stop tracking an iterator its child reader
+    /// has already torn down.
+    public RowGroupIterator(FileMetadataCache fileMetadataCache,
+                            Consumer<RowGroupIterator> closeListener,
+                            HardwoodContextImpl context,
                             long maxRows, long tailSkip, long physicalSkip) {
-        this(fileMetadataCache, false, context, maxRows, tailSkip, physicalSkip);
+        this(fileMetadataCache, false, closeListener, context, maxRows, tailSkip, physicalSkip);
     }
 
     private RowGroupIterator(FileMetadataCache fileMetadataCache, boolean ownsFileMetadataCache,
+                             Consumer<RowGroupIterator> closeListener,
                              HardwoodContextImpl context, long maxRows, long tailSkip,
                              long physicalSkip) {
         if (tailSkip < 0) {
@@ -222,6 +235,7 @@ public class RowGroupIterator {
         }
         this.fileMetadataCache = fileMetadataCache;
         this.ownsFileMetadataCache = ownsFileMetadataCache;
+        this.closeListener = closeListener;
         this.inputFiles = fileMetadataCache.inputFiles();
         this.context = context;
         this.maxRows = maxRows;
@@ -240,16 +254,19 @@ public class RowGroupIterator {
         return firstRowGroupSkip;
     }
 
-    /// Sets the reference schema and pre-prepared first file, skipping [#openFirst()].
-    /// Used when the file is already open and metadata has been read externally
-    /// (e.g., by [dev.hardwood.reader.ParquetFileReader]).
+    /// Sets the reference schema and this iterator's row-group subset for the
+    /// first file, skipping [#openFirst()]. Used when metadata has been read
+    /// externally (e.g., by [dev.hardwood.reader.ParquetFileReader], which seeds
+    /// the shared [FileMetadataCache] with that same footer).
+    ///
+    /// The row groups stay iterator-local: they are one reader's filtered view,
+    /// not a property of the file, so they never reach the shared cache.
     ///
     /// @param schema the file schema from the first file
     /// @param rowGroups the (already filtered) row groups from the first file
     public void setFirstFile(FileSchema schema, List<RowGroup> rowGroups) {
         this.referenceSchema = schema;
         this.firstFileRowGroups = rowGroups;
-        fileMetadataCache.setFirstFile(schema, rowGroups);
     }
 
     /// Opens the first file and returns its schema.
@@ -946,7 +963,9 @@ public class RowGroupIterator {
 
     /// Releases iterator-local caches. Standalone iterators also wait for
     /// in-flight metadata loads and close their input files; iterators owned by
-    /// ParquetFileReader leave those shared resources to the parent.
+    /// ParquetFileReader leave those shared resources to the parent and instead
+    /// tell it to stop tracking this iterator, so a closed child reader's work
+    /// list does not stay reachable for the parent's whole lifetime.
     public void close() {
         metadataCache.clear();
         fetchPlanCache.clear();
@@ -962,6 +981,8 @@ public class RowGroupIterator {
                 }
             }
         }
+
+        closeListener.accept(this);
     }
 
     // ==================== Internal ====================

--- a/core/src/main/java/dev/hardwood/reader/ColumnReader.java
+++ b/core/src/main/java/dev/hardwood/reader/ColumnReader.java
@@ -8,15 +8,11 @@
 package dev.hardwood.reader;
 
 import java.util.Arrays;
-import java.util.List;
 
 import dev.hardwood.Experimental;
-import dev.hardwood.InputFile;
 import dev.hardwood.Validity;
 import dev.hardwood.internal.ExceptionContext;
-import dev.hardwood.internal.predicate.ResolvedPredicate;
 import dev.hardwood.internal.reader.BatchExchange;
-import dev.hardwood.internal.reader.BatchSizing;
 import dev.hardwood.internal.reader.BinaryBatchValues;
 import dev.hardwood.internal.reader.FlatColumnWorker;
 import dev.hardwood.internal.reader.HardwoodContextImpl;
@@ -26,9 +22,6 @@ import dev.hardwood.internal.reader.NestedColumnWorker;
 import dev.hardwood.internal.reader.NestedLevelComputer;
 import dev.hardwood.internal.reader.PageSource;
 import dev.hardwood.internal.reader.RowGroupIterator;
-import dev.hardwood.internal.schema.ProjectedSchema;
-import dev.hardwood.metadata.RowGroup;
-import dev.hardwood.schema.ColumnProjection;
 import dev.hardwood.schema.ColumnSchema;
 import dev.hardwood.schema.FileSchema;
 
@@ -846,47 +839,6 @@ public class ColumnReader implements AutoCloseable {
     }
 
     // ==================== Factory ====================
-
-    /// Create a ColumnReader for a named column with optional page-level
-    /// filtering. `filter` may be `null`.
-    static ColumnReader create(String columnName, FileSchema schema,
-                               InputFile inputFile, List<RowGroup> rowGroups,
-                               HardwoodContextImpl context, boolean fixedListFastPathEnabled,
-                               ResolvedPredicate filter, int batchSize) {
-        return create(schema.getColumn(columnName), schema, inputFile, rowGroups, context,
-                fixedListFastPathEnabled, filter, batchSize);
-    }
-
-    /// Create a ColumnReader for a column by index with optional page-level
-    /// filtering. `filter` may be `null`.
-    static ColumnReader create(int columnIndex, FileSchema schema,
-                               InputFile inputFile, List<RowGroup> rowGroups,
-                               HardwoodContextImpl context, boolean fixedListFastPathEnabled,
-                               ResolvedPredicate filter, int batchSize) {
-        return create(schema.getColumn(columnIndex), schema, inputFile, rowGroups, context,
-                fixedListFastPathEnabled, filter, batchSize);
-    }
-
-    private static ColumnReader create(ColumnSchema columnSchema, FileSchema schema,
-                                       InputFile inputFile, List<RowGroup> rowGroups,
-                                       HardwoodContextImpl context, boolean fixedListFastPathEnabled,
-                                       ResolvedPredicate filter, int batchSize) {
-        ProjectedSchema projectedSchema = ProjectedSchema.create(schema,
-                ColumnProjection.columns(columnSchema.fieldPath().toString()));
-
-        int resolvedBatchSize = batchSize > 0
-                ? batchSize
-                : BatchSizing.computeOptimalBatchSize(projectedSchema,
-                        BatchSizing.valuesPerRow(projectedSchema, rowGroups));
-
-        RowGroupIterator rowGroupIterator = new RowGroupIterator(
-                List.of(inputFile), context, 0);
-        rowGroupIterator.setFirstFile(schema, rowGroups);
-        rowGroupIterator.initialize(projectedSchema, filter);
-
-        return createFromIterator(columnSchema, schema, rowGroupIterator, context, fixedListFastPathEnabled,
-                0, rowGroupIterator, resolvedBatchSize, NestedColumnWorker.IndexMode.REAL_VIEW);
-    }
 
     /// Creates a ColumnReader from a pre-configured RowGroupIterator.
     /// Used by both single-file and multi-file paths.

--- a/core/src/main/java/dev/hardwood/reader/ParquetFileReader.java
+++ b/core/src/main/java/dev/hardwood/reader/ParquetFileReader.java
@@ -8,10 +8,10 @@
 package dev.hardwood.reader;
 
 import java.io.IOException;
-import java.util.ArrayList;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Set;
+import java.util.concurrent.CopyOnWriteArrayList;
 
 import dev.hardwood.HardwoodContext;
 import dev.hardwood.InputFile;
@@ -58,6 +58,12 @@ import dev.hardwood.schema.FileSchema;
 /// }
 /// ```
 ///
+/// **After close:** the metadata accessors split on whether they can read from
+/// disk. [#getFileMetaData(int)] may have to load a footer, so it throws
+/// [IllegalStateException] once the reader is closed. [#getFileCount()],
+/// [#getFileMetaData()] and [#getFileSchema()] are served from state already in
+/// memory and stay usable.
+///
 /// **Limitation:** When using the default memory-mapped [InputFile], the file
 /// itself may be arbitrarily large, but each individual column chunk must be at
 /// most 2 GB ([Integer#MAX_VALUE] bytes) of compressed data. The in-memory and
@@ -80,7 +86,12 @@ public class ParquetFileReader implements AutoCloseable {
     private final boolean metadataFilteringEnabled;
     private final boolean ownsContext;
     private final boolean ownsInputFiles;
-    private final List<RowGroupIterator> rowGroupIterators = new ArrayList<>();
+    /// Iterators handed to child readers that have not been closed yet. Tracking
+    /// them lets [#close()] tear down an iterator whose child reader the caller
+    /// never closed; each iterator drops itself from here once it is closed, so a
+    /// long-lived reader does not accumulate the work lists of finished children.
+    /// Copy-on-write because a child reader may be closed from another thread.
+    private final List<RowGroupIterator> rowGroupIterators = new CopyOnWriteArrayList<>();
     private boolean closed;
 
     private ParquetFileReader(List<InputFile> inputFiles, FileMetaData firstFileMetaData,
@@ -437,10 +448,9 @@ public class ParquetFileReader implements AutoCloseable {
         // where canFastSkipTail and computeFetchPlans both ran the same
         // page-format check per row group.
         ProjectedSchema projectedSchema = ProjectedSchema.create(schema, projection, true);
-        RowGroupIterator iterator = new RowGroupIterator(fileMetadataCache, context, 0L, 0L, 0L);
+        RowGroupIterator iterator = trackedIterator(0L, 0L, 0L);
         iterator.setFirstFile(schema, subset);
         iterator.initialize(projectedSchema, null);
-        rowGroupIterators.add(iterator);
 
         boolean fastSkip = (skip == 0) || iterator.canFastSkipAllRowGroups();
         if (fastSkip && skip > 0) {
@@ -478,11 +488,9 @@ public class ParquetFileReader implements AutoCloseable {
 
         ProjectedSchema projectedSchema = ProjectedSchema.create(schema, projection, true);
 
-        RowGroupIterator iterator = new RowGroupIterator(
-                fileMetadataCache, context, maxRows, tailSkip, physicalSkip);
+        RowGroupIterator iterator = trackedIterator(maxRows, tailSkip, physicalSkip);
         iterator.setFirstFile(schema, firstFileRowGroups);
         iterator.initialize(projectedSchema, resolved, metadataFilteringEnabled);
-        rowGroupIterators.add(iterator);
 
         // Physical-skip residue: the iterator has seeked to the row group the offset
         // lands in and exposes the leading rows of that group still to be dropped. The
@@ -561,10 +569,9 @@ public class ParquetFileReader implements AutoCloseable {
             ColumnSchema column, List<RowGroup> rowGroups, int batchSize) {
         ProjectedSchema projected = ProjectedSchema.create(schema,
                 ColumnProjection.columns(column.fieldPath().toString()));
-        RowGroupIterator iterator = new RowGroupIterator(fileMetadataCache, context, 0, 0, 0);
+        RowGroupIterator iterator = trackedIterator(0, 0, 0);
         iterator.setFirstFile(schema, rowGroups);
         iterator.initialize(projected, null);
-        rowGroupIterators.add(iterator);
         return ColumnReader.createFromIterator(
                 column, schema, iterator, context, fixedListFastPathEnabled, 0, iterator,
                 resolveBatchSize(batchSize, projected, rowGroups), NestedColumnWorker.IndexMode.REAL_VIEW);
@@ -584,10 +591,9 @@ public class ParquetFileReader implements AutoCloseable {
         List<RowGroup> rowGroups = filterRowGroups(rowGroupFilter);
 
         if (resolved == null) {
-            RowGroupIterator iterator = new RowGroupIterator(fileMetadataCache, context, 0, 0, 0);
+            RowGroupIterator iterator = trackedIterator(0, 0, 0);
             iterator.setFirstFile(schema, rowGroups);
             ProjectedSchema projected = iterator.initialize(projection, null);
-            rowGroupIterators.add(iterator);
             // Every row group pruned (e.g. a byte-range row-group filter dropped
             // them all): nothing to decode.
             if (iterator.getWorkItems().isEmpty()) {
@@ -602,11 +608,10 @@ public class ParquetFileReader implements AutoCloseable {
         // stay row-aligned regardless of per-column page-skip capability), then
         // compact each exposed column to the matching records per batch.
         ColumnProjection augmented = augmentWithPredicateColumns(projection, resolved);
-        RowGroupIterator iterator = new RowGroupIterator(fileMetadataCache, context, 0, 0, 0);
+        RowGroupIterator iterator = trackedIterator(0, 0, 0);
         iterator.setFirstFile(schema, rowGroups);
         ProjectedSchema augProjected = iterator.initialize(augmented, resolved, metadataFilteringEnabled);
         ProjectedSchema payloadProjected = ProjectedSchema.create(schema, projection);
-        rowGroupIterators.add(iterator);
         // Statistics/bloom pruning dropped every row group — no record can match.
         // Skip building the per-column readers (worker threads + ~batch-sized
         // buffers) and the selection engine entirely; expose exhausted no-op
@@ -628,6 +633,20 @@ public class ParquetFileReader implements AutoCloseable {
     /// size derived from the projected column widths scaled by their list fan-out
     /// (from `rowGroups` metadata), the same logic the `RowReader` path uses, so
     /// both regimes agree.
+    /// Iterators still tracked for teardown by [#close()]. Visible for testing.
+    int trackedIteratorCount() {
+        return rowGroupIterators.size();
+    }
+
+    /// Creates an iterator over this reader's files and tracks it until it is
+    /// closed. See [#rowGroupIterators].
+    private RowGroupIterator trackedIterator(long maxRows, long tailSkip, long physicalSkip) {
+        RowGroupIterator iterator = new RowGroupIterator(fileMetadataCache, rowGroupIterators::remove,
+                context, maxRows, tailSkip, physicalSkip);
+        rowGroupIterators.add(iterator);
+        return iterator;
+    }
+
     private static int resolveBatchSize(int requested, ProjectedSchema projected, List<RowGroup> rowGroups) {
         return requested > 0
                 ? requested

--- a/core/src/main/java/dev/hardwood/reader/ParquetFileReader.java
+++ b/core/src/main/java/dev/hardwood/reader/ParquetFileReader.java
@@ -19,8 +19,10 @@ import dev.hardwood.internal.ExceptionContext;
 import dev.hardwood.internal.predicate.FilterPredicateResolver;
 import dev.hardwood.internal.predicate.ResolvedPredicate;
 import dev.hardwood.internal.reader.BatchSizing;
+import dev.hardwood.internal.reader.FileMetadataCache;
 import dev.hardwood.internal.reader.FlatRowReader;
 import dev.hardwood.internal.reader.HardwoodContextImpl;
+import dev.hardwood.internal.reader.NestedColumnWorker;
 import dev.hardwood.internal.reader.NestedRowReader;
 import dev.hardwood.internal.reader.ParquetMetadataReader;
 import dev.hardwood.internal.reader.RowGroupIterator;
@@ -30,6 +32,7 @@ import dev.hardwood.jfr.RowGroupByteRangeFilterEvent;
 import dev.hardwood.metadata.FileMetaData;
 import dev.hardwood.metadata.RowGroup;
 import dev.hardwood.schema.ColumnProjection;
+import dev.hardwood.schema.ColumnSchema;
 import dev.hardwood.schema.FileSchema;
 
 /// Reader for one or more Parquet files.
@@ -69,10 +72,8 @@ public class ParquetFileReader implements AutoCloseable {
     private static final int AUTO_BATCH_SIZE = 0;
 
     private final List<InputFile> inputFiles;
-    /// Metadata of the first file. For single-file readers this is the
-    /// file's metadata; for multi-file readers callers wanting per-file
-    /// metadata must open each file individually.
     private final FileMetaData firstFileMetaData;
+    private final FileMetadataCache fileMetadataCache;
     private final FileSchema schema;
     private final HardwoodContextImpl context;
     private final boolean fixedListFastPathEnabled;
@@ -80,12 +81,14 @@ public class ParquetFileReader implements AutoCloseable {
     private final boolean ownsContext;
     private final boolean ownsInputFiles;
     private final List<RowGroupIterator> rowGroupIterators = new ArrayList<>();
+    private boolean closed;
 
     private ParquetFileReader(List<InputFile> inputFiles, FileMetaData firstFileMetaData,
                               FileSchema schema, HardwoodContextImpl context, boolean fixedListFastPathEnabled,
                               boolean metadataFilteringEnabled, boolean ownsContext, boolean ownsInputFiles) {
         this.inputFiles = inputFiles;
         this.firstFileMetaData = firstFileMetaData;
+        this.fileMetadataCache = new FileMetadataCache(inputFiles, firstFileMetaData, schema);
         this.schema = schema;
         this.context = context;
         this.fixedListFastPathEnabled = fixedListFastPathEnabled;
@@ -241,11 +244,44 @@ public class ParquetFileReader implements AutoCloseable {
         }
     }
 
-    /// File metadata of the first input file. For multi-file readers,
-    /// per-file metadata for files beyond the first is not exposed; open
-    /// those files individually to inspect their metadata.
+    /// File metadata of the first input file.
     public FileMetaData getFileMetaData() {
         return firstFileMetaData;
+    }
+
+    /// Number of physical input files represented by this reader.
+    ///
+    /// This method performs no I/O.
+    public int getFileCount() {
+        return inputFiles.size();
+    }
+
+    /// Returns the metadata of one physical input file.
+    ///
+    /// Files are indexed in the order supplied to [#openAll(List)]. Metadata
+    /// for the first file is read when the reader is opened; metadata for later
+    /// files is read on first access or data-reader prefetch. In-progress,
+    /// successful, and failed loads are cached for this reader's lifetime, and
+    /// this synchronous accessor joins a load already in progress. Close and
+    /// reopen the reader to retry a failed load or inspect a changed file.
+    ///
+    /// This method returns the physical file's footer without performing
+    /// projection- or filter-specific cross-file schema validation. That
+    /// validation occurs when a row or column reader is planned.
+    ///
+    /// Input files must not be modified while this reader is open.
+    ///
+    /// @param fileIndex zero-based physical input file index
+    /// @return metadata parsed from that file's footer
+    /// @throws IndexOutOfBoundsException if `fileIndex` is outside
+    ///         `[0, getFileCount())`
+    /// @throws IllegalStateException if this reader is closed
+    /// @throws IOException if the file cannot be opened or its footer cannot be read
+    public FileMetaData getFileMetaData(int fileIndex) throws IOException {
+        if (closed) {
+            throw new IllegalStateException("ParquetFileReader is closed");
+        }
+        return fileMetadataCache.getFileMetaData(fileIndex);
     }
 
     public FileSchema getFileSchema() {
@@ -401,7 +437,7 @@ public class ParquetFileReader implements AutoCloseable {
         // where canFastSkipTail and computeFetchPlans both ran the same
         // page-format check per row group.
         ProjectedSchema projectedSchema = ProjectedSchema.create(schema, projection, true);
-        RowGroupIterator iterator = new RowGroupIterator(inputFiles, context, 0L, 0L);
+        RowGroupIterator iterator = new RowGroupIterator(fileMetadataCache, context, 0L, 0L, 0L);
         iterator.setFirstFile(schema, subset);
         iterator.initialize(projectedSchema, null);
         rowGroupIterators.add(iterator);
@@ -442,7 +478,8 @@ public class ParquetFileReader implements AutoCloseable {
 
         ProjectedSchema projectedSchema = ProjectedSchema.create(schema, projection, true);
 
-        RowGroupIterator iterator = new RowGroupIterator(inputFiles, context, maxRows, tailSkip, physicalSkip);
+        RowGroupIterator iterator = new RowGroupIterator(
+                fileMetadataCache, context, maxRows, tailSkip, physicalSkip);
         iterator.setFirstFile(schema, firstFileRowGroups);
         iterator.initialize(projectedSchema, resolved, metadataFilteringEnabled);
         rowGroupIterators.add(iterator);
@@ -500,9 +537,8 @@ public class ParquetFileReader implements AutoCloseable {
             return buildColumnReaders(ColumnProjection.columns(columnName), filter, rowGroupFilter, batchSize)
                     .getColumnReader(0);
         }
-        InputFile inputFile = inputFiles.get(0);
         List<RowGroup> rowGroups = filterRowGroups(rowGroupFilter);
-        return ColumnReader.create(columnName, schema, inputFile, rowGroups, context, fixedListFastPathEnabled, null, batchSize);
+        return buildColumnReader(schema.getColumn(columnName), rowGroups, batchSize);
     }
 
     ColumnReader buildColumnReader(int columnIndex, FilterPredicate filter) {
@@ -517,9 +553,21 @@ public class ParquetFileReader implements AutoCloseable {
             return buildColumnReaders(ColumnProjection.columns(columnName), filter, rowGroupFilter, batchSize)
                     .getColumnReader(0);
         }
-        InputFile inputFile = inputFiles.get(0);
         List<RowGroup> rowGroups = filterRowGroups(rowGroupFilter);
-        return ColumnReader.create(columnIndex, schema, inputFile, rowGroups, context, fixedListFastPathEnabled, null, batchSize);
+        return buildColumnReader(schema.getColumn(columnIndex), rowGroups, batchSize);
+    }
+
+    private ColumnReader buildColumnReader(
+            ColumnSchema column, List<RowGroup> rowGroups, int batchSize) {
+        ProjectedSchema projected = ProjectedSchema.create(schema,
+                ColumnProjection.columns(column.fieldPath().toString()));
+        RowGroupIterator iterator = new RowGroupIterator(fileMetadataCache, context, 0, 0, 0);
+        iterator.setFirstFile(schema, rowGroups);
+        iterator.initialize(projected, null);
+        rowGroupIterators.add(iterator);
+        return ColumnReader.createFromIterator(
+                column, schema, iterator, context, fixedListFastPathEnabled, 0, iterator,
+                resolveBatchSize(batchSize, projected, rowGroups), NestedColumnWorker.IndexMode.REAL_VIEW);
     }
 
     ColumnReaders buildColumnReaders(ColumnProjection projection, FilterPredicate filter) {
@@ -536,7 +584,7 @@ public class ParquetFileReader implements AutoCloseable {
         List<RowGroup> rowGroups = filterRowGroups(rowGroupFilter);
 
         if (resolved == null) {
-            RowGroupIterator iterator = new RowGroupIterator(inputFiles, context, 0);
+            RowGroupIterator iterator = new RowGroupIterator(fileMetadataCache, context, 0, 0, 0);
             iterator.setFirstFile(schema, rowGroups);
             ProjectedSchema projected = iterator.initialize(projection, null);
             rowGroupIterators.add(iterator);
@@ -554,7 +602,7 @@ public class ParquetFileReader implements AutoCloseable {
         // stay row-aligned regardless of per-column page-skip capability), then
         // compact each exposed column to the matching records per batch.
         ColumnProjection augmented = augmentWithPredicateColumns(projection, resolved);
-        RowGroupIterator iterator = new RowGroupIterator(inputFiles, context, 0);
+        RowGroupIterator iterator = new RowGroupIterator(fileMetadataCache, context, 0, 0, 0);
         iterator.setFirstFile(schema, rowGroups);
         ProjectedSchema augProjected = iterator.initialize(augmented, resolved, metadataFilteringEnabled);
         ProjectedSchema payloadProjected = ProjectedSchema.create(schema, projection);
@@ -969,10 +1017,13 @@ public class ParquetFileReader implements AutoCloseable {
 
     @Override
     public void close() throws IOException {
+        closed = true;
         for (RowGroupIterator iterator : rowGroupIterators) {
             iterator.close();
         }
         rowGroupIterators.clear();
+
+        fileMetadataCache.close();
 
         if (ownsContext) {
             context.close();

--- a/core/src/test/java/dev/hardwood/EncryptedFileTest.java
+++ b/core/src/test/java/dev/hardwood/EncryptedFileTest.java
@@ -10,9 +10,11 @@ package dev.hardwood;
 import java.io.IOException;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.util.List;
 
 import org.junit.jupiter.api.Test;
 
+import dev.hardwood.internal.EncryptedParquetException;
 import dev.hardwood.reader.ParquetFileReader;
 
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -42,5 +44,19 @@ class EncryptedFileTest {
                 .isInstanceOf(IOException.class)
                 .hasMessageContaining("encrypted_plaintext_footer.parquet")
                 .hasMessageContaining("Encrypted Parquet files are not supported");
+    }
+
+    @Test
+    void encryptedLaterFilePreservesSpecificCheckedException() throws Exception {
+        Path first = Paths.get("src/test/resources/plain_uncompressed.parquet");
+        Path encrypted = Paths.get("src/test/resources/encrypted_footer.parquet");
+
+        try (ParquetFileReader reader = ParquetFileReader.openAll(
+                List.of(InputFile.of(first), InputFile.of(encrypted)))) {
+            assertThatThrownBy(() -> reader.getFileMetaData(1))
+                    .isInstanceOf(EncryptedParquetException.class)
+                    .hasMessageContaining("encrypted_footer.parquet")
+                    .hasMessageContaining("Encrypted Parquet files are not supported");
+        }
     }
 }

--- a/core/src/test/java/dev/hardwood/MultiFileRowReaderTest.java
+++ b/core/src/test/java/dev/hardwood/MultiFileRowReaderTest.java
@@ -7,6 +7,9 @@
  */
 package dev.hardwood;
 
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.nio.ByteBuffer;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.ArrayList;
@@ -14,6 +17,9 @@ import java.util.List;
 
 import org.junit.jupiter.api.Test;
 
+import dev.hardwood.internal.reader.CountingInputFile;
+import dev.hardwood.metadata.FileMetaData;
+import dev.hardwood.reader.ColumnReaders;
 import dev.hardwood.reader.ParquetFileReader;
 import dev.hardwood.reader.RowReader;
 import dev.hardwood.row.PqStruct;
@@ -24,6 +30,191 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 /// Tests for MultiFileRowReader and cross-file prefetching.
 class MultiFileRowReaderTest {
+
+    @Test
+    void exposesPerFileMetadataLazily() throws Exception {
+        CountingInputFile file0 = new CountingInputFile(InputFile.of(
+                Paths.get("src/test/resources/multi_file_part0.parquet")));
+        CountingInputFile file1 = new CountingInputFile(InputFile.of(
+                Paths.get("src/test/resources/multi_file_part1.parquet")));
+        CountingInputFile file2 = new CountingInputFile(InputFile.of(
+                Paths.get("src/test/resources/multi_file_part1.parquet")));
+
+        try (ParquetFileReader reader = ParquetFileReader.openAll(List.of(file0, file1, file2))) {
+            int file0FooterReadsAfterOpen = file0.footerReadCount();
+
+            assertThat(reader.getFileCount()).isEqualTo(3);
+            assertThat(file0.footerReadCount()).isEqualTo(file0FooterReadsAfterOpen);
+            assertThat(file1.footerReadCount()).isZero();
+            assertThat(file2.footerReadCount()).isZero();
+
+            assertThat(reader.getFileMetaData(0)).isSameAs(reader.getFileMetaData());
+            assertThat(file0.footerReadCount()).isEqualTo(file0FooterReadsAfterOpen);
+
+            FileMetaData file1MetaData = reader.getFileMetaData(1);
+            assertThat(file1MetaData.numRows()).isEqualTo(100);
+            int file1FooterReadsAfterAccess = file1.footerReadCount();
+            assertThat(file1FooterReadsAfterAccess).isPositive();
+            assertThat(file2.footerReadCount()).isZero();
+
+            assertThat(reader.getFileMetaData(1)).isSameAs(file1MetaData);
+            assertThat(file1.footerReadCount()).isEqualTo(file1FooterReadsAfterAccess);
+            assertThat(reader.getFileMetaData(0).numRows()
+                    + file1MetaData.numRows()
+                    + reader.getFileMetaData(2).numRows()).isEqualTo(350);
+            assertThat(file2.footerReadCount()).isPositive();
+
+            assertThatThrownBy(() -> reader.getFileMetaData(-1))
+                    .isInstanceOf(IndexOutOfBoundsException.class);
+            assertThatThrownBy(() -> reader.getFileMetaData(3))
+                    .isInstanceOf(IndexOutOfBoundsException.class);
+        }
+    }
+
+    @Test
+    void dataReadersReusePerFileMetadata() throws Exception {
+        CountingInputFile file0 = new CountingInputFile(InputFile.of(
+                Paths.get("src/test/resources/multi_file_part0.parquet")));
+        CountingInputFile file1 = new CountingInputFile(InputFile.of(
+                Paths.get("src/test/resources/multi_file_part1.parquet")));
+
+        try (ParquetFileReader reader = ParquetFileReader.openAll(List.of(file0, file1))) {
+            reader.getFileMetaData(1);
+            int file1FooterReads = file1.footerReadCount();
+
+            try (RowReader rows = reader.rowReader()) {
+                while (rows.hasNext()) {
+                    rows.next();
+                }
+            }
+            assertThat(file1.footerReadCount()).isEqualTo(file1FooterReads);
+
+            try (ColumnReaders columns = reader.columnReaders(ColumnProjection.columns("id"))) {
+                while (columns.nextBatch()) {
+                    // Consume all batches so reuse is checked across the file boundary.
+                }
+            }
+            assertThat(file1.footerReadCount()).isEqualTo(file1FooterReads);
+        }
+    }
+
+    @Test
+    void rowReaderMetadataLoadIsReusedByIndexedAccess() throws Exception {
+        CountingInputFile file0 = new CountingInputFile(InputFile.of(
+                Paths.get("src/test/resources/multi_file_part0.parquet")));
+        CountingInputFile file1 = new CountingInputFile(InputFile.of(
+                Paths.get("src/test/resources/multi_file_part1.parquet")));
+
+        try (ParquetFileReader reader = ParquetFileReader.openAll(List.of(file0, file1))) {
+            try (RowReader rows = reader.rowReader()) {
+                while (rows.hasNext()) {
+                    rows.next();
+                }
+            }
+            int file1FooterReads = file1.footerReadCount();
+            assertThat(file1FooterReads).isPositive();
+
+            assertThat(reader.getFileMetaData(1).numRows()).isEqualTo(100);
+            assertThat(file1.footerReadCount()).isEqualTo(file1FooterReads);
+        }
+    }
+
+    @Test
+    void columnReaderMetadataLoadIsReusedByIndexedAccess() throws Exception {
+        CountingInputFile file0 = new CountingInputFile(InputFile.of(
+                Paths.get("src/test/resources/multi_file_part0.parquet")));
+        CountingInputFile file1 = new CountingInputFile(InputFile.of(
+                Paths.get("src/test/resources/multi_file_part1.parquet")));
+
+        try (ParquetFileReader reader = ParquetFileReader.openAll(List.of(file0, file1))) {
+            try (ColumnReaders columns = reader.columnReaders(ColumnProjection.columns("id"))) {
+                while (columns.nextBatch()) {
+                    // Consume all batches so the second file is read.
+                }
+            }
+            int file1FooterReads = file1.footerReadCount();
+            assertThat(file1FooterReads).isPositive();
+
+            assertThat(reader.getFileMetaData(1).numRows()).isEqualTo(100);
+            assertThat(file1.footerReadCount()).isEqualTo(file1FooterReads);
+        }
+    }
+
+    @Test
+    void childReadersLeaveInputLifecycleToParent() throws Exception {
+        CountingInputFile file0 = new CountingInputFile(InputFile.of(
+                Paths.get("src/test/resources/multi_file_part0.parquet")));
+        CountingInputFile file1 = new CountingInputFile(InputFile.of(
+                Paths.get("src/test/resources/multi_file_part1.parquet")));
+        ParquetFileReader reader = ParquetFileReader.openAll(List.of(file0, file1));
+
+        try {
+            try (RowReader rows = reader.rowReader()) {
+                assertThat(rows.hasNext()).isTrue();
+                rows.next();
+            }
+            assertThat(file0.closeCount()).isZero();
+            assertThat(file1.closeCount()).isZero();
+
+            try (ColumnReaders columns = reader.columnReaders(ColumnProjection.columns("id"))) {
+                while (columns.nextBatch()) {
+                    // Consume all batches before closing the child reader.
+                }
+            }
+            assertThat(file0.closeCount()).isZero();
+            assertThat(file1.closeCount()).isZero();
+        }
+        finally {
+            reader.close();
+        }
+
+        assertThat(file0.closeCount()).isEqualTo(1);
+        assertThat(file1.closeCount()).isEqualTo(1);
+    }
+
+    @Test
+    void failedMetadataIsSharedWithDataReaderAndRetriedAfterReopen() throws Exception {
+        CountingInputFile valid = new CountingInputFile(InputFile.of(
+                Paths.get("src/test/resources/multi_file_part0.parquet")));
+        CountingInputFile invalid = new CountingInputFile(ByteBuffer.allocate(12));
+
+        try (ParquetFileReader reader = ParquetFileReader.openAll(List.of(valid, invalid))) {
+            assertThatThrownBy(() -> reader.getFileMetaData(1))
+                    .isInstanceOf(IOException.class)
+                    .hasMessageContaining("Not a Parquet file");
+            int readsAfterFailure = invalid.footerReadCount();
+
+            assertThatThrownBy(reader::rowReader)
+                    .isInstanceOf(UncheckedIOException.class)
+                    .hasMessageContaining("Failed to read metadata");
+            assertThat(invalid.footerReadCount()).isEqualTo(readsAfterFailure);
+        }
+
+        int readsBeforeReopen = invalid.footerReadCount();
+        try (ParquetFileReader reader = ParquetFileReader.openAll(List.of(valid, invalid))) {
+            assertThatThrownBy(() -> reader.getFileMetaData(1))
+                    .isInstanceOf(IOException.class)
+                    .hasMessageContaining("Not a Parquet file");
+        }
+        assertThat(invalid.footerReadCount()).isGreaterThan(readsBeforeReopen);
+    }
+
+    @Test
+    void rejectsIndexedMetadataAccessAfterClose() throws Exception {
+        CountingInputFile file0 = new CountingInputFile(InputFile.of(
+                Paths.get("src/test/resources/multi_file_part0.parquet")));
+        CountingInputFile file1 = new CountingInputFile(InputFile.of(
+                Paths.get("src/test/resources/multi_file_part1.parquet")));
+        ParquetFileReader reader = ParquetFileReader.openAll(List.of(file0, file1));
+
+        reader.close();
+
+        assertThat(reader.getFileCount()).isEqualTo(2);
+        assertThatThrownBy(() -> reader.getFileMetaData(0))
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessage("ParquetFileReader is closed");
+        assertThat(file1.footerReadCount()).isZero();
+    }
 
     @Test
     void testReadSingleFile() throws Exception {

--- a/core/src/test/java/dev/hardwood/RowReaderCloseIdempotencyTest.java
+++ b/core/src/test/java/dev/hardwood/RowReaderCloseIdempotencyTest.java
@@ -26,7 +26,8 @@ import static org.assertj.core.api.Assertions.assertThatCode;
 ///
 /// The decode-pipeline rework in v1.0.0.Beta2 turned `close()` from a single
 /// boolean write into a per-column worker quiesce (virtual-thread joins,
-/// in-flight decode draining) plus, on the column path, an [InputFile] close.
+/// in-flight decode draining) plus, on the column path, iterator-local cache
+/// teardown.
 /// Without an idempotency guard every redundant `close()` re-ran that work
 /// (issue #659).
 class RowReaderCloseIdempotencyTest {
@@ -69,25 +70,34 @@ class RowReaderCloseIdempotencyTest {
     }
 
     @Test
-    void columnReaderClosesUnderlyingFileExactlyOnce() throws Exception {
+    void columnReaderLeavesInputLifecycleToParent() throws Exception {
         CountingInputFile file = new CountingInputFile(
                 InputFile.of(Paths.get("src/test/resources/page_index_test.parquet")));
 
         ParquetFileReader fileReader = ParquetFileReader.open(file);
-        ColumnReader columnReader = fileReader.columnReader(0);
-        while (columnReader.nextBatch()) {
-            // drain
-        }
+        try {
+            ColumnReader columnReader = fileReader.columnReader(0);
+            for (int i = 0; i < 5; i++) {
+                columnReader.close();
+            }
 
-        for (int i = 0; i < 5; i++) {
-            columnReader.close();
+            assertThat(file.closeCount.get())
+                    .as("ColumnReader.close() must leave the parent-owned input open")
+                    .isZero();
+
+            try (RowReader rowReader = fileReader.rowReader()) {
+                assertThat(rowReader.hasNext()).isTrue();
+                rowReader.next();
+            }
+            assertThat(file.closeCount.get()).isZero();
+        }
+        finally {
+            fileReader.close();
         }
 
         assertThat(file.closeCount.get())
-                .as("redundant ColumnReader.close() must not re-close the input file")
+                .as("ParquetFileReader.close() must close its input exactly once")
                 .isEqualTo(1);
-
-        fileReader.close();
     }
 
     @Test

--- a/core/src/test/java/dev/hardwood/RowReaderCloseIdempotencyTest.java
+++ b/core/src/test/java/dev/hardwood/RowReaderCloseIdempotencyTest.java
@@ -7,13 +7,11 @@
  */
 package dev.hardwood;
 
-import java.io.IOException;
-import java.nio.ByteBuffer;
 import java.nio.file.Paths;
-import java.util.concurrent.atomic.AtomicInteger;
 
 import org.junit.jupiter.api.Test;
 
+import dev.hardwood.internal.reader.CountingInputFile;
 import dev.hardwood.reader.ColumnReader;
 import dev.hardwood.reader.ParquetFileReader;
 import dev.hardwood.reader.RowReader;
@@ -32,43 +30,6 @@ import static org.assertj.core.api.Assertions.assertThatCode;
 /// (issue #659).
 class RowReaderCloseIdempotencyTest {
 
-    /// Counts how often the wrapped [InputFile] is closed.
-    private static final class CountingInputFile implements InputFile {
-
-        private final InputFile delegate;
-        private final AtomicInteger closeCount = new AtomicInteger();
-
-        CountingInputFile(InputFile delegate) {
-            this.delegate = delegate;
-        }
-
-        @Override
-        public void open() throws IOException {
-            delegate.open();
-        }
-
-        @Override
-        public ByteBuffer readRange(long offset, int length) throws IOException {
-            return delegate.readRange(offset, length);
-        }
-
-        @Override
-        public long length() throws IOException {
-            return delegate.length();
-        }
-
-        @Override
-        public String name() {
-            return delegate.name();
-        }
-
-        @Override
-        public void close() throws IOException {
-            closeCount.incrementAndGet();
-            delegate.close();
-        }
-    }
-
     @Test
     void columnReaderLeavesInputLifecycleToParent() throws Exception {
         CountingInputFile file = new CountingInputFile(
@@ -77,11 +38,18 @@ class RowReaderCloseIdempotencyTest {
         ParquetFileReader fileReader = ParquetFileReader.open(file);
         try {
             ColumnReader columnReader = fileReader.columnReader(0);
-            for (int i = 0; i < 5; i++) {
-                columnReader.close();
+            // Drain first: the teardown #659 is about — quiescing started
+            // per-column workers — only exists once decoding has run.
+            while (columnReader.nextBatch()) {
+                // drain
             }
+            assertThatCode(() -> {
+                for (int i = 0; i < 5; i++) {
+                    columnReader.close();
+                }
+            }).doesNotThrowAnyException();
 
-            assertThat(file.closeCount.get())
+            assertThat(file.closeCount())
                     .as("ColumnReader.close() must leave the parent-owned input open")
                     .isZero();
 
@@ -89,13 +57,13 @@ class RowReaderCloseIdempotencyTest {
                 assertThat(rowReader.hasNext()).isTrue();
                 rowReader.next();
             }
-            assertThat(file.closeCount.get()).isZero();
+            assertThat(file.closeCount()).isZero();
         }
         finally {
             fileReader.close();
         }
 
-        assertThat(file.closeCount.get())
+        assertThat(file.closeCount())
                 .as("ParquetFileReader.close() must close its input exactly once")
                 .isEqualTo(1);
     }

--- a/core/src/test/java/dev/hardwood/SchemaCompatibilityTest.java
+++ b/core/src/test/java/dev/hardwood/SchemaCompatibilityTest.java
@@ -24,6 +24,19 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 class SchemaCompatibilityTest {
 
     @Test
+    void metadataAccessDoesNotValidateSchemaCompatibility() throws Exception {
+        Path micros = Paths.get("src/test/resources/compat_ts_micros.parquet");
+        Path millis = Paths.get("src/test/resources/compat_ts_millis.parquet");
+
+        try (Hardwood hardwood = Hardwood.create();
+             ParquetFileReader parquet = hardwood.openAll(InputFile.ofPaths(micros, millis))) {
+            assertThat(parquet.getFileMetaData(1).numRows()).isEqualTo(2);
+            assertThatThrownBy(parquet::rowReader)
+                    .isInstanceOf(SchemaIncompatibleException.class);
+        }
+    }
+
+    @Test
     void rejectTimestampUnitMismatch() {
         Path micros = Paths.get("src/test/resources/compat_ts_micros.parquet");
         Path millis = Paths.get("src/test/resources/compat_ts_millis.parquet");

--- a/core/src/test/java/dev/hardwood/internal/reader/CountingInputFile.java
+++ b/core/src/test/java/dev/hardwood/internal/reader/CountingInputFile.java
@@ -13,6 +13,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
 
 import dev.hardwood.InputFile;
+import dev.hardwood.internal.FetchReason;
 
 /// An [InputFile] wrapper that delegates to another `InputFile` and counts both the number of
 /// [#readRange] calls and the total bytes read. Useful in tests that need to assert on I/O patterns
@@ -20,7 +21,9 @@ import dev.hardwood.InputFile;
 public class CountingInputFile implements InputFile {
 
     private final InputFile delegate;
+    private final AtomicInteger closeCount = new AtomicInteger();
     private final AtomicInteger readRangeCount = new AtomicInteger();
+    private final AtomicInteger footerReadCount = new AtomicInteger();
     private final AtomicLong bytesRead = new AtomicLong();
 
     public CountingInputFile(InputFile delegate) {
@@ -40,6 +43,14 @@ public class CountingInputFile implements InputFile {
         return bytesRead.get();
     }
 
+    public int closeCount() {
+        return closeCount.get();
+    }
+
+    public int footerReadCount() {
+        return footerReadCount.get();
+    }
+
     @Override
     public void open() throws IOException {
         delegate.open();
@@ -48,6 +59,9 @@ public class CountingInputFile implements InputFile {
     @Override
     public ByteBuffer readRange(long offset, int length) throws IOException {
         readRangeCount.incrementAndGet();
+        if (FetchReason.current().startsWith("footer-")) {
+            footerReadCount.incrementAndGet();
+        }
         bytesRead.addAndGet(length);
         return delegate.readRange(offset, length);
     }
@@ -64,6 +78,7 @@ public class CountingInputFile implements InputFile {
 
     @Override
     public void close() throws IOException {
+        closeCount.incrementAndGet();
         delegate.close();
     }
 }

--- a/core/src/test/java/dev/hardwood/internal/reader/FileMetadataCacheTest.java
+++ b/core/src/test/java/dev/hardwood/internal/reader/FileMetadataCacheTest.java
@@ -1,0 +1,222 @@
+/*
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Copyright The original authors
+ *
+ *  Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package dev.hardwood.internal.reader;
+
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.nio.file.Paths;
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+
+import dev.hardwood.InputFile;
+import dev.hardwood.internal.FetchReason;
+import dev.hardwood.internal.reader.FileMetadataCache.PreparedFile;
+import dev.hardwood.metadata.FileMetaData;
+import dev.hardwood.reader.ParquetFileReader;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class FileMetadataCacheTest {
+
+    private static final long WAIT_SECONDS = 5;
+    private static final String FIRST_FILE = "src/test/resources/multi_file_part0.parquet";
+    private static final String LATER_FILE = "src/test/resources/multi_file_part1.parquet";
+
+    @Test
+    @Timeout(value = 30, unit = TimeUnit.SECONDS)
+    void concurrentCheckedAndDataLookupsJoinOneInProgressLoad() throws Exception {
+        LatchInputFile inputFile = LatchInputFile.blocked(LATER_FILE);
+        FileMetadataCache cache = new FileMetadataCache(List.of(inputFile));
+
+        try (ExecutorService executor = Executors.newVirtualThreadPerTaskExecutor()) {
+            Future<FileMetaData> firstChecked = executor.submit(() -> cache.getFileMetaData(0));
+            assertThat(inputFile.awaitFooterRead()).isTrue();
+
+            CountDownLatch callersReady = new CountDownLatch(2);
+            CountDownLatch callTogether = new CountDownLatch(1);
+            Future<FileMetaData> secondChecked = executor.submit(() -> {
+                callersReady.countDown();
+                callTogether.await();
+                return cache.getFileMetaData(0);
+            });
+            Future<PreparedFile> dataPath = executor.submit(() -> {
+                callersReady.countDown();
+                callTogether.await();
+                return cache.getFile(0);
+            });
+            assertThat(callersReady.await(WAIT_SECONDS, TimeUnit.SECONDS)).isTrue();
+            callTogether.countDown();
+
+            assertThat(secondChecked.isDone()).isFalse();
+            assertThat(dataPath.isDone()).isFalse();
+            inputFile.releaseFooterRead();
+
+            FileMetaData metadata = firstChecked.get(WAIT_SECONDS, TimeUnit.SECONDS);
+            assertThat(secondChecked.get(WAIT_SECONDS, TimeUnit.SECONDS)).isSameAs(metadata);
+            assertThat(dataPath.get(WAIT_SECONDS, TimeUnit.SECONDS).metaData()).isSameAs(metadata);
+            assertThat(inputFile.openCount()).isEqualTo(1);
+        }
+        finally {
+            inputFile.releaseFooterRead();
+            cache.close();
+            assertThat(inputFile.closeCount()).isZero();
+            inputFile.close();
+        }
+    }
+
+    @Test
+    void closePreventsLaterLoadsWithoutClosingInputs() throws Exception {
+        LatchInputFile inputFile = LatchInputFile.unblocked(LATER_FILE);
+        FileMetadataCache cache = new FileMetadataCache(List.of(inputFile));
+
+        cache.close();
+        cache.prefetch(0);
+
+        assertThat(inputFile.openCount()).isZero();
+        assertThat(inputFile.closeCount()).isZero();
+        assertThatThrownBy(() -> cache.getFileChecked(0))
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessage("FileMetadataCache is closed");
+
+        cache.close();
+        assertThat(inputFile.closeCount()).isZero();
+        inputFile.close();
+    }
+
+    @Test
+    @Timeout(value = 30, unit = TimeUnit.SECONDS)
+    void parentCloseWaitsForRegisteredLoadBeforeClosingInputs() throws Exception {
+        CountingInputFile first = new CountingInputFile(InputFile.of(Paths.get(FIRST_FILE)));
+        LatchInputFile later = LatchInputFile.blocked(LATER_FILE);
+        ParquetFileReader reader = ParquetFileReader.openAll(List.of(first, later));
+        Future<Void> closeFuture = null;
+
+        try (ExecutorService executor = Executors.newVirtualThreadPerTaskExecutor()) {
+            Future<FileMetaData> metadata = executor.submit(() -> reader.getFileMetaData(1));
+            assertThat(later.awaitFooterRead()).isTrue();
+
+            CountDownLatch closeInvoked = new CountDownLatch(1);
+            closeFuture = executor.submit(() -> {
+                closeInvoked.countDown();
+                reader.close();
+                return null;
+            });
+            assertThat(closeInvoked.await(WAIT_SECONDS, TimeUnit.SECONDS)).isTrue();
+            Future<Void> registeredClose = closeFuture;
+            assertThatThrownBy(() -> registeredClose.get(250, TimeUnit.MILLISECONDS))
+                    .isInstanceOf(TimeoutException.class);
+            assertThat(first.closeCount()).isZero();
+            assertThat(later.closeCount()).isZero();
+
+            later.releaseFooterRead();
+            assertThat(metadata.get(WAIT_SECONDS, TimeUnit.SECONDS).numRows()).isEqualTo(100);
+            closeFuture.get(WAIT_SECONDS, TimeUnit.SECONDS);
+        }
+        finally {
+            later.releaseFooterRead();
+            if (closeFuture == null) {
+                reader.close();
+            }
+            else {
+                closeFuture.get(WAIT_SECONDS, TimeUnit.SECONDS);
+            }
+        }
+
+        assertThat(first.closeCount()).isEqualTo(1);
+        assertThat(later.closeCount()).isEqualTo(1);
+    }
+
+    private static final class LatchInputFile implements InputFile {
+
+        private final InputFile delegate;
+        private final CountDownLatch footerReadStarted = new CountDownLatch(1);
+        private final CountDownLatch releaseFooterRead;
+        private final AtomicBoolean firstFooterRead = new AtomicBoolean(true);
+        private final AtomicInteger openCount = new AtomicInteger();
+        private final AtomicInteger closeCount = new AtomicInteger();
+
+        private LatchInputFile(String path, boolean blocked) {
+            this.delegate = InputFile.of(Paths.get(path));
+            this.releaseFooterRead = new CountDownLatch(blocked ? 1 : 0);
+        }
+
+        static LatchInputFile blocked(String path) {
+            return new LatchInputFile(path, true);
+        }
+
+        static LatchInputFile unblocked(String path) {
+            return new LatchInputFile(path, false);
+        }
+
+        boolean awaitFooterRead() throws InterruptedException {
+            return footerReadStarted.await(WAIT_SECONDS, TimeUnit.SECONDS);
+        }
+
+        void releaseFooterRead() {
+            releaseFooterRead.countDown();
+        }
+
+        int openCount() {
+            return openCount.get();
+        }
+
+        int closeCount() {
+            return closeCount.get();
+        }
+
+        @Override
+        public void open() throws IOException {
+            openCount.incrementAndGet();
+            delegate.open();
+        }
+
+        @Override
+        public ByteBuffer readRange(long offset, int length) throws IOException {
+            if (FetchReason.current().startsWith("footer-") && firstFooterRead.compareAndSet(true, false)) {
+                footerReadStarted.countDown();
+                try {
+                    if (!releaseFooterRead.await(WAIT_SECONDS, TimeUnit.SECONDS)) {
+                        throw new IOException("Timed out waiting to release footer read");
+                    }
+                }
+                catch (InterruptedException e) {
+                    Thread.currentThread().interrupt();
+                    throw new IOException("Interrupted while waiting to release footer read", e);
+                }
+            }
+            return delegate.readRange(offset, length);
+        }
+
+        @Override
+        public long length() throws IOException {
+            return delegate.length();
+        }
+
+        @Override
+        public String name() {
+            return delegate.name();
+        }
+
+        @Override
+        public void close() throws IOException {
+            closeCount.incrementAndGet();
+            delegate.close();
+        }
+    }
+}

--- a/core/src/test/java/dev/hardwood/reader/IteratorTrackingTest.java
+++ b/core/src/test/java/dev/hardwood/reader/IteratorTrackingTest.java
@@ -1,0 +1,87 @@
+/*
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Copyright The original authors
+ *
+ *  Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package dev.hardwood.reader;
+
+import java.nio.file.Paths;
+
+import org.junit.jupiter.api.Test;
+
+import dev.hardwood.InputFile;
+import dev.hardwood.internal.reader.CountingInputFile;
+import dev.hardwood.schema.ColumnProjection;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/// A [ParquetFileReader] tracks the [dev.hardwood.internal.reader.RowGroupIterator]s
+/// it hands to child readers so that [ParquetFileReader#close()] can tear down an
+/// iterator whose child reader the caller never closed.
+///
+/// Where a child exclusively owns its iterator — the single-column
+/// [ParquetFileReader#columnReader(int)] path — that tracking must not outlive the
+/// child, or a reader used for many sequential column reads retains every finished
+/// child's work list until it is itself closed.
+class IteratorTrackingTest {
+
+    private static final String FILE = "src/test/resources/page_index_test.parquet";
+
+    @Test
+    void closingAChildReaderStopsTrackingItsIterator() throws Exception {
+        try (ParquetFileReader reader = ParquetFileReader.open(InputFile.of(Paths.get(FILE)))) {
+            assertThat(reader.trackedIteratorCount()).isZero();
+
+            for (int i = 0; i < 4; i++) {
+                ColumnReader columnReader = reader.columnReader(0);
+                assertThat(reader.trackedIteratorCount())
+                        .as("an open child reader's iterator is tracked")
+                        .isEqualTo(1);
+                while (columnReader.nextBatch()) {
+                    // drain
+                }
+                columnReader.close();
+                assertThat(reader.trackedIteratorCount())
+                        .as("iteration %d must not leave its iterator behind", i)
+                        .isZero();
+            }
+
+            // The row-reader and multi-column paths share one iterator across
+            // sibling readers, so no individual child owns it and closing them
+            // leaves it tracked until the parent closes. Only the single-column
+            // path hands out an iterator its reader exclusively owns.
+            try (RowReader rows = reader.rowReader()) {
+                while (rows.hasNext()) {
+                    rows.next();
+                }
+            }
+            try (ColumnReaders columns = reader.columnReaders(ColumnProjection.columns("id"))) {
+                while (columns.nextBatch()) {
+                    // drain
+                }
+            }
+            assertThat(reader.trackedIteratorCount()).isEqualTo(2);
+        }
+    }
+
+    @Test
+    void parentCloseStillTearsDownAnUnclosedChildsIterator() throws Exception {
+        CountingInputFile file = new CountingInputFile(InputFile.of(Paths.get(FILE)));
+        ParquetFileReader reader = ParquetFileReader.open(file);
+
+        ColumnReader leaked = reader.columnReader(0);
+        assertThat(leaked.nextBatch()).isTrue();
+        assertThat(reader.trackedIteratorCount())
+                .as("the never-closed child is still tracked")
+                .isEqualTo(1);
+
+        reader.close();
+
+        assertThat(reader.trackedIteratorCount()).isZero();
+        assertThat(file.closeCount())
+                .as("the parent still owns and closes the input")
+                .isEqualTo(1);
+    }
+}

--- a/docs/content/concepts/compatibility-philosophy.md
+++ b/docs/content/concepts/compatibility-philosophy.md
@@ -68,12 +68,13 @@ point — the reader can see in the code which rows the filter admits.
 
 ### Schema validation across multiple files
 
-When a reader spans multiple files, the first file's schema is the reference, and every
-subsequent file is validated against it *as it is opened*: each column the read touches — the
-projected ones plus any a filter tests — must exist with a matching physical type, logical type,
-repetition type, fixed byte length, and enclosing groups of the same nullability and
-repeatedness, or a `SchemaIncompatibleException` is thrown up front. A silently mismatched
-column that produced garbage values mid-stream would be the worse outcome.
+When a data reader spans multiple files, the first file's schema is the reference, and each
+subsequent file reached by the data-reader plan is validated against it: every column the read
+touches — the projected ones plus any a filter tests — must exist with a matching physical type,
+logical type, repetition type, fixed byte length, and enclosing groups of the same nullability and
+repeatedness, or a `SchemaIncompatibleException` is thrown up front. Metadata inspection alone
+does not perform this projection-specific validation. A silently mismatched column that produced
+garbage values mid-stream would be the worse outcome.
 
 The match is by field path, never by position. A Parquet footer lists column chunks in the order
 of the schema's flattened leaves, so a column's ordinal belongs to the file that was written, not

--- a/docs/content/concepts/compatibility-philosophy.md
+++ b/docs/content/concepts/compatibility-philosophy.md
@@ -72,9 +72,11 @@ When a data reader spans multiple files, the first file's schema is the referenc
 subsequent file reached by the data-reader plan is validated against it: every column the read
 touches — the projected ones plus any a filter tests — must exist with a matching physical type,
 logical type, repetition type, fixed byte length, and enclosing groups of the same nullability and
-repeatedness, or a `SchemaIncompatibleException` is thrown up front. Metadata inspection alone
-does not perform this projection-specific validation. A silently mismatched column that produced
-garbage values mid-stream would be the worse outcome.
+repeatedness, or a `SchemaIncompatibleException` is thrown up front, rather than surfacing as
+garbage values halfway through a scan.
+
+Which columns a read touches is known only once a reader is planned, so that is when the check
+runs. Inspecting a file's metadata reports the footer as it is on disk and does not run it.
 
 The match is by field path, never by position. A Parquet footer lists column chunks in the order
 of the schema's flattened leaves, so a column's ordinal belongs to the file that was written, not

--- a/docs/content/how-to/metadata.md
+++ b/docs/content/how-to/metadata.md
@@ -89,6 +89,31 @@ try (ParquetFileReader reader = ParquetFileReader.open(InputFile.of(path))) {
 }
 ```
 
+## Metadata for multiple files
+
+For a multi-file reader, use `getFileCount()` and `getFileMetaData(int)` to inspect each
+physical input file in order. The first file's footer is read when the reader is opened.
+Later footers are read when indexed metadata access or data-reader prefetch first needs them.
+In-progress, successful, and failed loads are cached for the lifetime of the parent reader, so
+metadata, row, and column access all reuse the same parsed footer.
+
+```java
+try (Hardwood hardwood = Hardwood.create();
+     ParquetFileReader reader = hardwood.openAll(files)) {
+    long totalRows = 0;
+    for (int fileIndex = 0; fileIndex < reader.getFileCount(); fileIndex++) {
+        totalRows = Math.addExact(
+            totalRows,
+            reader.getFileMetaData(fileIndex).numRows());
+    }
+}
+```
+
+Indexed metadata access reports the physical file's footer; it does not validate that file against
+the first file for a particular projection or filter. Cross-file schema validation happens when a
+row or column reader is planned. Keep every input file unchanged until the parent reader is closed.
+Close and reopen the parent reader to retry a failed footer load or inspect a changed file.
+
 ## Size statistics and level histograms
 
 `ColumnMetaData.sizeStatistics()` reports how much data a column chunk holds, without reading any of it:

--- a/docs/content/how-to/multi-file.md
+++ b/docs/content/how-to/multi-file.md
@@ -44,7 +44,16 @@ try (Hardwood hardwood = Hardwood.create();
 
 Cross-file prefetching is automatic: when pages from file N are running low, pages from file N+1 are already being prefetched. This eliminates I/O stalls at file boundaries.
 
-The schema of the first file is the reference schema. Each subsequent file is validated against it as it is opened. Columns are matched by field path, so files may declare them in any order. Every projected column, and every column a filter predicate tests, must exist with a matching physical type, logical type, repetition type, and fixed byte length, and its enclosing groups must match in nullability and repeatedness, otherwise a `SchemaIncompatibleException` is thrown. Columns that are neither projected nor filtered on are not checked, so files may carry additional columns or omit unused ones. With no explicit projection, all columns of the first file are projected and therefore required in every subsequent file.
+The schema of the first file is the reference schema. When a data reader is planned, each
+subsequent file reached by the data-reader plan is validated against it for that reader's
+projection and filter. Merely inspecting a file's metadata does not perform this
+projection-specific validation. Columns are matched by field path, so files may declare them in
+any order. Every projected column, and every column a filter predicate tests, must exist with a
+matching physical type, logical type, repetition type, and fixed byte length, and its enclosing
+groups must match in nullability and repeatedness, otherwise a `SchemaIncompatibleException` is
+thrown. Columns that are neither projected nor filtered on are not checked, so files may carry
+additional columns or omit unused ones. With no explicit projection, all columns of the first file
+are projected and therefore required in every subsequent file reached by the data-reader plan.
 
 By default, `Hardwood.create()` sizes the thread pool to the number of available processors. To control the decode parallelism, create a `HardwoodContext` of the desired size and pass it to `Hardwood.create(HardwoodContext)`:
 
@@ -60,4 +69,3 @@ try (HardwoodContext context = HardwoodContext.create(4);  // 4 threads
 ```
 
 The caller owns the supplied context: it is not closed when the `Hardwood` instance is closed, so the same context — and its thread pool — can be reused across later reads and shared with single-file reads via `ParquetFileReader.open(InputFile, HardwoodContext)`.
-

--- a/pom.xml
+++ b/pom.xml
@@ -127,8 +127,12 @@
             </newVersion>
             <parameter>
               <onlyModified>true</onlyModified>
+              <!-- Every module keeps its non-public API in an "internal" package:
+                   dev.hardwood.internal in the core, dev.hardwood.<module>.internal
+                   elsewhere. Both forms are excluded, subpackages included. -->
               <excludes>
                 <exclude>dev.hardwood.internal</exclude>
+                <exclude>dev.hardwood.*.internal</exclude>
               </excludes>
             </parameter>
             <outputDirectory>${maven.multiModuleProjectDirectory}/target/japicmp/${project.artifactId}</outputDirectory>


### PR DESCRIPTION
Fixes #655.

## Summary

* Adds indexed metadata access for every input file while preserving the existing first-file accessor.
* Loads later footers lazily and shares completed, in-progress, and failed loads between metadata and data-reader paths.
* Preserves per-reader schema validation and column-ordinal mappings.
* Coordinates cache closure with input ownership and preserves specific checked I/O exceptions.
* Documents the API, lifecycle, compatibility, and validation behavior.

## Testing

Added coverage for metadata ordering and bounds, concurrent footer reuse, cached failures and reopen retries, close coordination, encrypted files, schema compatibility, ordinal remapping, and input ownership.

`./mvnw clean verify` passes across all 13 reactor modules.

## Authorship

Hardwood is built with AI, not by AI. LLM assistance is welcome; submitting raw LLM output without understanding is not.
Neither are unattended agents opening pull requests.
See the [contribution guide](https://github.com/hardwood-hq/hardwood/blob/main/CONTRIBUTING.md) for more details.
Check this box to confirm:

* [x] This change is coming from a human who understands what it does and why, and can discuss it in review

## Checklist

* [x] Build via `./mvnw clean verify` passes
* [x] The commit message is prefixed with the issue key ("#123 Adding support for...")
* [x] Code changes are covered by tests
* [x] If this PR adds or changes user-facing behaviour, `docs/` has been updated