### PR TITLE
#897 Fail early during Avro materialization and plan construction

### DIFF
--- a/_designs/AVRO_DECODE_PLAN.md
+++ b/_designs/AVRO_DECODE_PLAN.md
@@ -46,7 +46,7 @@ plan.child(0);      // plan for the first field of the record
 | `VARIANT` | `getVariant` | two-field `GenericRecord` of the canonical Variant bytes |
 | `LIST` | `getList` | `java.util.List` |
 | `MAP` | `getMap` | `java.util.Map` |
-| `OTHER` | `getValue` | whatever the row reader yields |
+| `NULL` | no non-null value is valid | a non-null value is an invariant failure |
 
 Children are positional:
 
@@ -91,15 +91,26 @@ private Object materializeField(StructAccessor accessor, String name, AvroPlanNo
 nested struct are the same traversal; the plan node supplies what used to differ.
 List elements and map entries keep their own switch — `PqList` and `PqMap.Entry`
 expose positional and value accessors rather than name-based ones — but they switch
-on the same `Kind`, and the kinds Avro represents physically — the numerics, `bytes`
-and `fixed` — go through one shared step at all three positions, reached by each
-position's raw accessor. Only the kinds whose Avro form is the *logical* value (a uuid
-string, a decimal's unscaled bytes, an interned string) and the group kinds read
-per-position. Values are cast to the type their `Kind` implies rather than sniffed:
-the accessors and the plan classify from the same schema node, so the two agree by
-construction and no file can make them disagree.
+on the same `Kind`. Values obtained through generic `Object` accessors are validated
+against the representation their `Kind` requires before conversion; typed object
+accessors are checked for an unexpected null after the enclosing null guard. Field and
+map positions use typed accessors for logical and group kinds, while list elements use
+`PqList.get(index)` and validate its returned object. Physical kinds use raw accessors
+at all three positions and share the same type and fixed-width checks. Every mismatch
+throws an `IllegalArgumentException` naming the flat materialization position, Avro
+type, and actual Java value type. The location model is intentionally flat: nested
+failures name the innermost field, list element, or map value.
+
+The `NULL` kind represents a Parquet NULL logical type. A null value is consumed by
+the enclosing null guard; reaching a `NULL` node with a non-null value is an invariant
+failure. LIST and MAP groups must have a discoverable element or complete key/value
+group during planning; malformed containers are rejected instead of receiving an
+untyped child plan.
 
 No logical-type lookup, property read, or union resolution happens per value.
+
+The complete plan is built before the underlying `RowReader` is acquired. This keeps
+planning failures from opening and then stranding a row-reader resource.
 
 Where Avro's type system cannot carry a Parquet distinction, the converted schema is
 annotated from the node's `Kind` — an unsigned `INT32` widens to Avro `LONG` and its

--- a/_designs/AVRO_DECODE_PLAN.md
+++ b/_designs/AVRO_DECODE_PLAN.md
@@ -52,7 +52,8 @@ Children are positional:
 
 - a `STRUCT` node has one child per field of its record, at the field's Avro position;
 - a `LIST` node has one child, the element plan, reached through `listElement()`;
-- a `MAP` node has one child, the value plan, reached through `mapValue()`;
+- a `MAP` node has one child, the value plan, reached through `mapValue()`; a
+  key-only map uses a `NULL` value plan because every entry has a null value;
 - every other node is a leaf.
 
 Building the plan and building the schema is one traversal, because the pairing is
@@ -101,11 +102,15 @@ throws an `IllegalArgumentException` naming the flat materialization position, A
 type, and actual Java value type. The location model is intentionally flat: nested
 failures name the innermost field, list element, or map value.
 
+Parquet `ENUM` materializes through the `STRING` kind. The Parquet annotation carries
+no declared symbol set, so materialization validates the Java representation as a
+non-null `String`; membership validation is not defined for this schema shape.
+
 The `NULL` kind represents a Parquet NULL logical type. A null value is consumed by
 the enclosing null guard; reaching a `NULL` node with a non-null value is an invariant
-failure. LIST and MAP groups must have a discoverable element or complete key/value
-group during planning; malformed containers are rejected instead of receiving an
-untyped child plan.
+failure. A key-only MAP produces a `map<null>` schema and `NULL` value plan. LIST groups
+without a discoverable element and MAP groups without a discoverable key are malformed
+and rejected instead of receiving an untyped child plan.
 
 No logical-type lookup, property read, or union resolution happens per value.
 

--- a/avro/src/main/java/dev/hardwood/avro/AvroReaders.java
+++ b/avro/src/main/java/dev/hardwood/avro/AvroReaders.java
@@ -117,6 +117,7 @@ public final class AvroReaders {
         }
     }
 
+    /// Builds the plan before acquiring the row reader so a planning failure cannot strand it.
     static AvroRowReader buildReader(Supplier<AvroPlanNode> planSupplier,
             Supplier<RowReader> rowReaderSupplier) {
         AvroPlanNode plan = planSupplier.get();

--- a/avro/src/main/java/dev/hardwood/avro/AvroReaders.java
+++ b/avro/src/main/java/dev/hardwood/avro/AvroReaders.java
@@ -7,6 +7,9 @@
  */
 package dev.hardwood.avro;
 
+import java.util.function.Supplier;
+
+import dev.hardwood.avro.internal.AvroPlanNode;
 import dev.hardwood.avro.internal.AvroSchemaConverter;
 import dev.hardwood.reader.FilterPredicate;
 import dev.hardwood.reader.ParquetFileReader;
@@ -108,9 +111,16 @@ public final class AvroReaders {
             if (tailRows > 0) {
                 underlying.tail(tailRows);
             }
-            RowReader rowReader = underlying.build();
-            return new AvroRowReader(rowReader,
-                    AvroSchemaConverter.plan(fileReader.getFileSchema(), projection));
+            return buildReader(
+                    () -> AvroSchemaConverter.plan(fileReader.getFileSchema(), projection),
+                    underlying::build);
         }
+    }
+
+    static AvroRowReader buildReader(Supplier<AvroPlanNode> planSupplier,
+            Supplier<RowReader> rowReaderSupplier) {
+        AvroPlanNode plan = planSupplier.get();
+        RowReader rowReader = rowReaderSupplier.get();
+        return new AvroRowReader(rowReader, plan);
     }
 }

--- a/avro/src/main/java/dev/hardwood/avro/AvroRowReader.java
+++ b/avro/src/main/java/dev/hardwood/avro/AvroRowReader.java
@@ -176,6 +176,7 @@ public class AvroRowReader implements AutoCloseable {
     ///
     /// @param raw the value in its physical representation
     /// @param node the plan node for the value's position
+    /// @param location the value's position for a materialization failure
     /// @return the value as its Avro schema requires
     private static Object rawToAvro(Object raw, AvroPlanNode node, ValueLocation location) {
         return switch (node.kind()) {
@@ -189,7 +190,7 @@ public class AvroRowReader implements AutoCloseable {
             case LONG -> requireValueType(raw, Long.class, node, location);
             case FLOAT -> requireValueType(raw, Float.class, node, location);
             case DOUBLE -> requireValueType(raw, Double.class, node, location);
-            default -> throw new IllegalStateException(
+            case STRING, UUID, DECIMAL, STRUCT, VARIANT, LIST, MAP, NULL -> throw new IllegalStateException(
                     "Not a physically represented kind: " + node.kind());
         };
     }
@@ -219,31 +220,28 @@ public class AvroRowReader implements AutoCloseable {
     /// each kind takes whichever its Avro representation is defined in terms of — the
     /// same split the field and map paths make between their raw and typed accessors.
     ///
-    /// The casts hold by construction: the accessors and the plan classify the element
-    /// from the same [dev.hardwood.schema.SchemaNode], so a value that contradicts its
-    /// [AvroPlanNode.Kind] means the two have diverged — a bug in Hardwood, not
-    /// something a file can provoke.
+    /// Each accessor result is validated against the planned representation. A mismatch
+    /// throws an `IllegalArgumentException` naming the element index, Avro type, and
+    /// actual Java value type.
     private Object materializeListElement(PqList pqList, int index, AvroPlanNode node) {
+        ValueLocation location = new ListElementLocation(index);
         return switch (node.kind()) {
             case BOOLEAN, INT, LONG, FLOAT, DOUBLE, UNSIGNED_INT32, BINARY, FIXED ->
-                    rawToAvro(pqList.getRaw(index), node, new ListElementLocation(index));
+                    rawToAvro(pqList.getRaw(index), node, location);
             // Decoded value: the Avro representation is defined in terms of the logical
             // value, which the raw physical bytes or number do not carry.
-            case UUID -> uuidString(requireValueType(pqList.get(index), UUID.class, node,
-                    new ListElementLocation(index)));
-            case DECIMAL -> decimalBytes(requireValueType(pqList.get(index), BigDecimal.class, node,
-                    new ListElementLocation(index)));
-            case STRING -> requireValueType(pqList.get(index), String.class, node,
-                    new ListElementLocation(index));
-            case STRUCT -> materializeRecord(requireValueType(pqList.get(index), PqStruct.class, node,
-                    new ListElementLocation(index)), node, RecordPosition.STRUCT);
-            case VARIANT -> materializeVariant(requireValueType(pqList.get(index), PqVariant.class, node,
-                    new ListElementLocation(index)), node.avro());
-            case LIST -> materializeList(requireValueType(pqList.get(index), PqList.class, node,
-                    new ListElementLocation(index)), node.listElement());
-            case MAP -> materializeMap(requireValueType(pqList.get(index), PqMap.class, node,
-                    new ListElementLocation(index)), node.mapValue());
-            case NULL -> throw materializationFailure(node, new ListElementLocation(index), pqList.get(index),
+            case UUID -> uuidString(requireValueType(pqList.get(index), UUID.class, node, location));
+            case DECIMAL -> decimalBytes(requireValueType(pqList.get(index), BigDecimal.class, node, location));
+            case STRING -> requireValueType(pqList.get(index), String.class, node, location);
+            case STRUCT -> materializeRecord(requireValueType(pqList.get(index), PqStruct.class, node, location),
+                    node, RecordPosition.STRUCT);
+            case VARIANT -> materializeVariant(requireValueType(pqList.get(index), PqVariant.class, node, location),
+                    node.avro());
+            case LIST -> materializeList(requireValueType(pqList.get(index), PqList.class, node, location),
+                    node.listElement());
+            case MAP -> materializeMap(requireValueType(pqList.get(index), PqMap.class, node, location),
+                    node.mapValue());
+            case NULL -> throw materializationFailure(node, location, pqList.get(index),
                     "NULL has no non-null materialization");
         };
     }
@@ -256,13 +254,12 @@ public class AvroRowReader implements AutoCloseable {
                 result.put(key, null);
                 continue;
             }
-            result.put(key, materializeMapValue(entry, value));
+            result.put(key, materializeMapValue(entry, key, value));
         }
         return result;
     }
 
-    private Object materializeMapValue(PqMap.Entry entry, AvroPlanNode node) {
-        String key = entry.getStringKey();
+    private Object materializeMapValue(PqMap.Entry entry, String key, AvroPlanNode node) {
         ValueLocation location = new MapValueLocation(key);
         return switch (node.kind()) {
             case BOOLEAN, INT, LONG, FLOAT, DOUBLE, UNSIGNED_INT32, BINARY, FIXED ->
@@ -286,15 +283,15 @@ public class AvroRowReader implements AutoCloseable {
     /// Encode a decimal as the two's-complement big-endian unscaled bytes Avro's
     /// `decimal` logical type expects on a `BYTES` schema.
     private static ByteBuffer decimalBytes(BigDecimal value) {
-        return value == null ? null : ByteBuffer.wrap(value.unscaledValue().toByteArray());
+        return ByteBuffer.wrap(value.unscaledValue().toByteArray());
     }
 
     private static String uuidString(UUID value) {
-        return value == null ? null : value.toString();
+        return value.toString();
     }
 
     private static ByteBuffer wrapBytes(byte[] bytes) {
-        return bytes != null ? ByteBuffer.wrap(bytes) : null;
+        return ByteBuffer.wrap(bytes);
     }
 
     /// Wrap raw bytes as a [GenericData.Fixed] of the schema's declared size.
@@ -305,9 +302,6 @@ public class AvroRowReader implements AutoCloseable {
     /// column stores exactly `type_length` bytes per value, so a payload whose width
     /// does not match the declared `fixed` size is malformed and rejected.
     private static GenericData.Fixed wrapFixed(byte[] bytes, AvroPlanNode node, ValueLocation location) {
-        if (bytes == null) {
-            return null;
-        }
         Schema fixedSchema = node.avro();
         int size = fixedSchema.getFixedSize();
         if (bytes.length != size) {

--- a/avro/src/main/java/dev/hardwood/avro/AvroRowReader.java
+++ b/avro/src/main/java/dev/hardwood/avro/AvroRowReader.java
@@ -45,6 +45,44 @@ import dev.hardwood.row.StructAccessor;
 /// ```
 public class AvroRowReader implements AutoCloseable {
 
+    private sealed interface ValueLocation
+            permits RootFieldLocation, StructFieldLocation, ListElementLocation, MapValueLocation {
+        String description();
+    }
+
+    private record RootFieldLocation(String name) implements ValueLocation {
+        @Override
+        public String description() {
+            return "field '" + name + "'";
+        }
+    }
+
+    private record StructFieldLocation(String name) implements ValueLocation {
+        @Override
+        public String description() {
+            return "struct field '" + name + "'";
+        }
+    }
+
+    private record ListElementLocation(int index) implements ValueLocation {
+        @Override
+        public String description() {
+            return "list element " + index;
+        }
+    }
+
+    private record MapValueLocation(String key) implements ValueLocation {
+        @Override
+        public String description() {
+            return "map value for key '" + key + "'";
+        }
+    }
+
+    private enum RecordPosition {
+        ROOT,
+        STRUCT
+    }
+
     private final RowReader rowReader;
 
     /// Per-value accessor decisions, taken from the Parquet schema when the Avro
@@ -70,7 +108,7 @@ public class AvroRowReader implements AutoCloseable {
     /// @return the current row as a GenericRecord
     public GenericRecord next() {
         rowReader.next();
-        return materializeRecord(rowReader, plan);
+        return materializeRecord(rowReader, plan, RecordPosition.ROOT);
     }
 
     /// Returns the Avro schema used for materialization.
@@ -87,7 +125,8 @@ public class AvroRowReader implements AutoCloseable {
 
     /// Materialize a row or a nested struct. [RowReader] and [PqStruct] are both
     /// [StructAccessor], so the two differ only in the plan node they are read with.
-    private GenericRecord materializeRecord(StructAccessor accessor, AvroPlanNode node) {
+    private GenericRecord materializeRecord(StructAccessor accessor, AvroPlanNode node,
+            RecordPosition position) {
         Schema recordSchema = node.avro();
         GenericRecord record = new GenericData.Record(recordSchema);
         List<Schema.Field> fields = recordSchema.getFields();
@@ -97,23 +136,32 @@ public class AvroRowReader implements AutoCloseable {
                 record.put(i, null);
                 continue;
             }
-            record.put(i, materializeField(accessor, name, node.child(i)));
+            ValueLocation location = position == RecordPosition.ROOT
+                    ? new RootFieldLocation(name)
+                    : new StructFieldLocation(name);
+            record.put(i, materializeField(accessor, name, node.child(i), location));
         }
         return record;
     }
 
-    private Object materializeField(StructAccessor accessor, String name, AvroPlanNode node) {
+    private Object materializeField(StructAccessor accessor, String name, AvroPlanNode node,
+            ValueLocation location) {
         return switch (node.kind()) {
             case BOOLEAN, INT, LONG, FLOAT, DOUBLE, UNSIGNED_INT32, BINARY, FIXED ->
-                    rawToAvro(accessor.getRawValue(name), node);
-            case STRING -> accessor.getString(name);
-            case UUID -> uuidString(accessor.getUuid(name));
-            case DECIMAL -> decimalBytes(accessor.getDecimal(name));
-            case STRUCT -> materializeRecord(accessor.getStruct(name), node);
-            case VARIANT -> materializeVariant(accessor.getVariant(name), node.avro());
-            case LIST -> materializeList(accessor.getList(name), node.listElement());
-            case MAP -> materializeMap(accessor.getMap(name), node.mapValue());
-            case OTHER -> accessor.getValue(name);
+                    rawToAvro(accessor.getRawValue(name), node, location);
+            case STRING -> requireValue(accessor.getString(name), node, location);
+            case UUID -> uuidString(requireValue(accessor.getUuid(name), node, location));
+            case DECIMAL -> decimalBytes(requireValue(accessor.getDecimal(name), node, location));
+            case STRUCT -> materializeRecord(requireValue(accessor.getStruct(name), node, location),
+                    node, RecordPosition.STRUCT);
+            case VARIANT -> materializeVariant(requireValue(accessor.getVariant(name), node, location),
+                    node.avro());
+            case LIST -> materializeList(requireValue(accessor.getList(name), node, location),
+                    node.listElement());
+            case MAP -> materializeMap(requireValue(accessor.getMap(name), node, location),
+                    node.mapValue());
+            case NULL -> throw materializationFailure(node, location, accessor.getValue(name),
+                    "NULL has no non-null materialization");
         };
     }
 
@@ -129,22 +177,24 @@ public class AvroRowReader implements AutoCloseable {
     /// @param raw the value in its physical representation
     /// @param node the plan node for the value's position
     /// @return the value as its Avro schema requires
-    private static Object rawToAvro(Object raw, AvroPlanNode node) {
+    private static Object rawToAvro(Object raw, AvroPlanNode node, ValueLocation location) {
         return switch (node.kind()) {
-            case UNSIGNED_INT32 -> Integer.toUnsignedLong((Integer) raw);
-            case BINARY -> wrapBytes((byte[]) raw);
-            case FIXED -> wrapFixed((byte[]) raw, node.avro());
+            case UNSIGNED_INT32 -> Integer.toUnsignedLong(
+                    requireValueType(raw, Integer.class, node, location));
+            case BINARY -> wrapBytes(requireValueType(raw, byte[].class, node, location));
+            case FIXED -> wrapFixed(requireValueType(raw, byte[].class, node, location), node, location);
             // Already in their Avro representation as read.
-            case BOOLEAN, INT, LONG, FLOAT, DOUBLE -> raw;
+            case BOOLEAN -> requireValueType(raw, Boolean.class, node, location);
+            case INT -> requireValueType(raw, Integer.class, node, location);
+            case LONG -> requireValueType(raw, Long.class, node, location);
+            case FLOAT -> requireValueType(raw, Float.class, node, location);
+            case DOUBLE -> requireValueType(raw, Double.class, node, location);
             default -> throw new IllegalStateException(
                     "Not a physically represented kind: " + node.kind());
         };
     }
 
     private static GenericRecord materializeVariant(PqVariant variant, Schema recordSchema) {
-        if (variant == null) {
-            return null;
-        }
         GenericRecord record = new GenericData.Record(recordSchema);
         record.put(0, ByteBuffer.wrap(variant.metadata()));
         record.put(1, ByteBuffer.wrap(variant.value()));
@@ -176,16 +226,25 @@ public class AvroRowReader implements AutoCloseable {
     private Object materializeListElement(PqList pqList, int index, AvroPlanNode node) {
         return switch (node.kind()) {
             case BOOLEAN, INT, LONG, FLOAT, DOUBLE, UNSIGNED_INT32, BINARY, FIXED ->
-                    rawToAvro(pqList.getRaw(index), node);
+                    rawToAvro(pqList.getRaw(index), node, new ListElementLocation(index));
             // Decoded value: the Avro representation is defined in terms of the logical
             // value, which the raw physical bytes or number do not carry.
-            case UUID -> uuidString((UUID) pqList.get(index));
-            case DECIMAL -> decimalBytes((BigDecimal) pqList.get(index));
-            case STRING, OTHER -> pqList.get(index);
-            case STRUCT -> materializeRecord((PqStruct) pqList.get(index), node);
-            case VARIANT -> materializeVariant((PqVariant) pqList.get(index), node.avro());
-            case LIST -> materializeList((PqList) pqList.get(index), node.listElement());
-            case MAP -> materializeMap((PqMap) pqList.get(index), node.mapValue());
+            case UUID -> uuidString(requireValueType(pqList.get(index), UUID.class, node,
+                    new ListElementLocation(index)));
+            case DECIMAL -> decimalBytes(requireValueType(pqList.get(index), BigDecimal.class, node,
+                    new ListElementLocation(index)));
+            case STRING -> requireValueType(pqList.get(index), String.class, node,
+                    new ListElementLocation(index));
+            case STRUCT -> materializeRecord(requireValueType(pqList.get(index), PqStruct.class, node,
+                    new ListElementLocation(index)), node, RecordPosition.STRUCT);
+            case VARIANT -> materializeVariant(requireValueType(pqList.get(index), PqVariant.class, node,
+                    new ListElementLocation(index)), node.avro());
+            case LIST -> materializeList(requireValueType(pqList.get(index), PqList.class, node,
+                    new ListElementLocation(index)), node.listElement());
+            case MAP -> materializeMap(requireValueType(pqList.get(index), PqMap.class, node,
+                    new ListElementLocation(index)), node.mapValue());
+            case NULL -> throw materializationFailure(node, new ListElementLocation(index), pqList.get(index),
+                    "NULL has no non-null materialization");
         };
     }
 
@@ -203,17 +262,24 @@ public class AvroRowReader implements AutoCloseable {
     }
 
     private Object materializeMapValue(PqMap.Entry entry, AvroPlanNode node) {
+        String key = entry.getStringKey();
+        ValueLocation location = new MapValueLocation(key);
         return switch (node.kind()) {
             case BOOLEAN, INT, LONG, FLOAT, DOUBLE, UNSIGNED_INT32, BINARY, FIXED ->
-                    rawToAvro(entry.getRawValue(), node);
-            case STRING -> entry.getStringValue();
-            case UUID -> uuidString(entry.getUuidValue());
-            case DECIMAL -> decimalBytes(entry.getDecimalValue());
-            case STRUCT -> materializeRecord(entry.getStructValue(), node);
-            case VARIANT -> materializeVariant(entry.getVariantValue(), node.avro());
-            case LIST -> materializeList(entry.getListValue(), node.listElement());
-            case MAP -> materializeMap(entry.getMapValue(), node.mapValue());
-            case OTHER -> entry.getValue();
+                    rawToAvro(entry.getRawValue(), node, location);
+            case STRING -> requireValue(entry.getStringValue(), node, location);
+            case UUID -> uuidString(requireValue(entry.getUuidValue(), node, location));
+            case DECIMAL -> decimalBytes(requireValue(entry.getDecimalValue(), node, location));
+            case STRUCT -> materializeRecord(requireValue(entry.getStructValue(), node, location),
+                    node, RecordPosition.STRUCT);
+            case VARIANT -> materializeVariant(requireValue(entry.getVariantValue(), node, location),
+                    node.avro());
+            case LIST -> materializeList(requireValue(entry.getListValue(), node, location),
+                    node.listElement());
+            case MAP -> materializeMap(requireValue(entry.getMapValue(), node, location),
+                    node.mapValue());
+            case NULL -> throw materializationFailure(node, location, entry.getValue(),
+                    "NULL has no non-null materialization");
         };
     }
 
@@ -238,16 +304,40 @@ public class AvroRowReader implements AutoCloseable {
     /// record is serialized through a `GenericDatumWriter`. A `FIXED_LEN_BYTE_ARRAY`
     /// column stores exactly `type_length` bytes per value, so a payload whose width
     /// does not match the declared `fixed` size is malformed and rejected.
-    private static GenericData.Fixed wrapFixed(byte[] bytes, Schema fixedSchema) {
+    private static GenericData.Fixed wrapFixed(byte[] bytes, AvroPlanNode node, ValueLocation location) {
         if (bytes == null) {
             return null;
         }
+        Schema fixedSchema = node.avro();
         int size = fixedSchema.getFixedSize();
         if (bytes.length != size) {
-            throw new IllegalArgumentException(
-                    "FIXED value of " + bytes.length + " bytes does not match fixed(" + size
-                            + ") schema '" + fixedSchema.getFullName() + "'");
+            throw materializationFailure(node, location, bytes,
+                    "required fixed width " + size + " but received " + bytes.length);
         }
         return new GenericData.Fixed(fixedSchema, bytes);
+    }
+
+    private static <T> T requireValue(T value, AvroPlanNode node, ValueLocation location) {
+        if (value == null) {
+            throw materializationFailure(node, location, null, "required non-null value");
+        }
+        return value;
+    }
+
+    private static <T> T requireValueType(Object value, Class<T> expectedClass, AvroPlanNode node,
+            ValueLocation location) {
+        if (!expectedClass.isInstance(value)) {
+            throw materializationFailure(node, location, value,
+                    "required " + expectedClass.getTypeName());
+        }
+        return expectedClass.cast(value);
+    }
+
+    private static IllegalArgumentException materializationFailure(AvroPlanNode node,
+            ValueLocation location, Object value, String detail) {
+        String actualType = value == null ? "null" : value.getClass().getTypeName();
+        return new IllegalArgumentException("Cannot materialize " + location.description()
+                + " as Avro " + node.avro().getType() + ": actual Java value type " + actualType
+                + " (" + detail + ")");
     }
 }

--- a/avro/src/main/java/dev/hardwood/avro/internal/AvroPlanNode.java
+++ b/avro/src/main/java/dev/hardwood/avro/internal/AvroPlanNode.java
@@ -44,8 +44,9 @@ public final class AvroPlanNode {
         VARIANT,
         LIST,
         MAP,
-        /// No typed accessor applies — read through the generic `getValue` path.
-        OTHER
+        /// The Parquet NULL logical type. A non-null value at this position is
+        /// always a materialization invariant failure.
+        NULL
     }
 
     private static final AvroPlanNode[] NO_CHILDREN = new AvroPlanNode[0];

--- a/avro/src/main/java/dev/hardwood/avro/internal/AvroSchemaConverter.java
+++ b/avro/src/main/java/dev/hardwood/avro/internal/AvroSchemaConverter.java
@@ -191,9 +191,15 @@ public final class AvroSchemaConverter {
         // MAP -> key_value (repeated) -> key, value
         SchemaNode keyNode = mapGroup.getMapKey();
         SchemaNode valueNode = mapGroup.getMapValue();
-        if (keyNode == null || valueNode == null) {
+        if (keyNode == null) {
             throw new IllegalArgumentException("MAP group '" + mapGroup.name()
-                    + "' must contain a complete key/value group");
+                    + "' must contain a repeated key/value group with a key");
+        }
+        if (valueNode == null) {
+            Schema nullSchema = Schema.create(Schema.Type.NULL);
+            AvroPlanNode value = AvroPlanNode.leaf(nullSchema, Kind.NULL, mapGroup);
+            return AvroPlanNode.container(
+                    Schema.createMap(nullSchema), Kind.MAP, mapGroup, value);
         }
         // Prune the value subtree so a map<_, struct> with a sub-field
         // projection narrows to the served fields (the key is always read).

--- a/avro/src/main/java/dev/hardwood/avro/internal/AvroSchemaConverter.java
+++ b/avro/src/main/java/dev/hardwood/avro/internal/AvroSchemaConverter.java
@@ -9,7 +9,6 @@ package dev.hardwood.avro.internal;
 
 import java.util.ArrayList;
 import java.util.List;
-import java.util.function.UnaryOperator;
 
 import org.apache.avro.LogicalTypes;
 import org.apache.avro.Schema;
@@ -177,8 +176,8 @@ public final class AvroSchemaConverter {
     private AvroPlanNode convertList(SchemaNode.GroupNode listGroup) {
         SchemaNode element = listGroup.getListElement();
         if (element == null) {
-            // Fallback for malformed list
-            return untypedContainer(Schema::createArray, Kind.LIST, listGroup);
+            throw new IllegalArgumentException("LIST group '" + listGroup.name()
+                    + "' has no element");
         }
         // The list column is only reached when it has a projected leaf; prune the
         // element subtree so a list<struct> with a sub-field projection narrows to
@@ -190,28 +189,17 @@ public final class AvroSchemaConverter {
 
     private AvroPlanNode convertMap(SchemaNode.GroupNode mapGroup) {
         // MAP -> key_value (repeated) -> key, value
-        if (mapGroup.children().isEmpty()) {
-            return untypedContainer(Schema::createMap, Kind.MAP, mapGroup);
+        SchemaNode keyNode = mapGroup.getMapKey();
+        SchemaNode valueNode = mapGroup.getMapValue();
+        if (keyNode == null || valueNode == null) {
+            throw new IllegalArgumentException("MAP group '" + mapGroup.name()
+                    + "' must contain a complete key/value group");
         }
-        SchemaNode inner = mapGroup.children().getFirst();
-        if (inner instanceof SchemaNode.GroupNode kvGroup && kvGroup.children().size() >= 2) {
-            SchemaNode valueNode = kvGroup.children().get(1);
-            // Prune the value subtree so a map<_, struct> with a sub-field
-            // projection narrows to the served fields (the key is always read).
-            AvroPlanNode value = convertNode(valueNode);
-            return AvroPlanNode.container(
-                    Schema.createMap(fieldSchema(value, valueNode)), Kind.MAP, mapGroup, value);
-        }
-        return untypedContainer(Schema::createMap, Kind.MAP, mapGroup);
-    }
-
-    /// A list or map whose element type the schema does not describe: the container
-    /// materializes, and its values come back through the generic accessor.
-    private static AvroPlanNode untypedContainer(UnaryOperator<Schema> container, Kind kind,
-            SchemaNode.GroupNode group) {
-        Schema nullSchema = Schema.create(Schema.Type.NULL);
-        return AvroPlanNode.container(container.apply(nullSchema), kind, group,
-                AvroPlanNode.leaf(nullSchema, Kind.OTHER, group));
+        // Prune the value subtree so a map<_, struct> with a sub-field
+        // projection narrows to the served fields (the key is always read).
+        AvroPlanNode value = convertNode(valueNode);
+        return AvroPlanNode.container(
+                Schema.createMap(fieldSchema(value, valueNode)), Kind.MAP, mapGroup, value);
     }
 
     private AvroPlanNode convertPrimitive(SchemaNode.PrimitiveNode prim) {
@@ -261,7 +249,7 @@ public final class AvroSchemaConverter {
             case LogicalType.GeometryType g -> binary(prim);
             case LogicalType.GeographyType g -> binary(prim);
             case LogicalType.NullType n -> AvroPlanNode.leaf(
-                    Schema.create(Schema.Type.NULL), Kind.OTHER, prim);
+                    Schema.create(Schema.Type.NULL), Kind.NULL, prim);
         };
     }
 

--- a/avro/src/test/java/dev/hardwood/avro/AvroRowReaderTest.java
+++ b/avro/src/test/java/dev/hardwood/avro/AvroRowReaderTest.java
@@ -8,12 +8,14 @@
 package dev.hardwood.avro;
 
 import java.io.ByteArrayOutputStream;
+import java.lang.reflect.Proxy;
 import java.math.BigDecimal;
 import java.math.BigInteger;
 import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Path;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -29,21 +31,143 @@ import org.apache.avro.io.EncoderFactory;
 import org.junit.jupiter.api.Test;
 
 import dev.hardwood.InputFile;
+import dev.hardwood.avro.internal.AvroPlanNode;
 import dev.hardwood.avro.internal.AvroSchemaConverter;
+import dev.hardwood.metadata.PhysicalType;
+import dev.hardwood.metadata.RepetitionType;
+import dev.hardwood.metadata.SchemaElement;
 import dev.hardwood.reader.FilterPredicate;
 import dev.hardwood.reader.ParquetFileReader;
 import dev.hardwood.reader.RowReader;
+import dev.hardwood.row.PqList;
+import dev.hardwood.row.PqMap;
+import dev.hardwood.row.PqStruct;
 import dev.hardwood.row.PqVariant;
 import dev.hardwood.row.VariantType;
 import dev.hardwood.schema.ColumnProjection;
+import dev.hardwood.schema.FileSchema;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 class AvroRowReaderTest {
 
     private static final Path TEST_RESOURCES = Path.of("").toAbsolutePath()
             .resolve("../core/src/test/resources").normalize();
+
+    @Test
+    void planFailurePreventsRowReaderAcquisition() {
+        boolean[] acquired = { false };
+
+        assertThatThrownBy(() -> AvroReaders.buildReader(
+                () -> {
+                    throw new IllegalArgumentException("plan failed");
+                },
+                () -> {
+                    acquired[0] = true;
+                    throw new AssertionError("row reader must not be acquired");
+                }))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("plan failed");
+        assertThat(acquired[0]).isFalse();
+    }
+
+    @Test
+    void wrongRawTypeNamesRootFieldAndAvroType() {
+        FileSchema schema = primitiveSchema("value", PhysicalType.INT32, RepetitionType.REQUIRED);
+        AvroPlanNode plan = AvroSchemaConverter.plan(schema, ColumnProjection.all());
+        RowReader rows = proxy(RowReader.class, values(
+                "next", null,
+                "isNull", false,
+                "getRawValue", "wrong"));
+
+        assertThatThrownBy(() -> new AvroRowReader(rows, plan).next())
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("field 'value'")
+                .hasMessageContaining("Avro INT")
+                .hasMessageContaining("java.lang.String");
+    }
+
+    @Test
+    void wrongRawTypeNamesNestedStructField() {
+        FileSchema schema = nestedPrimitiveSchema();
+        AvroPlanNode plan = AvroSchemaConverter.plan(schema, ColumnProjection.all());
+        PqStruct struct = proxy(PqStruct.class, values(
+                "isNull", false,
+                "getRawValue", "wrong"));
+        RowReader rows = proxy(RowReader.class, values(
+                "next", null,
+                "isNull", false,
+                "getStruct", struct));
+
+        assertThatThrownBy(() -> new AvroRowReader(rows, plan).next())
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("struct field 'value'")
+                .hasMessageContaining("Avro INT")
+                .hasMessageContaining("java.lang.String");
+    }
+
+    @Test
+    void wrongDecodedTypeNamesListElement() {
+        FileSchema schema = listStringSchema();
+        AvroPlanNode plan = AvroSchemaConverter.plan(schema, ColumnProjection.all());
+        PqList list = proxy(PqList.class, values(
+                "size", 1,
+                "isNull", false,
+                "get", 42));
+        RowReader rows = proxy(RowReader.class, values(
+                "next", null,
+                "isNull", false,
+                "getList", list));
+
+        assertThatThrownBy(() -> new AvroRowReader(rows, plan).next())
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("list element 0")
+                .hasMessageContaining("Avro STRING")
+                .hasMessageContaining("java.lang.Integer");
+    }
+
+    @Test
+    void wrongFixedWidthNamesRootField() {
+        SchemaElement root = new SchemaElement("root", null, null, null, 1, null, null, null, null, null);
+        SchemaElement value = new SchemaElement("value", PhysicalType.FIXED_LEN_BYTE_ARRAY, 4,
+                RepetitionType.REQUIRED, null, null, null, null, null, null);
+        FileSchema schema = FileSchema.fromSchemaElements(List.of(root, value));
+        AvroPlanNode plan = AvroSchemaConverter.plan(schema, ColumnProjection.all());
+        RowReader rows = proxy(RowReader.class, values(
+                "next", null,
+                "isNull", false,
+                "getRawValue", new byte[] { 1, 2 }));
+
+        assertThatThrownBy(() -> new AvroRowReader(rows, plan).next())
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("field 'value'")
+                .hasMessageContaining("Avro FIXED")
+                .hasMessageContaining("required fixed width 4")
+                .hasMessageContaining("byte[]");
+    }
+
+    @Test
+    void nullDecodedTypeNamesMapValue() {
+        FileSchema schema = mapStringSchema();
+        AvroPlanNode plan = AvroSchemaConverter.plan(schema, ColumnProjection.all());
+        PqMap.Entry entry = proxy(PqMap.Entry.class, values(
+                "getStringKey", "key",
+                "isValueNull", false,
+                "getStringValue", null));
+        PqMap map = proxy(PqMap.class, values("getEntries", List.of(entry), "size", 1));
+        RowReader rows = proxy(RowReader.class, values(
+                "next", null,
+                "isNull", false,
+                "getMap", map));
+
+        assertThatThrownBy(() -> new AvroRowReader(rows, plan).next())
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("map value for key 'key'")
+                .hasMessageContaining("Avro STRING")
+                .hasMessageContaining("actual Java value type null");
+    }
 
     @Test
     void readFlatSchema() throws Exception {
@@ -1152,6 +1276,79 @@ class AvroRowReaderTest {
 
     private static BigDecimal decimalFromFixed(Object fixed) {
         return new BigDecimal(new BigInteger(((GenericData.Fixed) fixed).bytes()), 2);
+    }
+
+    private static FileSchema primitiveSchema(String name, PhysicalType type, RepetitionType repetition) {
+        SchemaElement root = new SchemaElement("root", null, null, null, 1, null, null, null, null, null);
+        SchemaElement value = new SchemaElement(name, type, null, repetition,
+                null, null, null, null, null, null);
+        return FileSchema.fromSchemaElements(List.of(root, value));
+    }
+
+    private static FileSchema nestedPrimitiveSchema() {
+        SchemaElement root = new SchemaElement("root", null, null, null, 1, null, null, null, null, null);
+        SchemaElement struct = new SchemaElement("record", null, null, RepetitionType.REQUIRED,
+                1, null, null, null, null, null);
+        SchemaElement value = new SchemaElement("value", PhysicalType.INT32, null,
+                RepetitionType.REQUIRED, null, null, null, null, null, null);
+        return FileSchema.fromSchemaElements(List.of(root, struct, value));
+    }
+
+    private static FileSchema listStringSchema() {
+        SchemaElement root = new SchemaElement("root", null, null, null, 1, null, null, null, null, null);
+        SchemaElement list = new SchemaElement("items", null, null, RepetitionType.REQUIRED,
+                1, null, null, null, null, new dev.hardwood.metadata.LogicalType.ListType());
+        SchemaElement repeated = new SchemaElement("list", null, null, RepetitionType.REPEATED,
+                1, null, null, null, null, null);
+        SchemaElement element = new SchemaElement("element", PhysicalType.BYTE_ARRAY, null,
+                RepetitionType.REQUIRED, null, null, null, null, null,
+                new dev.hardwood.metadata.LogicalType.StringType());
+        return FileSchema.fromSchemaElements(List.of(root, list, repeated, element));
+    }
+
+    private static FileSchema mapStringSchema() {
+        SchemaElement root = new SchemaElement("root", null, null, null, 1, null, null, null, null, null);
+        SchemaElement map = new SchemaElement("attributes", null, null, RepetitionType.REQUIRED,
+                1, null, null, null, null, new dev.hardwood.metadata.LogicalType.MapType());
+        SchemaElement keyValue = new SchemaElement("key_value", null, null, RepetitionType.REPEATED,
+                2, null, null, null, null, null);
+        SchemaElement key = new SchemaElement("key", PhysicalType.BYTE_ARRAY, null,
+                RepetitionType.REQUIRED, null, null, null, null, null,
+                new dev.hardwood.metadata.LogicalType.StringType());
+        SchemaElement value = new SchemaElement("value", PhysicalType.BYTE_ARRAY, null,
+                RepetitionType.REQUIRED, null, null, null, null, null,
+                new dev.hardwood.metadata.LogicalType.StringType());
+        return FileSchema.fromSchemaElements(List.of(root, map, keyValue, key, value));
+    }
+
+    private static Map<String, Object> values(Object... entries) {
+        Map<String, Object> values = new HashMap<>();
+        for (int i = 0; i < entries.length; i += 2) {
+            values.put((String) entries[i], entries[i + 1]);
+        }
+        return values;
+    }
+
+    @SuppressWarnings("unchecked")
+    private static <T> T proxy(Class<T> type, Map<String, Object> values) {
+        return (T) Proxy.newProxyInstance(
+                type.getClassLoader(),
+                new Class<?>[] { type },
+                (proxy, method, arguments) -> {
+                    if (method.getName().equals("toString")) {
+                        return type.getSimpleName() + " proxy";
+                    }
+                    if (method.getName().equals("hashCode")) {
+                        return System.identityHashCode(proxy);
+                    }
+                    if (method.getName().equals("equals")) {
+                        return proxy == arguments[0];
+                    }
+                    if (values.containsKey(method.getName())) {
+                        return values.get(method.getName());
+                    }
+                    throw new AssertionError("Unexpected accessor: " + method.getName());
+                });
     }
 
     private static Schema resolveNullable(Schema schema) {

--- a/avro/src/test/java/dev/hardwood/avro/AvroRowReaderTest.java
+++ b/avro/src/test/java/dev/hardwood/avro/AvroRowReaderTest.java
@@ -33,6 +33,10 @@ import org.junit.jupiter.api.Test;
 import dev.hardwood.InputFile;
 import dev.hardwood.avro.internal.AvroPlanNode;
 import dev.hardwood.avro.internal.AvroSchemaConverter;
+import dev.hardwood.metadata.LogicalType.ListType;
+import dev.hardwood.metadata.LogicalType.MapType;
+import dev.hardwood.metadata.LogicalType.NullType;
+import dev.hardwood.metadata.LogicalType.StringType;
 import dev.hardwood.metadata.PhysicalType;
 import dev.hardwood.metadata.RepetitionType;
 import dev.hardwood.metadata.SchemaElement;
@@ -170,6 +174,26 @@ class AvroRowReaderTest {
     }
 
     @Test
+    void nonNullValueForNullLogicalTypeFailsAtRootField() {
+        SchemaElement root = new SchemaElement("root", null, null, null, 1, null, null, null, null, null);
+        SchemaElement value = new SchemaElement("value", PhysicalType.INT32, null,
+                RepetitionType.OPTIONAL, null, null, null, null, null, new NullType());
+        FileSchema schema = FileSchema.fromSchemaElements(List.of(root, value));
+        AvroPlanNode plan = AvroSchemaConverter.plan(schema, ColumnProjection.all());
+        RowReader rows = proxy(RowReader.class, values(
+                "next", null,
+                "isNull", false,
+                "getValue", 42));
+
+        assertThatThrownBy(() -> new AvroRowReader(rows, plan).next())
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("field 'value'")
+                .hasMessageContaining("Avro NULL")
+                .hasMessageContaining("java.lang.Integer")
+                .hasMessageContaining("NULL has no non-null materialization");
+    }
+
+    @Test
     void readFlatSchema() throws Exception {
         // plain_uncompressed.parquet: id INT64, value INT64 — 3 rows
         try (ParquetFileReader fileReader = ParquetFileReader.open(
@@ -274,6 +298,29 @@ class AvroRowReaderTest {
             @SuppressWarnings("unchecked")
             Map<String, Object> attrMap = (Map<String, Object>) attrs;
             assertThat(attrMap).isNotEmpty();
+        }
+    }
+
+    @Test
+    void readKeyOnlyMapAsNullValuedMap() throws Exception {
+        try (ParquetFileReader fileReader = ParquetFileReader.open(
+                InputFile.of(TEST_RESOURCES.resolve("map_key_only_test.parquet")));
+             AvroRowReader reader = AvroReaders.rowReader(fileReader)) {
+
+            Schema mapSchema = resolveNullable(reader.getSchema().getField("tags").schema());
+            assertThat(mapSchema.getType()).isEqualTo(Schema.Type.MAP);
+            assertThat(mapSchema.getValueType().getType()).isEqualTo(Schema.Type.NULL);
+
+            List<GenericRecord> records = readAll(reader);
+            assertThat(records).hasSize(2);
+            @SuppressWarnings("unchecked")
+            Map<String, Object> firstTags = (Map<String, Object>) records.get(0).get("tags");
+            @SuppressWarnings("unchecked")
+            Map<String, Object> secondTags = (Map<String, Object>) records.get(1).get("tags");
+            assertThat(firstTags)
+                    .containsEntry("a", null)
+                    .containsEntry("b", null);
+            assertThat(secondTags).containsEntry("c", null);
         }
     }
 
@@ -1297,27 +1344,27 @@ class AvroRowReaderTest {
     private static FileSchema listStringSchema() {
         SchemaElement root = new SchemaElement("root", null, null, null, 1, null, null, null, null, null);
         SchemaElement list = new SchemaElement("items", null, null, RepetitionType.REQUIRED,
-                1, null, null, null, null, new dev.hardwood.metadata.LogicalType.ListType());
+                1, null, null, null, null, new ListType());
         SchemaElement repeated = new SchemaElement("list", null, null, RepetitionType.REPEATED,
                 1, null, null, null, null, null);
         SchemaElement element = new SchemaElement("element", PhysicalType.BYTE_ARRAY, null,
                 RepetitionType.REQUIRED, null, null, null, null, null,
-                new dev.hardwood.metadata.LogicalType.StringType());
+                new StringType());
         return FileSchema.fromSchemaElements(List.of(root, list, repeated, element));
     }
 
     private static FileSchema mapStringSchema() {
         SchemaElement root = new SchemaElement("root", null, null, null, 1, null, null, null, null, null);
         SchemaElement map = new SchemaElement("attributes", null, null, RepetitionType.REQUIRED,
-                1, null, null, null, null, new dev.hardwood.metadata.LogicalType.MapType());
+                1, null, null, null, null, new MapType());
         SchemaElement keyValue = new SchemaElement("key_value", null, null, RepetitionType.REPEATED,
                 2, null, null, null, null, null);
         SchemaElement key = new SchemaElement("key", PhysicalType.BYTE_ARRAY, null,
                 RepetitionType.REQUIRED, null, null, null, null, null,
-                new dev.hardwood.metadata.LogicalType.StringType());
+                new StringType());
         SchemaElement value = new SchemaElement("value", PhysicalType.BYTE_ARRAY, null,
                 RepetitionType.REQUIRED, null, null, null, null, null,
-                new dev.hardwood.metadata.LogicalType.StringType());
+                new StringType());
         return FileSchema.fromSchemaElements(List.of(root, map, keyValue, key, value));
     }
 

--- a/avro/src/test/java/dev/hardwood/avro/internal/AvroSchemaConverterTest.java
+++ b/avro/src/test/java/dev/hardwood/avro/internal/AvroSchemaConverterTest.java
@@ -139,6 +139,38 @@ class AvroSchemaConverterTest {
         // Guard against regressing to `union [null, null]` — still NULL on the
         // top branch but illegal Avro that would throw at schema construction.
         assertThat(field.schema().isUnion()).isFalse();
+        assertThat(AvroSchemaConverter.plan(schema, ColumnProjection.all()).child(0).kind())
+                .isEqualTo(AvroPlanNode.Kind.NULL);
+    }
+
+    @Test
+    void rejectsListWithoutElementDuringPlanning() {
+        SchemaElement root = new SchemaElement("root", null, null, null, 1, null, null, null, null, null);
+        SchemaElement list = new SchemaElement("items", null, null, RepetitionType.OPTIONAL,
+                0, null, null, null, null, new LogicalType.ListType());
+        FileSchema schema = FileSchema.fromSchemaElements(List.of(root, list));
+
+        assertThatThrownBy(() -> AvroSchemaConverter.plan(schema, ColumnProjection.all()))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("items")
+                .hasMessageContaining("element");
+    }
+
+    @Test
+    void rejectsMapWithoutCompleteKeyValueGroupDuringPlanning() {
+        SchemaElement root = new SchemaElement("root", null, null, null, 1, null, null, null, null, null);
+        SchemaElement map = new SchemaElement("attributes", null, null, RepetitionType.OPTIONAL,
+                1, null, null, null, null, new LogicalType.MapType());
+        SchemaElement keyValue = new SchemaElement("key_value", null, null, RepetitionType.REPEATED,
+                1, null, null, null, null, null);
+        SchemaElement key = new SchemaElement("key", PhysicalType.BYTE_ARRAY, null,
+                RepetitionType.REQUIRED, null, null, null, null, null, new LogicalType.StringType());
+        FileSchema schema = FileSchema.fromSchemaElements(List.of(root, map, keyValue, key));
+
+        assertThatThrownBy(() -> AvroSchemaConverter.plan(schema, ColumnProjection.all()))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("attributes")
+                .hasMessageContaining("key/value");
     }
 
     /// `list<null>` with an OPTIONAL element must produce `array<null>`, not

--- a/avro/src/test/java/dev/hardwood/avro/internal/AvroSchemaConverterTest.java
+++ b/avro/src/test/java/dev/hardwood/avro/internal/AvroSchemaConverterTest.java
@@ -157,7 +157,7 @@ class AvroSchemaConverterTest {
     }
 
     @Test
-    void rejectsMapWithoutCompleteKeyValueGroupDuringPlanning() {
+    void keyOnlyMapBecomesMapOfBareNull() {
         SchemaElement root = new SchemaElement("root", null, null, null, 1, null, null, null, null, null);
         SchemaElement map = new SchemaElement("attributes", null, null, RepetitionType.OPTIONAL,
                 1, null, null, null, null, new LogicalType.MapType());
@@ -167,10 +167,10 @@ class AvroSchemaConverterTest {
                 RepetitionType.REQUIRED, null, null, null, null, null, new LogicalType.StringType());
         FileSchema schema = FileSchema.fromSchemaElements(List.of(root, map, keyValue, key));
 
-        assertThatThrownBy(() -> AvroSchemaConverter.plan(schema, ColumnProjection.all()))
-                .isInstanceOf(IllegalArgumentException.class)
-                .hasMessageContaining("attributes")
-                .hasMessageContaining("key/value");
+        AvroPlanNode plan = AvroSchemaConverter.plan(schema, ColumnProjection.all());
+        Schema mapSchema = pickMapBranch(plan.avro().getField("attributes").schema());
+        assertThat(mapSchema.getValueType().getType()).isEqualTo(Schema.Type.NULL);
+        assertThat(plan.child(0).mapValue().kind()).isEqualTo(AvroPlanNode.Kind.NULL);
     }
 
     /// `list<null>` with an OPTIONAL element must produce `array<null>`, not

--- a/docs/content/how-to/avro.md
+++ b/docs/content/how-to/avro.md
@@ -78,6 +78,10 @@ Values are stored in Avro's standard representations: timestamps as `Long` (mill
 
 A Parquet column annotated with the `NULL` logical type (e.g. PyArrow's `pa.null()` columns) maps to a bare Avro `null` field — not the usual `union [null, T]` nullable wrap, which is illegal when `T` is itself `null`. The same collapse applies inside lists and maps: a `list<null>` element or `map<string, null>` value position becomes a bare `null` in the corresponding Avro `array` / `map` schema.
 
+A key-only Parquet MAP, whose repeated `key_value` group has no value column, also maps to an Avro `map` with bare `null` values. Each decoded key is present in the Java map with a `null` value.
+
+Reader construction validates container schemas before acquiring the underlying row reader. It throws `IllegalArgumentException` when a LIST group has no discoverable element or a MAP group has no discoverable key; these malformed schemas cannot be materialized consistently with an Avro schema.
+
 ## Lifecycle
 
 `AvroRowReader` does **not** take ownership of the `ParquetFileReader` it wraps — closing the `AvroRowReader` releases the inner readers and column workers, but the underlying `ParquetFileReader` must be closed separately by the caller. The two-`try`-with-resources pattern in the examples above reflects this.


### PR DESCRIPTION
Fixes #897

## ProblemStatement

The reader did not verify the contract between the decode plan and the internal row accessors. A previous instance of this mismatch was `UINT32`: its Parquet storage is `INT32`, while its Avro representation is `long`:

```text
## parquet schema:
required int32 count (INTEGER(32,false));

## avro schema
{"name":"count","type":"long"}
```

An older materializer selected the `long` accessor from that Avro type. The reader therefore tried to read the `INT32` batch as `long[]` and threw:
```text
java.lang.ClassCastException: class [I cannot be cast to class [J
```

The same class of mismatch could otherwise return an undecoded value or fail with a bare cast exception, rather than naming the affected field or container position.

Two related invalid-footer-schema failures were also deferred:
- An invalid `LIST` footer entry with no element node, for example:
  ```text
  optional group labels (LIST) {}
  ```
  was converted to `{"type":"array","items":"null"}` rather than rejected while building the
  schema.
- This invalid footer schema element has no possible Avro `fixed` schema, because its required
  width is absent:
  ```text
  SchemaElement { name: "id", type: FIXED_LEN_BYTE_ARRAY, type_length: <unset> }
  ```
  The builder opened its `RowReader` before conversion detected that error, leaving the reader with no owner to close it.

## Solution

The reader uses the decode plan's Avro type and accessor representation to check each value before returning it:
```java
case STRING -> requireValueType(
        pqList.get(index), String.class, node, new ListElementLocation(index));
```

For example, a bad first string element now fails at `next()` with a message like:
```text
Cannot materialize list element 0 as Avro STRING:
actual Java value type java.lang.Integer (required java.lang.String)
```

Invalid `LIST` and `MAP` footer shapes are rejected while building the plan; they no longer become `array<null>` or `map<null>` plans. Supported maps with keys but no value field remain maps whose values are null.

Plan construction now precedes row-reader acquisition:
```java
AvroPlanNode plan = AvroSchemaConverter.plan(fileReader.getFileSchema(), projection);
RowReader rowReader = underlying.build();
return new AvroRowReader(rowReader, plan);
```

## Authorship
- [x] This change is coming from a human who understands what it does and why, and can discuss it in review

## Checklist
- [x] Build via `./mvnw clean verify` passes
- [x] The commit message is prefixed with the issue key (`#897`)
- [x] Code changes are covered by tests
- [x] If this PR adds or changes user-facing behaviour, `docs/` has been updated
