### PR TITLE
#914 Reject non-string keys in Avro maps

### DIFF
--- a/avro/src/main/java/dev/hardwood/avro/AvroReaders.java
+++ b/avro/src/main/java/dev/hardwood/avro/AvroReaders.java
@@ -7,10 +7,10 @@
  */
 package dev.hardwood.avro;
 
+import dev.hardwood.avro.internal.AvroPlanNode;
 import dev.hardwood.avro.internal.AvroSchemaConverter;
 import dev.hardwood.reader.FilterPredicate;
 import dev.hardwood.reader.ParquetFileReader;
-import dev.hardwood.reader.RowReader;
 import dev.hardwood.schema.ColumnProjection;
 
 /// Factory for creating [AvroRowReader] instances from a
@@ -97,6 +97,11 @@ public final class AvroReaders {
         }
 
         public AvroRowReader build() {
+            // Convert before building the underlying reader: conversion rejects
+            // schemas Avro cannot represent, and building the underlying reader
+            // already starts a column worker per projected column — workers that
+            // a rejection here would orphan, with no AvroRowReader to close them.
+            AvroPlanNode plan = AvroSchemaConverter.plan(fileReader.getFileSchema(), projection);
             ParquetFileReader.RowReaderBuilder underlying = fileReader.buildRowReader()
                     .projection(projection);
             if (filter != null) {
@@ -108,9 +113,7 @@ public final class AvroReaders {
             if (tailRows > 0) {
                 underlying.tail(tailRows);
             }
-            RowReader rowReader = underlying.build();
-            return new AvroRowReader(rowReader,
-                    AvroSchemaConverter.plan(fileReader.getFileSchema(), projection));
+            return new AvroRowReader(underlying.build(), plan);
         }
     }
 }

--- a/avro/src/main/java/dev/hardwood/avro/internal/AvroSchemaConverter.java
+++ b/avro/src/main/java/dev/hardwood/avro/internal/AvroSchemaConverter.java
@@ -195,6 +195,13 @@ public final class AvroSchemaConverter {
         }
         SchemaNode inner = mapGroup.children().getFirst();
         if (inner instanceof SchemaNode.GroupNode kvGroup && kvGroup.children().size() >= 2) {
+            SchemaNode keyNode = kvGroup.children().getFirst();
+            if (!(keyNode instanceof SchemaNode.PrimitiveNode key)
+                    || key.type() != PhysicalType.BYTE_ARRAY
+                    || !(key.logicalType() instanceof LogicalType.StringType)) {
+                throw new IllegalArgumentException("Map '" + mapGroup.name()
+                        + "' key type must be BYTE_ARRAY (STRING), but is " + mapKeyType(keyNode));
+            }
             SchemaNode valueNode = kvGroup.children().get(1);
             // Prune the value subtree so a map<_, struct> with a sub-field
             // projection narrows to the served fields (the key is always read).
@@ -203,6 +210,15 @@ public final class AvroSchemaConverter {
                     Schema.createMap(fieldSchema(value, valueNode)), Kind.MAP, mapGroup, value);
         }
         return untypedContainer(Schema::createMap, Kind.MAP, mapGroup);
+    }
+
+    private static String mapKeyType(SchemaNode keyNode) {
+        if (keyNode instanceof SchemaNode.PrimitiveNode key) {
+            return key.logicalType() == null
+                    ? key.type().toString()
+                    : key.type() + " (" + key.logicalType() + ")";
+        }
+        return "group '" + keyNode.name() + "'";
     }
 
     /// A list or map whose element type the schema does not describe: the container

--- a/avro/src/main/java/dev/hardwood/avro/internal/AvroSchemaConverter.java
+++ b/avro/src/main/java/dev/hardwood/avro/internal/AvroSchemaConverter.java
@@ -29,6 +29,13 @@ import dev.hardwood.schema.SchemaNode;
 /// `AvroSchemaConverter`, producing Avro schemas that are compatible
 /// with standard Avro tools and libraries.
 ///
+/// It diverges in one place, and only by accepting more: a map key annotated
+/// `ENUM` or `JSON` converts to a string-keyed Avro map, where parquet-java
+/// requires `STRING`. Both annotations describe UTF-8 text the string accessor
+/// serves, and `ENUM` / `JSON` values already convert to Avro strings. So a
+/// file that converts here does not necessarily convert under parquet-java —
+/// never the reverse.
+///
 /// Conversion yields a decode plan — see [#plan] — pairing each converted value
 /// position with the Parquet node it comes from, for readers that need the
 /// Parquet-side annotations the Avro schema does not carry. The converted schema
@@ -72,24 +79,33 @@ public final class AvroSchemaConverter {
     }
 
     private AvroPlanNode convertRoot() {
-        return convertGroup(fileSchema.getRootNode(), fileSchema.getName());
+        return convertGroup(fileSchema.getRootNode(), fileSchema.getName(), "");
     }
 
     /// Convert a struct group (or the schema root) to an Avro record, retaining
     /// only children that contain a projected leaf when a projection is active.
-    private AvroPlanNode convertGroup(SchemaNode.GroupNode group, String recordName) {
+    private AvroPlanNode convertGroup(SchemaNode.GroupNode group, String recordName, String path) {
         List<Schema.Field> fields = new ArrayList<>();
         List<AvroPlanNode> children = new ArrayList<>();
         for (SchemaNode child : group.children()) {
             if (projected != null && !hasProjectedLeaf(child, projected)) {
                 continue;
             }
-            AvroPlanNode childNode = convertNode(child);
+            AvroPlanNode childNode = convertNode(child, childPath(path, child.name()));
             fields.add(new Schema.Field(child.name(), fieldSchema(childNode, child), null, null));
             children.add(childNode);
         }
         return AvroPlanNode.record(
                 Schema.createRecord(recordName, null, null, false, fields), group, children);
+    }
+
+    /// The dotted path a converted node is reported under when conversion rejects
+    /// it. Names the value positions of the converted schema, so the synthetic
+    /// `list` and `key_value` levels of the Parquet encoding do not appear: a map
+    /// nested in `holder` is `holder.nested`, a map at a list element position is
+    /// `items.element`, and a map at a map value position is `outer.value`.
+    private static String childPath(String path, String name) {
+        return path.isEmpty() ? name : path + "." + name;
     }
 
     /// The schema a converted node takes as a field, list element, or map value:
@@ -118,10 +134,10 @@ public final class AvroSchemaConverter {
         };
     }
 
-    private AvroPlanNode convertNode(SchemaNode node) {
+    private AvroPlanNode convertNode(SchemaNode node, String path) {
         return switch (node) {
             case SchemaNode.PrimitiveNode prim -> convertPrimitive(prim);
-            case SchemaNode.GroupNode group -> convertGroupNode(group);
+            case SchemaNode.GroupNode group -> convertGroupNode(group, path);
         };
     }
 
@@ -130,23 +146,23 @@ public final class AvroSchemaConverter {
     /// annotation is a struct to neither. Converting it to an Avro RECORD anyway
     /// would yield a record the reader cannot fill, since the accessors would serve
     /// the group's leaf instead — so reject it here, once, rather than per value.
-    private AvroPlanNode convertGroupNode(SchemaNode.GroupNode group) {
+    private AvroPlanNode convertGroupNode(SchemaNode.GroupNode group, String path) {
         if (group.isVariant()) {
             return convertVariant(group);
         }
         if (group.isList()) {
-            return convertList(group);
+            return convertList(group, path);
         }
         if (group.isMap()) {
-            return convertMap(group);
+            return convertMap(group, path);
         }
         if (!group.isStruct()) {
-            throw new IllegalArgumentException("Group '" + group.name()
+            throw new IllegalArgumentException("Group '" + path
                     + "' carries an annotation Avro conversion does not recognise: "
                     + groupAnnotation(group));
         }
         // Plain struct — prune unprojected children recursively.
-        return convertGroup(group, group.name());
+        return convertGroup(group, group.name(), path);
     }
 
     private static String groupAnnotation(SchemaNode.GroupNode group) {
@@ -174,7 +190,7 @@ public final class AvroSchemaConverter {
         return AvroPlanNode.leaf(schema, Kind.VARIANT, group);
     }
 
-    private AvroPlanNode convertList(SchemaNode.GroupNode listGroup) {
+    private AvroPlanNode convertList(SchemaNode.GroupNode listGroup, String path) {
         SchemaNode element = listGroup.getListElement();
         if (element == null) {
             // Fallback for malformed list
@@ -183,42 +199,61 @@ public final class AvroSchemaConverter {
         // The list column is only reached when it has a projected leaf; prune the
         // element subtree so a list<struct> with a sub-field projection narrows to
         // the served fields.
-        AvroPlanNode elementNode = convertNode(element);
+        AvroPlanNode elementNode = convertNode(element, childPath(path, element.name()));
         return AvroPlanNode.container(
                 Schema.createArray(fieldSchema(elementNode, element)), Kind.LIST, listGroup, elementNode);
     }
 
-    private AvroPlanNode convertMap(SchemaNode.GroupNode mapGroup) {
+    private AvroPlanNode convertMap(SchemaNode.GroupNode mapGroup, String path) {
         // MAP -> key_value (repeated) -> key, value
         if (mapGroup.children().isEmpty()) {
             return untypedContainer(Schema::createMap, Kind.MAP, mapGroup);
         }
         SchemaNode inner = mapGroup.children().getFirst();
         if (inner instanceof SchemaNode.GroupNode kvGroup && kvGroup.children().size() >= 2) {
-            SchemaNode keyNode = kvGroup.children().getFirst();
-            if (!(keyNode instanceof SchemaNode.PrimitiveNode key)
-                    || key.type() != PhysicalType.BYTE_ARRAY
-                    || !(key.logicalType() instanceof LogicalType.StringType)) {
-                throw new IllegalArgumentException("Map '" + mapGroup.name()
-                        + "' key type must be BYTE_ARRAY (STRING), but is " + mapKeyType(keyNode));
-            }
+            requireAvroStringKey(kvGroup.children().getFirst(), path);
             SchemaNode valueNode = kvGroup.children().get(1);
             // Prune the value subtree so a map<_, struct> with a sub-field
             // projection narrows to the served fields (the key is always read).
-            AvroPlanNode value = convertNode(valueNode);
+            AvroPlanNode value = convertNode(valueNode, childPath(path, valueNode.name()));
             return AvroPlanNode.container(
                     Schema.createMap(fieldSchema(value, valueNode)), Kind.MAP, mapGroup, value);
         }
         return untypedContainer(Schema::createMap, Kind.MAP, mapGroup);
     }
 
-    private static String mapKeyType(SchemaNode keyNode) {
-        if (keyNode instanceof SchemaNode.PrimitiveNode key) {
-            return key.logicalType() == null
-                    ? key.type().toString()
-                    : key.type() + " (" + key.logicalType() + ")";
+    /// An Avro `MAP` carries no key schema — the spec fixes keys as strings — so a
+    /// Parquet map is only representable when its key converts to an Avro `STRING`.
+    /// The reader reads the key through [dev.hardwood.row.PqMap.Entry#getStringKey],
+    /// which a key of any other type cannot serve; reject the whole map here rather
+    /// than let a schema claiming string keys fail per value during materialization.
+    ///
+    /// "Converts to an Avro `STRING`" is [Kind#STRING], as decided by
+    /// [#convertLogicalType] — a `BYTE_ARRAY` annotated `STRING`, `ENUM` or `JSON`.
+    /// A `UUID` key also converts to an Avro string but is [Kind#UUID], carrying
+    /// bytes the string accessor would hand back as mojibake, so it is rejected too.
+    private void requireAvroStringKey(SchemaNode keyNode, String path) {
+        if (!(keyNode instanceof SchemaNode.PrimitiveNode key)
+                || convertPrimitive(key).kind() != Kind.STRING) {
+            throw new IllegalArgumentException("Map '" + path
+                    + "' key must be a BYTE_ARRAY annotated as STRING, ENUM or JSON"
+                    + " — Avro map keys are strings — but is " + mapKeyType(keyNode));
         }
-        return "group '" + keyNode.name() + "'";
+    }
+
+    /// Describe a map key for the rejection message. A `BYTE_ARRAY` key is rejected
+    /// for the annotation it lacks rather than its physical type, so name the missing
+    /// annotation instead of repeating the type the message just asked for.
+    private static String mapKeyType(SchemaNode keyNode) {
+        if (!(keyNode instanceof SchemaNode.PrimitiveNode key)) {
+            return "group '" + keyNode.name() + "'";
+        }
+        if (key.logicalType() != null) {
+            return key.type() + " (" + key.logicalType() + ")";
+        }
+        return key.type() == PhysicalType.BYTE_ARRAY
+                ? "BYTE_ARRAY with no logical annotation"
+                : key.type().toString();
     }
 
     /// A list or map whose element type the schema does not describe: the container

--- a/avro/src/test/java/dev/hardwood/avro/AvroRowReaderTest.java
+++ b/avro/src/test/java/dev/hardwood/avro/AvroRowReaderTest.java
@@ -39,11 +39,35 @@ import dev.hardwood.schema.ColumnProjection;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 class AvroRowReaderTest {
 
     private static final Path TEST_RESOURCES = Path.of("").toAbsolutePath()
             .resolve("../core/src/test/resources").normalize();
+
+    @Test
+    void rejectMapsWhoseKeysCannotBeRepresentedByAvro() throws Exception {
+        assertUnsupportedMapKey("map_types_test.parquet", "int_map", "INT32");
+        assertUnsupportedMapKey("typed_accessors_issue_445.parquet", "time_keyed", "INT32");
+        assertUnsupportedMapKey("map_typed_keys_test.parquet", "long_keyed", "INT64");
+    }
+
+    private static void assertUnsupportedMapKey(String fixture, String column, String keyType)
+            throws Exception {
+        try (ParquetFileReader fileReader = ParquetFileReader.open(
+                InputFile.of(TEST_RESOURCES.resolve(fixture)))) {
+            assertThatThrownBy(() -> {
+                try (AvroRowReader ignored = AvroReaders.buildRowReader(fileReader)
+                        .projection(ColumnProjection.columns(column)).build()) {
+                    // Schema conversion happens while the reader is built.
+                }
+            })
+                    .isInstanceOf(IllegalArgumentException.class)
+                    .hasMessageContaining(column)
+                    .hasMessageContaining(keyType);
+        }
+    }
 
     @Test
     void readFlatSchema() throws Exception {

--- a/avro/src/test/java/dev/hardwood/avro/AvroRowReaderTest.java
+++ b/avro/src/test/java/dev/hardwood/avro/AvroRowReaderTest.java
@@ -53,6 +53,23 @@ class AvroRowReaderTest {
         assertUnsupportedMapKey("map_typed_keys_test.parquet", "long_keyed", "INT64");
     }
 
+    /// The rejection covers the projected schema, so an unreadable map costs only
+    /// its own column: the remaining columns of the same file still read.
+    @Test
+    void readsRemainingColumnsOfAFileCarryingAnUnsupportedMap() throws Exception {
+        // map_types_test.parquet: id INT32, string_map, int_map (map<int32, int64>), bool_map — 3 rows
+        try (ParquetFileReader fileReader = ParquetFileReader.open(
+                InputFile.of(TEST_RESOURCES.resolve("map_types_test.parquet")));
+                AvroRowReader reader = AvroReaders.buildRowReader(fileReader)
+                        .projection(ColumnProjection.columns("id")).build()) {
+            List<Object> ids = new ArrayList<>();
+            while (reader.hasNext()) {
+                ids.add(reader.next().get("id"));
+            }
+            assertThat(ids).containsExactly(1, 2, 3);
+        }
+    }
+
     private static void assertUnsupportedMapKey(String fixture, String column, String keyType)
             throws Exception {
         try (ParquetFileReader fileReader = ParquetFileReader.open(

--- a/avro/src/test/java/dev/hardwood/avro/internal/AvroSchemaConverterTest.java
+++ b/avro/src/test/java/dev/hardwood/avro/internal/AvroSchemaConverterTest.java
@@ -108,7 +108,7 @@ class AvroSchemaConverterTest {
         List<SchemaElement> elements = new ArrayList<>(List.of(root, holder));
         elements.addAll(intKeyedMap("nested"));
 
-        assertRejectsMap(FileSchema.fromSchemaElements(elements), "nested", "INT32");
+        assertRejectsMap(FileSchema.fromSchemaElements(elements), "holder.nested", "INT32");
     }
 
     @Test
@@ -120,7 +120,7 @@ class AvroSchemaConverterTest {
         List<SchemaElement> elements = new ArrayList<>(List.of(root, items, list));
         elements.addAll(intKeyedMap("element"));
 
-        assertRejectsMap(FileSchema.fromSchemaElements(elements), "element", "INT32");
+        assertRejectsMap(FileSchema.fromSchemaElements(elements), "items.element", "INT32");
     }
 
     @Test
@@ -134,24 +134,106 @@ class AvroSchemaConverterTest {
         List<SchemaElement> elements = new ArrayList<>(List.of(root, outer, outerKv, outerKey));
         elements.addAll(intKeyedMap("value"));
 
-        assertRejectsMap(FileSchema.fromSchemaElements(elements), "value", "INT32");
+        assertRejectsMap(FileSchema.fromSchemaElements(elements), "outer.value", "INT32");
     }
 
-    private static void assertRejectsMap(FileSchema schema, String mapName, String keyType) {
+    /// Avro has no key schema, so every key it can represent arrives as a string.
+    /// That is exactly the set [AvroSchemaConverter] renders as an Avro `STRING`:
+    /// a `BYTE_ARRAY` annotated `STRING`, `ENUM` or `JSON`.
+    @Test
+    void acceptsEveryMapKeyAvroRendersAsString() {
+        assertMapConverts(mapKeyedBy(
+                primitive("key", PhysicalType.BYTE_ARRAY, null, new LogicalType.StringType())));
+        assertMapConverts(mapKeyedBy(
+                primitive("key", PhysicalType.BYTE_ARRAY, null, new LogicalType.EnumType())));
+        assertMapConverts(mapKeyedBy(
+                primitive("key", PhysicalType.BYTE_ARRAY, null, new LogicalType.JsonType())));
+    }
+
+    /// Writers predating the logical-type union annotate string keys with the legacy
+    /// `UTF8` converted type alone. Those maps are ordinary string-keyed maps and
+    /// must not be rejected.
+    @Test
+    void acceptsMapKeyCarryingOnlyTheLegacyUtf8ConvertedType() {
+        assertMapConverts(mapKeyedBy(
+                primitive("key", PhysicalType.BYTE_ARRAY, ConvertedType.UTF8, null)));
+    }
+
+    /// An unannotated `BYTE_ARRAY` key holds arbitrary bytes. Decoding those as UTF-8
+    /// would substitute replacement characters, and two distinct keys that both decode
+    /// to the same replacement sequence would collide into one Avro map entry —
+    /// dropping the other. Reject instead of mangling.
+    @Test
+    void rejectsUnannotatedBinaryMapKey() {
+        assertRejectsMap(mapKeyedBy(primitive("key", PhysicalType.BYTE_ARRAY, null, null)),
+                "m", "BYTE_ARRAY with no logical annotation");
+    }
+
+    /// A `UUID` key converts to an Avro `STRING`, but it is 16 raw bytes rather than
+    /// text — the string accessor would hand back mojibake.
+    @Test
+    void rejectsUuidMapKey() {
+        assertRejectsMap(mapKeyedBy(primitive("key", PhysicalType.FIXED_LEN_BYTE_ARRAY,
+                null, new LogicalType.UuidType())), "m", "UUID");
+    }
+
+    /// The Parquet spec requires a primitive map key; a group in the key position has
+    /// no value for the string accessor to read.
+    @Test
+    void rejectsMapWithGroupKey() {
+        List<SchemaElement> elements = List.of(
+                group("root", null, 1),
+                annotatedGroup("m", RepetitionType.OPTIONAL, 1, new LogicalType.MapType()),
+                group("key_value", RepetitionType.REPEATED, 2),
+                group("key", RepetitionType.REQUIRED, 1),
+                primitive("part", PhysicalType.INT32, null, null),
+                new SchemaElement("value", PhysicalType.INT64, null,
+                        RepetitionType.OPTIONAL, null, null, null, null, null, null));
+
+        assertRejectsMap(FileSchema.fromSchemaElements(elements), "m", "group 'key'");
+    }
+
+    private static void assertMapConverts(FileSchema schema) {
+        Schema map = pickMapBranch(convert(schema).getField("m").schema());
+        assertThat(map.getType()).isEqualTo(Schema.Type.MAP);
+    }
+
+    /// A map key Avro cannot represent is reported under the map's full path, so a
+    /// map nested below the root is diagnosable without hunting for which `element`
+    /// or `value` position the message means.
+    private static void assertRejectsMap(FileSchema schema, String mapPath, String keyType) {
         assertThatThrownBy(() -> AvroSchemaConverter.plan(schema, ColumnProjection.all()))
                 .isInstanceOf(IllegalArgumentException.class)
-                .hasMessageContaining(mapName)
+                .hasMessageContaining("Map '" + mapPath + "'")
                 .hasMessageContaining(keyType);
     }
 
     private static List<SchemaElement> intKeyedMap(String name) {
+        return keyedMap(name, primitive("key", PhysicalType.INT32, null, null));
+    }
+
+    /// A `map<?, int64>` whose key element is given, so key handling can be varied
+    /// without restating the surrounding MAP / `key_value` shape.
+    private static List<SchemaElement> keyedMap(String name, SchemaElement key) {
         return List.of(
                 annotatedGroup(name, RepetitionType.OPTIONAL, 1, new LogicalType.MapType()),
                 group("key_value", RepetitionType.REPEATED, 2),
-                new SchemaElement("key", PhysicalType.INT32, null,
-                        RepetitionType.REQUIRED, null, null, null, null, null, null),
+                key,
                 new SchemaElement("value", PhysicalType.INT64, null,
                         RepetitionType.OPTIONAL, null, null, null, null, null, null));
+    }
+
+    /// A single-field schema whose field `m` is a `map<?, int64>` with the given key.
+    private static FileSchema mapKeyedBy(SchemaElement key) {
+        List<SchemaElement> elements = new ArrayList<>(List.of(group("root", null, 1)));
+        elements.addAll(keyedMap("m", key));
+        return FileSchema.fromSchemaElements(elements);
+    }
+
+    private static SchemaElement primitive(String name, PhysicalType type,
+            ConvertedType convertedType, LogicalType logicalType) {
+        return new SchemaElement(name, type, null, RepetitionType.REQUIRED, null,
+                convertedType, null, null, null, logicalType);
     }
 
     private static SchemaElement group(String name, RepetitionType repetition, int children) {

--- a/avro/src/test/java/dev/hardwood/avro/internal/AvroSchemaConverterTest.java
+++ b/avro/src/test/java/dev/hardwood/avro/internal/AvroSchemaConverterTest.java
@@ -7,6 +7,7 @@
  */
 package dev.hardwood.avro.internal;
 
+import java.util.ArrayList;
 import java.util.List;
 
 import org.apache.avro.Schema;
@@ -98,6 +99,70 @@ class AvroSchemaConverterTest {
                 .isInstanceOf(IllegalArgumentException.class)
                 .hasMessageContaining("legacy")
                 .hasMessageContaining("MAP_KEY_VALUE");
+    }
+
+    @Test
+    void rejectsNonStringKeyedMapNestedInStruct() {
+        SchemaElement root = group("root", null, 1);
+        SchemaElement holder = group("holder", RepetitionType.OPTIONAL, 1);
+        List<SchemaElement> elements = new ArrayList<>(List.of(root, holder));
+        elements.addAll(intKeyedMap("nested"));
+
+        assertRejectsMap(FileSchema.fromSchemaElements(elements), "nested", "INT32");
+    }
+
+    @Test
+    void rejectsNonStringKeyedMapUsedAsListElement() {
+        SchemaElement root = group("root", null, 1);
+        SchemaElement items = annotatedGroup("items", RepetitionType.OPTIONAL, 1,
+                new LogicalType.ListType());
+        SchemaElement list = group("list", RepetitionType.REPEATED, 1);
+        List<SchemaElement> elements = new ArrayList<>(List.of(root, items, list));
+        elements.addAll(intKeyedMap("element"));
+
+        assertRejectsMap(FileSchema.fromSchemaElements(elements), "element", "INT32");
+    }
+
+    @Test
+    void rejectsNonStringKeyedMapUsedAsMapValue() {
+        SchemaElement root = group("root", null, 1);
+        SchemaElement outer = annotatedGroup("outer", RepetitionType.OPTIONAL, 1,
+                new LogicalType.MapType());
+        SchemaElement outerKv = group("key_value", RepetitionType.REPEATED, 2);
+        SchemaElement outerKey = new SchemaElement("key", PhysicalType.BYTE_ARRAY, null,
+                RepetitionType.REQUIRED, null, null, null, null, null, new LogicalType.StringType());
+        List<SchemaElement> elements = new ArrayList<>(List.of(root, outer, outerKv, outerKey));
+        elements.addAll(intKeyedMap("value"));
+
+        assertRejectsMap(FileSchema.fromSchemaElements(elements), "value", "INT32");
+    }
+
+    private static void assertRejectsMap(FileSchema schema, String mapName, String keyType) {
+        assertThatThrownBy(() -> AvroSchemaConverter.plan(schema, ColumnProjection.all()))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining(mapName)
+                .hasMessageContaining(keyType);
+    }
+
+    private static List<SchemaElement> intKeyedMap(String name) {
+        return List.of(
+                annotatedGroup(name, RepetitionType.OPTIONAL, 1, new LogicalType.MapType()),
+                group("key_value", RepetitionType.REPEATED, 2),
+                new SchemaElement("key", PhysicalType.INT32, null,
+                        RepetitionType.REQUIRED, null, null, null, null, null, null),
+                new SchemaElement("value", PhysicalType.INT64, null,
+                        RepetitionType.OPTIONAL, null, null, null, null, null, null));
+    }
+
+    private static SchemaElement group(String name, RepetitionType repetition, int children) {
+        return new SchemaElement(name, null, null, repetition, children,
+                null, null, null, null, null);
+    }
+
+    private static SchemaElement annotatedGroup(String name, RepetitionType repetition, int children,
+            LogicalType logicalType) {
+        return new SchemaElement(name, null, null, repetition, children,
+                null, null, null, null, logicalType);
     }
 
     /// A Variant group and an ordinary group of the identical two-byte-field shape,

--- a/docs/content/how-to/avro.md
+++ b/docs/content/how-to/avro.md
@@ -76,6 +76,8 @@ AvroRowReader reader = AvroReaders.buildRowReader(fileReader)
 
 Values are stored in Avro's standard representations: timestamps as `Long` (millis/micros since epoch), dates as `Integer` (days since epoch), decimals as `ByteBuffer`, binary data as `ByteBuffer`, and ENUM values as `String`. This matches the behavior of parquet-java's `AvroReadSupport`.
 
+Avro maps always have string keys. Accordingly, a Parquet map key must be a `BYTE_ARRAY` annotated as `STRING`; building an `AvroRowReader` for a map with any other key type fails during schema conversion with an error naming the map and key type. Use Hardwood's `RowReader` when the original non-string map key type must be preserved.
+
 A Parquet column annotated with the `NULL` logical type (e.g. PyArrow's `pa.null()` columns) maps to a bare Avro `null` field — not the usual `union [null, T]` nullable wrap, which is illegal when `T` is itself `null`. The same collapse applies inside lists and maps: a `list<null>` element or `map<string, null>` value position becomes a bare `null` in the corresponding Avro `array` / `map` schema.
 
 ## Lifecycle

--- a/docs/content/how-to/avro.md
+++ b/docs/content/how-to/avro.md
@@ -76,7 +76,7 @@ AvroRowReader reader = AvroReaders.buildRowReader(fileReader)
 
 Values are stored in Avro's standard representations: timestamps as `Long` (millis/micros since epoch), dates as `Integer` (days since epoch), decimals as `ByteBuffer`, binary data as `ByteBuffer`, and ENUM values as `String`. This matches the behavior of parquet-java's `AvroReadSupport`.
 
-Avro maps always have string keys. Accordingly, a Parquet map key must be a `BYTE_ARRAY` annotated as `STRING`; building an `AvroRowReader` for a map with any other key type fails during schema conversion with an error naming the map and key type. Use Hardwood's `RowReader` when the original non-string map key type must be preserved.
+Avro maps always have string keys, so a Parquet map key must be a `BYTE_ARRAY` annotated as `STRING`, `ENUM`, or `JSON`. Building an `AvroRowReader` whose projection contains a map with any other key type — including an unannotated `BYTE_ARRAY` key, whose bytes are not necessarily text — fails with an error naming the map's path and its key type. The file's other columns are unaffected: narrow the projection to exclude the map, or read it through Hardwood's `RowReader`, which serves the key in its original type.
 
 A Parquet column annotated with the `NULL` logical type (e.g. PyArrow's `pa.null()` columns) maps to a bare Avro `null` field — not the usual `union [null, T]` nullable wrap, which is illegal when `T` is itself `null`. The same collapse applies inside lists and maps: a `list<null>` element or `map<string, null>` value position becomes a bare `null` in the corresponding Avro `array` / `map` schema.
 


### PR DESCRIPTION
## Summary

Fixes #914.

Rejects Parquet maps with non-string keys during Avro schema conversion. The resulting error identifies the map and its key type instead of allowing an incorrect Avro schema to cause a later `ClassCastException`.

This matches parquet-java’s behavior because Avro maps only support string keys.

## Changes

- Validate that Parquet map keys are `BYTE_ARRAY` annotated as `STRING`
- Cover the existing `int_map`, `time_keyed`, and `long_keyed` fixtures
- Document the Avro map-key limitation and recommend `RowReader` when typed keys must be preserved

## Authorship

Hardwood is built with AI, not by AI. LLM assistance is welcome; submitting raw LLM output without understanding is not.
Neither are unattended agents opening pull requests.
See the [contribution guide](https://github.com/hardwood-hq/hardwood/blob/main/CONTRIBUTING.md) for more details.
Check this box to confirm:

- [x] This change is coming from a human who understands what it does and why, and can discuss it in review

## Checklist

- [ ] Build via `./mvnw clean verify` passes
- [ ] The commit message is prefixed with the issue key ("#123 Adding support for...")
- [x] Code changes are covered by tests
- [x] If this PR adds or changes user-facing behaviour, `docs/` has been updated

## Acceptance Criteria

- [x] A map<int32, V> column read through AvroRowReader either produces well-defined values or fails with an error naming the column and its key type — not a ClassCastException from the batch layer.
- [x] Whichever option is taken applies at every map position: top level, nested in a struct, as a list element, and as a map value.
- [x] The behaviour is covered against the existing int_map, time_keyed and long_keyed fixtures.