### PR TITLE
#919 Wide-schema metadata decode: benchmark, comparison and allocation work

### DIFF
--- a/PERFORMANCE.md
+++ b/PERFORMANCE.md
@@ -233,6 +233,10 @@ java --add-modules jdk.incubator.vector \
 | `PipelineBenchmark.a_assembleColumns` | Synchronous page decoding + column assembly |
 | `PipelineBenchmark.b_consumeRows` | Full pipeline with row-oriented access |
 | `SimdBenchmark.*` | SIMD operations (countNonNulls, markNulls, dictionary, bit unpacking) |
+| `WideSchemaMetadataBenchmark.decodeFooter` | Thrift footer decode for 10 … 100,000 `FLOAT64` columns, bytes already in memory |
+| `WideSchemaMetadataBenchmark.buildSchema` | `FileSchema` construction from decoded schema elements, same widths |
+| `WideSchemaMetadataBenchmark.openFile` | Full `ParquetFileReader.open()`: mmap, footer read, decode, schema build |
+| `WideSchemaMetadataParquetJavaBenchmark.*` | The same three steps through parquet-java, for comparison |
 
 **JMH options:**
 

--- a/core/src/main/java/dev/hardwood/internal/thrift/BloomFilterHeaderReader.java
+++ b/core/src/main/java/dev/hardwood/internal/thrift/BloomFilterHeaderReader.java
@@ -30,26 +30,26 @@ public class BloomFilterHeaderReader {
         BloomFilterHeader.Compression compression = null;
 
         while (true) {
-            ThriftCompactReader.FieldHeader header = reader.readFieldHeader();
-            if (header == null) {
+            int header = reader.readFieldHeader();
+            if (header == ThriftCompactReader.STOP_FIELD) {
                 break;
             }
 
-            switch (header.fieldId()) {
-                case 1 -> numBytes = readRequiredBitsetSize(reader, header.type());
+            switch (ThriftCompactReader.fieldId(header)) {
+                case 1 -> numBytes = readRequiredBitsetSize(reader, ThriftCompactReader.fieldType(header));
                 case 2 -> {
-                    short variant = readUnionVariant(reader, header.type(), "algorithm");
+                    short variant = readUnionVariant(reader, ThriftCompactReader.fieldType(header), "algorithm");
                     algorithm = BloomFilterHeader.Algorithm.fromVariant(variant);
                 }
                 case 3 -> {
-                    short variant = readUnionVariant(reader, header.type(), "hash");
+                    short variant = readUnionVariant(reader, ThriftCompactReader.fieldType(header), "hash");
                     hash = BloomFilterHeader.Hash.fromVariant(variant);
                 }
                 case 4 -> {
-                    short variant = readUnionVariant(reader, header.type(), "compression");
+                    short variant = readUnionVariant(reader, ThriftCompactReader.fieldType(header), "compression");
                     compression = BloomFilterHeader.Compression.fromVariant(variant);
                 }
-                default -> reader.skipField(header.type());
+                default -> reader.skipField(ThriftCompactReader.fieldType(header));
             }
         }
 
@@ -79,20 +79,20 @@ public class BloomFilterHeaderReader {
         }
         short saved = reader.pushFieldIdContext();
         try {
-            ThriftCompactReader.FieldHeader variant = reader.readFieldHeader();
-            if (variant == null) {
+            int variant = reader.readFieldHeader();
+            if (variant == ThriftCompactReader.STOP_FIELD) {
                 throw invalidHeader("union field '" + name + "' has no variant set");
             }
             // The variant's value is an empty struct; a different wire type would make skipField
             // consume the wrong number of bytes and desync the rest of the header.
-            if (variant.type() != Codes.STRUCT) {
-                throw wrongWireType("union field '" + name + "' variant " + variant.fieldId(), variant.type());
+            if (ThriftCompactReader.fieldType(variant) != Codes.STRUCT) {
+                throw wrongWireType("union field '" + name + "' variant " + ThriftCompactReader.fieldId(variant), ThriftCompactReader.fieldType(variant));
             }
-            reader.skipField(variant.type()); // consume the variant's value (the empty inner struct)
-            if (reader.readFieldHeader() != null) {
+            reader.skipField(ThriftCompactReader.fieldType(variant)); // consume the variant's value (the empty inner struct)
+            if (reader.readFieldHeader() != ThriftCompactReader.STOP_FIELD) {
                 throw invalidHeader("union field '" + name + "' has more than one variant set");
             }
-            return variant.fieldId();
+            return ThriftCompactReader.fieldId(variant);
         } finally {
             reader.popFieldIdContext(saved);
         }

--- a/core/src/main/java/dev/hardwood/internal/thrift/BoundingBoxReader.java
+++ b/core/src/main/java/dev/hardwood/internal/thrift/BoundingBoxReader.java
@@ -36,21 +36,21 @@ public class BoundingBoxReader {
         Double mmax = null;
 
         while (true) {
-            ThriftCompactReader.FieldHeader header = reader.readFieldHeader();
-            if (header == null) {
+            int header = reader.readFieldHeader();
+            if (header == ThriftCompactReader.STOP_FIELD) {
                 break;
             }
 
-            switch (header.fieldId()) {
-                case 1 -> xmin = readRequiredDouble(reader, header.type(), "xmin");
-                case 2 -> xmax = readRequiredDouble(reader, header.type(), "xmax");
-                case 3 -> ymin = readRequiredDouble(reader, header.type(), "ymin");
-                case 4 -> ymax = readRequiredDouble(reader, header.type(), "ymax");
-                case 5 -> zmin = readOptionalDouble(reader, header.type());
-                case 6 -> zmax = readOptionalDouble(reader, header.type());
-                case 7 -> mmin = readOptionalDouble(reader, header.type());
-                case 8 -> mmax = readOptionalDouble(reader, header.type());
-                default -> reader.skipField(header.type());
+            switch (ThriftCompactReader.fieldId(header)) {
+                case 1 -> xmin = readRequiredDouble(reader, ThriftCompactReader.fieldType(header), "xmin");
+                case 2 -> xmax = readRequiredDouble(reader, ThriftCompactReader.fieldType(header), "xmax");
+                case 3 -> ymin = readRequiredDouble(reader, ThriftCompactReader.fieldType(header), "ymin");
+                case 4 -> ymax = readRequiredDouble(reader, ThriftCompactReader.fieldType(header), "ymax");
+                case 5 -> zmin = readOptionalDouble(reader, ThriftCompactReader.fieldType(header));
+                case 6 -> zmax = readOptionalDouble(reader, ThriftCompactReader.fieldType(header));
+                case 7 -> mmin = readOptionalDouble(reader, ThriftCompactReader.fieldType(header));
+                case 8 -> mmax = readOptionalDouble(reader, ThriftCompactReader.fieldType(header));
+                default -> reader.skipField(ThriftCompactReader.fieldType(header));
             }
         }
 

--- a/core/src/main/java/dev/hardwood/internal/thrift/ColumnChunkReader.java
+++ b/core/src/main/java/dev/hardwood/internal/thrift/ColumnChunkReader.java
@@ -36,19 +36,19 @@ public class ColumnChunkReader {
         String filePath = "";
 
         while (true) {
-            ThriftCompactReader.FieldHeader header = reader.readFieldHeader();
-            if (header == null) {
+            int header = reader.readFieldHeader();
+            if (header == ThriftCompactReader.STOP_FIELD) {
                 break;
             }
 
-            switch (header.fieldId()) {
+            switch (ThriftCompactReader.fieldId(header)) {
                 case 1: // file_path (optional string - deprecated)
                     if (reader.acceptField(header, Codes.BINARY)) {
                         filePath = reader.readString();
                     }
                     break;
                 case 2: // file_offset (required i64)
-                    reader.skipField(header.type());
+                    reader.skipField(ThriftCompactReader.fieldType(header));
                     break;
                 case 3: // meta_data (required)
                     if (reader.acceptField(header, Codes.STRUCT)) {
@@ -76,7 +76,7 @@ public class ColumnChunkReader {
                     }
                     break;
                 default:
-                    reader.skipField(header.type());
+                    reader.skipField(ThriftCompactReader.fieldType(header));
                     break;
             }
         }

--- a/core/src/main/java/dev/hardwood/internal/thrift/ColumnIndexReader.java
+++ b/core/src/main/java/dev/hardwood/internal/thrift/ColumnIndexReader.java
@@ -55,12 +55,12 @@ public class ColumnIndexReader {
         long[] nanCounts = null;
 
         while (true) {
-            ThriftCompactReader.FieldHeader header = reader.readFieldHeader();
-            if (header == null) {
+            int header = reader.readFieldHeader();
+            if (header == ThriftCompactReader.STOP_FIELD) {
                 break;
             }
 
-            switch (header.fieldId()) {
+            switch (ThriftCompactReader.fieldId(header)) {
                 case 1: // null_pages (required list<bool>)
                     if (reader.acceptField(header, Codes.LIST)) {
                         nullPages = reader.readBoolArray("ColumnIndex.null_pages");
@@ -104,7 +104,7 @@ public class ColumnIndexReader {
                     }
                     break;
                 default:
-                    reader.skipField(header.type());
+                    reader.skipField(ThriftCompactReader.fieldType(header));
                     break;
             }
         }

--- a/core/src/main/java/dev/hardwood/internal/thrift/ColumnMetaDataReader.java
+++ b/core/src/main/java/dev/hardwood/internal/thrift/ColumnMetaDataReader.java
@@ -8,7 +8,6 @@
 package dev.hardwood.internal.thrift;
 
 import java.io.IOException;
-import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
@@ -27,6 +26,9 @@ import dev.hardwood.metadata.Statistics;
 /// Reader for ColumnMetaData from Thrift Compact Protocol.
 public class ColumnMetaDataReader {
 
+    /// Stand-in for a `ColumnMetaData` that carries no `path_in_schema` at all.
+    private static final FieldPath EMPTY_PATH = new FieldPath(List.of());
+
     public static ColumnMetaData read(ThriftCompactReader reader) throws IOException {
         short saved = reader.pushFieldIdContext();
         try {
@@ -40,7 +42,7 @@ public class ColumnMetaDataReader {
     private static ColumnMetaData readInternal(ThriftCompactReader reader) throws IOException {
         PhysicalType type = null;
         List<Encoding> encodings = Collections.emptyList();
-        List<String> pathInSchema = Collections.emptyList();
+        FieldPath pathInSchema = EMPTY_PATH;
         CompressionCodec codec = null;
         long numValues = 0;
         long totalUncompressedSize = 0;
@@ -56,12 +58,12 @@ public class ColumnMetaDataReader {
         SizeStatistics sizeStatistics = null;
 
         while (true) {
-            ThriftCompactReader.FieldHeader header = reader.readFieldHeader();
-            if (header == null) {
+            int header = reader.readFieldHeader();
+            if (header == ThriftCompactReader.STOP_FIELD) {
                 break;
             }
 
-            switch (header.fieldId()) {
+            switch (ThriftCompactReader.fieldId(header)) {
                 case 1: // type
                     if (reader.acceptField(header, Codes.I32)) {
                         type = ThriftEnumLookup.physicalType(reader.readI32());
@@ -74,7 +76,7 @@ public class ColumnMetaDataReader {
                     break;
                 case 3: // path_in_schema (required list<string>)
                     if (reader.acceptField(header, Codes.LIST)) {
-                        pathInSchema = reader.readStringList("ColumnMetaData.path_in_schema");
+                        pathInSchema = reader.pathCache().next(reader, "ColumnMetaData.path_in_schema");
                     }
                     break;
                 case 4: // codec
@@ -108,7 +110,7 @@ public class ColumnMetaDataReader {
                     }
                     break;
                 case 10: // index_page_offset (optional) - skipped for now
-                    reader.skipField(header.type());
+                    reader.skipField(ThriftCompactReader.fieldType(header));
                     break;
                 case 11: // dictionary_page_offset (optional)
                     if (reader.acceptField(header, Codes.I64)) {
@@ -146,12 +148,12 @@ public class ColumnMetaDataReader {
                     }
                     break;
                 default:
-                    reader.skipField(header.type());
+                    reader.skipField(ThriftCompactReader.fieldType(header));
                     break;
             }
         }
 
-        return new ColumnMetaData(type, encodings, new FieldPath(pathInSchema), codec,
+        return new ColumnMetaData(type, encodings, pathInSchema, codec,
                 numValues, totalUncompressedSize, totalCompressedSize, keyValueMetadata, dataPageOffset,
                 dictionaryPageOffset, statistics, geospatialStatistics, bloomFilterOffset, bloomFilterLength,
                 encodingStats, sizeStatistics);
@@ -160,12 +162,12 @@ public class ColumnMetaDataReader {
     /// `Encoding` is a Thrift enum, so its list elements are `i32` on the wire and are mapped
     /// to the enum one by one.
     private static List<Encoding> readEncodings(ThriftCompactReader reader) throws IOException {
-        ThriftCompactReader.CollectionHeader listHeader =
+        long listHeader =
                 reader.requireListHeader(Codes.I32, "ColumnMetaData.encodings");
-        List<Encoding> encodings = new ArrayList<>(listHeader.size());
-        for (int i = 0; i < listHeader.size(); i++) {
-            encodings.add(ThriftEnumLookup.encoding(reader.readI32()));
+        Encoding[] encodings = new Encoding[ThriftCompactReader.listSize(listHeader)];
+        for (int i = 0; i < encodings.length; i++) {
+            encodings[i] = ThriftEnumLookup.encoding(reader.readI32());
         }
-        return Collections.unmodifiableList(encodings);
+        return List.of(encodings);
     }
 }

--- a/core/src/main/java/dev/hardwood/internal/thrift/ColumnOrderReader.java
+++ b/core/src/main/java/dev/hardwood/internal/thrift/ColumnOrderReader.java
@@ -26,14 +26,14 @@ public class ColumnOrderReader {
         short saved = reader.pushFieldIdContext();
         try {
             ColumnOrder order = ColumnOrder.UNKNOWN;
-            ThriftCompactReader.FieldHeader header = reader.readFieldHeader();
-            while (header != null) {
-                order = switch (header.fieldId()) {
+            int header = reader.readFieldHeader();
+            while (header != ThriftCompactReader.STOP_FIELD) {
+                order = switch (ThriftCompactReader.fieldId(header)) {
                     case TYPE_ORDER -> ColumnOrder.TYPE_DEFINED_ORDER;
                     case IEEE_754_TOTAL_ORDER -> ColumnOrder.IEEE754_TOTAL_ORDER;
                     default -> ColumnOrder.UNKNOWN;
                 };
-                reader.skipField(header.type());
+                reader.skipField(ThriftCompactReader.fieldType(header));
                 header = reader.readFieldHeader();
             }
             return order;

--- a/core/src/main/java/dev/hardwood/internal/thrift/DataPageHeaderReader.java
+++ b/core/src/main/java/dev/hardwood/internal/thrift/DataPageHeaderReader.java
@@ -35,12 +35,12 @@ public class DataPageHeaderReader {
         Statistics statistics = null;
 
         while (true) {
-            ThriftCompactReader.FieldHeader header = reader.readFieldHeader();
-            if (header == null) {
+            int header = reader.readFieldHeader();
+            if (header == ThriftCompactReader.STOP_FIELD) {
                 break;
             }
 
-            switch (header.fieldId()) {
+            switch (ThriftCompactReader.fieldId(header)) {
                 case 1: // num_values
                     if (reader.acceptField(header, Codes.I32)) {
                         numValues = reader.readNonNegativeI32("DataPageHeader.num_values");
@@ -67,7 +67,7 @@ public class DataPageHeaderReader {
                     }
                     break;
                 default:
-                    reader.skipField(header.type());
+                    reader.skipField(ThriftCompactReader.fieldType(header));
                     break;
             }
         }

--- a/core/src/main/java/dev/hardwood/internal/thrift/DataPageHeaderV2Reader.java
+++ b/core/src/main/java/dev/hardwood/internal/thrift/DataPageHeaderV2Reader.java
@@ -38,12 +38,12 @@ public class DataPageHeaderV2Reader {
         Statistics statistics = null;
 
         while (true) {
-            ThriftCompactReader.FieldHeader header = reader.readFieldHeader();
-            if (header == null) {
+            int header = reader.readFieldHeader();
+            if (header == ThriftCompactReader.STOP_FIELD) {
                 break;
             }
 
-            switch (header.fieldId()) {
+            switch (ThriftCompactReader.fieldId(header)) {
                 case 1: // num_values
                     if (reader.acceptField(header, Codes.I32)) {
                         numValues = reader.readNonNegativeI32("DataPageHeaderV2.num_values");
@@ -83,7 +83,7 @@ public class DataPageHeaderV2Reader {
                     }
                     break;
                 default:
-                    reader.skipField(header.type());
+                    reader.skipField(ThriftCompactReader.fieldType(header));
                     break;
             }
         }

--- a/core/src/main/java/dev/hardwood/internal/thrift/DictionaryPageHeaderReader.java
+++ b/core/src/main/java/dev/hardwood/internal/thrift/DictionaryPageHeaderReader.java
@@ -31,12 +31,12 @@ public class DictionaryPageHeaderReader {
         Encoding encoding = null;
 
         while (true) {
-            ThriftCompactReader.FieldHeader header = reader.readFieldHeader();
-            if (header == null) {
+            int header = reader.readFieldHeader();
+            if (header == ThriftCompactReader.STOP_FIELD) {
                 break;
             }
 
-            switch (header.fieldId()) {
+            switch (ThriftCompactReader.fieldId(header)) {
                 case 1: // num_values
                     if (reader.acceptField(header, Codes.I32)) {
                         numValues = reader.readNonNegativeI32("DictionaryPageHeader.num_values");
@@ -48,7 +48,7 @@ public class DictionaryPageHeaderReader {
                     }
                     break;
                 default:
-                    reader.skipField(header.type());
+                    reader.skipField(ThriftCompactReader.fieldType(header));
                     break;
             }
         }

--- a/core/src/main/java/dev/hardwood/internal/thrift/FileMetaDataReader.java
+++ b/core/src/main/java/dev/hardwood/internal/thrift/FileMetaDataReader.java
@@ -43,12 +43,12 @@ public class FileMetaDataReader {
         List<ColumnOrder> columnOrders = Collections.emptyList();
 
         while (true) {
-            ThriftCompactReader.FieldHeader header = reader.readFieldHeader();
-            if (header == null) {
+            int header = reader.readFieldHeader();
+            if (header == ThriftCompactReader.STOP_FIELD) {
                 break;
             }
 
-            switch (header.fieldId()) {
+            switch (ThriftCompactReader.fieldId(header)) {
                 case 1: // version
                     if (reader.acceptField(header, Codes.I32)) {
                         version = reader.readI32();
@@ -90,7 +90,7 @@ public class FileMetaDataReader {
                     // later page scan crash with an unattributable error.
                     throw new EncryptedParquetException();
                 default:
-                    reader.skipField(header.type());
+                    reader.skipField(ThriftCompactReader.fieldType(header));
                     break;
             }
         }
@@ -103,13 +103,13 @@ public class FileMetaDataReader {
     /// this reader will not decode leaves them empty — the same shape as a writer that omits
     /// the field.
     private static List<ColumnOrder> readColumnOrders(ThriftCompactReader reader) throws IOException {
-        ThriftCompactReader.CollectionHeader listHeader =
+        long listHeader =
                 reader.acceptListHeader(Codes.STRUCT, "FileMetaData.column_orders");
-        if (listHeader == null) {
+        if (listHeader == ThriftCompactReader.ABSENT_LIST) {
             return List.of();
         }
-        List<ColumnOrder> orders = new ArrayList<>(listHeader.size());
-        for (int i = 0; i < listHeader.size(); i++) {
+        List<ColumnOrder> orders = new ArrayList<>(ThriftCompactReader.listSize(listHeader));
+        for (int i = 0; i < ThriftCompactReader.listSize(listHeader); i++) {
             orders.add(ColumnOrderReader.read(reader));
         }
         return Collections.unmodifiableList(orders);

--- a/core/src/main/java/dev/hardwood/internal/thrift/GeospatialStatisticsReader.java
+++ b/core/src/main/java/dev/hardwood/internal/thrift/GeospatialStatisticsReader.java
@@ -34,12 +34,12 @@ public class GeospatialStatisticsReader {
         List<Integer> geospatialTypes = List.of();
 
         while (true) {
-            ThriftCompactReader.FieldHeader header = reader.readFieldHeader();
-            if (header == null) {
+            int header = reader.readFieldHeader();
+            if (header == ThriftCompactReader.STOP_FIELD) {
                 break;
             }
 
-            switch (header.fieldId()) {
+            switch (ThriftCompactReader.fieldId(header)) {
                 case 1: // bbox (optional BoundingBox)
                     if (reader.acceptField(header, Codes.STRUCT)) {
                         bbox = BoundingBoxReader.read(reader);
@@ -51,7 +51,7 @@ public class GeospatialStatisticsReader {
                     }
                     break;
                 default:
-                    reader.skipField(header.type());
+                    reader.skipField(ThriftCompactReader.fieldType(header));
                     break;
             }
         }
@@ -60,13 +60,13 @@ public class GeospatialStatisticsReader {
     }
 
     private static List<Integer> readGeospatialTypes(ThriftCompactReader reader) throws IOException {
-        ThriftCompactReader.CollectionHeader listHeader =
+        long listHeader =
                 reader.acceptListHeader(Codes.I32, "GeospatialStatistics.geospatial_types");
-        if (listHeader == null) {
+        if (listHeader == ThriftCompactReader.ABSENT_LIST) {
             return List.of();
         }
-        List<Integer> geospatialTypes = new ArrayList<>(listHeader.size());
-        for (int i = 0; i < listHeader.size(); i++) {
+        List<Integer> geospatialTypes = new ArrayList<>(ThriftCompactReader.listSize(listHeader));
+        for (int i = 0; i < ThriftCompactReader.listSize(listHeader); i++) {
             geospatialTypes.add(reader.readI32());
         }
         return Collections.unmodifiableList(geospatialTypes);

--- a/core/src/main/java/dev/hardwood/internal/thrift/KeyValueMetadataReader.java
+++ b/core/src/main/java/dev/hardwood/internal/thrift/KeyValueMetadataReader.java
@@ -25,12 +25,12 @@ class KeyValueMetadataReader {
     ///
     /// @param fieldName fully-qualified name of the field being read, for the log message
     static Map<String, String> read(ThriftCompactReader reader, String fieldName) throws IOException {
-        ThriftCompactReader.CollectionHeader listHeader = reader.acceptListHeader(Codes.STRUCT, fieldName);
-        if (listHeader == null) {
+        long listHeader = reader.acceptListHeader(Codes.STRUCT, fieldName);
+        if (listHeader == ThriftCompactReader.ABSENT_LIST) {
             return Map.of();
         }
-        Map<String, String> result = new LinkedHashMap<>(listHeader.size());
-        for (int i = 0; i < listHeader.size(); i++) {
+        Map<String, String> result = new LinkedHashMap<>(ThriftCompactReader.listSize(listHeader));
+        for (int i = 0; i < ThriftCompactReader.listSize(listHeader); i++) {
             readKeyValue(reader, result);
         }
         return Collections.unmodifiableMap(result);
@@ -44,12 +44,12 @@ class KeyValueMetadataReader {
             String value = null;
 
             while (true) {
-                ThriftCompactReader.FieldHeader header = reader.readFieldHeader();
-                if (header == null) {
+                int header = reader.readFieldHeader();
+                if (header == ThriftCompactReader.STOP_FIELD) {
                     break;
                 }
 
-                switch (header.fieldId()) {
+                switch (ThriftCompactReader.fieldId(header)) {
                     case 1: // key (required string)
                         if (reader.acceptField(header, Codes.BINARY)) {
                             key = reader.readString();
@@ -61,7 +61,7 @@ class KeyValueMetadataReader {
                         }
                         break;
                     default:
-                        reader.skipField(header.type());
+                        reader.skipField(ThriftCompactReader.fieldType(header));
                         break;
                 }
             }

--- a/core/src/main/java/dev/hardwood/internal/thrift/LogicalTypeReader.java
+++ b/core/src/main/java/dev/hardwood/internal/thrift/LogicalTypeReader.java
@@ -32,74 +32,74 @@ public class LogicalTypeReader {
         LogicalType result = null;
 
         while (true) {
-            ThriftCompactReader.FieldHeader header = reader.readFieldHeader();
-            if (header == null) {
+            int header = reader.readFieldHeader();
+            if (header == ThriftCompactReader.STOP_FIELD) {
                 return result;
             }
 
             // Union: only one field should be set, but we need to read to the end
             if (result == null) {
-                result = switch (header.fieldId()) {
+                result = switch (ThriftCompactReader.fieldId(header)) {
                     case 1 -> { // STRING
-                        reader.skipField(header.type()); // Empty struct
+                        reader.skipField(ThriftCompactReader.fieldType(header)); // Empty struct
                         yield new LogicalType.StringType();
                     }
                     case 2 -> { // MAP
-                        reader.skipField(header.type()); // Empty Struct
+                        reader.skipField(ThriftCompactReader.fieldType(header)); // Empty Struct
                         yield new LogicalType.MapType();
                     }
                     case 3 -> { // LIST
-                        reader.skipField(header.type()); // Empty Struct
+                        reader.skipField(ThriftCompactReader.fieldType(header)); // Empty Struct
                         yield new LogicalType.ListType();
                     }
                     case 4 -> { // ENUM
-                        reader.skipField(header.type()); // Empty struct
+                        reader.skipField(ThriftCompactReader.fieldType(header)); // Empty struct
                         yield new LogicalType.EnumType();
                     }
                     case 5 -> readDecimalType(reader);
                     case 6 -> { // DATE
-                        reader.skipField(header.type()); // Empty struct
+                        reader.skipField(ThriftCompactReader.fieldType(header)); // Empty struct
                         yield new LogicalType.DateType();
                     }
                     case 7 -> readTimeType(reader);
                     case 8 -> readTimestampType(reader);
                     case 9 -> { // INTERVAL
-                        reader.skipField(header.type()); // Empty struct
+                        reader.skipField(ThriftCompactReader.fieldType(header)); // Empty struct
                         yield new LogicalType.IntervalType();
                     }
                     case 10 -> readIntType(reader);
                     case 11 -> { // NULL
-                        reader.skipField(header.type()); // Empty struct
+                        reader.skipField(ThriftCompactReader.fieldType(header)); // Empty struct
                         yield new LogicalType.NullType();
                     }
                     case 12 -> { // JSON
-                        reader.skipField(header.type()); // Empty struct
+                        reader.skipField(ThriftCompactReader.fieldType(header)); // Empty struct
                         yield new LogicalType.JsonType();
                     }
                     case 13 -> { // BSON
-                        reader.skipField(header.type()); // Empty struct
+                        reader.skipField(ThriftCompactReader.fieldType(header)); // Empty struct
                         yield new LogicalType.BsonType();
                     }
                     case 14 -> { // UUID
-                        reader.skipField(header.type()); // Empty struct
+                        reader.skipField(ThriftCompactReader.fieldType(header)); // Empty struct
                         yield new LogicalType.UuidType();
                     }
                     case 15 -> { // FLOAT16
-                        reader.skipField(header.type()); // Empty struct
+                        reader.skipField(ThriftCompactReader.fieldType(header)); // Empty struct
                         yield new LogicalType.Float16Type();
                     }
                     case 16 -> readVariantType(reader);
                     case 17 -> readGeometryType(reader);
                     case 18 -> readGeographyType(reader);
                     default -> {
-                        reader.skipField(header.type());
+                        reader.skipField(ThriftCompactReader.fieldType(header));
                         yield null;
                     }
                 };
             }
             else {
                 // Already found the union variant, skip remaining fields
-                reader.skipField(header.type());
+                reader.skipField(ThriftCompactReader.fieldType(header));
             }
         }
     }
@@ -119,12 +119,12 @@ public class LogicalTypeReader {
         int precision = -1;
 
         while (true) {
-            ThriftCompactReader.FieldHeader header = reader.readFieldHeader();
-            if (header == null) {
+            int header = reader.readFieldHeader();
+            if (header == ThriftCompactReader.STOP_FIELD) {
                 break;
             }
 
-            switch (header.fieldId()) {
+            switch (ThriftCompactReader.fieldId(header)) {
                 case 1: // scale (required)
                     if (reader.acceptField(header, Codes.I32)) {
                         scale = reader.readI32();
@@ -136,7 +136,7 @@ public class LogicalTypeReader {
                     }
                     break;
                 default:
-                    reader.skipField(header.type());
+                    reader.skipField(ThriftCompactReader.fieldType(header));
                     break;
             }
         }
@@ -165,12 +165,12 @@ public class LogicalTypeReader {
         LogicalType.TimeType.TimeUnit unit = LogicalType.TimeType.TimeUnit.MILLIS;
 
         while (true) {
-            ThriftCompactReader.FieldHeader header = reader.readFieldHeader();
-            if (header == null) {
+            int header = reader.readFieldHeader();
+            if (header == ThriftCompactReader.STOP_FIELD) {
                 break;
             }
 
-            switch (header.fieldId()) {
+            switch (ThriftCompactReader.fieldId(header)) {
                 case 1: // isAdjustedToUTC (required)
                     isAdjustedToUTC = reader.readBooleanField(header, isAdjustedToUTC);
                     break;
@@ -178,7 +178,7 @@ public class LogicalTypeReader {
                     unit = readTimeUnit(reader);
                     break;
                 default:
-                    reader.skipField(header.type());
+                    reader.skipField(ThriftCompactReader.fieldType(header));
                     break;
             }
         }
@@ -201,12 +201,12 @@ public class LogicalTypeReader {
         LogicalType.TimestampType.TimeUnit unit = LogicalType.TimestampType.TimeUnit.MILLIS;
 
         while (true) {
-            ThriftCompactReader.FieldHeader header = reader.readFieldHeader();
-            if (header == null) {
+            int header = reader.readFieldHeader();
+            if (header == ThriftCompactReader.STOP_FIELD) {
                 break;
             }
 
-            switch (header.fieldId()) {
+            switch (ThriftCompactReader.fieldId(header)) {
                 case 1: // isAdjustedToUTC (required)
                     isAdjustedToUTC = reader.readBooleanField(header, isAdjustedToUTC);
                     break;
@@ -214,7 +214,7 @@ public class LogicalTypeReader {
                     unit = readTimeUnit(reader);
                     break;
                 default:
-                    reader.skipField(header.type());
+                    reader.skipField(ThriftCompactReader.fieldType(header));
                     break;
             }
         }
@@ -237,12 +237,12 @@ public class LogicalTypeReader {
         boolean isSigned = true;
 
         while (true) {
-            ThriftCompactReader.FieldHeader header = reader.readFieldHeader();
-            if (header == null) {
+            int header = reader.readFieldHeader();
+            if (header == ThriftCompactReader.STOP_FIELD) {
                 break;
             }
 
-            switch (header.fieldId()) {
+            switch (ThriftCompactReader.fieldId(header)) {
                 case 1: // bitWidth (required)
                     if (reader.acceptField(header, Codes.BYTE)) {
                         bitWidth = reader.readByte();
@@ -252,7 +252,7 @@ public class LogicalTypeReader {
                     isSigned = reader.readBooleanField(header, isSigned);
                     break;
                 default:
-                    reader.skipField(header.type());
+                    reader.skipField(ThriftCompactReader.fieldType(header));
                     break;
             }
         }
@@ -274,19 +274,19 @@ public class LogicalTypeReader {
         int specVersion = 1; // Per Parquet Variant spec: default when unset.
 
         while (true) {
-            ThriftCompactReader.FieldHeader header = reader.readFieldHeader();
-            if (header == null) {
+            int header = reader.readFieldHeader();
+            if (header == ThriftCompactReader.STOP_FIELD) {
                 break;
             }
 
-            switch (header.fieldId()) {
+            switch (ThriftCompactReader.fieldId(header)) {
                 case 1: // specification_version (optional i8)
                     if (reader.acceptField(header, Codes.BYTE)) {
                         specVersion = reader.readByte();
                     }
                     break;
                 default:
-                    reader.skipField(header.type());
+                    reader.skipField(ThriftCompactReader.fieldType(header));
                     break;
             }
         }
@@ -323,19 +323,19 @@ public class LogicalTypeReader {
     private static LogicalType.GeometryType readGeometryTypeInternal(ThriftCompactReader reader) throws IOException {
         String crs = null;
         while (true) {
-            ThriftCompactReader.FieldHeader header = reader.readFieldHeader();
-            if (header == null) {
+            int header = reader.readFieldHeader();
+            if (header == ThriftCompactReader.STOP_FIELD) {
                 break;
             }
 
-            switch (header.fieldId()) {
+            switch (ThriftCompactReader.fieldId(header)) {
                 case 1: // CRS
                     if (reader.acceptField(header, Codes.BINARY)) {
                         crs = reader.readString();
                     }
                     break;
                 default:
-                    reader.skipField(header.type());
+                    reader.skipField(ThriftCompactReader.fieldType(header));
                     break;
             }
         }
@@ -361,12 +361,12 @@ public class LogicalTypeReader {
         String crs = null;
         EdgeInterpolationAlgorithm edgeInterpolation = null;
         while (true) {
-            ThriftCompactReader.FieldHeader header = reader.readFieldHeader();
-            if (header == null) {
+            int header = reader.readFieldHeader();
+            if (header == ThriftCompactReader.STOP_FIELD) {
                 break;
             }
 
-            switch (header.fieldId()) {
+            switch (ThriftCompactReader.fieldId(header)) {
                 case 1: // CRS
                     if (reader.acceptField(header, Codes.BINARY)) {
                         crs = reader.readString();
@@ -378,7 +378,7 @@ public class LogicalTypeReader {
                     }
                     break;
                 default:
-                    reader.skipField(header.type());
+                    reader.skipField(ThriftCompactReader.fieldType(header));
                     break;
             }
         }
@@ -405,16 +405,16 @@ public class LogicalTypeReader {
     ///
     /// @param unionName name of the union, for the error message
     private static int readUnionVariantId(ThriftCompactReader reader, String unionName) throws IOException {
-        ThriftCompactReader.FieldHeader variant = reader.readFieldHeader();
-        if (variant == null) {
+        int variant = reader.readFieldHeader();
+        if (variant == ThriftCompactReader.STOP_FIELD) {
             throw new IOException("Malformed Parquet metadata: " + unionName
                     + " union has no variant set");
         }
-        reader.skipField(variant.type());
-        if (reader.readFieldHeader() != null) {
+        reader.skipField(ThriftCompactReader.fieldType(variant));
+        if (reader.readFieldHeader() != ThriftCompactReader.STOP_FIELD) {
             throw new IOException("Malformed Parquet metadata: " + unionName
                     + " union has more than one variant set");
         }
-        return variant.fieldId();
+        return ThriftCompactReader.fieldId(variant);
     }
 }

--- a/core/src/main/java/dev/hardwood/internal/thrift/OffsetIndexReader.java
+++ b/core/src/main/java/dev/hardwood/internal/thrift/OffsetIndexReader.java
@@ -38,12 +38,12 @@ public class OffsetIndexReader {
         long[] unencodedByteArrayDataBytes = null;
 
         while (true) {
-            ThriftCompactReader.FieldHeader header = reader.readFieldHeader();
-            if (header == null) {
+            int header = reader.readFieldHeader();
+            if (header == ThriftCompactReader.STOP_FIELD) {
                 break;
             }
 
-            switch (header.fieldId()) {
+            switch (ThriftCompactReader.fieldId(header)) {
                 case 1: // page_locations (required list<PageLocation>)
                     if (reader.acceptField(header, Codes.LIST)) {
                         pageLocations = reader.readStructList(
@@ -57,7 +57,7 @@ public class OffsetIndexReader {
                     }
                     break;
                 default:
-                    reader.skipField(header.type());
+                    reader.skipField(ThriftCompactReader.fieldType(header));
                     break;
             }
         }

--- a/core/src/main/java/dev/hardwood/internal/thrift/PageEncodingStatsReader.java
+++ b/core/src/main/java/dev/hardwood/internal/thrift/PageEncodingStatsReader.java
@@ -34,22 +34,22 @@ class PageEncodingStatsReader {
     /// The reader is always left positioned on the byte after the list, so the rest of the
     /// footer parses regardless of what this field contained.
     static List<PageEncodingStats> read(ThriftCompactReader reader) throws IOException {
-        ThriftCompactReader.CollectionHeader listHeader =
+        long listHeader =
                 reader.acceptListHeader(Codes.STRUCT, "ColumnMetaData.encoding_stats");
-        if (listHeader == null) {
+        if (listHeader == ThriftCompactReader.ABSENT_LIST) {
             return List.of();
         }
-        List<PageEncodingStats> result = new ArrayList<>(listHeader.size());
-        for (int i = 0; i < listHeader.size(); i++) {
+        List<PageEncodingStats> result = new ArrayList<>(ThriftCompactReader.listSize(listHeader));
+        for (int i = 0; i < ThriftCompactReader.listSize(listHeader); i++) {
             PageEncodingStats stats = readStats(reader);
             if (stats != null) {
                 result.add(stats);
             }
         }
-        if (result.size() != listHeader.size()) {
+        if (result.size() != ThriftCompactReader.listSize(listHeader)) {
             LOG.log(System.Logger.Level.WARNING,
-                    "Ignoring ColumnMetaData.encoding_stats: " + (listHeader.size() - result.size())
-                            + " of " + listHeader.size() + " entries are missing a required field");
+                    "Ignoring ColumnMetaData.encoding_stats: " + (ThriftCompactReader.listSize(listHeader) - result.size())
+                            + " of " + ThriftCompactReader.listSize(listHeader) + " entries are missing a required field");
             return List.of();
         }
         return Collections.unmodifiableList(result);
@@ -69,17 +69,17 @@ class PageEncodingStatsReader {
             int count = -1;
 
             while (true) {
-                ThriftCompactReader.FieldHeader header = reader.readFieldHeader();
-                if (header == null) {
+                int header = reader.readFieldHeader();
+                if (header == ThriftCompactReader.STOP_FIELD) {
                     break;
                 }
                 // Every field defined on this struct is an i32, so one wire-type gate covers
                 // all three: anything else is a field this version cannot use.
-                if (header.type() != Codes.I32) {
-                    reader.skipField(header.type());
+                if (ThriftCompactReader.fieldType(header) != Codes.I32) {
+                    reader.skipField(ThriftCompactReader.fieldType(header));
                     continue;
                 }
-                switch (header.fieldId()) {
+                switch (ThriftCompactReader.fieldId(header)) {
                     case 1 -> pageType = ThriftEnumLookup.pageType(reader.readI32());
                     case 2 -> encoding = ThriftEnumLookup.encoding(reader.readI32());
                     case 3 -> count = reader.readI32();

--- a/core/src/main/java/dev/hardwood/internal/thrift/PageHeaderReader.java
+++ b/core/src/main/java/dev/hardwood/internal/thrift/PageHeaderReader.java
@@ -39,12 +39,12 @@ public class PageHeaderReader {
         DictionaryPageHeader dictionaryPageHeader = null;
 
         while (true) {
-            ThriftCompactReader.FieldHeader header = reader.readFieldHeader();
-            if (header == null) {
+            int header = reader.readFieldHeader();
+            if (header == ThriftCompactReader.STOP_FIELD) {
                 break;
             }
 
-            switch (header.fieldId()) {
+            switch (ThriftCompactReader.fieldId(header)) {
                 case 1: // type
                     if (reader.acceptField(header, Codes.I32)) {
                         int rawType = reader.readI32();
@@ -76,7 +76,7 @@ public class PageHeaderReader {
                     }
                     break;
                 case 6: // index_page_header (optional) - skipped for now
-                    reader.skipField(header.type());
+                    reader.skipField(ThriftCompactReader.fieldType(header));
                     break;
                 case 7: // dictionary_page_header
                     if (reader.acceptField(header, Codes.STRUCT)) {
@@ -89,7 +89,7 @@ public class PageHeaderReader {
                     }
                     break;
                 default:
-                    reader.skipField(header.type());
+                    reader.skipField(ThriftCompactReader.fieldType(header));
                     break;
             }
         }

--- a/core/src/main/java/dev/hardwood/internal/thrift/PageLocationReader.java
+++ b/core/src/main/java/dev/hardwood/internal/thrift/PageLocationReader.java
@@ -31,12 +31,12 @@ public class PageLocationReader {
         long firstRowIndex = 0;
 
         while (true) {
-            ThriftCompactReader.FieldHeader header = reader.readFieldHeader();
-            if (header == null) {
+            int header = reader.readFieldHeader();
+            if (header == ThriftCompactReader.STOP_FIELD) {
                 break;
             }
 
-            switch (header.fieldId()) {
+            switch (ThriftCompactReader.fieldId(header)) {
                 case 1: // offset (i64)
                     if (reader.acceptField(header, Codes.I64)) {
                         offset = reader.readNonNegativeI64("PageLocation.offset");
@@ -53,7 +53,7 @@ public class PageLocationReader {
                     }
                     break;
                 default:
-                    reader.skipField(header.type());
+                    reader.skipField(ThriftCompactReader.fieldType(header));
                     break;
             }
         }

--- a/core/src/main/java/dev/hardwood/internal/thrift/RepeatedPathCache.java
+++ b/core/src/main/java/dev/hardwood/internal/thrift/RepeatedPathCache.java
@@ -1,0 +1,74 @@
+/*
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Copyright The original authors
+ *
+ *  Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package dev.hardwood.internal.thrift;
+
+import java.io.IOException;
+import java.util.Arrays;
+
+import dev.hardwood.metadata.FieldPath;
+
+/// Per-decode cache of the `path_in_schema` of each column, so a footer materializes one
+/// [FieldPath] per column rather than one per column chunk.
+///
+/// A footer repeats a column's path in every row group's chunk of that column — on a file of
+/// 100,000 columns and ten row groups, a million paths of which only 100,000 are distinct, each
+/// otherwise costing a `String`, its bytes, a list and a `FieldPath`.
+///
+/// The cache is keyed by position, the way [dev.hardwood.internal.reader.Dictionary] keys its
+/// interned strings by dictionary index: chunks appear in schema order within a row group, so
+/// the n-th path of one row group is the n-th path of the next. That is a convention rather
+/// than a rule the format enforces, so it is a **prediction**, checked by comparing the cached
+/// entry against the encoded bytes about to be read — a hit skips the decode entirely, a miss
+/// decodes and re-primes that position. Content-keyed interning was measured against this and
+/// lost: hashing every path and probing a table of them costs more than the allocation it saves.
+///
+/// A cache instance belongs to one [ThriftCompactReader] and is used by a single thread.
+final class RepeatedPathCache {
+
+    private static final int INITIAL_CAPACITY = 16;
+
+    /// The encoded `list<string>` bytes of the path at each position, as they appear in the
+    /// footer, so a repeat is recognised without decoding it.
+    private byte[][] encoded = new byte[INITIAL_CAPACITY][];
+    private FieldPath[] paths = new FieldPath[INITIAL_CAPACITY];
+    private int position;
+
+    /// Starts the column chunks of a row group, so the next path read is predicted from the
+    /// first column of the previous row group.
+    void startRowGroup() {
+        position = 0;
+    }
+
+    /// The [FieldPath] of the `path_in_schema` list the reader is positioned on, consuming it
+    /// either way.
+    ///
+    /// @param reader positioned on the list header of the path
+    /// @param fieldName fully-qualified field name for the error message
+    FieldPath next(ThriftCompactReader reader, String fieldName) throws IOException {
+        int slot = position++;
+        byte[] predicted = slot < encoded.length ? encoded[slot] : null;
+        if (predicted != null && reader.matchesAt(predicted)) {
+            reader.skipBytes(predicted.length);
+            return paths[slot];
+        }
+        int start = reader.position();
+        FieldPath path = new FieldPath(reader.readStringList(fieldName));
+        store(slot, reader.copyRange(start, reader.position() - start), path);
+        return path;
+    }
+
+    private void store(int slot, byte[] encodedPath, FieldPath path) {
+        if (slot >= encoded.length) {
+            int capacity = Math.max(slot + 1, encoded.length * 2);
+            encoded = Arrays.copyOf(encoded, capacity);
+            paths = Arrays.copyOf(paths, capacity);
+        }
+        encoded[slot] = encodedPath;
+        paths[slot] = path;
+    }
+}

--- a/core/src/main/java/dev/hardwood/internal/thrift/RowGroupReader.java
+++ b/core/src/main/java/dev/hardwood/internal/thrift/RowGroupReader.java
@@ -34,14 +34,17 @@ public class RowGroupReader {
         long numRows = 0;
 
         while (true) {
-            ThriftCompactReader.FieldHeader header = reader.readFieldHeader();
-            if (header == null) {
+            int header = reader.readFieldHeader();
+            if (header == ThriftCompactReader.STOP_FIELD) {
                 break;
             }
 
-            switch (header.fieldId()) {
+            switch (ThriftCompactReader.fieldId(header)) {
                 case 1: // columns (required list<ColumnChunk>)
                     if (reader.acceptField(header, Codes.LIST)) {
+                        // Chunks come in schema order, so each column's path repeats the one the
+                        // previous row group held at the same position.
+                        reader.pathCache().startRowGroup();
                         columns = reader.readStructList("RowGroup.columns", ColumnChunkReader::read);
                     }
                     break;
@@ -56,7 +59,7 @@ public class RowGroupReader {
                     }
                     break;
                 default:
-                    reader.skipField(header.type());
+                    reader.skipField(ThriftCompactReader.fieldType(header));
                     break;
             }
         }

--- a/core/src/main/java/dev/hardwood/internal/thrift/SchemaElementReader.java
+++ b/core/src/main/java/dev/hardwood/internal/thrift/SchemaElementReader.java
@@ -42,12 +42,12 @@ public class SchemaElementReader {
         LogicalType logicalType = null;
 
         while (true) {
-            ThriftCompactReader.FieldHeader header = reader.readFieldHeader();
-            if (header == null) {
+            int header = reader.readFieldHeader();
+            if (header == ThriftCompactReader.STOP_FIELD) {
                 break;
             }
 
-            switch (header.fieldId()) {
+            switch (ThriftCompactReader.fieldId(header)) {
                 case 1: // type (optional)
                     if (reader.acceptField(header, Codes.I32)) {
                         type = ThriftEnumLookup.physicalType(reader.readI32());
@@ -99,7 +99,7 @@ public class SchemaElementReader {
                     }
                     break;
                 default:
-                    reader.skipField(header.type());
+                    reader.skipField(ThriftCompactReader.fieldType(header));
                     break;
             }
         }

--- a/core/src/main/java/dev/hardwood/internal/thrift/SizeStatisticsReader.java
+++ b/core/src/main/java/dev/hardwood/internal/thrift/SizeStatisticsReader.java
@@ -37,12 +37,12 @@ public class SizeStatisticsReader {
         long[] definitionLevelHistogram = null;
 
         while (true) {
-            ThriftCompactReader.FieldHeader header = reader.readFieldHeader();
-            if (header == null) {
+            int header = reader.readFieldHeader();
+            if (header == ThriftCompactReader.STOP_FIELD) {
                 break;
             }
 
-            switch (header.fieldId()) {
+            switch (ThriftCompactReader.fieldId(header)) {
                 case 1: // unencoded_byte_array_data_bytes (optional i64)
                     if (reader.acceptField(header, Codes.I64)) {
                         unencodedByteArrayDataBytes = reader.readI64();
@@ -61,7 +61,7 @@ public class SizeStatisticsReader {
                     }
                     break;
                 default:
-                    reader.skipField(header.type());
+                    reader.skipField(ThriftCompactReader.fieldType(header));
                     break;
             }
         }

--- a/core/src/main/java/dev/hardwood/internal/thrift/StatisticsReader.java
+++ b/core/src/main/java/dev/hardwood/internal/thrift/StatisticsReader.java
@@ -41,12 +41,12 @@ public class StatisticsReader {
         Long nanCount = null;
 
         while (true) {
-            ThriftCompactReader.FieldHeader header = reader.readFieldHeader();
-            if (header == null) {
+            int header = reader.readFieldHeader();
+            if (header == ThriftCompactReader.STOP_FIELD) {
                 break;
             }
 
-            switch (header.fieldId()) {
+            switch (ThriftCompactReader.fieldId(header)) {
                 case 1: // max (deprecated)
                     if (reader.acceptField(header, Codes.BINARY)) {
                         deprecatedMax = reader.readBinary();
@@ -89,7 +89,7 @@ public class StatisticsReader {
                     }
                     break;
                 default:
-                    reader.skipField(header.type());
+                    reader.skipField(ThriftCompactReader.fieldType(header));
                     break;
             }
         }

--- a/core/src/main/java/dev/hardwood/internal/thrift/ThriftCompactReader.java
+++ b/core/src/main/java/dev/hardwood/internal/thrift/ThriftCompactReader.java
@@ -13,6 +13,7 @@ import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 
@@ -45,9 +46,26 @@ public class ThriftCompactReader {
     private static final byte TYPE_MAP = Codes.MAP;
     private static final byte TYPE_STRUCT = Codes.STRUCT;
 
+    /// Returned by [#readFieldHeader] for the STOP field that ends a struct. No real header packs
+    /// to this value: it would take a wire type of `0xFF`, and the type comes from a nibble.
+    public static final int STOP_FIELD = -1;
+
+    private static final int FIELD_ID_SHIFT = 8;
+    private static final int TYPE_MASK = 0xFF;
+
+    /// Returned by [#acceptListHeader] for a list field that is absent or carries the wrong
+    /// element type. No real header packs to this value: it would need a negative element count.
+    static final long ABSENT_LIST = -1;
+
+    /// Element type occupies the low byte of a packed list header, the count the rest.
+    private static final int ELEMENT_TYPE_BITS = 8;
+
     private final ByteBuffer buffer;
     private final int startPosition;
     private short lastFieldId = 0;
+    /// Per-decode cache of repeated column paths, created on first use so the page-header path —
+    /// which has none — never allocates one.
+    private RepeatedPathCache pathCache;
 
     /// Creates a reader that reads directly from a ByteBuffer.
     ///
@@ -74,6 +92,52 @@ public class ThriftCompactReader {
     /// Returns the number of bytes still available to read in the buffer.
     public int remaining() {
         return buffer.remaining();
+    }
+
+    /// This decode's cache of repeated column paths.
+    RepeatedPathCache pathCache() {
+        if (pathCache == null) {
+            pathCache = new RepeatedPathCache();
+        }
+        return pathCache;
+    }
+
+    /// The reader's current offset into its buffer, for capturing a byte range that was read.
+    int position() {
+        return buffer.position();
+    }
+
+    /// Whether the bytes at the current position are `expected`, without moving the position.
+    boolean matchesAt(byte[] expected) {
+        if (buffer.remaining() < expected.length) {
+            return false;
+        }
+        int from = buffer.position();
+        if (buffer.hasArray()) {
+            int offset = buffer.arrayOffset() + from;
+            return Arrays.equals(expected, 0, expected.length, buffer.array(), offset, offset + expected.length);
+        }
+        for (int i = 0; i < expected.length; i++) {
+            if (expected[i] != buffer.get(from + i)) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    /// Advances past `length` bytes already known to be present.
+    void skipBytes(int length) throws EOFException {
+        if (buffer.remaining() < length) {
+            throw new EOFException("Unexpected EOF while skipping " + length + " bytes");
+        }
+        buffer.position(buffer.position() + length);
+    }
+
+    /// A copy of `length` bytes from `from`, independent of this reader's buffer.
+    byte[] copyRange(int from, int length) {
+        byte[] bytes = new byte[length];
+        buffer.get(from, bytes, 0, length);
+        return bytes;
     }
 
     /// Returns a zero-copy, read-only, little-endian view of the next `length` bytes and advances
@@ -197,18 +261,39 @@ public class ThriftCompactReader {
     }
 
     /// Read a string value.
+    ///
+    /// A heap-backed buffer — which is what the footer and every page header are read from — is
+    /// decoded in place, so the string costs one object rather than a `byte[]` copy and then the
+    /// string built from it.
     public String readString() throws IOException {
-        return new String(readBinary(), StandardCharsets.UTF_8);
+        int length = checkedBinaryLength(readVarint());
+        if (buffer.hasArray()) {
+            if (buffer.remaining() < length) {
+                throw new EOFException("Unexpected EOF while reading bytes");
+            }
+            String value = new String(buffer.array(), buffer.arrayOffset() + buffer.position(), length,
+                    StandardCharsets.UTF_8);
+            buffer.position(buffer.position() + length);
+            return value;
+        }
+        byte[] data = new byte[length];
+        readBytes(data);
+        return new String(data, StandardCharsets.UTF_8);
     }
 
-    /// Read a field header and return field info.
-    /// Returns null when STOP field is encountered.
-    public FieldHeader readFieldHeader() throws IOException {
+    /// Read a field header and return it packed into an `int`: the field id in the upper bits,
+    /// the wire type in the low byte. Returns [#STOP_FIELD] when the STOP field is encountered.
+    ///
+    /// The header is packed rather than returned as an object because a struct-heavy footer
+    /// reads one per field — a wide file's footer runs to tens of millions — and the object
+    /// escapes into [#acceptField], so it is allocated for real rather than scalarized.
+    /// Unpack it with [#fieldId] and [#fieldType].
+    public int readFieldHeader() throws IOException {
         byte b = readByte();
 
         if (b == ThriftCompactConstants.STOP) {
             lastFieldId = 0;
-            return null;
+            return STOP_FIELD;
         }
 
         byte type = (byte) (b & 0x0F);
@@ -225,7 +310,18 @@ public class ThriftCompactReader {
         }
 
         lastFieldId = fieldId;
-        return new FieldHeader(fieldId, type);
+        return (fieldId << FIELD_ID_SHIFT) | type;
+    }
+
+    /// The field id of a header returned by [#readFieldHeader].
+    public static short fieldId(int fieldHeader) {
+        return (short) (fieldHeader >> FIELD_ID_SHIFT);
+    }
+
+    /// The wire type of a header returned by [#readFieldHeader], one of
+    /// [ThriftCompactConstants.FieldType.Codes].
+    public static byte fieldType(int fieldHeader) {
+        return (byte) (fieldHeader & TYPE_MASK);
     }
 
     /// Gate a struct field on its declared wire type: returns `true` with the reader positioned
@@ -239,11 +335,12 @@ public class ThriftCompactReader {
     ///
     /// @param header the field header just read
     /// @param expectedType wire code the field must declare, from [ThriftCompactConstants.FieldType.Codes]
-    boolean acceptField(FieldHeader header, byte expectedType) throws IOException {
-        if (header.type() == expectedType) {
+    boolean acceptField(int header, byte expectedType) throws IOException {
+        byte type = fieldType(header);
+        if (type == expectedType) {
             return true;
         }
-        skipField(header.type());
+        skipField(type);
         return false;
     }
 
@@ -253,14 +350,15 @@ public class ThriftCompactReader {
     /// @param header the field header just read
     /// @param fallback value to report for a field declared as anything but `bool`, which is
     ///     skipped as [#acceptField] would
-    boolean readBooleanField(FieldHeader header, boolean fallback) throws IOException {
-        if (header.type() == TYPE_BOOLEAN_TRUE) {
+    boolean readBooleanField(int header, boolean fallback) throws IOException {
+        byte type = fieldType(header);
+        if (type == TYPE_BOOLEAN_TRUE) {
             return true;
         }
-        if (header.type() == TYPE_BOOLEAN_FALSE) {
+        if (type == TYPE_BOOLEAN_FALSE) {
             return false;
         }
-        skipField(header.type());
+        skipField(type);
         return fallback;
     }
 
@@ -272,7 +370,7 @@ public class ThriftCompactReader {
     /// a five-byte varint into a multi-gigabyte allocation, and a count past the `int` range would
     /// wrap to a negative capacity (an unchecked exception) or to zero (a silently empty
     /// collection) instead of a controlled error naming the file.
-    public CollectionHeader readListHeader() throws IOException {
+    public long readListHeader() throws IOException {
         byte sizeAndType = readByte();
         int size = (sizeAndType >> 4) & 0x0F;
         byte elementType = (byte) (sizeAndType & 0x0F);
@@ -282,7 +380,18 @@ public class ThriftCompactReader {
             size = checkedCollectionSize(readVarint());
         }
 
-        return new CollectionHeader(elementType, size);
+        return ((long) size << ELEMENT_TYPE_BITS) | elementType;
+    }
+
+    /// The element count of a header returned by [#readListHeader].
+    public static int listSize(long listHeader) {
+        return (int) (listHeader >> ELEMENT_TYPE_BITS);
+    }
+
+    /// The element wire type of a header returned by [#readListHeader], one of
+    /// [ThriftCompactConstants.ElementType].
+    public static byte elementType(long listHeader) {
+        return (byte) (listHeader & TYPE_MASK);
     }
 
     /// Read the header of a **required** list field and check its declared element type.
@@ -294,10 +403,10 @@ public class ThriftCompactReader {
     /// @param expectedElementType wire code the elements must declare
     /// @param fieldName fully-qualified field name for the error message
     /// @throws IOException if the list declares a different element type
-    CollectionHeader requireListHeader(byte expectedElementType, String fieldName) throws IOException {
-        CollectionHeader header = readListHeader();
-        if (header.elementType() != expectedElementType) {
-            throw wrongElementType(fieldName, header.elementType(), hex(expectedElementType));
+    long requireListHeader(byte expectedElementType, String fieldName) throws IOException {
+        long header = readListHeader();
+        if (elementType(header) != expectedElementType) {
+            throw wrongElementType(fieldName, elementType(header), hex(expectedElementType));
         }
         return header;
     }
@@ -314,13 +423,13 @@ public class ThriftCompactReader {
     /// @param fieldName fully-qualified field name for the log message
     /// @return the header, or `null` if the list declares a different element type and has been
     ///     skipped
-    CollectionHeader acceptListHeader(byte expectedElementType, String fieldName) throws IOException {
-        CollectionHeader header = readListHeader();
-        if (header.elementType() != expectedElementType) {
+    long acceptListHeader(byte expectedElementType, String fieldName) throws IOException {
+        long header = readListHeader();
+        if (elementType(header) != expectedElementType) {
             skipElements(header);
             LOG.log(System.Logger.Level.WARNING, "Ignoring " + fieldName + ": wrong Thrift element type "
-                    + hex(header.elementType()) + " (expected " + hex(expectedElementType) + ")");
-            return null;
+                    + hex(elementType(header)) + " (expected " + hex(expectedElementType) + ")");
+            return ABSENT_LIST;
         }
         return header;
     }
@@ -331,9 +440,9 @@ public class ThriftCompactReader {
     /// @param fieldName fully-qualified field name for the error message
     /// @param elementReader reader for one element
     <T> List<T> readStructList(String fieldName, StructReader<T> elementReader) throws IOException {
-        CollectionHeader header = requireListHeader(Codes.STRUCT, fieldName);
-        List<T> values = new ArrayList<>(header.size());
-        for (int i = 0; i < header.size(); i++) {
+        long header = requireListHeader(Codes.STRUCT, fieldName);
+        List<T> values = new ArrayList<>(listSize(header));
+        for (int i = 0, n = listSize(header); i < n; i++) {
             values.add(elementReader.read(this));
         }
         return Collections.unmodifiableList(values);
@@ -341,23 +450,26 @@ public class ThriftCompactReader {
 
     /// Read a required `list<string>` in full.
     ///
+    /// The result is an immutable [List#of] list rather than a wrapped [ArrayList], saving two
+    /// objects per list — worth having where a footer holds one such list per column chunk.
+    ///
     /// @param fieldName fully-qualified field name for the error message
     List<String> readStringList(String fieldName) throws IOException {
-        CollectionHeader header = requireListHeader(Codes.BINARY, fieldName);
-        List<String> values = new ArrayList<>(header.size());
-        for (int i = 0; i < header.size(); i++) {
-            values.add(readString());
+        long header = requireListHeader(Codes.BINARY, fieldName);
+        String[] values = new String[listSize(header)];
+        for (int i = 0; i < values.length; i++) {
+            values[i] = readString();
         }
-        return Collections.unmodifiableList(values);
+        return List.of(values);
     }
 
     /// Read a required `list<binary>` in full.
     ///
     /// @param fieldName fully-qualified field name for the error message
     List<byte[]> readBinaryList(String fieldName) throws IOException {
-        CollectionHeader header = requireListHeader(Codes.BINARY, fieldName);
-        List<byte[]> values = new ArrayList<>(header.size());
-        for (int i = 0; i < header.size(); i++) {
+        long header = requireListHeader(Codes.BINARY, fieldName);
+        List<byte[]> values = new ArrayList<>(listSize(header));
+        for (int i = 0, n = listSize(header); i < n; i++) {
             values.add(readBinary());
         }
         return Collections.unmodifiableList(values);
@@ -370,11 +482,11 @@ public class ThriftCompactReader {
     ///
     /// @param fieldName fully-qualified field name for the error message
     boolean[] readBoolArray(String fieldName) throws IOException {
-        CollectionHeader header = readListHeader();
-        if (header.elementType() != TYPE_BOOLEAN_TRUE && header.elementType() != TYPE_BOOLEAN_FALSE) {
-            throw wrongElementType(fieldName, header.elementType(), "bool");
+        long header = readListHeader();
+        if (elementType(header) != TYPE_BOOLEAN_TRUE && elementType(header) != TYPE_BOOLEAN_FALSE) {
+            throw wrongElementType(fieldName, elementType(header), "bool");
         }
-        boolean[] values = new boolean[header.size()];
+        boolean[] values = new boolean[listSize(header)];
         for (int i = 0; i < values.length; i++) {
             values[i] = readBoolean();
         }
@@ -391,11 +503,11 @@ public class ThriftCompactReader {
     ///
     /// @param fieldName fully-qualified field name for the log message
     long[] readOptionalI64Array(String fieldName) throws IOException {
-        CollectionHeader header = acceptListHeader(Codes.I64, fieldName);
-        if (header == null) {
+        long header = acceptListHeader(Codes.I64, fieldName);
+        if (header == ABSENT_LIST) {
             return null;
         }
-        long[] values = new long[header.size()];
+        long[] values = new long[listSize(header)];
         for (int i = 0; i < values.length; i++) {
             values[i] = readI64();
         }
@@ -442,9 +554,10 @@ public class ThriftCompactReader {
     }
 
     /// Skip every element of a list, set or map whose header has just been read.
-    public void skipElements(CollectionHeader header) throws IOException {
-        for (int i = 0; i < header.size(); i++) {
-            skipElement(header.elementType());
+    public void skipElements(long header) throws IOException {
+        byte type = elementType(header);
+        for (int i = 0, n = listSize(header); i < n; i++) {
+            skipElement(type);
         }
     }
 
@@ -489,7 +602,9 @@ public class ThriftCompactReader {
                 readDouble();
                 break;
             case TYPE_BINARY:
-                readBinary();
+                // Advance past the value rather than materializing it: a skipped binary is one
+                // nobody asked for, and copying it to drop it costs an allocation per field.
+                skipBytes(checkedBinaryLength(readVarint()));
                 break;
             case TYPE_LIST:
             case TYPE_SET:
@@ -524,11 +639,11 @@ public class ThriftCompactReader {
         short saved = pushFieldIdContext();
         try {
             while (true) {
-                FieldHeader header = readFieldHeader();
-                if (header == null) {
+                int header = readFieldHeader();
+                if (header == STOP_FIELD) {
                     break;
                 }
-                skipField(header.type());
+                skipField(fieldType(header));
             }
         }
         finally {
@@ -555,9 +670,4 @@ public class ThriftCompactReader {
         T read(ThriftCompactReader reader) throws IOException;
     }
 
-    public static record FieldHeader(short fieldId, byte type) {
-    }
-
-    public static record CollectionHeader(byte elementType, int size) {
-    }
 }

--- a/core/src/main/java/dev/hardwood/internal/thrift/ThriftCompactReader.java
+++ b/core/src/main/java/dev/hardwood/internal/thrift/ThriftCompactReader.java
@@ -60,6 +60,11 @@ public class ThriftCompactReader {
     /// Element type occupies the low byte of a packed list header, the count the rest.
     private static final int ELEMENT_TYPE_BITS = 8;
 
+    /// Bytes a varint may occupy: seven bits each, for a 64-bit value.
+    private static final int MAX_VARINT_BYTES = 10;
+    /// Shift the last of those bytes contributes at, and so the largest a shift may reach.
+    private static final int MAX_VARINT_SHIFT = 7 * (MAX_VARINT_BYTES - 1);
+
     private final ByteBuffer buffer;
     private final int startPosition;
     private short lastFieldId = 0;
@@ -155,9 +160,25 @@ public class ThriftCompactReader {
     }
 
     /// Read an unsigned varint from the buffer.
-    public long readVarint() throws EOFException {
-        long result = 0;
-        int shift = 0;
+    ///
+    /// Ten bytes carry the 64 bits a varint can hold, and an eleventh is rejected: Java applies a
+    /// `long` shift modulo 64, so its payload would land back over the low bits of the result and
+    /// the read would answer with a wrong number instead of failing.
+    ///
+    /// @throws IOException if the varint runs past ten bytes
+    public long readVarint() throws IOException {
+        if (!buffer.hasRemaining()) {
+            throw new EOFException("Unexpected EOF while reading varint");
+        }
+        // Most of a footer's varints are one byte — every field id, every small size, every enum
+        // value — and a non-negative first byte is exactly the single-byte case.
+        byte first = buffer.get();
+        if (first >= 0) {
+            return first;
+        }
+
+        long result = first & 0x7FL;
+        int shift = 7;
         while (buffer.hasRemaining()) {
             int b = buffer.get() & 0xFF;
             result |= (long) (b & 0x7F) << shift;
@@ -165,6 +186,9 @@ public class ThriftCompactReader {
                 return result;
             }
             shift += 7;
+            if (shift > MAX_VARINT_SHIFT) {
+                throw new IOException("Malformed varint: more than " + MAX_VARINT_BYTES + " bytes");
+            }
         }
         throw new EOFException("Unexpected EOF while reading varint");
     }
@@ -262,9 +286,9 @@ public class ThriftCompactReader {
 
     /// Read a string value.
     ///
-    /// A heap-backed buffer — which is what the footer and every page header are read from — is
-    /// decoded in place, so the string costs one object rather than a `byte[]` copy and then the
-    /// string built from it.
+    /// A heap-backed buffer is decoded in place, so the string costs one object rather than a
+    /// `byte[]` copy and the string built from it. A memory-mapped file hands its footer and its
+    /// page headers over as direct buffers, which take the copying path.
     public String readString() throws IOException {
         int length = checkedBinaryLength(readVarint());
         if (buffer.hasArray()) {
@@ -302,11 +326,11 @@ public class ThriftCompactReader {
         short fieldId;
         if (fieldIdDelta == 0) {
             // Field ID is encoded separately
-            fieldId = (short) readZigzag();
+            fieldId = checkedFieldId(readZigzag());
         }
         else {
             // Field ID is delta from last field
-            fieldId = (short) (lastFieldId + fieldIdDelta);
+            fieldId = checkedFieldId(lastFieldId + fieldIdDelta);
         }
 
         lastFieldId = fieldId;
@@ -412,7 +436,7 @@ public class ThriftCompactReader {
     }
 
     /// Read the header of an **optional** list field and check its declared element type,
-    /// reporting `null` for a list this reader will not decode.
+    /// reporting [#ABSENT_LIST] for a list this reader will not decode.
     ///
     /// Elements of the declared type occupy a different number of bytes than the ones the field
     /// is defined to hold, so decoding them anyway would desynchronise the stream and corrupt
@@ -421,8 +445,8 @@ public class ThriftCompactReader {
     ///
     /// @param expectedElementType wire code the elements must declare
     /// @param fieldName fully-qualified field name for the log message
-    /// @return the header, or `null` if the list declares a different element type and has been
-    ///     skipped
+    /// @return the header, or [#ABSENT_LIST] if the list declares a different element type and
+    ///     has been skipped
     long acceptListHeader(byte expectedElementType, String fieldName) throws IOException {
         long header = readListHeader();
         if (elementType(header) != expectedElementType) {
@@ -450,8 +474,12 @@ public class ThriftCompactReader {
 
     /// Read a required `list<string>` in full.
     ///
-    /// The result is an immutable [List#of] list rather than a wrapped [ArrayList], saving two
-    /// objects per list — worth having where a footer holds one such list per column chunk.
+    /// The result comes from [List#of], which holds a one- or two-element list in its own
+    /// fields: a `path_in_schema` of that length then costs neither a backing array nor an
+    /// unmodifiable wrapper, and a footer holds one such list per column chunk. This is a
+    /// property of the short cases only — [List#of] copies the array it is handed — so the
+    /// readers of collections that run to one element per column, page or row group fill an
+    /// [ArrayList] instead, where the copy would cost more than the wrapper saves.
     ///
     /// @param fieldName fully-qualified field name for the error message
     List<String> readStringList(String fieldName) throws IOException {
@@ -542,6 +570,18 @@ public class ThriftCompactReader {
                     + declaredSize + " elements but only " + buffer.remaining() + " bytes remain");
         }
         return Math.toIntExact(declaredSize);
+    }
+
+    /// Validate a field id, however the header arrived at it, against the `i16` range Thrift
+    /// defines for one. Narrowing an out-of-range id instead would fold it onto a real one — id
+    /// 65537 reads as id 1 — and the struct reader would then decode that field's bytes as
+    /// whatever it holds field 1 to be, which is wrong data rather than a failed read.
+    private static short checkedFieldId(long declaredId) throws IOException {
+        if (declaredId < Short.MIN_VALUE || declaredId > Short.MAX_VALUE) {
+            throw new IOException("Malformed Parquet metadata: field id " + declaredId
+                    + " is outside the Thrift i16 range");
+        }
+        return (short) declaredId;
     }
 
     private static IOException wrongElementType(String fieldName, byte actual, String expected) {

--- a/core/src/test/java/dev/hardwood/internal/thrift/LogicalTypeReaderTest.java
+++ b/core/src/test/java/dev/hardwood/internal/thrift/LogicalTypeReaderTest.java
@@ -57,8 +57,8 @@ class LogicalTypeReaderTest {
         ThriftCompactReader reader = new ThriftCompactReader(ByteBuffer.wrap(writer.toByteArray()));
         assertThat(LogicalTypeReader.read(reader)).isNull();
 
-        ThriftCompactReader.FieldHeader sentinel = reader.readFieldHeader();
-        assertThat(sentinel.fieldId()).isEqualTo((short) 1);
+        int sentinel = reader.readFieldHeader();
+        assertThat(ThriftCompactReader.fieldId(sentinel)).isEqualTo((short) 1);
         assertThat(reader.readI32()).isEqualTo(7);
     }
 

--- a/core/src/test/java/dev/hardwood/internal/thrift/RepeatedPathCacheTest.java
+++ b/core/src/test/java/dev/hardwood/internal/thrift/RepeatedPathCacheTest.java
@@ -1,0 +1,145 @@
+/*
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Copyright The original authors
+ *
+ *  Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package dev.hardwood.internal.thrift;
+
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+import org.junit.jupiter.api.Test;
+
+import dev.hardwood.metadata.ColumnChunk;
+import dev.hardwood.metadata.ColumnMetaData;
+import dev.hardwood.metadata.CompressionCodec;
+import dev.hardwood.metadata.Encoding;
+import dev.hardwood.metadata.FieldPath;
+import dev.hardwood.metadata.FileMetaData;
+import dev.hardwood.metadata.PhysicalType;
+import dev.hardwood.metadata.RepetitionType;
+import dev.hardwood.metadata.RowGroup;
+import dev.hardwood.metadata.SchemaElement;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/// The `path_in_schema` of a column repeats in every row group's chunk of it, and the decoder
+/// caches it by position — the n-th chunk of a row group is expected to name the same column as
+/// the n-th chunk of the row group before it.
+///
+/// The format requires that ordering (`RowGroup.columns` "must have the same order as the
+/// SchemaElement list in FileMetaData"), but the decoder treats it as a prediction and checks
+/// the cached path against the bytes it is about to read. These tests pin both halves: the
+/// prediction pays off on a conforming file, and a file that breaks the ordering still decodes
+/// to the paths it actually carries.
+class RepeatedPathCacheTest {
+
+    @Test
+    void sharesOnePathInstanceAcrossRowGroupsOfTheSameColumn() throws IOException {
+        FileMetaData decoded = roundTrip(List.of(
+                List.of("a", "b", "c"),
+                List.of("a", "b", "c"),
+                List.of("a", "b", "c")));
+
+        assertThat(pathsOf(decoded, 0)).containsExactly("a", "b", "c");
+        assertThat(pathsOf(decoded, 1)).containsExactly("a", "b", "c");
+        assertThat(pathsOf(decoded, 2)).containsExactly("a", "b", "c");
+
+        // One FieldPath per column rather than one per chunk: what the cache is for.
+        for (int column = 0; column < 3; column++) {
+            FieldPath first = pathAt(decoded, 0, column);
+            assertThat(pathAt(decoded, 1, column)).isSameAs(first);
+            assertThat(pathAt(decoded, 2, column)).isSameAs(first);
+        }
+    }
+
+    @Test
+    void decodesRowGroupsThatOrderTheirColumnsDifferently() throws IOException {
+        // Against the spec, and so the case the positional prediction would get wrong if it
+        // trusted position instead of checking the bytes.
+        FileMetaData decoded = roundTrip(List.of(
+                List.of("a", "b", "c"),
+                List.of("c", "a", "b"),
+                List.of("b", "c", "a")));
+
+        assertThat(pathsOf(decoded, 0)).containsExactly("a", "b", "c");
+        assertThat(pathsOf(decoded, 1)).containsExactly("c", "a", "b");
+        assertThat(pathsOf(decoded, 2)).containsExactly("b", "c", "a");
+    }
+
+    @Test
+    void decodesRowGroupsOfDifferingColumnCounts() throws IOException {
+        // A shorter row group leaves the cache primed past its end; the next longer one must
+        // still decode every path it carries.
+        FileMetaData decoded = roundTrip(List.of(
+                List.of("a", "b", "c"),
+                List.of("a"),
+                List.of("a", "b", "c")));
+
+        assertThat(pathsOf(decoded, 0)).containsExactly("a", "b", "c");
+        assertThat(pathsOf(decoded, 1)).containsExactly("a");
+        assertThat(pathsOf(decoded, 2)).containsExactly("a", "b", "c");
+    }
+
+    @Test
+    void decodesNestedPathsOfSeveralComponents() throws IOException {
+        FileMetaData decoded = roundTrip(List.of(
+                List.of("address.zip", "address.city"),
+                List.of("address.zip", "address.city")));
+
+        assertThat(pathAt(decoded, 0, 0).elements()).containsExactly("address", "zip");
+        assertThat(pathAt(decoded, 1, 1).elements()).containsExactly("address", "city");
+        assertThat(pathAt(decoded, 1, 0)).isSameAs(pathAt(decoded, 0, 0));
+    }
+
+    /// Writes a footer whose row groups carry the given column paths — one inner list per row
+    /// group, each element a dot-separated path — and reads it back.
+    private static FileMetaData roundTrip(List<List<String>> rowGroupPaths) throws IOException {
+        List<RowGroup> rowGroups = new ArrayList<>();
+        for (List<String> paths : rowGroupPaths) {
+            List<ColumnChunk> chunks = new ArrayList<>();
+            for (String path : paths) {
+                chunks.add(new ColumnChunk(columnMetaData(path), null, null, null, null, ""));
+            }
+            rowGroups.add(new RowGroup(List.copyOf(chunks), 1024, 10));
+        }
+
+        FileMetaData metaData = new FileMetaData(1, schemaElements(rowGroupPaths.get(0)), 10,
+                List.copyOf(rowGroups), Map.of(), "test", List.of());
+        ThriftCompactWriter writer = new ThriftCompactWriter();
+        FileMetaDataWriter.write(writer, metaData);
+        return FileMetaDataReader.read(new ThriftCompactReader(ByteBuffer.wrap(writer.toByteArray())));
+    }
+
+    private static ColumnMetaData columnMetaData(String path) {
+        return new ColumnMetaData(PhysicalType.DOUBLE, List.of(Encoding.PLAIN),
+                FieldPath.of(path.split("\\.")), CompressionCodec.UNCOMPRESSED,
+                10, 80, 80, Map.of(), 4, null, null, null, null, null, List.of(), null);
+    }
+
+    private static List<SchemaElement> schemaElements(List<String> paths) {
+        List<SchemaElement> elements = new ArrayList<>();
+        elements.add(new SchemaElement("schema", null, null, RepetitionType.REQUIRED, paths.size(),
+                null, null, null, null, null));
+        for (String path : paths) {
+            elements.add(new SchemaElement(path.replace('.', '_'), PhysicalType.DOUBLE, null,
+                    RepetitionType.REQUIRED, null, null, null, null, null, null));
+        }
+        return elements;
+    }
+
+    private static List<String> pathsOf(FileMetaData metaData, int rowGroup) {
+        return metaData.rowGroups().get(rowGroup).columns().stream()
+                .map(chunk -> String.join(".", chunk.metaData().pathInSchema().elements()))
+                .toList();
+    }
+
+    private static FieldPath pathAt(FileMetaData metaData, int rowGroup, int column) {
+        return metaData.rowGroups().get(rowGroup).columns().get(column).metaData().pathInSchema();
+    }
+}

--- a/core/src/test/java/dev/hardwood/internal/thrift/ThriftCompactReaderTest.java
+++ b/core/src/test/java/dev/hardwood/internal/thrift/ThriftCompactReaderTest.java
@@ -222,6 +222,60 @@ class ThriftCompactReaderTest {
         assertThat(ThriftCompactReader.elementType(header)).isEqualTo(ElementType.BOOL.code());
     }
 
+    /// A varint carries at most ten bytes for a 64-bit value. Java masks a `long` shift to six
+    /// bits, so an eleventh byte would fold its payload back over the low bits of the result and
+    /// answer with a wrong number rather than fail — the one outcome a decoder must never have.
+    @Test
+    void varintRejectsMoreThanTenBytes() {
+        // Eleven continuation bytes followed by a terminator: shift reaches 70, which Java
+        // applies as 70 & 63 = 6.
+        ThriftCompactReader reader = reader(
+                0x80, 0x80, 0x80, 0x80, 0x80, 0x80, 0x80, 0x80, 0x80, 0x80, 0x01);
+
+        assertThatThrownBy(reader::readVarint)
+                .isInstanceOf(IOException.class)
+                .hasMessageContaining("varint");
+    }
+
+    /// The widest varint the format can carry is still read in full.
+    @Test
+    void varintAcceptsTenBytes() throws IOException {
+        // -1 as an unsigned 64-bit varint: nine 0xFF bytes and a final 0x01.
+        ThriftCompactReader reader = reader(
+                0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0x01);
+
+        assertThat(reader.readVarint()).isEqualTo(-1L);
+    }
+
+    /// Thrift defines a field id as an `i16`, so a long-form header declaring one outside that
+    /// range is malformed. Narrowing it instead of rejecting it turns id 65537 into id 1, and the
+    /// struct reader then decodes that field's bytes as whatever field 1 holds.
+    @Test
+    void fieldHeaderRejectsFieldIdOutsideI16() {
+        // Long form (delta nibble 0) of type I32, then zigzag varint of 65537.
+        ThriftCompactReader reader = reader(FieldType.Codes.I32, 0x82, 0x80, 0x08, STOP);
+
+        assertThatThrownBy(reader::readFieldHeader)
+                .isInstanceOf(IOException.class)
+                .hasMessageContaining("65537");
+    }
+
+    /// The same bound applies when the id is reached by delta: a header may add up to 15 to the
+    /// previous id, and the sum has to stay an `i16` like the id it stands for.
+    @Test
+    void fieldHeaderRejectsDeltaPastI16() {
+        // Long form of I32 carrying id 32767, then a short-form header adding 1 to it.
+        ThriftCompactReader reader = reader(
+                FieldType.Codes.I32, 0xFE, 0xFF, 0x03, fieldHeader(1, FieldType.I32), STOP);
+
+        assertThatThrownBy(() -> {
+            reader.readFieldHeader();
+            reader.readFieldHeader();
+        })
+                .isInstanceOf(IOException.class)
+                .hasMessageContaining("32768");
+    }
+
     /// A `bool` is the one type encoded differently as a collection element than as a struct
     /// field: the field form carries its value in the type nibble of its header and has no
     /// payload, the element form is a bare byte. Skipping a `list<bool>` by field rules consumes

--- a/core/src/test/java/dev/hardwood/internal/thrift/ThriftCompactReaderTest.java
+++ b/core/src/test/java/dev/hardwood/internal/thrift/ThriftCompactReaderTest.java
@@ -151,25 +151,25 @@ class ThriftCompactReaderTest {
         ThriftCompactReader reader = new ThriftCompactReader(buffer);
 
         // Read field 1
-        ThriftCompactReader.FieldHeader f1 = reader.readFieldHeader();
-        assertThat(f1.fieldId()).isEqualTo((short) 1);
+        int f1 = reader.readFieldHeader();
+        assertThat(ThriftCompactReader.fieldId(f1)).isEqualTo((short) 1);
         int val1 = reader.readI32();
         assertThat(val1).isEqualTo(5);
 
         // Skip field 2 (struct)
-        ThriftCompactReader.FieldHeader f2 = reader.readFieldHeader();
-        assertThat(f2.fieldId()).isEqualTo((short) 2);
-        reader.skipField(f2.type());
+        int f2 = reader.readFieldHeader();
+        assertThat(ThriftCompactReader.fieldId(f2)).isEqualTo((short) 2);
+        reader.skipField(ThriftCompactReader.fieldType(f2));
 
         // Read field 3 - should correctly be field 3, not field 1
-        ThriftCompactReader.FieldHeader f3 = reader.readFieldHeader();
-        assertThat(f3.fieldId()).isEqualTo((short) 3);
+        int f3 = reader.readFieldHeader();
+        assertThat(ThriftCompactReader.fieldId(f3)).isEqualTo((short) 3);
         int val3 = reader.readI32();
         assertThat(val3).isEqualTo(15);
 
         // Should be at STOP
-        ThriftCompactReader.FieldHeader stop = reader.readFieldHeader();
-        assertThat(stop).isNull();
+        int stop = reader.readFieldHeader();
+        assertThat(stop).isEqualTo(ThriftCompactReader.STOP_FIELD);
     }
 
     /// A long-form element count larger than the bytes left cannot describe real elements — the
@@ -216,10 +216,10 @@ class ThriftCompactReaderTest {
             bytes[i + 2] = FieldType.Codes.BOOLEAN_TRUE;
         }
 
-        ThriftCompactReader.CollectionHeader header = reader(bytes).readListHeader();
+        long header = reader(bytes).readListHeader();
 
-        assertThat(header.size()).isEqualTo(15);
-        assertThat(header.elementType()).isEqualTo(ElementType.BOOL.code());
+        assertThat(ThriftCompactReader.listSize(header)).isEqualTo(15);
+        assertThat(ThriftCompactReader.elementType(header)).isEqualTo(ElementType.BOOL.code());
     }
 
     /// A `bool` is the one type encoded differently as a collection element than as a struct

--- a/performance-testing/micro-benchmarks/README.md
+++ b/performance-testing/micro-benchmarks/README.md
@@ -44,11 +44,21 @@ allocation profiling, `-rf json -rff out.json` for machine-readable results,
 | `nested/NestedListReadBenchmark` | `LIST<primitive>` reads across element types and null densities vs. a flat floor | self-generating (`NestedListFileGenerator`) |
 | `nested/NestedMultiListReadBenchmark` | Multi-list-column schema effects on the nested read path | self-generating (`NestedListFileGenerator`) |
 | `mixed/MixedSchemaReadBenchmark` | Schema-composition effects (scalars next to lists, structs, depth) on the nested path (#732) | self-generating (`MixedSchemaFileGenerator`) |
+| `wide/WideSchemaMetadataBenchmark` | Footer decode, schema build and `open()` for 10 … 100,000 `FLOAT64` columns (#919) | self-generating (`WideSchemaFileGenerator`) |
+| `wide/WideSchemaMetadataParquetJavaBenchmark` | The same three steps through parquet-java, over the same fixtures | self-generating (`WideSchemaFileGenerator`) |
 
 Python generator scripts live in the parent `performance-testing/` directory and
 default their output to `performance-testing/test-data-setup/target/benchmark-data`;
 pass that directory as `-p dataDir=...`. Fixture generation is idempotent —
 existing files are skipped.
+
+The widest wide-schema fixture (100,000 columns × 10 row groups) is a ~150 MB file
+with a ~69 MB footer that decodes into ~270 MB of live metadata and allocates
+~300 MB per decode. The wide-schema benchmarks fork with `-Xmx8g` so that allocation
+rate does not turn the result into a GC measurement; they run correctly on far less.
+Narrow the sweep with `-p columns=10,100,1000` to keep the run small. Run them
+together — the class filter `WideSchemaMetadata` matches both — to get the Hardwood
+and parquet-java numbers in one table.
 
 ## Correctness gates
 

--- a/performance-testing/micro-benchmarks/src/main/java/dev/hardwood/benchmarks/wide/Footers.java
+++ b/performance-testing/micro-benchmarks/src/main/java/dev/hardwood/benchmarks/wide/Footers.java
@@ -1,0 +1,49 @@
+/*
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Copyright The original authors
+ *
+ *  Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package dev.hardwood.benchmarks.wide;
+
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
+import java.nio.channels.FileChannel;
+import java.nio.file.Path;
+import java.nio.file.StandardOpenOption;
+
+/// Reads a Parquet file's footer bytes, so the metadata-decode benchmarks can hand the same
+/// bytes to either implementation without measuring the read.
+final class Footers {
+
+    private static final int TRAILER_LENGTH = Integer.BYTES + 4;
+
+    private Footers() {
+    }
+
+    /// The footer body of `path`: the metadata itself, without the trailing length and magic.
+    static byte[] read(Path path) throws IOException {
+        try (FileChannel channel = FileChannel.open(path, StandardOpenOption.READ)) {
+            long size = channel.size();
+            ByteBuffer trailer = ByteBuffer.allocate(TRAILER_LENGTH).order(ByteOrder.LITTLE_ENDIAN);
+            readFully(channel, trailer, size - TRAILER_LENGTH);
+            int footerLength = trailer.flip().getInt();
+            ByteBuffer buffer = ByteBuffer.allocate(footerLength);
+            readFully(channel, buffer, size - TRAILER_LENGTH - footerLength);
+            return buffer.array();
+        }
+    }
+
+    private static void readFully(FileChannel channel, ByteBuffer buffer, long position) throws IOException {
+        long offset = position;
+        while (buffer.hasRemaining()) {
+            int read = channel.read(buffer, offset);
+            if (read < 0) {
+                throw new IOException("Unexpected end of file at " + offset);
+            }
+            offset += read;
+        }
+    }
+}

--- a/performance-testing/micro-benchmarks/src/main/java/dev/hardwood/benchmarks/wide/Footers.java
+++ b/performance-testing/micro-benchmarks/src/main/java/dev/hardwood/benchmarks/wide/Footers.java
@@ -27,13 +27,28 @@ final class Footers {
     static byte[] read(Path path) throws IOException {
         try (FileChannel channel = FileChannel.open(path, StandardOpenOption.READ)) {
             long size = channel.size();
-            ByteBuffer trailer = ByteBuffer.allocate(TRAILER_LENGTH).order(ByteOrder.LITTLE_ENDIAN);
-            readFully(channel, trailer, size - TRAILER_LENGTH);
-            int footerLength = trailer.flip().getInt();
+            int footerLength = footerLength(channel, size);
             ByteBuffer buffer = ByteBuffer.allocate(footerLength);
             readFully(channel, buffer, size - TRAILER_LENGTH - footerLength);
             return buffer.array();
         }
+    }
+
+    /// The same footer body as a memory-mapped, and therefore direct, buffer: the form
+    /// [dev.hardwood.internal.reader.MappedInputFile] hands the decoder for a local file, whose
+    /// bytes the decoder cannot reach through an array.
+    static ByteBuffer map(Path path) throws IOException {
+        try (FileChannel channel = FileChannel.open(path, StandardOpenOption.READ)) {
+            long size = channel.size();
+            int footerLength = footerLength(channel, size);
+            return channel.map(FileChannel.MapMode.READ_ONLY, size - TRAILER_LENGTH - footerLength, footerLength);
+        }
+    }
+
+    private static int footerLength(FileChannel channel, long size) throws IOException {
+        ByteBuffer trailer = ByteBuffer.allocate(TRAILER_LENGTH).order(ByteOrder.LITTLE_ENDIAN);
+        readFully(channel, trailer, size - TRAILER_LENGTH);
+        return trailer.flip().getInt();
     }
 
     private static void readFully(FileChannel channel, ByteBuffer buffer, long position) throws IOException {

--- a/performance-testing/micro-benchmarks/src/main/java/dev/hardwood/benchmarks/wide/WideSchemaFileGenerator.java
+++ b/performance-testing/micro-benchmarks/src/main/java/dev/hardwood/benchmarks/wide/WideSchemaFileGenerator.java
@@ -1,0 +1,151 @@
+/*
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Copyright The original authors
+ *
+ *  Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package dev.hardwood.benchmarks.wide;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import dev.hardwood.InputFile;
+import dev.hardwood.OutputFile;
+import dev.hardwood.benchmarks.BenchmarkData;
+import dev.hardwood.internal.reader.ParquetMetadataReader;
+import dev.hardwood.metadata.CompressionCodec;
+import dev.hardwood.metadata.FileMetaData;
+import dev.hardwood.metadata.PhysicalType;
+import dev.hardwood.metadata.RepetitionType;
+import dev.hardwood.schema.FileSchema;
+import dev.hardwood.writer.ParquetFileWriter;
+import dev.hardwood.writer.WriterConfig;
+
+/// Generates the wide-schema corpus for [WideSchemaMetadataBenchmark]: for a given column
+/// count, one file of that many `REQUIRED DOUBLE` columns spread over [#ROW_GROUPS] row
+/// groups, so its footer carries `columns × ROW_GROUPS` `ColumnChunk` structures. Each file
+/// is skipped when already present.
+///
+/// The files carry only as many rows as it takes to produce the row groups
+/// ([#ROWS_PER_ROW_GROUP] each): the benchmark measures footer decode, so the values exist
+/// only to give every column chunk a page and non-degenerate statistics. Row groups are cut
+/// deterministically by sizing the row-group target to exactly one batch of `PLAIN`
+/// dictionary-free values, and the produced file is verified to hold [#ROW_GROUPS] of them.
+public final class WideSchemaFileGenerator {
+
+    /// Row groups per file, so a file has `columns × ROW_GROUPS` column chunks.
+    public static final int ROW_GROUPS = 10;
+
+    /// Rows per row group. Small on purpose — the fixture is a metadata fixture.
+    public static final int ROWS_PER_ROW_GROUP = 8;
+
+    private static final int VALUE_BYTES = Double.BYTES;
+
+    private WideSchemaFileGenerator() {
+    }
+
+    /// The column counts swept by default, matching the reference blog post.
+    public static int[] defaultColumnCounts() {
+        return new int[]{ 10, 100, 1_000, 10_000, 100_000 };
+    }
+
+    public static Path file(Path dir, int columns) {
+        return dir.resolve("wide_float64_" + columns + ".parquet");
+    }
+
+    /// The name of the column at `index`, zero-padded so a file's column names all have the
+    /// same length and the footer size stays linear in the column count.
+    public static String columnName(int index) {
+        return String.format("col_%06d", index);
+    }
+
+    /// Writes the fixture for `columns` columns if it is not already present.
+    public static void ensureFile(Path dir, int columns) throws IOException {
+        Path path = file(dir, columns);
+        if (Files.exists(path)) {
+            return;
+        }
+        Files.createDirectories(dir);
+        System.out.printf("Generating wide-schema fixture (%,d columns x %d row groups)...%n",
+                columns, ROW_GROUPS);
+
+        FileSchema schema = schema(columns);
+        // One row group's worth of PLAIN values, so each batch fills the row-group budget
+        // exactly and the writer cuts a row group at every batch boundary. The page target
+        // is one row group per page as well, which keeps the writer's per-column pending
+        // buffers small — they are sized from it, and there are up to 100,000 of them.
+        long rowGroupTargetBytes = (long) ROWS_PER_ROW_GROUP * VALUE_BYTES * columns;
+        WriterConfig config = WriterConfig.builder()
+                .pageTargetBytes(ROWS_PER_ROW_GROUP * VALUE_BYTES)
+                .rowGroupTargetBytes(rowGroupTargetBytes)
+                .enableDictionary(false)
+                .codec(CompressionCodec.UNCOMPRESSED)
+                .build();
+
+        try (ParquetFileWriter writer = ParquetFileWriter.create(OutputFile.of(path), schema, config)) {
+            for (int group = 0; group < ROW_GROUPS; group++) {
+                int groupIndex = group;
+                writer.writeBatch(batch -> {
+                    for (int c = 0; c < columns; c++) {
+                        batch.doubles(c, values(groupIndex, c));
+                    }
+                });
+            }
+        }
+
+        verify(path, columns);
+    }
+
+    /// One row group's values for one column: distinct across columns and row groups so
+    /// every chunk's statistics carry a distinct min/max pair, as they would in real data.
+    private static double[] values(int rowGroup, int column) {
+        double[] values = new double[ROWS_PER_ROW_GROUP];
+        double base = rowGroup * 1_000_000.0 + column;
+        for (int i = 0; i < ROWS_PER_ROW_GROUP; i++) {
+            values[i] = base + i * 0.5;
+        }
+        return values;
+    }
+
+    private static FileSchema schema(int columns) {
+        FileSchema.Builder builder = FileSchema.builder("wide");
+        for (int c = 0; c < columns; c++) {
+            builder.addColumn(columnName(c), PhysicalType.DOUBLE, RepetitionType.REQUIRED);
+        }
+        return builder.build();
+    }
+
+    /// Fails the generation if the written file does not have the intended shape — a footer
+    /// with fewer row groups than asked for would silently shrink the metadata under
+    /// measurement.
+    private static void verify(Path path, int columns) throws IOException {
+        try (InputFile input = InputFile.of(path)) {
+            input.open();
+            FileMetaData metaData = ParquetMetadataReader.readMetadata(input);
+            if (metaData.rowGroups().size() != ROW_GROUPS) {
+                throw new IllegalStateException(path + ": expected " + ROW_GROUPS + " row groups but wrote "
+                        + metaData.rowGroups().size());
+            }
+            System.out.printf("  %s: %,d columns, %d row groups, %,d column chunks, %,d bytes on disk%n",
+                    path.getFileName(), columns, ROW_GROUPS, (long) columns * ROW_GROUPS, Files.size(path));
+        }
+    }
+
+    /// Generates the fixtures for the given column counts, or the defaults when none are given.
+    public static void main(String[] args) throws IOException {
+        Path dir = Path.of(args.length > 0 ? args[0] : BenchmarkData.dir());
+        int[] columnCounts = defaultColumnCounts();
+        if (args.length > 1) {
+            columnCounts = new int[args.length - 1];
+            for (int i = 1; i < args.length; i++) {
+                columnCounts[i - 1] = Integer.parseInt(args[i]);
+            }
+        }
+        for (int columns : columnCounts) {
+            ensureFile(dir, columns);
+        }
+        System.out.println("Wide-schema corpus ready in " + dir);
+    }
+}

--- a/performance-testing/micro-benchmarks/src/main/java/dev/hardwood/benchmarks/wide/WideSchemaMetadataBenchmark.java
+++ b/performance-testing/micro-benchmarks/src/main/java/dev/hardwood/benchmarks/wide/WideSchemaMetadataBenchmark.java
@@ -1,0 +1,126 @@
+/*
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Copyright The original authors
+ *
+ *  Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package dev.hardwood.benchmarks.wide;
+
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.TearDown;
+import org.openjdk.jmh.annotations.Warmup;
+import org.openjdk.jmh.infra.Blackhole;
+
+import dev.hardwood.HardwoodContext;
+import dev.hardwood.InputFile;
+import dev.hardwood.benchmarks.BenchmarkData;
+import dev.hardwood.internal.thrift.FileMetaDataReader;
+import dev.hardwood.internal.thrift.ThriftCompactReader;
+import dev.hardwood.metadata.FileMetaData;
+import dev.hardwood.metadata.SchemaElement;
+import dev.hardwood.reader.ParquetFileReader;
+import dev.hardwood.schema.FileSchema;
+
+/// Footer metadata decode as a function of schema width: files of 10 to 100,000 `FLOAT64`
+/// columns over [WideSchemaFileGenerator#ROW_GROUPS] row groups, so the footer holds
+/// `columns × 10` `ColumnChunk` structures. This is the shape of a machine-learning feature
+/// table, and the cost is paid in full on open — before a single value is read, and
+/// regardless of how few columns the read then projects.
+///
+/// - `decodeFooter` — Thrift decode of the footer bytes into a [FileMetaData], with the
+///   bytes already in memory. No I/O, no schema building: the parser alone.
+/// - `buildSchema` — [FileSchema] construction from already-decoded schema elements, the
+///   other half of what `open` does beyond reading bytes.
+/// - `openFile` — what a caller actually pays for [ParquetFileReader#open]: memory-map the
+///   file, read the footer off it, decode it, and build the schema.
+///
+/// [WideSchemaMetadataParquetJavaBenchmark] runs the same three steps through parquet-java over
+/// the identical fixtures; run both (the class filter `WideSchemaMetadata` matches each) for the
+/// comparison. Note what the two decodes produce: Hardwood's yields the metadata its reader uses
+/// directly, while parquet-java's decode yields generated Thrift structures a caller still has
+/// to convert, which is why its conversion step is measured too.
+///
+/// Divide a result by the column count for the per-column cost, which is what makes the
+/// numbers comparable across widths and against other implementations.
+///
+/// The fixtures are generated on demand from `@Setup` (also runnable up front, see
+/// [WideSchemaFileGenerator]) and cached in the benchmark data directory.
+///
+/// The fork's `-Xmx` is sized for the widest fixture, whose million column chunks decode into
+/// roughly 270 MB of live metadata while allocating some 300 MB per decode. A single decode
+/// fits in a fraction of that heap, but on a tight one the repeated decodes of a JMH iteration
+/// turn the result into a measurement of the collector rather than the parser. Run it with
+/// `-prof gc` when changing the allocation behaviour of the parser.
+@BenchmarkMode(Mode.AverageTime)
+@OutputTimeUnit(TimeUnit.MILLISECONDS)
+@State(Scope.Benchmark)
+@Fork(value = 2, jvmArgs = { "-Xms2g", "-Xmx8g", "--add-modules", "jdk.incubator.vector" })
+@Warmup(iterations = 3, time = 1)
+@Measurement(iterations = 5, time = 1)
+public class WideSchemaMetadataBenchmark {
+
+    @Param({ "10", "100", "1000", "10000", "100000" })
+    private int columns;
+
+    private Path path;
+    /// The footer bytes, read once so `decodeFooter` measures only the parser.
+    private ByteBuffer footer;
+    private List<SchemaElement> schemaElements;
+    private HardwoodContext context;
+
+    @Setup
+    public void setup() throws IOException {
+        Path dir = Path.of(BenchmarkData.dir());
+        WideSchemaFileGenerator.ensureFile(dir, columns);
+        path = WideSchemaFileGenerator.file(dir, columns).toAbsolutePath().normalize();
+        footer = ByteBuffer.wrap(Footers.read(path));
+        schemaElements = decode().schema();
+        context = HardwoodContext.create();
+        System.out.printf("%,d columns: %,d footer bytes (%,.1f bytes/column)%n",
+                columns, footer.remaining(), (double) footer.remaining() / columns);
+    }
+
+    @TearDown
+    public void tearDown() {
+        context.close();
+    }
+
+    @Benchmark
+    public void decodeFooter(Blackhole blackhole) throws IOException {
+        blackhole.consume(decode());
+    }
+
+    @Benchmark
+    public void buildSchema(Blackhole blackhole) {
+        blackhole.consume(FileSchema.fromSchemaElements(schemaElements));
+    }
+
+    @Benchmark
+    public void openFile(Blackhole blackhole) throws IOException {
+        try (ParquetFileReader reader = ParquetFileReader.open(InputFile.of(path), context)) {
+            blackhole.consume(reader.getFileSchema());
+        }
+    }
+
+    private FileMetaData decode() throws IOException {
+        // A duplicate so each invocation starts at the footer's first byte.
+        return FileMetaDataReader.read(new ThriftCompactReader(footer.duplicate()));
+    }
+
+}

--- a/performance-testing/micro-benchmarks/src/main/java/dev/hardwood/benchmarks/wide/WideSchemaMetadataBenchmark.java
+++ b/performance-testing/micro-benchmarks/src/main/java/dev/hardwood/benchmarks/wide/WideSchemaMetadataBenchmark.java
@@ -45,6 +45,17 @@ import dev.hardwood.schema.FileSchema;
 ///
 /// - `decodeFooter` — Thrift decode of the footer bytes into a [FileMetaData], with the
 ///   bytes already in memory. No I/O, no schema building: the parser alone.
+/// - `decodeFooterMapped` — the same decode over a memory-mapped, and so direct, buffer. The
+///   decoder reads strings and compares cached column paths straight out of the backing array
+///   where it has one, and copies byte by byte where it does not; this arm is what the second
+///   case costs, and it is the buffer a local file read produces.
+/// - `decodeFooterMappedCopied` — the mapped footer copied onto the heap and then decoded, so
+///   the decode runs on an array. Against `decodeFooterMapped` this is what buying the array
+///   for a footer read once and dropped is worth: it is worth nothing. The two decodes cost
+///   the same to within a few percent at every width — a direct buffer's `get` is a bare
+///   memory load where a heap buffer's is an array access the JIT bounds-checks, which offsets
+///   the array-only paths — and the copy adds the footer's own size in allocation on top. The
+///   reader therefore decodes off whatever buffer the file hands it.
 /// - `buildSchema` — [FileSchema] construction from already-decoded schema elements, the
 ///   other half of what `open` does beyond reading bytes.
 /// - `openFile` — what a caller actually pays for [ParquetFileReader#open]: memory-map the
@@ -81,6 +92,8 @@ public class WideSchemaMetadataBenchmark {
     private Path path;
     /// The footer bytes, read once so `decodeFooter` measures only the parser.
     private ByteBuffer footer;
+    /// The same bytes as a mapped, direct buffer, for `decodeFooterMapped`.
+    private ByteBuffer mappedFooter;
     private List<SchemaElement> schemaElements;
     private HardwoodContext context;
 
@@ -90,6 +103,7 @@ public class WideSchemaMetadataBenchmark {
         WideSchemaFileGenerator.ensureFile(dir, columns);
         path = WideSchemaFileGenerator.file(dir, columns).toAbsolutePath().normalize();
         footer = ByteBuffer.wrap(Footers.read(path));
+        mappedFooter = Footers.map(path);
         schemaElements = decode().schema();
         context = HardwoodContext.create();
         System.out.printf("%,d columns: %,d footer bytes (%,.1f bytes/column)%n",
@@ -104,6 +118,18 @@ public class WideSchemaMetadataBenchmark {
     @Benchmark
     public void decodeFooter(Blackhole blackhole) throws IOException {
         blackhole.consume(decode());
+    }
+
+    @Benchmark
+    public void decodeFooterMapped(Blackhole blackhole) throws IOException {
+        blackhole.consume(FileMetaDataReader.read(new ThriftCompactReader(mappedFooter.duplicate())));
+    }
+
+    @Benchmark
+    public void decodeFooterMappedCopied(Blackhole blackhole) throws IOException {
+        ByteBuffer copy = ByteBuffer.allocate(mappedFooter.remaining());
+        copy.put(mappedFooter.duplicate());
+        blackhole.consume(FileMetaDataReader.read(new ThriftCompactReader(copy.flip())));
     }
 
     @Benchmark

--- a/performance-testing/micro-benchmarks/src/main/java/dev/hardwood/benchmarks/wide/WideSchemaMetadataParquetJavaBenchmark.java
+++ b/performance-testing/micro-benchmarks/src/main/java/dev/hardwood/benchmarks/wide/WideSchemaMetadataParquetJavaBenchmark.java
@@ -13,6 +13,7 @@ import java.nio.file.Path;
 import java.util.concurrent.TimeUnit;
 
 import org.apache.hadoop.conf.Configuration;
+import org.apache.parquet.Version;
 import org.apache.parquet.format.FileMetaData;
 import org.apache.parquet.format.Util;
 import org.apache.parquet.format.converter.ParquetMetadataConverter;
@@ -76,6 +77,9 @@ public class WideSchemaMetadataParquetJavaBenchmark {
         decodedFooter = Util.readFileMetaData(new ByteArrayInputStream(footerBytes));
         hadoopConf = new Configuration();
         hadoopPath = new org.apache.hadoop.fs.Path(path.toString());
+        // Stamped from the artifact on the classpath, so a published comparison names the
+        // version it actually measured rather than the one whoever ran it believed was pinned.
+        System.out.printf("%,d columns against parquet-java %s%n", columns, Version.VERSION_NUMBER);
     }
 
     @Benchmark

--- a/performance-testing/micro-benchmarks/src/main/java/dev/hardwood/benchmarks/wide/WideSchemaMetadataParquetJavaBenchmark.java
+++ b/performance-testing/micro-benchmarks/src/main/java/dev/hardwood/benchmarks/wide/WideSchemaMetadataParquetJavaBenchmark.java
@@ -1,0 +1,107 @@
+/*
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Copyright The original authors
+ *
+ *  Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package dev.hardwood.benchmarks.wide;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.nio.file.Path;
+import java.util.concurrent.TimeUnit;
+
+import org.apache.hadoop.conf.Configuration;
+import org.apache.parquet.format.FileMetaData;
+import org.apache.parquet.format.Util;
+import org.apache.parquet.format.converter.ParquetMetadataConverter;
+import org.apache.parquet.hadoop.ParquetFileReader;
+import shaded.parquet.org.apache.thrift.protocol.TCompactProtocol;
+import shaded.parquet.org.apache.thrift.transport.TIOStreamTransport;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
+import org.openjdk.jmh.infra.Blackhole;
+
+import dev.hardwood.benchmarks.BenchmarkData;
+
+/// The parquet-java counterpart of [WideSchemaMetadataBenchmark], over the identical fixtures,
+/// so the two are compared on the same machine, JVM and bytes. Run both together — the class
+/// filter `WideSchemaMetadata` matches each — and read the pairs:
+///
+/// - `decodeFooter` — `Util.readFileMetaData`, the Thrift decode alone, stopping at the
+///   generated `format.FileMetaData` structures a caller still has to convert.
+/// - `decodeFooterStockThrift` — the same generated structures read straight off an Apache
+///   Thrift `TCompactProtocol`, without the `InterningProtocol` that `Util` wraps around it.
+///   parquet-java interns every string the footer repeats; the gap between this and
+///   `decodeFooter` is what that costs or saves on a schema this wide.
+/// - `buildMetadata` — `ParquetMetadataConverter.fromParquetMetadata` over an already-decoded
+///   footer: the conversion into `ParquetMetadata` and its `MessageType`, which is the work
+///   Hardwood's decode and `FileSchema` construction cover between them.
+/// - `openFile` — `ParquetFileReader.open`, what a caller pays end to end.
+///
+/// This class lives beside its Hardwood twin rather than inside it because both libraries name
+/// their reader `ParquetFileReader`.
+@BenchmarkMode(Mode.AverageTime)
+@OutputTimeUnit(TimeUnit.MILLISECONDS)
+@State(Scope.Benchmark)
+@Fork(value = 2, jvmArgs = { "-Xms2g", "-Xmx8g", "--add-modules", "jdk.incubator.vector" })
+@Warmup(iterations = 3, time = 1)
+@Measurement(iterations = 5, time = 1)
+public class WideSchemaMetadataParquetJavaBenchmark {
+
+    @Param({ "10", "100", "1000", "10000", "100000" })
+    private int columns;
+
+    private byte[] footerBytes;
+    private FileMetaData decodedFooter;
+    private Configuration hadoopConf;
+    private org.apache.hadoop.fs.Path hadoopPath;
+
+    @Setup
+    public void setup() throws IOException {
+        Path dir = Path.of(BenchmarkData.dir());
+        WideSchemaFileGenerator.ensureFile(dir, columns);
+        Path path = WideSchemaFileGenerator.file(dir, columns).toAbsolutePath().normalize();
+        footerBytes = Footers.read(path);
+        decodedFooter = Util.readFileMetaData(new ByteArrayInputStream(footerBytes));
+        hadoopConf = new Configuration();
+        hadoopPath = new org.apache.hadoop.fs.Path(path.toString());
+    }
+
+    @Benchmark
+    public void decodeFooter(Blackhole blackhole) throws IOException {
+        blackhole.consume(Util.readFileMetaData(new ByteArrayInputStream(footerBytes)));
+    }
+
+    /// The Thrift runtime parquet-java ships is shaded into its own namespace, so the stock
+    /// decode has to be spelled with the shaded names — there is no unshaded `libthrift` on
+    /// this classpath to reach for instead.
+    @Benchmark
+    public void decodeFooterStockThrift(Blackhole blackhole) throws Exception {
+        FileMetaData metaData = new FileMetaData();
+        metaData.read(new TCompactProtocol(new TIOStreamTransport(new ByteArrayInputStream(footerBytes))));
+        blackhole.consume(metaData);
+    }
+
+    @Benchmark
+    public void buildMetadata(Blackhole blackhole) throws IOException {
+        blackhole.consume(new ParquetMetadataConverter().fromParquetMetadata(decodedFooter));
+    }
+
+    @Benchmark
+    public void openFile(Blackhole blackhole) throws IOException {
+        try (ParquetFileReader reader = ParquetFileReader.open(hadoopConf, hadoopPath)) {
+            blackhole.consume(reader.getFileMetaData().getSchema());
+        }
+    }
+}

--- a/performance-testing/micro-benchmarks/src/main/java/dev/hardwood/benchmarks/wide/WideSchemaSkipFloorBenchmark.java
+++ b/performance-testing/micro-benchmarks/src/main/java/dev/hardwood/benchmarks/wide/WideSchemaSkipFloorBenchmark.java
@@ -1,0 +1,131 @@
+/*
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Copyright The original authors
+ *
+ *  Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package dev.hardwood.benchmarks.wide;
+
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.nio.file.Path;
+import java.util.concurrent.TimeUnit;
+
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
+import org.openjdk.jmh.infra.Blackhole;
+
+import dev.hardwood.benchmarks.BenchmarkData;
+import dev.hardwood.internal.thrift.FileMetaDataReader;
+import dev.hardwood.internal.thrift.ThriftCompactReader;
+
+/// What a lazily-materializing footer decode would cost, measured as the floor it converges to.
+///
+/// A lazy design cannot avoid walking the footer — Thrift carries no index, so the byte range of
+/// each column chunk is only found by parsing forward. What it *can* avoid is building the
+/// records: on a file of 100,000 columns and ten row groups, a projected read of three columns
+/// materializes a million `ColumnMetaData` (and their statistics, paths and encoding lists) to
+/// use thirty of them.
+///
+/// - `fullDecode` — today's decode, every structure materialized. The baseline.
+/// - `skipToChunkIndex` — the structural walk a lazy decode would do eagerly: descend into the
+///   row groups, record each column chunk's `(offset, length)` in the footer, and skip its body.
+///   Materializing a chunk later is then a decode of that byte range alone.
+/// - `skipRowGroups` — schema only, the row-group list skipped whole. The absolute floor, and
+///   what a schema-only caller (`hardwood schema`, a projection planner reading names) could pay.
+///
+/// The gap between `fullDecode` and `skipToChunkIndex` is the prize a lazy design plays for; the
+/// gap between `skipToChunkIndex` and `skipRowGroups` is what the chunk index itself costs.
+@BenchmarkMode(Mode.AverageTime)
+@OutputTimeUnit(TimeUnit.MILLISECONDS)
+@State(Scope.Benchmark)
+@Fork(value = 2, jvmArgs = { "-Xms2g", "-Xmx8g", "--add-modules", "jdk.incubator.vector" })
+@Warmup(iterations = 2, time = 2)
+@Measurement(iterations = 5, time = 2)
+public class WideSchemaSkipFloorBenchmark {
+
+    /// `FileMetaData.row_groups`.
+    private static final int FIELD_ROW_GROUPS = 4;
+    /// `RowGroup.columns`.
+    private static final int FIELD_COLUMNS = 1;
+
+    @Param({ "1000", "10000", "100000" })
+    private int columns;
+
+    private ByteBuffer footer;
+
+    @Setup
+    public void setup() throws IOException {
+        Path dir = Path.of(BenchmarkData.dir());
+        WideSchemaFileGenerator.ensureFile(dir, columns);
+        footer = ByteBuffer.wrap(Footers.read(WideSchemaFileGenerator.file(dir, columns)));
+    }
+
+    @Benchmark
+    public void fullDecode(Blackhole blackhole) throws IOException {
+        blackhole.consume(FileMetaDataReader.read(new ThriftCompactReader(footer.duplicate())));
+    }
+
+    @Benchmark
+    public void skipToChunkIndex(Blackhole blackhole) throws IOException {
+        ThriftCompactReader reader = new ThriftCompactReader(footer.duplicate());
+        // The index a lazy FileMetaData would hold: where each chunk's bytes start and end.
+        int[] chunkOffsets = new int[columns * WideSchemaFileGenerator.ROW_GROUPS + 1];
+        int chunkCount = 0;
+        int header;
+        while ((header = reader.readFieldHeader()) != ThriftCompactReader.STOP_FIELD) {
+            if (ThriftCompactReader.fieldId(header) != FIELD_ROW_GROUPS) {
+                reader.skipField(ThriftCompactReader.fieldType(header));
+                continue;
+            }
+            long rowGroups = reader.readListHeader();
+            for (int g = 0, n = ThriftCompactReader.listSize(rowGroups); g < n; g++) {
+                chunkCount = skipRowGroup(reader, chunkOffsets, chunkCount);
+            }
+        }
+        blackhole.consume(chunkOffsets);
+        blackhole.consume(chunkCount);
+    }
+
+    /// Walks one row group, recording where each of its column chunks begins and skipping the
+    /// chunk itself.
+    private static int skipRowGroup(ThriftCompactReader reader, int[] chunkOffsets, int chunkCount)
+            throws IOException {
+        int count = chunkCount;
+        int header;
+        while ((header = reader.readFieldHeader()) != ThriftCompactReader.STOP_FIELD) {
+            if (ThriftCompactReader.fieldId(header) != FIELD_COLUMNS) {
+                reader.skipField(ThriftCompactReader.fieldType(header));
+                continue;
+            }
+            long chunks = reader.readListHeader();
+            for (int c = 0, n = ThriftCompactReader.listSize(chunks); c < n; c++) {
+                chunkOffsets[count++] = reader.getBytesRead();
+                reader.skipStruct();
+            }
+        }
+        return count;
+    }
+
+    @Benchmark
+    public void skipRowGroups(Blackhole blackhole) throws IOException {
+        ThriftCompactReader reader = new ThriftCompactReader(footer.duplicate());
+        int fields = 0;
+        int header;
+        while ((header = reader.readFieldHeader()) != ThriftCompactReader.STOP_FIELD) {
+            reader.skipField(ThriftCompactReader.fieldType(header));
+            fields++;
+        }
+        blackhole.consume(fields);
+    }
+}


### PR DESCRIPTION
Closes #919, closes #920.

Prompted by InfluxData's [How Good is Parquet for Wide Tables Really?](https://www.influxdata.com/blog/how-good-parquet-wide-tables/), which measures footer decode against column count and reports ~5 µs and ~700 bytes of footer per column for parquet-rs 51. We had no comparable number.

## What is here

**`#919` — the benchmark.** `WideSchemaMetadataBenchmark` sweeps 10 … 100,000 `FLOAT64` columns over ten row groups (so `columns × 10` column chunks), splitting the cost into Thrift decode, `FileSchema` construction, and the `open()` a caller actually pays. `WideSchemaMetadataParquetJavaBenchmark` runs the same three steps through parquet-java over the identical fixtures. Fixtures are written by our own writer on demand rather than checked in; the widest is 150 MB with a 69 MB footer.

**`#920` — the decode.** The benchmark showed decode allocating ~7.5 bytes per footer byte — 750 MB of garbage for a 69 MB footer, retaining 456 MB. Addressed by packing the Thrift field header into an `int` (it was one object per field read, tens of millions per wide footer, escaping into `acceptField` rather than being scalarized), decoding strings in place from heap-backed buffers, building one- and two-element lists with `List.of`, and caching each column's `path_in_schema` positionally.

The path cache deserves a note for review: `RowGroup.columns` is *required* to follow schema order ("This list must have the same order as the SchemaElement list in FileMetaData"), but the cache treats that as a **prediction** and verifies the cached entry against the encoded bytes before reusing it. A file that breaks the ordering decodes correctly and merely loses the shortcut. `RepeatedPathCacheTest` covers shuffled row groups, row groups of differing column counts, and multi-component paths.

Content-keyed interning of strings and paths was implemented and measured as the alternative, and rejected: it cut allocation further but cost 40-60% more wall-clock, because hashing and probing a table is a cache miss per string where the decode is otherwise a sequential scan. The positional cache is the same trick `Dictionary.internedString` already uses on the value path — an index, not a hash. parquet-java reaches for interning too, through `String.intern()` in its `InterningProtocol`, and pays for it (see the `stock Thrift` column below).

**`#920` — skipping.** Skipping a field allocated as much as reading one: the binary case read the value into a fresh array only to drop it, and every list header — several per column chunk — escaped as a record. Both are fixed, taking a full footer walk from 131 MB of allocation to 453 B. Nobody pays this on a full decode; it is the floor for anything that walks past metadata rather than through it, an unrecognised field today and selective decoding later.

**`#919` — the skip floor.** `WideSchemaSkipFloorBenchmark` measures what that floor is: a structural walk that materializes nothing still costs about two thirds of a full decode, because Thrift carries no index and the byte range of each chunk is only found by parsing forward. Worth having recorded — it bounds what any selective or deferred decoding scheme can win, and says such a scheme is a memory change first and a latency change second.

## Numbers

n300, 8 Gracemont cores pinned at 1.50 GHz (calibrated, no thermal throttling), Temurin 25. Same fixtures for every contender, and the same warmup for every JMH benchmark (2 iterations), matching the warmup phase the parquet-rs harness uses. `decode` is Thrift decode of an in-memory footer; note parquet-rs builds its `SchemaDescriptor` inside decode, which we split out as `buildSchema`.

Decode, ms:

| columns | Hardwood before | Hardwood after | Hardwood after, mapped | parquet-rs 59.2 | parquet-java 1.17.1 | stock Thrift |
|---:|---:|---:|---:|---:|---:|---:|
| 10 | 0.062 | 0.050 | 0.049 | 0.039 | 0.218 | 0.184 |
| 100 | 0.607 | 0.490 | 0.465 | 0.392 | 2.182 | 1.914 |
| 1,000 | 6.04 | 5.07 | 4.73 | 4.70 | 21.8 | 21.1 |
| 10,000 | 61.5 | 46.5 | 48.4 | 47.3 | 228.3 | 204.5 |
| 100,000 | 709.3 | 471.2 | 497.5 | 709.4 | 2360.5 | 2233.6 |

`decode` reads an in-memory footer off the heap. `decode, mapped` reads the same bytes off a
memory-mapped, and so direct, buffer, which is what every input this reader has — a mapped local
file, the range cache, S3 — actually hands it. The two differ by at most a few percent and change
sign across the sweep, so the heap column is representative rather than favourable; see below.

`buildSchema` adds 0.24 / 2.54 / 25.2 ms at 1k / 10k / 100k; parquet-rs's separate Arrow-schema step is 0.32 / 5.54 / 33.5 ms.

Full open, ms: 0.079 / 0.565 / 5.13 / 51.7 / **555** (Hardwood) against 0.055 / 0.418 / 5.02 / 48.5 / **754** (parquet-rs) and 1.8 / 14.6 / 159 / 1466 / **15870** (parquet-java).

So `#920` buys 16-34% on decode, most of it at the wide end. Against parquet-rs the honest reading is still a **crossover**: comparing like with like (our decode + schema build against its decode), parquet-rs is ahead up to 10,000 columns — though only by 3.6% there now, 49.0 ms against 47.3 — and we are ahead at 100,000, 497 ms against 709, where our full open wins too. Allocation per decode fell 752 -> 305 MB and the retained metadata 456 -> 273 MB, which is why the wide end moves most.

The `stock Thrift` column reads the same generated structures off a bare `TCompactProtocol`, without the `InterningProtocol` that parquet-java's `Util` wraps around it: interning every repeated string through the JVM string pool costs them 6-19% here.

`#920`'s skip fixes do not move these numbers — they pay only where a walk passes metadata by rather than materializing it, where they take a full footer walk from 131 MB of allocation to 453 B.

Two caveats on the comparison. It is eager against eager: parquet-rs has since shipped `ParquetMetaDataOptions` with statistics policies (`skip_except` for named columns), so a narrow-projection query there can skip decoding statistics it will never read, and would land below these numbers — we decode everything, as does the parquet-rs configuration measured here. And the widths below 100,000 columns favour parquet-rs on this hardware; the crossover is real but it is a crossover, not a lead.

## Review follow-ups

`#920` grew three changes out of @iifawzi's review.

**A varint's single-byte case returns before entering the loop.** A footer's varints are
overwhelmingly one byte — every field id, every small size, every enum value — and a non-negative
first byte is exactly that case. Worth 10% of the heap decode and 8.7% of the mapped one at
100,000 columns, at no cost in allocation, and it lands on the page-header path too since that
shares `readVarint`. The decode column above includes it.

**Two reads answered a malformed footer with a wrong number.** `readVarint` let its shift grow
unbounded, and Java applies a `long` shift modulo 64, so an eleventh byte folded its payload back
over the low bits of the result. `readFieldHeader` narrowed a long-form field id to `short`, which
maps id 65537 onto id 1 and has the struct reader decode that field's bytes as whatever it holds
field 1 to be. Both are now rejected, each covered by a test that fails without the fix, and
neither check is measurable in the decode.

**The buffer the decoder is handed does not matter.** Every input here produces a direct buffer —
a mapped local file, the range cache over a sparse temp file, and S3's `allocateDirect` fetches —
so the `hasArray()` paths that read a string in place and compare a cached column path through
`Arrays.equals` never fire in production. Buying them with one copy of the footer onto the heap
was implemented and measured, and it loses at every width: 19% / 4.8% / 0.6% slower on decode and
16% / 7% / 1.6% on open, plus the footer's own size in allocation. A direct buffer's `get` is a
bare memory load where a heap buffer's is an array access the JIT bounds-checks, and that offsets
what the array-only paths win. `decodeFooterMapped` is the arm that pins this down; the decoder
goes on reading whatever buffer the file gives it.

## Measurement provenance

The Hardwood columns are a fresh run of the branch head; the `before` column and the three
contenders are from the original run, on the same box at the same pinned clock. `buildSchema`,
which nothing in this branch touches, reproduces across the two sessions to within 1% — 25.4 ms
against 25.2 at 100,000 columns — which is the check that the two are comparable. `openFile` at
100,000 columns is the least stable arm at ±42 ms; every other figure quoted here is within 1.5%.
The parquet-java version is stamped by the benchmark from the artifact on its classpath, so the
table names the version it measured rather than the one it was assumed to be.

Footer size is ~690 bytes per column, matching the post's ~700.


