### PR TITLE
#9 write support stage 14: write-path interop gate

### DIFF
--- a/_designs/WRITER_DICTIONARY.md
+++ b/_designs/WRITER_DICTIONARY.md
@@ -56,7 +56,7 @@ type stays `INT32`; type breadth (stage 12) repeats this proven mechanism for th
 types — most importantly `BYTE_ARRAY`, where dictionary encoding is the dominant real-world
 encoding — inheriting the page and chunk layout unchanged. Compression (stage 10) and
 statistics (stage 11) layer on afterwards. `DELTA_*` and `BYTE_STREAM_SPLIT` remain out of
-scope (stage 14). Only the modern `RLE_DICTIONARY` form is produced; the deprecated
+scope (stage 19). Only the modern `RLE_DICTIONARY` form is produced; the deprecated
 `PLAIN_DICTIONARY` (which the reader still tolerates) is not written.
 
 ## Column-chunk layout

--- a/_designs/WRITER_INTEROP_GATE.md
+++ b/_designs/WRITER_INTEROP_GATE.md
@@ -1,0 +1,180 @@
+# Write-path interop gate (#9, stage 14)
+
+**Status: Complete.** Tracking issues: #9, #907. Delivery stage 14 (Gate) of
+[WRITER_SUPPORT.md](WRITER_SUPPORT.md). This document is the reference the gate is
+implemented against and the contract every later writer increment extends.
+
+## Context
+
+Stages 1–13 produce every primitive physical type, in every column shape the reader
+supports, with paging, row-group cadence, nulls, nesting, dictionary encoding,
+compression, statistics, and logical-type annotations. Every one of them landed with a
+test that reads the produced file back — through Hardwood's own reader, and through
+DuckDB.
+
+Neither reader can observe the defect class that matters most on a write path: bytes that
+only a permissive decoder accepts. #901 is what that costs. A column chunk whose
+dictionary held exactly one entry produced an `RLE_DICTIONARY` index stream with no run
+header — the page body was the bit-width byte `0x00` and nothing else. Hardwood's decoder
+short-circuits on a zero bit width and never reads the stream; DuckDB is lenient in the
+same place. Both suites passed on a file that parquet-java and PyArrow both reject, on a
+shape as ordinary as a constant column.
+
+Fixing #901 pinned that encoder's bytes. It did not close the class. Every increment from
+here multiplies the produced shapes — the row-oriented layer, the remaining codecs, the
+delta and byte-stream-split encoders, page indexes, Bloom filters — and each one is a
+fresh opportunity to emit a stream only Hardwood can read.
+
+## Goal
+
+A test that a strict, independent implementation has to pass on files Hardwood writes, run
+on every PR, covering every shape stages 1–13 can produce.
+
+The acceptance criterion from #907: the gate fails against the writer as of the parent
+commit of the #901 fix, and passes after it.
+
+## The strict reader
+
+**parquet-java** (`org.apache.parquet`, 1.17.1) is the reader. It is the canonical
+implementation, so what it accepts is the operative definition of a conformant file, and
+it is already on `parquet-testing-runner`'s test classpath — the module carries
+`parquet-avro`, `parquet-hadoop` and `hadoop-common` at test scope and runs on every PR,
+so the gate needs no new dependency and no new CI job.
+
+PyArrow also catches this defect class, and its failure modes differ from parquet-java's
+per physical type. It is not part of the gate: adding it means wiring a Python step into
+the Java build for a second opinion on the same question. It remains the ad-hoc
+verification recipe it is today.
+
+### Reading through the Group API, not Avro
+
+The module's existing read-direction comparison reads reference rows through
+`AvroParquetReader`, which maps Parquet onto Avro's type system. That mapping is a
+restriction: Avro cannot represent several annotations stage 13 emits — `UUID`,
+`FLOAT16`, `INTERVAL`, the unsigned integer widths — so an Avro-based gate would have to
+exclude parts of the matrix for reasons that have nothing to do with whether the bytes are
+conformant.
+
+The gate reads through parquet-java's Group API instead — `ParquetReader<Group>` over
+`GroupReadSupport` — which materializes any valid file with no object model in the way.
+A read failure therefore means the bytes are bad, which is precisely what the gate is
+asserting. The Group path exercises the same decoders the Avro path does, including the
+`DictionaryValuesReader` that rejected #901.
+
+The footer is read separately through parquet-java's `ParquetFileReader`, so the gate also
+covers the metadata a value comparison cannot see: the declared encodings, the column-chunk
+statistics, and the `column_orders` that give those statistics their meaning.
+
+## What the gate asserts
+
+Per file, four things:
+
+1. **It reads.** parquet-java materializes every row without throwing. This alone is the
+   #901 check.
+2. **The values agree.** Every value parquet-java produces equals the value that was
+   written — not merely what Hardwood reads back. Nulls, list and map cardinalities, and
+   empty-versus-absent repeated values are compared as written.
+3. **The metadata agrees.** parquet-java parses the footer, and the column-chunk
+   statistics it exposes — `min`, `max`, `null_count` — match the written data under
+   *its* comparator, which it derives from the annotation and the footer's
+   `column_orders`. Agreement here is the first cross-implementation check on stage 13b:
+   an order the two implementations disagree about produces bounds that would prune a row
+   group holding a matching row.
+4. **The case covered what it claims to.** The encodings say the case actually produced
+   the dictionary, `PLAIN` fallback or plain-only chunk it exists to cover, and the layout
+   cases walk parquet-java's page readers to count the data pages they crossed. Without
+   this a change to the writer's encoding choice or page sizing would silently empty an
+   axis rather than fail it.
+
+   This one has to read the **page** value encodings, not the column chunk's `encodings`
+   list. That list always contains `PLAIN` — a dictionary page body is itself `PLAIN` — so
+   a chunk that overflowed its dictionary and fell back mid-chunk declares exactly what a
+   dictionary-only chunk declares, and asserting over it cannot fail. Each data page header
+   carries its own encoding, and those do separate the two.
+
+## The matrix
+
+The floor is a **single-entry dictionary per physical type** — the #901 shape — in every
+repetition shape.
+
+Beyond the floor, the matrix varies one axis at a time against a representative base
+rather than taking the full cross product, which would multiply to hundreds of files for
+coverage the axes already give independently. Every axis is swept across all seven
+writable physical types (`BOOLEAN`, `INT32`, `INT64`, `FLOAT`, `DOUBLE`, `BYTE_ARRAY`,
+`FIXED_LEN_BYTE_ARRAY`), since the value encoders are per-type and that is where an
+encoding defect lives.
+
+| Axis | Values |
+|------|--------|
+| Repetition | `REQUIRED`; `OPTIONAL` all-present; `OPTIONAL` with interleaved nulls; `OPTIONAL` all-null |
+| Encoding | single-entry dictionary; multi-entry dictionary; dictionary overflowing to mid-chunk `PLAIN`; dictionary disabled |
+| Codec | `UNCOMPRESSED`; `ZSTD` |
+| Layout | one page (pinned exactly); several pages; several row groups |
+
+Two further groups are enumerated rather than swept, because their shapes differ too much
+to parameterize:
+
+- **Nesting** — `REQUIRED` and `OPTIONAL` structs, nested structs, lists (including empty
+  lists, absent lists, lists of lists, lists of structs), and maps (including maps of
+  lists and maps of structs). These are the shapes that carry repetition and definition
+  level streams, which a flat column does not exercise at all.
+- **Logical types** — every annotation stage 13 emits, including the `UNKNOWN` of a
+  `NullType` column, read back through parquet-java's schema so that both the annotation
+  and the values it governs are checked. The bounds are asserted as the true extremes of
+  the row's own values, reduced with parquet-java's comparator for that column, rather than
+  merely as `min <= max`: most annotations carry values that sort identically under every
+  candidate order, so a consistency check passes for them whichever order the writer used.
+
+Only `UNCOMPRESSED` and `ZSTD` appear on the codec axis because those are the only codecs
+the writer produces today. Stage 19 adds the rest, and extends this axis with them.
+
+## What the gate found
+
+Running the matrix surfaced a defect the existing suites could not see, which is the point
+of building it: `created_by` is the bare string `hardwood`, and parquet-java's
+`VersionParser` expects `<app> version <version> (build <hash>)`. Every read in the new
+suite logs a `CorruptStatistics` warning, and under the PARQUET-251 heuristic parquet-java
+discards the deprecated `min`/`max` of a binary column whose writer it cannot identify.
+Hardwood's bounds survive only because it writes solely the modern `min_value`/`max_value`,
+which the heuristic does not gate — so today's correctness rests on a field the writer
+happens not to emit. Fixing the identifier is increment 15; the gate's footer assertions
+extend with it.
+
+## Extension contract
+
+Every writer increment after this one extends the matrix with the shapes it introduces,
+in the same commit that introduces them. Concretely:
+
+| Increment | Extension |
+|-----------|-----------|
+| 15 (parseable `created_by`) | The footer assertions gain that parquet-java's `VersionParser` accepts the identifier |
+| 16 (row-oriented `ParquetWriter`) | The record-shaped entry point, over the nested and logical-type groups |
+| 18 (S3 `OutputFile`) | None — the backend does not change the bytes |
+| 19 (codecs, delta / BSS encoders) | The codec axis gains the remaining codecs; the encoding axis gains the delta and byte-stream-split forms |
+| 20 (parallel encoding) | None — the output is byte-identical by construction, which its own tests assert |
+| 21 (row-group-global dictionary selection) | The encoding axis loses the mid-chunk `PLAIN` fallback and gains the whole-chunk choice |
+| 22 (page index) | The footer assertions gain the OffsetIndex and ColumnIndex, read through parquet-java |
+| 23 (Bloom filters) | The footer assertions gain the Bloom filter, read and probed through parquet-java |
+
+## Placement
+
+`parquet-testing-runner`, alongside the read-direction comparison it inverts. Three test
+classes, split by what they parameterize over rather than by size:
+
+- `WriterInteropTest` — the swept flat matrix, plus the footer, statistics and encoding
+  assertions. `TypeFixture` holds the per-physical-type half — how to declare a column,
+  fill a batch with its values, read one back out of a `Group`, and what bounds its values
+  imply — and `InteropCase` describes one point of the matrix, with the values a pure
+  function of the row index so the same description drives the writer and the assertion.
+- `WriterNestedInteropTest` — the enumerated `struct`, `LIST` and `MAP` shapes.
+- `WriterLogicalTypeInteropTest` — the annotation table, pairing each Hardwood
+  `LogicalType` with the parquet-java `LogicalTypeAnnotation` it must read back as, plus
+  the two sort orders that differ from their physical type's own (unsigned integers and
+  binary `DECIMAL`).
+
+A shared `ParquetJavaReader` helper wraps the Group reader, the footer reader and the page
+walk, so the parquet-java surface the gate depends on sits in one place. It is separate
+from `Utils`, which serves the read direction and carries the Avro comparison.
+
+None of the classes touch the `parquet-testing` fixture repository: the gate's inputs are
+files Hardwood writes, so it does not need the clone the read-direction tests do.

--- a/_designs/WRITER_LOGICAL_TYPES.md
+++ b/_designs/WRITER_LOGICAL_TYPES.md
@@ -53,7 +53,7 @@ and in DuckDB, Spark, and pandas.
 Value conversion — accepting a `LocalDate` or a `BigDecimal` and lowering it to the physical
 representation — is **not** in scope. This stage annotates; the caller still supplies physical
 values (days-since-epoch, unscaled bytes). The inverse of `LogicalTypeConverter` arrives with
-the row-oriented `ParquetWriter` in stage 17.
+the row-oriented `ParquetWriter` in stage 16.
 
 ### Increment split
 

--- a/_designs/WRITER_PRIMITIVE_TYPES.md
+++ b/_designs/WRITER_PRIMITIVE_TYPES.md
@@ -48,7 +48,7 @@ a dictionary, and compared for `min` / `max`.
 
 Logical-type annotations (STRING over `BYTE_ARRAY`, DECIMAL over `FIXED_LEN_BYTE_ARRAY`, …)
 are stage 13; this stage writes the physical bytes only. `DELTA_*` and `BYTE_STREAM_SPLIT`
-encoders are stage 14; every column here is `PLAIN` or `RLE_DICTIONARY`.
+encoders are stage 19; every column here is `PLAIN` or `RLE_DICTIONARY`.
 
 ## The value seam
 
@@ -189,7 +189,7 @@ untruncated binary bound), and `StatisticsWriter` emits `is_min_value_exact` /
 
 The whole writer surface is `@Experimental` and is not yet in the user documentation under
 `docs/content/`; it is documented as a settled API by the milestone's dedicated docs increment
-(stage 18 of [WRITER_SUPPORT.md](WRITER_SUPPORT.md)), not per primitive-type increment.
+(stage 17 of [WRITER_SUPPORT.md](WRITER_SUPPORT.md)), not per primitive-type increment.
 
 ## Row-group flush
 
@@ -207,7 +207,7 @@ as `Integer.SIZE`. This holds only while every value is four bytes. Two changes 
   exact for a non-dictionary column and runs high for a dictionary-encoded one, whose buffered
   index stream is smaller than the summed `PLAIN` widths, so dictionary row groups flush somewhat
   below the target. Sizing a row group from its true encoded bytes — measured once the whole group
-  is buffered — is stage 16 (row-group-global dictionary selection), where the per-chunk
+  is buffered — is stage 21 (row-group-global dictionary selection), where the per-chunk
   encoding choice is already made from the fully buffered group. The proxy is retained only to
   bound the page-level entry count.
 
@@ -256,5 +256,5 @@ file:
 
 Together they complete roadmap boxes 2.1 (all physical types) and the truncation half of 9.1.
 Stage 13 (logical-type annotations) then layers STRING / DATE / DECIMAL / … onto these physical
-types, and stage 16 (row-group-global dictionary selection) exploits the accurate per-type
+types, and stage 21 (row-group-global dictionary selection) exploits the accurate per-type
 dictionary byte accounting introduced here.

--- a/_designs/WRITER_SUPPORT.md
+++ b/_designs/WRITER_SUPPORT.md
@@ -39,8 +39,8 @@ is serialized onto the schema and converted at the API boundary.
 
 The optional index structures — OffsetIndex, ColumnIndex, and Bloom filters, with the
 per-page statistics that drive page-level pruning (including the `DataPageHeader` inline
-statistics) — are numbered increments 20–21 below, on the settled surface alongside the S3
-`OutputFile` backend (increment 19). Sequenced as separate later milestones, each its own
+statistics) — are numbered increments 22–23 below, following the write-support milestone
+on the settled surface. Sequenced as separate later milestones, each its own
 design: DataPage V2, the Avro write API, and a CLI write/convert command. Sorting-column
 metadata and custom record materializers are non-goals. Key-aligned layout control —
 forcing a page boundary at key-value changes (one page per key) for point-query workloads
@@ -175,7 +175,7 @@ public interface OutputFile extends Closeable {
   write never leaves a truncated file presented as valid.
 - **In-memory backend** (`internal.writer.ByteBufferOutputFile`): a growable buffer,
   the write-side counterpart to `ByteBufferInputFile`, used for tests and round-trips.
-- **S3 backend** (`internal.writer.S3OutputFile`, increment 19): sequential writes buffer
+- **S3 backend** (`internal.writer.S3OutputFile`, increment 18): sequential writes buffer
   to the multipart part size and upload parts; `close()` completes the multipart upload.
   In-flight bytes are bounded to the part size times a small concurrency multiple, so a
   fast producer cannot outrun the uploads; `CreateMultipartUpload` is deferred until the
@@ -257,7 +257,7 @@ The writer auto-selects sensible per-column encodings and exposes overrides thro
   not dictionary-friendly is written `PLAIN` instead. The dictionary-vs-`PLAIN` choice is
   made per column chunk from its cardinality — incrementally with a mid-chunk `PLAIN`
   fallback on dictionary-size overflow initially (stage 9), then as a row-group-global
-  decision taken once the group is buffered (stage 16), so no chunk mixes encodings. The
+  decision taken once the group is buffered (stage 21), so no chunk mixes encodings. The
   delta and byte-stream-split encodings are optional and deferred to a later breadth
   increment.
 - **Compression**: `UNCOMPRESSED` first, then `SNAPPY` / `ZSTD` / `GZIP` / `LZ4` —
@@ -285,8 +285,8 @@ then only a bound and not the actual extreme.
 
 These are **column-chunk** statistics, feeding row-group pruning. Per-page statistics — the
 `DataPageHeader` inline statistics and the OffsetIndex / ColumnIndex structures that enable
-page-level skipping — arrive with page index writing (increment 20), and Bloom filters with
-increment 21. A file is valid without any of them.
+page-level skipping — arrive with page index writing (increment 22), and Bloom filters with
+increment 23. A file is valid without any of them.
 
 ## Threading model
 
@@ -303,11 +303,26 @@ single-threaded writer is correct.
 ## Validation strategy
 
 Every increment lands with tests that prove the produced bytes are a valid Parquet
-file readable by an independent engine, so no unverified write code accumulates in
-`main`. The cross-engine differential is the primary check; the read-side oracle is
-established in `_designs/DIFFERENTIAL_TESTING.md` and the writer runs it in reverse.
+file readable by independent implementations, so no unverified write code accumulates
+in `main`. Cross-implementation reads are the primary check, graded by strictness: a
+strict reader establishes conformance, a lenient one adds a second decoder's agreement
+on the values. The read-side oracle is established in
+`_designs/DIFFERENTIAL_TESTING.md` and the writer runs it in reverse.
 
-1. **DuckDB differential (primary)**: hardwood writes a file, then DuckDB reads it
+1. **Strict-reader interop gate (primary)**: hardwood writes a file, parquet-java reads
+   it, and the values are asserted to agree. parquet-java is the canonical
+   implementation, so what it accepts is the operative definition of a conformant file.
+   A permissive consumer agreeing on the values does not establish conformance: an
+   encoder can emit a stream that only lenient decoders accept, and neither a
+   hardwood-to-hardwood round trip nor a lenient engine can see it. The floor of the
+   matrix is a single-entry dictionary per physical type — the shape where a zero-bit
+   index stream carries no run header, which hardwood and DuckDB both accept and
+   parquet-java rejects — and the matrix grows with the shapes each later increment
+   introduces. `parquet-testing-runner` hosts the gate: it already carries
+   `parquet-avro`, `parquet-hadoop` and `hadoop-common` at test scope, runs on every
+   PR, and is where the reverse direction (parquet-java writes, hardwood reads)
+   already lives. Settled in [WRITER_INTEROP_GATE.md](WRITER_INTEROP_GATE.md).
+2. **DuckDB differential**: hardwood writes a file, then DuckDB reads it
    through `read_parquet('<path>')` and the values are asserted to agree. This is the
    exact inverse of [DifferentialReadTest], which has DuckDB read fixtures hardwood
    also reads; here DuckDB is the consumer of hardwood-written bytes. Because DuckDB
@@ -316,15 +331,16 @@ established in `_designs/DIFFERENTIAL_TESTING.md` and the writer runs it in reve
    comparison is robust to scan order (`ORDER BY` that column). Boundary values
    (signed extremes, all-null columns once nullable columns land, empty row groups)
    are written explicitly to stress the encoders.
-2. **Round-trip**: write with hardwood, read back with hardwood, assert value and
+3. **Round-trip**: write with hardwood, read back with hardwood, assert value and
    null equality. This is the fast inner-loop check and pins reader/writer agreement
    on details DuckDB does not surface (e.g. exact encodings, statistics).
-3. **Property/fuzz** (later increments): random in-scope schemas and data round-tripped
+4. **Property/fuzz** (later increments): random in-scope schemas and data round-tripped
    and run through the DuckDB differential, to surface edge cases beyond the
    hand-written cases (dictionary overflow, page and row-group boundaries).
 
-DuckDB is already a `test`-scope dependency (`org.duckdb:duckdb_jdbc`); no new tooling
-is required. Reading hardwood-written files with PyArrow is used for ad-hoc
+Neither reader needs new tooling: DuckDB is already a `test`-scope dependency
+(`org.duckdb:duckdb_jdbc`), and parquet-java is already on `parquet-testing-runner`'s
+test classpath. Reading hardwood-written files with PyArrow is used for ad-hoc
 verification but is not part of the automated suite.
 
 ## Delivery plan
@@ -338,9 +354,19 @@ architectural dimension — paging, row-group cadence, nulls, nesting, dictionar
 compression, statistics — on a single type (`INT32`) before going wide. Type, encoding, and codec **breadth** is the same proven mechanism repeated, so
 it is deferred until every dimension is settled; otherwise a late dimension would
 reshape an already-multiplied surface (adding nulls, repetition levels, or the streaming
-API after N typed methods exist rewrites all N). Each increment carries a **Kind**: *Dimension* (changes
-the shape of the solution), *Breadth* (more of a proven mechanism), *Layer* (additive
-API), *Optimization*, *Spike* (design-only), or *Docs* (user-facing documentation).
+API after N typed methods exist rewrites all N).
+
+Once the shape is settled, a second principle takes over: the remainder is ranked by
+whether it gates *use* of the writer, not by how much it widens it. A caller needs an
+ergonomic entry point, documentation, and somewhere to write to; codec and encoding
+breadth, and encode-time optimizations, extend a writer that is already usable without
+them. The interop gate leads that group, because it is the only check on the shapes
+every later increment introduces, and the increments it precedes multiply them.
+
+Each increment carries a **Kind**: *Dimension* (changes the shape of the solution),
+*Breadth* (more of a proven mechanism), *Layer* (additive API), *Optimization*, *Gate*
+(a validation barrier the increments after it depend on), *Spike* (design-only), or
+*Docs* (user-facing documentation).
 
 | # | Increment | Kind | New capability | Roadmap boxes | Completed |
 |---|-----------|------|----------------|---------------|-----------|
@@ -357,35 +383,51 @@ API), *Optimization*, *Spike* (design-only), or *Docs* (user-facing documentatio
 | 11 | Column statistics (`INT32`: `min`/`max`/`null_count`, `ColumnOrder`-correct) accumulated during encode. | Dimension | Produced files support pushdown | 9.1 (stats) | [x] |
 | 12 | All primitive physical types (incl. `FIXED_LEN_BYTE_ARRAY` type length and `BYTE_ARRAY` min/max truncation), each inheriting paging, nulls, nesting, dictionary, compression and stats. Truncated `BYTE_ARRAY` bounds are flagged inexact (`is_min_value_exact` / `is_max_value_exact` = false), extending the exactness the fixed-width types write unconditionally as true. Variable-width values end the constant-bytes-per-row assumption, so the row-group flush moves from the fixed rows-per-group proxy (`rowGroupTargetBytes / (columnCount × 4)`) to tracking the actual buffered uncompressed bytes. Settled in `_designs/WRITER_PRIMITIVE_TYPES.md`; delivered in two stacked increments (12a fixed-width `BOOLEAN`/`INT64`/`FLOAT`/`DOUBLE`, 12b variable-width `BYTE_ARRAY`/`FIXED_LEN_BYTE_ARRAY` with truncation). | Breadth | Write any column type, flat or nested | 2.1, 9.1 (truncation) | [x] |
 | 13 | Logical-type annotations: `LogicalTypeWriter` serializes the `LogicalType` union and legacy `converted_type`/`scale`/`precision`; `FileSchema.Builder` logical-type overload. Both annotations are emitted together for every type with a legacy equivalent (STRING, DATE, DECIMAL, the INT/UINT widths, TIME/TIMESTAMP millis+micros, ENUM, JSON, BSON, `LIST`, `MAP`), the union taking read precedence and the `converted_type` kept for pre-union readers; only types without a legacy equivalent (UUID, FLOAT16, NANOS units, VARIANT, GEOMETRY/GEOGRAPHY) are union-only, and INTERVAL is `converted_type`-only because its union member is reserved but undefined. This makes stage 13 additive to the `converted_type`-only annotations stages 6–8 already write. An annotation also redefines the column's `min`/`max` ordering, so the statistics collectors become logical-type-aware and the footer's `column_orders` — required by the format wherever bounds are written — is emitted. Settled in `_designs/WRITER_LOGICAL_TYPES.md`; delivered in two stacked increments (13a annotations, 13b order-correct statistics and `column_orders`). | Breadth | Columns read back with their logical type (STRING, DATE, TIMESTAMP, DECIMAL, …) | 6.4 (annotation) | [x] |
-| 14 | Remaining codecs + optional delta and byte-stream-split encoders. | Breadth | Full codec / encoding choice | 2.4, 2.5 | [ ] |
-| 15 | Parallel column encoding + row-group pipelining. | Optimization | Write throughput | — | [ ] |
-| 16 | **Row-group-global dictionary selection**: replace the per-column-chunk optimistic build with mid-chunk `PLAIN` fallback (stage 9) with a choice made once the row group is fully buffered — each column chunk is encoded `RLE_DICTIONARY` or `PLAIN` as a whole from its true cardinality, so no chunk mixes encodings and no dictionary page is written for a chunk that ends up `PLAIN`. Trades a second encode pass and higher peak buffer occupancy for the optimal per-chunk choice; the payoff scales with the variable-width types from stage 12, where indices are far smaller than the values and the dictionary byte-limit is a poor proxy for whether encoding pays. With the whole group buffered the choice follows from the exact cardinality — and, where the byte-limit proxy is weakest, a direct comparison of the two encodings' sizes — so no predictive threshold is needed; the stage-9 streaming abort heuristic does not apply here. | Optimization | Optimal, uniform per-chunk encoding choice | 2.2 | [ ] |
-| 17 | Row-oriented `ParquetWriter` ergonomic layer on the columnar core, including nested record materialization and logical-type value conversion (inverse of `LogicalTypeConverter`). | Layer | Mainstream-friendly API | 6.1 (`ParquetWriter`), 6.4 (value conversion) | [ ] |
-| 18 | User-facing documentation under `docs/content/` for the writer public API (`OutputFile`, `ParquetFileWriter`, `FileSchema.Builder`): a `how-to` guide and a `reference` page, covering the settled surface including nesting and the row-oriented layer. | Docs | Documented, stable public API | — | [ ] |
-| 19 | S3 `OutputFile` backend: sequential multipart upload — buffer to the part size, upload parts, complete on `close()`. In-flight bytes bounded to the part size times a small concurrency multiple; lazy `CreateMultipartUpload` deferred to the first part flush, with a single `PutObject` fallback for a sub-part output. Reuses the read-side S3 / SigV4 stack. | Layer | Write directly to object storage | — | [ ] |
-| 20 | **Page index writing**: per-column-chunk OffsetIndex (page locations) and ColumnIndex (per-page `min`/`max`, null counts, boundary order), written after the row group's pages and referenced from the footer, so the reader can skip individual pages. Extends the column-chunk statistics of increment 11 to page granularity; the `DataPageHeader` inline `statistics` are the pre-index fallback covered here. Truncation and `is_*_value_exact` follow the increment 11 / 12 rules. Its own design. | Layer | Page-level pruning on produced files | 9.2 | [ ] |
-| 21 | **Bloom filter writing**: a split-block Bloom filter per eligible column chunk (XXHASH64), serialized with its header and referenced from the column metadata, for equality-predicate pruning where `min`/`max` do not help. Its own design. | Layer | Bloom-filter pruning on produced files | 9.3 | [ ] |
+| 14 | **Write-path interop gate**: `parquet-testing-runner` reads hardwood-written files with parquet-java and asserts value agreement, covering a single-entry dictionary per physical type as its floor and every shape increments 1–13 can produce. Closes the defect class where only hardwood and a lenient engine accept the bytes; the suites that precede it read back through hardwood and DuckDB, neither of which can observe it. Every increment after this one extends the matrix with the shapes it adds. Settled in `_designs/WRITER_INTEROP_GATE.md`. | Gate | Produced files are proven conformant, not merely self-consistent | — | [x] |
+| 15 | **Parseable `created_by`**: `WriterConfig.DEFAULT_CREATED_BY` follows the `<app> version <version> (build <hash>)` convention parquet-java's `VersionParser` expects, instead of the bare `hardwood` it writes today. parquet-java cannot parse the bare form, so it logs a `CorruptStatistics` warning on every read of a hardwood file and, under the PARQUET-251 heuristic, discards the deprecated `min`/`max` of a binary column outright. Hardwood's own bounds survive only because it writes solely the modern `min_value`/`max_value`, which the heuristic does not gate — so today's correctness rests on a field the writer happens not to emit. The interop gate (increment 14) surfaced this and extends with an assertion that parquet-java parses the identifier. | Dimension | Produced files carry a version identifier consumers can parse | — | [ ] |
+| 16 | Row-oriented `ParquetWriter` ergonomic layer on the columnar core, including nested record materialization and logical-type value conversion (inverse of `LogicalTypeConverter`). | Layer | Mainstream-friendly API | 6.1 (`ParquetWriter`), 6.4 (value conversion) | [ ] |
+| 17 | User-facing documentation under `docs/content/` for the writer public API (`OutputFile`, `ParquetFileWriter`, `FileSchema.Builder`): a `how-to` guide and a `reference` page, covering the settled surface including nesting and the row-oriented layer. | Docs | Documented, stable public API | — | [ ] |
+| 18 | S3 `OutputFile` backend: sequential multipart upload — buffer to the part size, upload parts, complete on `close()`. In-flight bytes bounded to the part size times a small concurrency multiple; lazy `CreateMultipartUpload` deferred to the first part flush, with a single `PutObject` fallback for a sub-part output. Reuses the read-side S3 / SigV4 stack. | Layer | Write directly to object storage | — | [ ] |
+| 19 | Remaining codecs + optional delta and byte-stream-split encoders. | Breadth | Full codec / encoding choice | 2.4, 2.5 | [ ] |
+| 20 | Parallel column encoding + row-group pipelining. | Optimization | Write throughput | — | [ ] |
+| 21 | **Row-group-global dictionary selection**: replace the per-column-chunk optimistic build with mid-chunk `PLAIN` fallback (stage 9) with a choice made once the row group is fully buffered — each column chunk is encoded `RLE_DICTIONARY` or `PLAIN` as a whole from its true cardinality, so no chunk mixes encodings and no dictionary page is written for a chunk that ends up `PLAIN`. Trades a second encode pass and higher peak buffer occupancy for the optimal per-chunk choice; the payoff scales with the variable-width types from stage 12, where indices are far smaller than the values and the dictionary byte-limit is a poor proxy for whether encoding pays. With the whole group buffered the choice follows from the exact cardinality — and, where the byte-limit proxy is weakest, a direct comparison of the two encodings' sizes — so no predictive threshold is needed; the stage-9 streaming abort heuristic does not apply here. | Optimization | Optimal, uniform per-chunk encoding choice | 2.2 | [ ] |
+| 22 | **Page index writing**: per-column-chunk OffsetIndex (page locations) and ColumnIndex (per-page `min`/`max`, null counts, boundary order), written after the row group's pages and referenced from the footer, so the reader can skip individual pages. Extends the column-chunk statistics of increment 11 to page granularity; the `DataPageHeader` inline `statistics` are the pre-index fallback covered here. Truncation and `is_*_value_exact` follow the increment 11 / 12 rules. Its own design. | Layer | Page-level pruning on produced files | 9.2 | [ ] |
+| 23 | **Bloom filter writing**: a split-block Bloom filter per eligible column chunk (XXHASH64), serialized with its header and referenced from the column metadata, for equality-predicate pruning where `min`/`max` do not help. Its own design. | Layer | Bloom-filter pruning on produced files | 9.3 | [ ] |
 
 Increments 1–4 settle the flat dimensions on `INT32`; 5–8 settle the nested shape —
 design, then struct / list / map shredding — on `INT32`; 9–11 finish the remaining
-dimensions (dictionary, compression, statistics) on the now flat-and-nested shape; 12–14
-are breadth on the settled shape, 15–16 are internal encoding optimizations, and 17 is the
-row-oriented layer; 18 documents the finished public surface. Together, increments 1–18
-constitute the write-support milestone (#9); increments 19–21 add the S3 `OutputFile` backend
-and the optional index structures (page indexes and Bloom filters, with the per-page
-statistics that make page-level pruning possible) on the settled surface. Sequenced as
-separate later milestones, each its own design and sequence: DataPage V2, the Avro write
-adapter, and a CLI write/convert command.
+dimensions (dictionary, compression, statistics) on the now flat-and-nested shape; 12–13
+are breadth on the settled shape. Increment 14 then gates everything those thirteen
+produce against a strict reader, 15 fixes the first thing that gate found, and 16–17 make
+the result usable by an external caller: the row-oriented layer and the documentation of
+the surface it completes. Those four are the content of `1.1.0.Beta1` — a
+conformance-gated, ergonomic, documented writer, local output only.
+
+Increment 18 opens `1.1.0.Beta2` with the object-store backend, and 19–21 widen and
+optimize the surface underneath it: the remaining codecs and optional encodings, parallel
+encoding, and row-group-global dictionary selection. Together, increments 1–21 constitute
+the write-support milestone (#9); 22–23 follow it, adding the optional index structures
+(page indexes and Bloom filters, with the per-page statistics that make page-level
+pruning possible) on the settled surface. Sequenced as separate later milestones, each
+its own design and sequence: DataPage V2, the Avro write adapter, and a CLI write/convert
+command.
 
 ## User documentation
 
-User-facing documentation under `docs/content/` is delivered as the closing increment
-of the milestone (stage 18), once the full public surface — including nesting and the
-row-oriented layer — is settled. Documenting the provisional `INT32`-only surface earlier
-would be throwaway, so deferring is a recorded, intentional exception to the CLAUDE.md
-rule that a new public API ships with a docs update — not an oversight. The public surface
+User-facing documentation under `docs/content/` is delivered at stage 17, immediately
+after the row-oriented layer settles the last of the core public surface — including
+nesting and the row-oriented entry point. Documenting the provisional `INT32`-only
+surface earlier would be throwaway, so deferring until the surface is settled is a
+recorded, intentional exception to the CLAUDE.md rule that a new public API ships with
+a docs update — not an oversight.
+
+The increments after stage 17 extend that surface additively rather than reshaping it,
+so each carries its own docs update in the normal way: stage 18 adds an S3 `OutputFile`
+factory, and stage 19 adds codec and encoding values to `WriterConfig`. Stages 20–21 are
+internal encode decisions with no public surface. Stage 15 changes only the default value
+of an already-documented option. The core surface
 (`OutputFile`, `ParquetFileWriter`, `FileSchema.Builder`) gets its `how-to`/`reference`
-pages at stage 18.
+pages at stage 17.
 
 ## Roadmap reconciliation
 

--- a/parquet-testing-runner/src/test/java/dev/hardwood/testing/InteropCase.java
+++ b/parquet-testing-runner/src/test/java/dev/hardwood/testing/InteropCase.java
@@ -1,0 +1,116 @@
+/*
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Copyright The original authors
+ *
+ *  Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package dev.hardwood.testing;
+
+import dev.hardwood.metadata.RepetitionType;
+import dev.hardwood.writer.WriterConfig;
+
+/// One point of the write-path interop gate's flat matrix: a single-column file described by its
+/// physical type, its repetition shape, how many distinct values it holds, how many rows, and the
+/// writer configuration that produced it.
+///
+/// The values themselves are a pure function of the row index — [#ordinal] maps a row onto a
+/// value ordinal, which [TypeFixture#value] turns into the value — so the case is both what the
+/// writer is fed and what parquet-java's output is asserted against.
+///
+/// @param name what this point of the matrix covers, for the test display name
+/// @param type the physical type under test
+/// @param nullability the repetition shape
+/// @param distinct how many distinct values the column cycles through
+/// @param rows how many rows to write
+/// @param config the writer configuration
+/// @param expectsPlainFallback whether the case is expected to overflow its dictionary and fall
+///        back to `PLAIN` mid-chunk
+record InteropCase(String name, TypeFixture type, Nullability nullability, int distinct, int rows,
+        WriterConfig config, boolean expectsPlainFallback) {
+
+    /// A case that stays within its dictionary limit.
+    static InteropCase of(String name, TypeFixture type, Nullability nullability, int distinct, int rows,
+            WriterConfig config) {
+        return new InteropCase(name, type, nullability, distinct, rows, config, false);
+    }
+
+    /// The repetition shapes a flat column can be written in.
+    enum Nullability {
+
+        /// No definition-level stream at all.
+        REQUIRED(RepetitionType.REQUIRED),
+        /// A levelled column whose every row happens to be present.
+        OPTIONAL_ALL_PRESENT(RepetitionType.OPTIONAL),
+        /// A levelled column with nulls interleaved among the values.
+        OPTIONAL_SOME_NULL(RepetitionType.OPTIONAL),
+        /// A levelled column with no present value at all, which carries a null count but no
+        /// bounds and no dictionary page.
+        OPTIONAL_ALL_NULL(RepetitionType.OPTIONAL);
+
+        private final RepetitionType repetitionType;
+
+        Nullability(RepetitionType repetitionType) {
+            this.repetitionType = repetitionType;
+        }
+
+        RepetitionType repetitionType() {
+            return repetitionType;
+        }
+    }
+
+    /// Every third row is null in the interleaved shape, which puts nulls both inside and across
+    /// the page and row-group boundaries the layout axis produces.
+    private static final int NULL_EVERY = 3;
+
+    /// Whether row `row` is written as null.
+    boolean isNull(int row) {
+        return switch (nullability) {
+            case REQUIRED, OPTIONAL_ALL_PRESENT -> false;
+            case OPTIONAL_SOME_NULL -> row % NULL_EVERY == NULL_EVERY - 1;
+            case OPTIONAL_ALL_NULL -> true;
+        };
+    }
+
+    /// The value ordinal of row `row`.
+    int ordinal(int row) {
+        return row % distinct;
+    }
+
+    /// The per-row null mask to pass to the batch setter, or `null` to use the mask-less setter.
+    /// An `OPTIONAL` column with no nulls deliberately goes through the mask-less setter, which
+    /// is the shape that writes an all-present definition-level stream.
+    boolean[] nulls() {
+        if (nullability == Nullability.REQUIRED || nullability == Nullability.OPTIONAL_ALL_PRESENT) {
+            return null;
+        }
+        boolean[] nulls = new boolean[rows];
+        for (int r = 0; r < rows; r++) {
+            nulls[r] = isNull(r);
+        }
+        return nulls;
+    }
+
+    /// How many rows are written as null.
+    long nullCount() {
+        long nulls = 0;
+        for (int r = 0; r < rows; r++) {
+            if (isNull(r)) {
+                nulls++;
+            }
+        }
+        return nulls;
+    }
+
+    /// Whether the produced column chunks should declare `RLE_DICTIONARY`. An all-null chunk has
+    /// no value to intern, so it writes no dictionary page.
+    boolean expectsDictionary() {
+        return config.enableDictionary() && type.dictionaryCapable()
+                && nullability != Nullability.OPTIONAL_ALL_NULL;
+    }
+
+    @Override
+    public String toString() {
+        return type + " / " + name + " / " + nullability;
+    }
+}

--- a/parquet-testing-runner/src/test/java/dev/hardwood/testing/ParquetJavaReader.java
+++ b/parquet-testing-runner/src/test/java/dev/hardwood/testing/ParquetJavaReader.java
@@ -1,0 +1,137 @@
+/*
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Copyright The original authors
+ *
+ *  Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package dev.hardwood.testing;
+
+import java.io.IOException;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.EnumSet;
+import java.util.List;
+import java.util.Set;
+
+import org.apache.hadoop.conf.Configuration;
+import org.apache.parquet.column.ColumnDescriptor;
+import org.apache.parquet.column.Encoding;
+import org.apache.parquet.column.page.DataPage;
+import org.apache.parquet.column.page.DataPageV1;
+import org.apache.parquet.column.page.PageReadStore;
+import org.apache.parquet.column.page.PageReader;
+import org.apache.parquet.example.data.Group;
+import org.apache.parquet.hadoop.ParquetFileReader;
+import org.apache.parquet.hadoop.ParquetReader;
+import org.apache.parquet.hadoop.example.GroupReadSupport;
+import org.apache.parquet.hadoop.metadata.ParquetMetadata;
+import org.apache.parquet.hadoop.util.HadoopInputFile;
+
+/// Reads a Parquet file with parquet-java, the strict reader of the write-path interop gate
+/// described in `_designs/WRITER_INTEROP_GATE.md`.
+///
+/// Rows come back as [Group]s rather than Avro records: the Group model materializes any valid
+/// file with no object model in the way, so annotations Avro cannot represent — `UUID`,
+/// `FLOAT16`, `INTERVAL`, the unsigned integer widths — are still readable, and a read failure
+/// means the bytes are bad rather than that Avro could not model the type. The Avro path used by
+/// the read-direction comparison lives in [Utils#readWithParquetJava].
+final class ParquetJavaReader {
+
+    private ParquetJavaReader() {
+    }
+
+    /// Every row of the file, materialized through parquet-java's Group record model.
+    ///
+    /// @param file the file to read
+    /// @return the rows, in file order
+    /// @throws IOException if parquet-java cannot read the file — which, for a file Hardwood
+    ///         wrote, is the gate failing
+    static List<Group> readGroups(Path file) throws IOException {
+        List<Group> rows = new ArrayList<>();
+        try (ParquetReader<Group> reader = ParquetReader
+                .builder(new GroupReadSupport(), hadoopPath(file))
+                .withConf(new Configuration())
+                .build()) {
+
+            Group row;
+            while ((row = reader.read()) != null) {
+                rows.add(row);
+            }
+        }
+        return rows;
+    }
+
+    /// The file's footer as parquet-java parses it: the schema, the row groups, and each column
+    /// chunk's encodings and statistics.
+    ///
+    /// @param file the file to read
+    /// @return the parsed footer
+    /// @throws IOException if parquet-java cannot parse the footer
+    static ParquetMetadata readFooter(Path file) throws IOException {
+        try (ParquetFileReader reader = ParquetFileReader
+                .open(HadoopInputFile.fromPath(hadoopPath(file), new Configuration()))) {
+            return reader.getFooter();
+        }
+    }
+
+    /// Walks every data page of every column chunk through parquet-java's page readers, and
+    /// reports what they were: how many there were, and which encodings their *values* declared.
+    ///
+    /// The page-level value encoding is the only place the encoding choice is observable. A
+    /// column chunk's `encodings` list is a union that always contains `PLAIN` — a dictionary
+    /// page body is itself `PLAIN` — so it cannot tell a dictionary-only chunk from one that
+    /// overflowed its dictionary and fell back mid-chunk. Each page header declares its own
+    /// encoding, and those do distinguish them.
+    ///
+    /// Each page is materialized on the way past, so a page that does not decompress or whose
+    /// header does not parse fails here.
+    ///
+    /// @param file the file to read
+    /// @return what the walk found
+    /// @throws IOException if parquet-java cannot read a page
+    static Pages readPages(Path file) throws IOException {
+        int count = 0;
+        Set<Encoding> valueEncodings = EnumSet.noneOf(Encoding.class);
+        try (ParquetFileReader reader = ParquetFileReader
+                .open(HadoopInputFile.fromPath(hadoopPath(file), new Configuration()))) {
+
+            List<ColumnDescriptor> columns = reader.getFileMetaData().getSchema().getColumns();
+            PageReadStore rowGroup;
+            while ((rowGroup = reader.readNextRowGroup()) != null) {
+                for (ColumnDescriptor column : columns) {
+                    PageReader pageReader = rowGroup.getPageReader(column);
+                    DataPage page;
+                    while ((page = pageReader.readPage()) != null) {
+                        count++;
+                        valueEncodings.add(valueEncoding(page));
+                    }
+                }
+            }
+        }
+        return new Pages(count, valueEncodings);
+    }
+
+    /// What a page walk found: the data page count and the set of encodings their values
+    /// declared, across every row group and column of the file.
+    ///
+    /// @param dataPageCount how many data pages the file holds
+    /// @param valueEncodings the distinct value encodings those pages declared
+    record Pages(int dataPageCount, Set<Encoding> valueEncodings) {
+    }
+
+    /// The encoding a data page declares for its values. The writer produces DataPage V1 only, so
+    /// anything else is a change in what is being written rather than a case this reader should
+    /// quietly accommodate.
+    private static Encoding valueEncoding(DataPage page) {
+        if (!(page instanceof DataPageV1 v1)) {
+            throw new IllegalStateException(
+                    "Expected a V1 data page but got " + page.getClass().getSimpleName());
+        }
+        return v1.getValueEncoding();
+    }
+
+    private static org.apache.hadoop.fs.Path hadoopPath(Path file) {
+        return new org.apache.hadoop.fs.Path(file.toUri());
+    }
+}

--- a/parquet-testing-runner/src/test/java/dev/hardwood/testing/TypeFixture.java
+++ b/parquet-testing-runner/src/test/java/dev/hardwood/testing/TypeFixture.java
@@ -1,0 +1,282 @@
+/*
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Copyright The original authors
+ *
+ *  Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package dev.hardwood.testing;
+
+import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
+
+import org.apache.parquet.example.data.Group;
+import org.apache.parquet.io.api.Binary;
+
+import dev.hardwood.metadata.PhysicalType;
+import dev.hardwood.metadata.RepetitionType;
+import dev.hardwood.schema.FileSchema;
+import dev.hardwood.writer.ColumnBatch;
+
+/// One writable physical type, in the three forms the write-path interop gate needs it: how to
+/// declare a column of it, how to fill a [ColumnBatch] column with its values, and how to read
+/// one back out of a parquet-java [Group].
+///
+/// Values are a pure function of an ordinal, so a case picks its distinct count and the values
+/// follow. The low ordinals are the type's boundary values — signed extremes, infinities, `NaN`,
+/// signed zeros, empty and high-byte binaries — so a small-cardinality case exercises them; from
+/// there the values are the ordinal itself, which keeps a high-cardinality case cheap to
+/// describe.
+enum TypeFixture {
+
+    BOOLEAN(PhysicalType.BOOLEAN, null, false),
+    INT32(PhysicalType.INT32, null, true),
+    INT64(PhysicalType.INT64, null, true),
+    FLOAT(PhysicalType.FLOAT, null, true),
+    DOUBLE(PhysicalType.DOUBLE, null, true),
+    BYTE_ARRAY(PhysicalType.BYTE_ARRAY, null, true),
+    FIXED_LEN_BYTE_ARRAY(PhysicalType.FIXED_LEN_BYTE_ARRAY, 8, true);
+
+    private static final int[] INT32_BOUNDARIES = {
+            0, 1, -1, Integer.MAX_VALUE, Integer.MIN_VALUE, 42, -100_000, 123_456 };
+
+    private static final long[] INT64_BOUNDARIES = {
+            0L, 1L, -1L, Long.MAX_VALUE, Long.MIN_VALUE, 42L, -1_000_000_000_000L, 987_654_321L };
+
+    private static final float[] FLOAT_BOUNDARIES = {
+            0.0f, 1.0f, -1.0f, Float.MAX_VALUE, -Float.MAX_VALUE, Float.MIN_VALUE,
+            Float.POSITIVE_INFINITY, Float.NEGATIVE_INFINITY, -0.0f, Float.NaN };
+
+    private static final double[] DOUBLE_BOUNDARIES = {
+            0.0, 1.0, -1.0, Double.MAX_VALUE, -Double.MAX_VALUE, Double.MIN_VALUE,
+            Double.POSITIVE_INFINITY, Double.NEGATIVE_INFINITY, -0.0, Double.NaN };
+
+    /// `BYTE_ARRAY` boundaries: an ordinary value first (so a single-entry dictionary case is the
+    /// #901 shape and nothing else), then the empty value and one whose bytes are above `0x7f`,
+    /// which orders differently under a signed comparison than the unsigned one the format
+    /// mandates for an unannotated binary.
+    private static final byte[][] BINARY_BOUNDARIES = {
+            "hardwood".getBytes(StandardCharsets.UTF_8),
+            new byte[0],
+            "a".getBytes(StandardCharsets.UTF_8),
+            { (byte) 0xff, (byte) 0xff } };
+
+    /// `FIXED_LEN_BYTE_ARRAY` boundaries at the declared length of 8, spanning the unsigned range
+    /// and both sides of the sign bit of the leading byte.
+    private static final byte[][] FIXED_BOUNDARIES = {
+            fixedOf((byte) 0x00), fixedOf((byte) 0xff), fixedOf((byte) 0x80), fixedOf((byte) 0x7f) };
+
+    private final PhysicalType physicalType;
+    private final Integer typeLength;
+    private final boolean dictionaryCapable;
+
+    TypeFixture(PhysicalType physicalType, Integer typeLength, boolean dictionaryCapable) {
+        this.physicalType = physicalType;
+        this.typeLength = typeLength;
+        this.dictionaryCapable = dictionaryCapable;
+    }
+
+    /// Whether the writer dictionary-encodes this type at all. `BOOLEAN` never is — a two-value
+    /// dictionary cannot beat the bit-packed `PLAIN` layout — so a dictionary case degenerates to
+    /// a `PLAIN` one for it.
+    boolean dictionaryCapable() {
+        return dictionaryCapable;
+    }
+
+    /// Adds a column of this type to a schema being built.
+    FileSchema.Builder declare(FileSchema.Builder builder, String column, RepetitionType repetition) {
+        return typeLength == null
+                ? builder.addColumn(column, physicalType, repetition)
+                : builder.addColumn(column, physicalType, repetition, typeLength);
+    }
+
+    /// Fills a batch column with the case's values, through the mask-less setter when no row is
+    /// null and the plain-mask setter otherwise.
+    void set(ColumnBatch batch, String column, InteropCase testCase) {
+        boolean[] nulls = testCase.nulls();
+        int rows = testCase.rows();
+        switch (this) {
+            case BOOLEAN -> {
+                boolean[] values = new boolean[rows];
+                for (int r = 0; r < rows; r++) {
+                    values[r] = (boolean) value(testCase.ordinal(r));
+                }
+                if (nulls == null) {
+                    batch.booleans(column, values);
+                }
+                else {
+                    batch.booleans(column, values, nulls);
+                }
+            }
+            case INT32 -> {
+                int[] values = new int[rows];
+                for (int r = 0; r < rows; r++) {
+                    values[r] = (int) value(testCase.ordinal(r));
+                }
+                if (nulls == null) {
+                    batch.ints(column, values);
+                }
+                else {
+                    batch.ints(column, values, nulls);
+                }
+            }
+            case INT64 -> {
+                long[] values = new long[rows];
+                for (int r = 0; r < rows; r++) {
+                    values[r] = (long) value(testCase.ordinal(r));
+                }
+                if (nulls == null) {
+                    batch.longs(column, values);
+                }
+                else {
+                    batch.longs(column, values, nulls);
+                }
+            }
+            case FLOAT -> {
+                float[] values = new float[rows];
+                for (int r = 0; r < rows; r++) {
+                    values[r] = (float) value(testCase.ordinal(r));
+                }
+                if (nulls == null) {
+                    batch.floats(column, values);
+                }
+                else {
+                    batch.floats(column, values, nulls);
+                }
+            }
+            case DOUBLE -> {
+                double[] values = new double[rows];
+                for (int r = 0; r < rows; r++) {
+                    values[r] = (double) value(testCase.ordinal(r));
+                }
+                if (nulls == null) {
+                    batch.doubles(column, values);
+                }
+                else {
+                    batch.doubles(column, values, nulls);
+                }
+            }
+            case BYTE_ARRAY -> {
+                byte[][] values = binaryValues(testCase);
+                if (nulls == null) {
+                    batch.bytes(column, values);
+                }
+                else {
+                    batch.bytes(column, values, nulls);
+                }
+            }
+            case FIXED_LEN_BYTE_ARRAY -> {
+                byte[][] values = binaryValues(testCase);
+                if (nulls == null) {
+                    batch.fixed(column, values);
+                }
+                else {
+                    batch.fixed(column, values, nulls);
+                }
+            }
+        }
+    }
+
+    private byte[][] binaryValues(InteropCase testCase) {
+        byte[][] values = new byte[testCase.rows()][];
+        for (int r = 0; r < values.length; r++) {
+            values[r] = (byte[]) value(testCase.ordinal(r));
+        }
+        return values;
+    }
+
+    /// The value at an ordinal, boxed, in the representation the batch setter and the [Group]
+    /// accessor both produce, so the two are directly comparable.
+    Object value(int ordinal) {
+        return switch (this) {
+            case BOOLEAN -> (ordinal & 1) == 0;
+            case INT32 -> ordinal < INT32_BOUNDARIES.length ? INT32_BOUNDARIES[ordinal] : ordinal;
+            case INT64 -> ordinal < INT64_BOUNDARIES.length ? INT64_BOUNDARIES[ordinal] : (long) ordinal;
+            case FLOAT -> ordinal < FLOAT_BOUNDARIES.length ? FLOAT_BOUNDARIES[ordinal] : (float) ordinal;
+            case DOUBLE -> ordinal < DOUBLE_BOUNDARIES.length ? DOUBLE_BOUNDARIES[ordinal] : (double) ordinal;
+            case BYTE_ARRAY -> ordinal < BINARY_BOUNDARIES.length
+                    ? BINARY_BOUNDARIES[ordinal]
+                    : ("v" + ordinal).getBytes(StandardCharsets.UTF_8);
+            case FIXED_LEN_BYTE_ARRAY -> ordinal < FIXED_BOUNDARIES.length
+                    ? FIXED_BOUNDARIES[ordinal]
+                    : ByteBuffer.allocate(Long.BYTES).putLong(ordinal).array();
+        };
+    }
+
+    /// The value at an ordinal in the representation parquet-java's statistics compare in, whose
+    /// natural order is the type-defined sort order the format specifies: signed for the numeric
+    /// types, unsigned lexicographical for the binary ones, which [Binary#compareTo] implements.
+    Comparable<?> statisticsValue(int ordinal) {
+        Object value = value(ordinal);
+        return value instanceof byte[] bytes ? Binary.fromConstantByteArray(bytes) : (Comparable<?>) value;
+    }
+
+    /// Reads this column's single value out of a parquet-java row.
+    Object read(Group row, int field) {
+        return switch (this) {
+            case BOOLEAN -> row.getBoolean(field, 0);
+            case INT32 -> row.getInteger(field, 0);
+            case INT64 -> row.getLong(field, 0);
+            case FLOAT -> row.getFloat(field, 0);
+            case DOUBLE -> row.getDouble(field, 0);
+            case BYTE_ARRAY, FIXED_LEN_BYTE_ARRAY -> row.getBinary(field, 0).getBytes();
+        };
+    }
+
+    /// The `min` the case's present values imply, or `null` if it has none. `NaN` is excluded:
+    /// the type-defined order for the floating-point types leaves it out of the bounds, so a
+    /// column holding one still gets bounds over the rest.
+    Comparable<?> expectedMin(InteropCase testCase) {
+        return normalizeZero(bound(testCase, true), true);
+    }
+
+    /// The `max` the case's present values imply, or `null` if it has none.
+    ///
+    /// @see #expectedMin
+    Comparable<?> expectedMax(InteropCase testCase) {
+        return normalizeZero(bound(testCase, false), false);
+    }
+
+    /// Applies the format's sign normalization of a floating-point zero bound, so a reader's
+    /// `[min, max]` test is correct for either signed zero: a zero `min` is written as `-0.0` and
+    /// a zero `max` as `+0.0`, whichever zero the data held.
+    private static Comparable<?> normalizeZero(Comparable<?> bound, boolean min) {
+        if (bound instanceof Float value && value == 0.0f) {
+            return min ? -0.0f : 0.0f;
+        }
+        if (bound instanceof Double value && value == 0.0) {
+            return min ? -0.0 : 0.0;
+        }
+        return bound;
+    }
+
+    @SuppressWarnings("unchecked")
+    private Comparable<Object> bound(InteropCase testCase, boolean min) {
+        Comparable<Object> best = null;
+        for (int r = 0; r < testCase.rows(); r++) {
+            if (testCase.isNull(r)) {
+                continue;
+            }
+            int ordinal = testCase.ordinal(r);
+            if (isNaN(value(ordinal))) {
+                continue;
+            }
+            Comparable<Object> candidate = (Comparable<Object>) statisticsValue(ordinal);
+            if (best == null || (min ? candidate.compareTo(best) < 0 : candidate.compareTo(best) > 0)) {
+                best = candidate;
+            }
+        }
+        return best;
+    }
+
+    private static boolean isNaN(Object value) {
+        return value instanceof Float f && Float.isNaN(f) || value instanceof Double d && Double.isNaN(d);
+    }
+
+    private static byte[] fixedOf(byte fill) {
+        byte[] value = new byte[8];
+        Arrays.fill(value, fill);
+        return value;
+    }
+}

--- a/parquet-testing-runner/src/test/java/dev/hardwood/testing/WriterInteropTest.java
+++ b/parquet-testing-runner/src/test/java/dev/hardwood/testing/WriterInteropTest.java
@@ -1,0 +1,310 @@
+/*
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Copyright The original authors
+ *
+ *  Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package dev.hardwood.testing;
+
+import java.io.IOException;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.function.BiFunction;
+import java.util.stream.Stream;
+
+import org.apache.parquet.column.Encoding;
+import org.apache.parquet.column.statistics.Statistics;
+import org.apache.parquet.example.data.Group;
+import org.apache.parquet.hadoop.metadata.BlockMetaData;
+import org.apache.parquet.hadoop.metadata.ColumnChunkMetaData;
+import org.apache.parquet.hadoop.metadata.ParquetMetadata;
+import org.junit.jupiter.api.io.TempDir;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import dev.hardwood.OutputFile;
+import dev.hardwood.metadata.CompressionCodec;
+import dev.hardwood.schema.FileSchema;
+import dev.hardwood.testing.InteropCase.Nullability;
+import dev.hardwood.testing.ParquetJavaReader.Pages;
+import dev.hardwood.writer.ParquetFileWriter;
+import dev.hardwood.writer.WriterConfig;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/// The flat half of the write-path interop gate (`_designs/WRITER_INTEROP_GATE.md`): Hardwood
+/// writes a single-column file, parquet-java reads it back through its Group record model, and
+/// the values, the null counts and the column-chunk statistics are asserted against the data
+/// that was written.
+///
+/// The matrix varies one axis at a time — repetition, encoding, codec, layout — against a
+/// representative base, and sweeps every axis across all seven writable physical types, since
+/// the value encoders are per type and that is where an encoding defect lives. Its floor is a
+/// single-entry dictionary per physical type, the shape that produced #901: an `RLE_DICTIONARY`
+/// index stream with no run header, which Hardwood's own reader and DuckDB both accept and
+/// parquet-java rejects.
+///
+/// The nested shapes are in [WriterNestedInteropTest] and the logical-type annotations in
+/// [WriterLogicalTypeInteropTest].
+class WriterInteropTest {
+
+    private static final String COLUMN = "v";
+
+    /// Enough rows that a case crosses a page and a row-group boundary at the small targets the
+    /// layout axis configures, and small enough that the whole matrix stays quick.
+    private static final int MANY_ROWS = 20_000;
+
+    private static final int FEW_ROWS = 2_000;
+
+    // ==================== Axes ====================
+
+    /// The floor of the matrix: a column chunk whose dictionary holds exactly one entry, in every
+    /// repetition shape, for every physical type.
+    static Stream<InteropCase> singleEntryDictionary() {
+        return sweep(List.of(Nullability.values()), (type, nullability) -> InteropCase.of(
+                "single-entry dictionary", type, nullability, 1, 200, WriterConfig.defaults()));
+    }
+
+    /// The encoding axis: the dictionary in its ordinary multi-entry form, overflowing to a
+    /// mid-chunk `PLAIN` fallback, and disabled outright.
+    static Stream<InteropCase> encodings() {
+        return sweep(List.of(
+                new EncodingAxis("multi-entry dictionary", 64, WriterConfig.defaults(), false),
+                new EncodingAxis("dictionary overflowing to PLAIN", FEW_ROWS,
+                        WriterConfig.builder().dictionaryPageLimitBytes(512).build(), true),
+                new EncodingAxis("dictionary disabled", 64,
+                        WriterConfig.builder().enableDictionary(false).build(), false)),
+                (type, axis) -> new InteropCase(axis.name(), type, Nullability.OPTIONAL_SOME_NULL,
+                        axis.distinct(), FEW_ROWS, axis.config(), axis.plainFallback()));
+    }
+
+    /// The codec axis, over every codec the writer can produce today. Stage 19 adds the rest and
+    /// extends this axis with them.
+    static Stream<InteropCase> codecs() {
+        return sweep(List.of(CompressionCodec.UNCOMPRESSED, CompressionCodec.ZSTD),
+                (type, codec) -> InteropCase.of("codec " + codec, type, Nullability.OPTIONAL_SOME_NULL,
+                        64, FEW_ROWS, WriterConfig.builder().codec(codec).build()));
+    }
+
+    /// The layout axis: one page, several pages within one row group, and several row groups.
+    ///
+    /// The single-page value is pinned exactly — 200 rows at the default 1 MiB targets is one
+    /// page in one row group for every type — so it establishes the "one page" end of the axis
+    /// instead of merely passing a bound any file satisfies. The other two are lower bounds: their
+    /// small page and row-group targets are crossed many times over, and how many times is an
+    /// artifact of the per-type value width rather than something worth pinning.
+    static Stream<LayoutCase> layouts() {
+        return sweep(List.of(
+                new LayoutAxis("single page", 200, WriterConfig.defaults(), 1, 1, LayoutBound.EXACTLY),
+                new LayoutAxis("multiple pages", MANY_ROWS,
+                        WriterConfig.builder().pageTargetBytes(1024).build(), 1, 2, LayoutBound.AT_LEAST),
+                // The target is well under a BOOLEAN column's buffered bits at this row count,
+                // which is the narrowest of the seven types and so sets the bar for all of them.
+                new LayoutAxis("multiple row groups", MANY_ROWS, WriterConfig.builder()
+                        .pageTargetBytes(1024).rowGroupTargetBytes(1024).build(), 2, 2, LayoutBound.AT_LEAST)),
+                (type, axis) -> new LayoutCase(
+                        InteropCase.of(axis.name(), type, Nullability.OPTIONAL_SOME_NULL, 64,
+                                axis.rows(), axis.config()),
+                        axis.rowGroups(), axis.dataPages(), axis.bound()));
+    }
+
+    // ==================== Tests ====================
+
+    @ParameterizedTest(name = "{0}")
+    @MethodSource
+    void singleEntryDictionary(InteropCase testCase, @TempDir Path dir) throws IOException {
+        verify(testCase, dir);
+    }
+
+    @ParameterizedTest(name = "{0}")
+    @MethodSource
+    void encodings(InteropCase testCase, @TempDir Path dir) throws IOException {
+        verify(testCase, dir);
+    }
+
+    @ParameterizedTest(name = "{0}")
+    @MethodSource
+    void codecs(InteropCase testCase, @TempDir Path dir) throws IOException {
+        verify(testCase, dir);
+    }
+
+    @ParameterizedTest(name = "{0}")
+    @MethodSource
+    void layouts(LayoutCase layoutCase, @TempDir Path dir) throws IOException {
+        Verified verified = verify(layoutCase.base(), dir);
+
+        int rowGroups = verified.footer().getBlocks().size();
+        int dataPages = verified.pages().dataPageCount();
+        if (layoutCase.bound() == LayoutBound.EXACTLY) {
+            assertThat(rowGroups).as("row groups").isEqualTo(layoutCase.rowGroups());
+            assertThat(dataPages).as("data pages").isEqualTo(layoutCase.dataPages());
+        }
+        else {
+            assertThat(rowGroups).as("row groups").isGreaterThanOrEqualTo(layoutCase.rowGroups());
+            assertThat(dataPages).as("data pages").isGreaterThanOrEqualTo(layoutCase.dataPages());
+        }
+    }
+
+    // ==================== The gate ====================
+
+    /// Writes the case's file with Hardwood and asserts everything parquet-java can see about it:
+    /// that it reads at all, that every value and null matches what was written, and that the
+    /// footer's row count, statistics and encodings do too.
+    private Verified verify(InteropCase testCase, Path dir) throws IOException {
+        Path file = dir.resolve("written.parquet");
+        write(testCase, file);
+
+        assertValues(testCase, ParquetJavaReader.readGroups(file));
+
+        ParquetMetadata footer = ParquetJavaReader.readFooter(file);
+        Pages pages = ParquetJavaReader.readPages(file);
+        assertRowCount(testCase, footer);
+        assertStatistics(testCase, footer);
+        assertEncodings(testCase, footer, pages);
+        return new Verified(footer, pages);
+    }
+
+    private void write(InteropCase testCase, Path file) throws IOException {
+        FileSchema schema = testCase.type()
+                .declare(FileSchema.builder("interop"), COLUMN, testCase.nullability().repetitionType())
+                .build();
+
+        try (ParquetFileWriter writer = ParquetFileWriter.create(OutputFile.of(file), schema, testCase.config())) {
+            writer.writeBatch(batch -> testCase.type().set(batch, COLUMN, testCase));
+        }
+    }
+
+    /// Every row parquet-java produces carries the value that was written, and a null row is
+    /// absent from its group rather than carrying a stand-in value.
+    private void assertValues(InteropCase testCase, List<Group> rows) {
+        assertThat(rows).as("row count").hasSize(testCase.rows());
+        for (int r = 0; r < rows.size(); r++) {
+            Group row = rows.get(r);
+            int field = row.getType().getFieldIndex(COLUMN);
+            if (testCase.isNull(r)) {
+                assertThat(row.getFieldRepetitionCount(field)).as("row %d is null", r).isZero();
+            }
+            else {
+                assertThat(row.getFieldRepetitionCount(field)).as("row %d is present", r).isOne();
+                assertThat(testCase.type().read(row, field)).as("row %d value", r)
+                        .isEqualTo(testCase.type().value(testCase.ordinal(r)));
+            }
+        }
+    }
+
+    private void assertRowCount(InteropCase testCase, ParquetMetadata footer) {
+        long rows = footer.getBlocks().stream().mapToLong(BlockMetaData::getRowCount).sum();
+        assertThat(rows).as("footer row count").isEqualTo(testCase.rows());
+    }
+
+    /// The column-chunk statistics parquet-java exposes agree with the written data. It builds
+    /// them with its own comparator, derived from the column's type and the footer's
+    /// `column_orders`, so agreement here is a cross-implementation check on the sort order the
+    /// bounds were computed in — not merely on the bytes they were stored as.
+    ///
+    /// Bounds are folded over the row groups, so the assertion holds whatever layout the case
+    /// produced.
+    private void assertStatistics(InteropCase testCase, ParquetMetadata footer) {
+        long nulls = 0;
+        Comparable<Object> min = null;
+        Comparable<Object> max = null;
+        for (ColumnChunkMetaData chunk : chunks(footer)) {
+            Statistics<?> statistics = chunk.getStatistics();
+            nulls += statistics.getNumNulls();
+            if (!statistics.hasNonNullValue()) {
+                continue;
+            }
+            min = extreme(min, statistics.genericGetMin(), true);
+            max = extreme(max, statistics.genericGetMax(), false);
+        }
+
+        assertThat(nulls).as("null count").isEqualTo(testCase.nullCount());
+        assertThat(min).as("min").isEqualTo(testCase.type().expectedMin(testCase));
+        assertThat(max).as("max").isEqualTo(testCase.type().expectedMax(testCase));
+    }
+
+    /// The case actually produced the encoding it exists to cover, so a change in the writer's
+    /// encoding choice becomes a failure rather than a silent loss of coverage.
+    ///
+    /// The discriminating assertion is on the *page* value encodings, not the chunk's `encodings`
+    /// list: that list always contains `PLAIN`, because a dictionary page body is itself `PLAIN`,
+    /// so it cannot tell a dictionary-only chunk from one that overflowed and fell back mid-chunk.
+    /// Each page declares its own encoding, and those separate the two.
+    private void assertEncodings(InteropCase testCase, ParquetMetadata footer, Pages pages) {
+        for (ColumnChunkMetaData chunk : chunks(footer)) {
+            assertThat(chunk.getEncodings()).as("declared chunk encodings")
+                    .matches(e -> e.contains(Encoding.RLE_DICTIONARY) == testCase.expectsDictionary(),
+                            testCase.expectsDictionary() ? "contains RLE_DICTIONARY" : "has no RLE_DICTIONARY");
+        }
+        assertThat(pages.valueEncodings()).as("page value encodings")
+                .containsExactlyInAnyOrderElementsOf(expectedPageEncodings(testCase));
+    }
+
+    /// The value encodings the case's data pages must declare. A dictionary-encoded chunk emits
+    /// `RLE_DICTIONARY` pages throughout; one that overflows its dictionary emits `PLAIN` pages
+    /// from the fallback on, so both appear; and a chunk with no dictionary at all — dictionary
+    /// disabled, a `BOOLEAN` column, or one with no present value to intern — is `PLAIN` only.
+    private static List<Encoding> expectedPageEncodings(InteropCase testCase) {
+        if (!testCase.expectsDictionary()) {
+            return List.of(Encoding.PLAIN);
+        }
+        return testCase.expectsPlainFallback()
+                ? List.of(Encoding.RLE_DICTIONARY, Encoding.PLAIN)
+                : List.of(Encoding.RLE_DICTIONARY);
+    }
+
+    private static List<ColumnChunkMetaData> chunks(ParquetMetadata footer) {
+        List<ColumnChunkMetaData> chunks = new ArrayList<>();
+        for (BlockMetaData block : footer.getBlocks()) {
+            chunks.addAll(block.getColumns());
+        }
+        return chunks;
+    }
+
+    /// Folds one row group's bound into the running one, in parquet-java's own comparison order
+    /// for the type.
+    @SuppressWarnings("unchecked")
+    private static Comparable<Object> extreme(Comparable<Object> current, Comparable<?> candidate, boolean min) {
+        Comparable<Object> other = (Comparable<Object>) candidate;
+        if (current == null) {
+            return other;
+        }
+        int order = other.compareTo(current);
+        return (min ? order < 0 : order > 0) ? other : current;
+    }
+
+    // ==================== Matrix plumbing ====================
+
+    /// The cross product of every physical type with one axis's values.
+    private static <A, C> Stream<C> sweep(List<A> axis, BiFunction<TypeFixture, A, C> factory) {
+        return Stream.of(TypeFixture.values())
+                .flatMap(type -> axis.stream().map(value -> factory.apply(type, value)));
+    }
+
+    private record EncodingAxis(String name, int distinct, WriterConfig config, boolean plainFallback) {
+    }
+
+    private record LayoutAxis(String name, int rows, WriterConfig config, int rowGroups, int dataPages,
+            LayoutBound bound) {
+    }
+
+    /// Whether a layout case's row-group and page counts are the exact numbers the configuration
+    /// produces, or the floor it must clear.
+    enum LayoutBound {
+        EXACTLY,
+        AT_LEAST
+    }
+
+    /// A flat case plus the layout the writer configuration was sized to produce.
+    record LayoutCase(InteropCase base, int rowGroups, int dataPages, LayoutBound bound) {
+        @Override
+        public String toString() {
+            return base.toString();
+        }
+    }
+
+    private record Verified(ParquetMetadata footer, Pages pages) {
+    }
+}

--- a/parquet-testing-runner/src/test/java/dev/hardwood/testing/WriterLogicalTypeInteropTest.java
+++ b/parquet-testing-runner/src/test/java/dev/hardwood/testing/WriterLogicalTypeInteropTest.java
@@ -1,0 +1,405 @@
+/*
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Copyright The original authors
+ *
+ *  Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package dev.hardwood.testing;
+
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.function.Consumer;
+import java.util.stream.Stream;
+
+import org.apache.parquet.column.schema.EdgeInterpolationAlgorithm;
+import org.apache.parquet.column.statistics.Statistics;
+import org.apache.parquet.example.data.Group;
+import org.apache.parquet.hadoop.metadata.ColumnChunkMetaData;
+import org.apache.parquet.hadoop.metadata.ParquetMetadata;
+import org.apache.parquet.io.api.Binary;
+import org.apache.parquet.schema.LogicalTypeAnnotation;
+import org.apache.parquet.schema.PrimitiveComparator;
+import org.apache.parquet.schema.PrimitiveType;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import dev.hardwood.OutputFile;
+import dev.hardwood.metadata.LogicalType;
+import dev.hardwood.metadata.LogicalType.TimeUnit;
+import dev.hardwood.metadata.PhysicalType;
+import dev.hardwood.metadata.RepetitionType;
+import dev.hardwood.schema.FileSchema;
+import dev.hardwood.writer.ColumnBatch;
+import dev.hardwood.writer.ParquetFileWriter;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/// The logical-type half of the write-path interop gate (`_designs/WRITER_INTEROP_GATE.md`):
+/// every annotation the writer emits is written onto a column, and parquet-java parses it out of
+/// the schema and reads the annotated values back.
+///
+/// An annotation is not decoration — it redefines the column's sort order, so it changes what
+/// `min` and `max` mean. The parameterized case pins that parquet-java sees the annotation the
+/// writer declared and that its own comparator finds the bounds consistent; the order-specific
+/// cases below pin the two orders that differ from the physical type's own, where a disagreement
+/// would prune away live rows rather than merely mis-sort.
+///
+/// The flat matrix is in [WriterInteropTest] and the nested shapes in [WriterNestedInteropTest].
+class WriterLogicalTypeInteropTest {
+
+    private static final String COLUMN = "v";
+
+    private static final int[] SMALL_INTS = { 0, 1, 2, 3 };
+    private static final long[] SMALL_LONGS = { 0L, 1L, 2L, 3L };
+
+    /// A well-formed little-endian WKB point, so a `GEOMETRY` / `GEOGRAPHY` column holds
+    /// something a geospatial consumer could actually decode.
+    private static final byte[] WKB_POINT = ByteBuffer.allocate(21)
+            .order(ByteOrder.LITTLE_ENDIAN)
+            .put((byte) 1).putInt(1).putDouble(1.5).putDouble(2.5)
+            .array();
+
+    /// Every annotation the writer emits, paired with the parquet-java annotation it must read
+    /// back as and with whether the format defines a sort order for it — `INTERVAL`, `GEOMETRY`
+    /// and `GEOGRAPHY` have none, so those columns carry a null count and no bounds.
+    static Stream<Annotated> annotations() {
+        return Stream.of(
+                binary(new LogicalType.StringType(), LogicalTypeAnnotation.stringType(), utf8()),
+                binary(new LogicalType.EnumType(), LogicalTypeAnnotation.enumType(), utf8()),
+                binary(new LogicalType.JsonType(), LogicalTypeAnnotation.jsonType(),
+                        new byte[][] { json("1"), json("2"), json("3"), json("4") }),
+                binary(new LogicalType.BsonType(), LogicalTypeAnnotation.bsonType(), utf8()),
+                binary(new LogicalType.DecimalType(2, 20), LogicalTypeAnnotation.decimalType(2, 20),
+                        new byte[][] { { 0x01 }, { 0x02 }, { 0x00, 0x03 }, { (byte) 0xff } }),
+                unordered(binary(new LogicalType.GeometryType("EPSG:4326"),
+                        LogicalTypeAnnotation.geometryType("EPSG:4326"), wkb())),
+                unordered(binary(new LogicalType.GeographyType("EPSG:4326",
+                        LogicalType.EdgeInterpolationAlgorithm.KARNEY),
+                        LogicalTypeAnnotation.geographyType("EPSG:4326", EdgeInterpolationAlgorithm.KARNEY),
+                        wkb())),
+
+                ints(new LogicalType.DateType(), LogicalTypeAnnotation.dateType()),
+                ints(new LogicalType.IntType(8, true), LogicalTypeAnnotation.intType(8, true)),
+                ints(new LogicalType.IntType(16, false), LogicalTypeAnnotation.intType(16, false)),
+                ints(new LogicalType.IntType(32, false), LogicalTypeAnnotation.intType(32, false)),
+                ints(new LogicalType.DecimalType(2, 9), LogicalTypeAnnotation.decimalType(2, 9)),
+                ints(new LogicalType.TimeType(true, TimeUnit.MILLIS),
+                        LogicalTypeAnnotation.timeType(true, LogicalTypeAnnotation.TimeUnit.MILLIS)),
+
+                longs(new LogicalType.IntType(64, false), LogicalTypeAnnotation.intType(64, false)),
+                longs(new LogicalType.DecimalType(4, 18), LogicalTypeAnnotation.decimalType(4, 18)),
+                longs(new LogicalType.TimeType(false, TimeUnit.MICROS),
+                        LogicalTypeAnnotation.timeType(false, LogicalTypeAnnotation.TimeUnit.MICROS)),
+                longs(new LogicalType.TimeType(true, TimeUnit.NANOS),
+                        LogicalTypeAnnotation.timeType(true, LogicalTypeAnnotation.TimeUnit.NANOS)),
+                longs(new LogicalType.TimestampType(true, TimeUnit.MILLIS),
+                        LogicalTypeAnnotation.timestampType(true, LogicalTypeAnnotation.TimeUnit.MILLIS)),
+                longs(new LogicalType.TimestampType(false, TimeUnit.MICROS),
+                        LogicalTypeAnnotation.timestampType(false, LogicalTypeAnnotation.TimeUnit.MICROS)),
+                longs(new LogicalType.TimestampType(true, TimeUnit.NANOS),
+                        LogicalTypeAnnotation.timestampType(true, LogicalTypeAnnotation.TimeUnit.NANOS)),
+
+                fixed(16, new LogicalType.UuidType(), LogicalTypeAnnotation.uuidType(), fill(16)),
+                fixed(2, new LogicalType.Float16Type(), LogicalTypeAnnotation.float16Type(), float16()),
+                unordered(fixed(12, new LogicalType.IntervalType(), LogicalTypeAnnotation.intervalType(),
+                        fill(12))),
+                fixed(8, new LogicalType.DecimalType(3, 18), LogicalTypeAnnotation.decimalType(3, 18), fill(8)),
+
+                nulls());
+    }
+
+    // ==================== Tests ====================
+
+    @ParameterizedTest(name = "{0}")
+    @MethodSource("annotations")
+    void annotationAndValuesSurviveTheFile(Annotated annotated, @TempDir Path dir) throws IOException {
+        Path file = write(dir, annotated);
+
+        ParquetMetadata footer = ParquetJavaReader.readFooter(file);
+        PrimitiveType column = footer.getFileMetaData().getSchema().getType(COLUMN).asPrimitiveType();
+        assertThat(column.getLogicalTypeAnnotation()).as("annotation").isEqualTo(annotated.parquetJava());
+        if (annotated.typeLength() != null) {
+            assertThat(column.getTypeLength()).as("type length").isEqualTo(annotated.typeLength());
+        }
+
+        List<Group> rows = ParquetJavaReader.readGroups(file);
+        assertThat(rows).hasSize(annotated.rowCount());
+        for (int r = 0; r < rows.size(); r++) {
+            if (annotated.allNull()) {
+                assertThat(rows.get(r).getFieldRepetitionCount(COLUMN)).as("row %d is null", r).isZero();
+            }
+            else {
+                assertThat(annotated.read(rows.get(r))).as("row %d", r).isEqualTo(annotated.expected(r));
+            }
+        }
+
+        Statistics<?> statistics = footer.getBlocks().get(0).getColumns().get(0).getStatistics();
+        assertThat(statistics.getNumNulls()).as("null count")
+                .isEqualTo(annotated.allNull() ? annotated.rowCount() : 0);
+        if (annotated.ordered()) {
+            assertBounds(annotated, statistics);
+        }
+        else {
+            assertThat(statistics.hasNonNullValue()).as("no bounds for an undefined order").isFalse();
+        }
+    }
+
+    /// The bounds parquet-java reads are the true extremes of the written values *in the order the
+    /// annotation defines*, reduced out of those values with parquet-java's own comparator for the
+    /// column. Asserting the extremes rather than merely that `min <= max` is what makes every row
+    /// of the table able to catch a bound computed in the wrong order: most of the annotations
+    /// carry values that sort identically under every candidate order, so a consistency check
+    /// passes for them no matter which order the writer used.
+    private static void assertBounds(Annotated annotated, Statistics<?> statistics) {
+        assertThat(statistics.hasNonNullValue()).as("bounds are written").isTrue();
+
+        List<Comparable<?>> values = annotated.statisticsValues();
+        assertThat(statistics.genericGetMin()).as("min")
+                .isEqualTo(extreme(values, statistics.comparator(), true));
+        assertThat(statistics.genericGetMax()).as("max")
+                .isEqualTo(extreme(values, statistics.comparator(), false));
+    }
+
+    /// The smallest or largest of `values` under `comparator`.
+    @SuppressWarnings({ "rawtypes", "unchecked" })
+    private static Comparable<?> extreme(List<Comparable<?>> values, PrimitiveComparator comparator, boolean min) {
+        Comparable<?> best = values.get(0);
+        for (Comparable<?> value : values) {
+            int order = comparator.compare(value, best);
+            if (min ? order < 0 : order > 0) {
+                best = value;
+            }
+        }
+        return best;
+    }
+
+    /// An unsigned annotation makes the bounds unsigned: `0xffffffff` is the largest value, not
+    /// the smallest, and a reader taking the signed order would prune every row group whose
+    /// values straddle the sign bit.
+    @Test
+    void unsignedIntegerBoundsUseUnsignedOrder(@TempDir Path dir) throws IOException {
+        FileSchema schema = FileSchema.builder("annotated")
+                .addColumn("i", PhysicalType.INT32, RepetitionType.REQUIRED, new LogicalType.IntType(32, false))
+                .addColumn("l", PhysicalType.INT64, RepetitionType.REQUIRED, new LogicalType.IntType(64, false))
+                .build();
+
+        // -1 is 4294967295 / 18446744073709551615 read unsigned, so it is the maximum of each.
+        Path file = write(dir, schema, batch -> batch
+                .ints("i", new int[] { 1, -1, 2 })
+                .longs("l", new long[] { 1L, -1L, 2L }));
+
+        List<ColumnChunkMetaData> columns =
+                ParquetJavaReader.readFooter(file).getBlocks().get(0).getColumns();
+        assertThat(columns.get(0).getStatistics().genericGetMin()).as("uint32 min").isEqualTo(1);
+        assertThat(columns.get(0).getStatistics().genericGetMax()).as("uint32 max").isEqualTo(-1);
+        assertThat(columns.get(1).getStatistics().genericGetMin()).as("uint64 min").isEqualTo(1L);
+        assertThat(columns.get(1).getStatistics().genericGetMax()).as("uint64 max").isEqualTo(-1L);
+    }
+
+    /// A `DECIMAL` over a binary type is compared as a signed big-endian integer, not as the
+    /// unsigned byte string an unannotated binary column uses, so a negative value is the
+    /// minimum even though its leading byte is the largest.
+    @Test
+    void binaryDecimalBoundsUseSignedOrder(@TempDir Path dir) throws IOException {
+        FileSchema schema = FileSchema.builder("annotated")
+                .addColumn(COLUMN, PhysicalType.FIXED_LEN_BYTE_ARRAY, RepetitionType.REQUIRED, 2,
+                        new LogicalType.DecimalType(0, 4))
+                .build();
+
+        byte[] one = { 0x00, 0x01 };
+        byte[] minusOne = { (byte) 0xff, (byte) 0xff };
+        byte[] two = { 0x00, 0x02 };
+        Path file = write(dir, schema, batch -> batch.fixed(COLUMN, new byte[][] { one, minusOne, two }));
+
+        Statistics<?> statistics = ParquetJavaReader.readFooter(file).getBlocks().get(0)
+                .getColumns().get(0).getStatistics();
+        assertThat(statistics.genericGetMin()).as("min").isEqualTo(Binary.fromConstantByteArray(minusOne));
+        assertThat(statistics.genericGetMax()).as("max").isEqualTo(Binary.fromConstantByteArray(two));
+    }
+
+    // ==================== Helpers ====================
+
+    private Path write(Path dir, Annotated annotated) throws IOException {
+        FileSchema schema = annotated.typeLength() == null
+                ? FileSchema.builder("annotated")
+                        .addColumn(COLUMN, annotated.physicalType(), annotated.repetition(), annotated.hardwood())
+                        .build()
+                : FileSchema.builder("annotated")
+                        .addColumn(COLUMN, annotated.physicalType(), annotated.repetition(),
+                                annotated.typeLength(), annotated.hardwood())
+                        .build();
+
+        return write(dir, schema, annotated::fill);
+    }
+
+    private Path write(Path dir, FileSchema schema, Consumer<ColumnBatch> filler) throws IOException {
+        Path file = dir.resolve("annotated.parquet");
+        try (ParquetFileWriter writer = ParquetFileWriter.create(OutputFile.of(file), schema)) {
+            writer.writeBatch(filler);
+        }
+        return file;
+    }
+
+    // ==================== The annotation table ====================
+
+    /// One annotation under test: how Hardwood declares it, the parquet-java annotation it must
+    /// read back as, the values written beneath it, and whether the format defines a sort order
+    /// for it.
+    record Annotated(PhysicalType physicalType, Integer typeLength, LogicalType hardwood,
+            LogicalTypeAnnotation parquetJava, byte[][] binaryValues, boolean ordered, boolean allNull) {
+
+        int rowCount() {
+            return binaryValues == null ? SMALL_INTS.length : binaryValues.length;
+        }
+
+        /// `UNKNOWN` annotates a column whose every value is null, so it is the one row that is
+        /// `OPTIONAL` and the one whose values are written through the null-mask setter.
+        RepetitionType repetition() {
+            return allNull ? RepetitionType.OPTIONAL : RepetitionType.REQUIRED;
+        }
+
+        void fill(ColumnBatch batch) {
+            if (allNull) {
+                fillAllNull(batch);
+                return;
+            }
+            switch (physicalType) {
+                case INT32 -> batch.ints(COLUMN, SMALL_INTS);
+                case INT64 -> batch.longs(COLUMN, SMALL_LONGS);
+                case BYTE_ARRAY -> batch.bytes(COLUMN, binaryValues);
+                case FIXED_LEN_BYTE_ARRAY -> batch.fixed(COLUMN, binaryValues);
+                default -> throw new IllegalStateException("No annotation case for " + physicalType);
+            }
+        }
+
+        /// Writes the all-null row's values. `UNKNOWN` is the only annotation with such a row and
+        /// it sits on `INT32`, so this writes ints; a row added on another physical type has to
+        /// extend this rather than silently get the wrong value width.
+        private void fillAllNull(ColumnBatch batch) {
+            if (physicalType != PhysicalType.INT32) {
+                throw new IllegalStateException("No all-null case for " + physicalType);
+            }
+            boolean[] nulls = new boolean[rowCount()];
+            Arrays.fill(nulls, true);
+            batch.ints(COLUMN, new int[rowCount()], nulls);
+        }
+
+        Object expected(int row) {
+            return switch (physicalType) {
+                case INT32 -> SMALL_INTS[row];
+                case INT64 -> SMALL_LONGS[row];
+                default -> binaryValues[row];
+            };
+        }
+
+        Object read(Group group) {
+            return switch (physicalType) {
+                case INT32 -> group.getInteger(COLUMN, 0);
+                case INT64 -> group.getLong(COLUMN, 0);
+                default -> group.getBinary(COLUMN, 0).getBytes();
+            };
+        }
+
+        /// The written values in the representation parquet-java's statistics compare in, so the
+        /// expected bounds can be reduced out of them with parquet-java's own comparator.
+        List<Comparable<?>> statisticsValues() {
+            List<Comparable<?>> values = new ArrayList<>(rowCount());
+            for (int row = 0; row < rowCount(); row++) {
+                Object value = expected(row);
+                values.add(value instanceof byte[] bytes
+                        ? Binary.fromConstantByteArray(bytes)
+                        : (Comparable<?>) value);
+            }
+            return values;
+        }
+
+        @Override
+        public String toString() {
+            return hardwood + " on " + physicalType + (typeLength == null ? "" : "(" + typeLength + ")");
+        }
+    }
+
+    private static Annotated ints(LogicalType hardwood, LogicalTypeAnnotation parquetJava) {
+        return new Annotated(PhysicalType.INT32, null, hardwood, parquetJava, null, true, false);
+    }
+
+    private static Annotated longs(LogicalType hardwood, LogicalTypeAnnotation parquetJava) {
+        return new Annotated(PhysicalType.INT64, null, hardwood, parquetJava, null, true, false);
+    }
+
+    /// The `UNKNOWN` row: an `OPTIONAL INT32` column whose every value is null, which is the only
+    /// shape the annotation is legal on and the only one whose meaning it can describe.
+    private static Annotated nulls() {
+        return new Annotated(PhysicalType.INT32, null, new LogicalType.NullType(),
+                LogicalTypeAnnotation.unknownType(), null, false, true);
+    }
+
+    private static Annotated binary(LogicalType hardwood, LogicalTypeAnnotation parquetJava, byte[][] values) {
+        return new Annotated(PhysicalType.BYTE_ARRAY, null, hardwood, parquetJava, values, true, false);
+    }
+
+    private static Annotated fixed(int typeLength, LogicalType hardwood, LogicalTypeAnnotation parquetJava,
+            byte[][] values) {
+        return new Annotated(PhysicalType.FIXED_LEN_BYTE_ARRAY, typeLength, hardwood, parquetJava, values, true, false);
+    }
+
+    /// Marks an annotation whose sort order the format leaves undefined, so no bounds are written.
+    private static Annotated unordered(Annotated annotated) {
+        return new Annotated(annotated.physicalType(), annotated.typeLength(), annotated.hardwood(),
+                annotated.parquetJava(), annotated.binaryValues(), false, annotated.allNull());
+    }
+
+    private static byte[][] utf8() {
+        return new byte[][] { bytes("ada"), bytes("alan"), bytes(""), bytes("grace") };
+    }
+
+    private static byte[][] wkb() {
+        return new byte[][] { WKB_POINT, WKB_POINT };
+    }
+
+    /// Four distinct fixed-length values, each a run of one byte value, so the same generator
+    /// serves `UUID`, `INTERVAL` and the fixed `DECIMAL` alike.
+    private static byte[][] fill(int length) {
+        byte[][] values = new byte[4][];
+        for (int i = 0; i < values.length; i++) {
+            values[i] = new byte[length];
+            Arrays.fill(values[i], (byte) (i + 1));
+        }
+        return values;
+    }
+
+    /// Four `FLOAT16` values — `+0.0`, `1.0`, `2.0`, `-1.0`.
+    ///
+    /// None is `NaN`, and the extremes are `-1.0` and `2.0` rather than a zero, so neither the
+    /// `NaN` exclusion nor the signed-zero normalization of a zero bound enters here; both are
+    /// covered on the `FLOAT` and `DOUBLE` columns of [WriterInteropTest].
+    private static byte[][] float16() {
+        return new byte[][] { half(0.0f), half(1.0f), half(2.0f), half(-1.0f) };
+    }
+
+    /// One half-precision value as the **little-endian** 2-byte pattern the format stores, so
+    /// `1.0` (`0x3c00`) is the bytes `00 3c` and not `3c 00`. Derived rather than written as a
+    /// literal: big-endian patterns all decode to near-zero subnormals of the same sign, which
+    /// leaves the `FLOAT16` row unable to tell the float16 order from an unsigned byte comparison.
+    private static byte[] half(float value) {
+        short bits = Float.floatToFloat16(value);
+        return new byte[] { (byte) bits, (byte) (bits >>> 8) };
+    }
+
+    private static byte[] json(String value) {
+        return bytes("{\"n\":" + value + "}");
+    }
+
+    private static byte[] bytes(String value) {
+        return value.getBytes(StandardCharsets.UTF_8);
+    }
+}

--- a/parquet-testing-runner/src/test/java/dev/hardwood/testing/WriterNestedInteropTest.java
+++ b/parquet-testing-runner/src/test/java/dev/hardwood/testing/WriterNestedInteropTest.java
@@ -1,0 +1,445 @@
+/*
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Copyright The original authors
+ *
+ *  Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package dev.hardwood.testing;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Consumer;
+
+import org.apache.parquet.example.data.Group;
+import org.apache.parquet.hadoop.metadata.ParquetMetadata;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import dev.hardwood.OutputFile;
+import dev.hardwood.Validity;
+import dev.hardwood.metadata.LogicalType;
+import dev.hardwood.metadata.PhysicalType;
+import dev.hardwood.metadata.RepetitionType;
+import dev.hardwood.schema.FileSchema;
+import dev.hardwood.writer.ColumnBatch;
+import dev.hardwood.writer.ParquetFileWriter;
+import dev.hardwood.writer.WriterConfig;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/// The nested half of the write-path interop gate (`_designs/WRITER_INTEROP_GATE.md`): Hardwood
+/// writes the `struct`, `LIST` and `MAP` shapes, and parquet-java reads them back.
+///
+/// These are the shapes that carry repetition and definition level streams, which a flat column
+/// does not exercise at all. The distinctions the levels encode — an empty list against an absent
+/// one, a null element inside a present list, a null `struct` instance whose leaves still occupy
+/// a definition level — are exactly what a level-stream defect erases, and none of them is
+/// visible from the values alone.
+///
+/// The flat matrix is in [WriterInteropTest].
+class WriterNestedInteropTest {
+
+    // ==================== Structs ====================
+
+    @Test
+    void requiredAndOptionalStructs(@TempDir Path dir) throws IOException {
+        FileSchema schema = FileSchema.builder("nested")
+                .struct("origin", RepetitionType.REQUIRED, s -> s
+                        .addColumn("x", PhysicalType.INT32, RepetitionType.REQUIRED))
+                .struct("person", RepetitionType.OPTIONAL, s -> s
+                        .addColumn("name", PhysicalType.BYTE_ARRAY, RepetitionType.OPTIONAL)
+                        .addColumn("born", PhysicalType.INT32, RepetitionType.REQUIRED))
+                .build();
+
+        // Record 1 has no person at all; record 2 has one whose name is null.
+        List<Group> rows = writeAndRead(dir, schema, batch -> batch
+                .ints("origin.x", new int[] { 10, 20, 30 })
+                .struct("person", Validity.ofNulls(new boolean[] { false, true, false }))
+                .bytes("person.name", new byte[][] { utf8("ada"), utf8("ignored"), utf8("alan") },
+                        new boolean[] { false, false, true })
+                .ints("person.born", new int[] { 1815, 0, 1912 }));
+
+        assertThat(rows).hasSize(3);
+        for (int r = 0; r < 3; r++) {
+            assertThat(rows.get(r).getGroup("origin", 0).getInteger("x", 0))
+                    .as("origin.x of row %d", r).isEqualTo(10 * (r + 1));
+        }
+
+        assertThat(count(rows.get(0), "person")).as("row 0 has a person").isOne();
+        assertThat(rows.get(0).getGroup("person", 0).getBinary("name", 0).getBytes()).isEqualTo(utf8("ada"));
+        assertThat(rows.get(0).getGroup("person", 0).getInteger("born", 0)).isEqualTo(1815);
+
+        assertThat(count(rows.get(1), "person")).as("row 1 has no person").isZero();
+
+        Group present = rows.get(2).getGroup("person", 0);
+        assertThat(count(present, "name")).as("row 2 has a person with no name").isZero();
+        assertThat(present.getInteger("born", 0)).isEqualTo(1912);
+    }
+
+    @Test
+    void nestedStructs(@TempDir Path dir) throws IOException {
+        FileSchema schema = FileSchema.builder("nested")
+                .struct("a", RepetitionType.OPTIONAL, outer -> outer
+                        .struct("b", RepetitionType.OPTIONAL, inner -> inner
+                                .addColumn("v", PhysicalType.INT32, RepetitionType.OPTIONAL)))
+                .build();
+
+        // Row 0: a.b.v = 1; row 1: a present, b absent; row 2: a absent; row 3: a.b present, v null.
+        List<Group> rows = writeAndRead(dir, schema, batch -> batch
+                .struct("a", Validity.ofNulls(new boolean[] { false, false, true, false }))
+                .struct("a.b", Validity.ofNulls(new boolean[] { false, true, true, false }))
+                .ints("a.b.v", new int[] { 1, 0, 0, 0 }, new boolean[] { false, true, true, true }));
+
+        assertThat(rows).hasSize(4);
+        assertThat(rows.get(0).getGroup("a", 0).getGroup("b", 0).getInteger("v", 0)).isEqualTo(1);
+        assertThat(count(rows.get(1).getGroup("a", 0), "b")).as("row 1 has no b").isZero();
+        assertThat(count(rows.get(2), "a")).as("row 2 has no a").isZero();
+        assertThat(count(rows.get(3).getGroup("a", 0).getGroup("b", 0), "v")).as("row 3 has no v").isZero();
+    }
+
+    // ==================== Lists ====================
+
+    @Test
+    void optionalListOfOptionalElements(@TempDir Path dir) throws IOException {
+        FileSchema schema = FileSchema.builder("nested")
+                .list("phones", RepetitionType.OPTIONAL,
+                        el -> el.primitive(PhysicalType.INT32, RepetitionType.OPTIONAL))
+                .build();
+
+        // Row 0: [1,2]; row 1: []; row 2: null; row 3: [3, null, 5].
+        List<Group> rows = writeAndRead(dir, schema, batch -> batch
+                .list("phones", new int[] { 0, 2, 2, 2, 5 },
+                        Validity.ofNulls(new boolean[] { false, false, true, false }))
+                .ints("phones.list.element", new int[] { 1, 2, 3, 0, 5 },
+                        new boolean[] { false, false, false, true, false }));
+
+        assertThat(intLists(rows, "phones")).containsExactly(
+                List.of(1, 2), List.of(), null, Arrays.asList(3, null, 5));
+    }
+
+    @Test
+    void requiredListOfRequiredElements(@TempDir Path dir) throws IOException {
+        FileSchema schema = FileSchema.builder("nested")
+                .list("v", RepetitionType.REQUIRED,
+                        el -> el.primitive(PhysicalType.INT32, RepetitionType.REQUIRED))
+                .build();
+
+        // No outer optional level: the definition levels only tell an empty list from an element.
+        List<Group> rows = writeAndRead(dir, schema, batch -> batch
+                .list("v", new int[] { 0, 2, 2, 3 })
+                .ints("v.list.element", new int[] { 1, 2, 3 }));
+
+        assertThat(intLists(rows, "v")).containsExactly(List.of(1, 2), List.of(), List.of(3));
+    }
+
+    @Test
+    void listOfLists(@TempDir Path dir) throws IOException {
+        FileSchema schema = FileSchema.builder("nested")
+                .list("m", RepetitionType.OPTIONAL, el -> el.list(RepetitionType.OPTIONAL,
+                        inner -> inner.primitive(PhysicalType.INT32, RepetitionType.OPTIONAL)))
+                .build();
+
+        // Row 0: [[1,2],[3]]; 1: []; 2: null; 3: [[]]; 4: [null] — two repetition levels.
+        List<Group> rows = writeAndRead(dir, schema, batch -> batch
+                .list("m", new int[] { 0, 2, 2, 2, 3, 4 },
+                        Validity.ofNulls(new boolean[] { false, false, true, false, false }))
+                .list("m.list.element", new int[] { 0, 2, 3, 3, 3 },
+                        Validity.ofNulls(new boolean[] { false, false, false, true }))
+                .ints("m.list.element.list.element", new int[] { 1, 2, 3 }));
+
+        List<List<List<Integer>>> actual = new ArrayList<>();
+        for (Group row : rows) {
+            if (count(row, "m") == 0) {
+                actual.add(null);
+                continue;
+            }
+            Group outer = row.getGroup("m", 0);
+            List<List<Integer>> inner = new ArrayList<>();
+            for (int i = 0; i < count(outer, "list"); i++) {
+                Group entry = outer.getGroup("list", i);
+                inner.add(count(entry, "element") == 0 ? null : intList(entry.getGroup("element", 0)));
+            }
+            actual.add(inner);
+        }
+
+        assertThat(actual).containsExactly(
+                List.of(List.of(1, 2), List.of(3)),
+                List.of(),
+                null,
+                List.of(List.of()),
+                Arrays.asList((List<Integer>) null));
+    }
+
+    @Test
+    void listOfStructs(@TempDir Path dir) throws IOException {
+        FileSchema schema = FileSchema.builder("nested")
+                .list("people", RepetitionType.OPTIONAL, el -> el.struct(RepetitionType.OPTIONAL, s -> s
+                        .addColumn("x", PhysicalType.INT32, RepetitionType.REQUIRED)
+                        .addColumn("y", PhysicalType.INT32, RepetitionType.OPTIONAL)))
+                .build();
+
+        // Row 0: [{1,10}, {2,null}]; row 1: [{3,30}].
+        List<Group> rows = writeAndRead(dir, schema, batch -> batch
+                .list("people", new int[] { 0, 2, 3 })
+                .ints("people.list.element.x", new int[] { 1, 2, 3 })
+                .ints("people.list.element.y", new int[] { 10, 0, 30 },
+                        new boolean[] { false, true, false }));
+
+        Group first = rows.get(0).getGroup("people", 0);
+        assertThat(count(first, "list")).isEqualTo(2);
+        assertThat(first.getGroup("list", 0).getGroup("element", 0).getInteger("x", 0)).isEqualTo(1);
+        assertThat(first.getGroup("list", 0).getGroup("element", 0).getInteger("y", 0)).isEqualTo(10);
+        Group secondElement = first.getGroup("list", 1).getGroup("element", 0);
+        assertThat(secondElement.getInteger("x", 0)).isEqualTo(2);
+        assertThat(count(secondElement, "y")).as("second element has no y").isZero();
+
+        Group second = rows.get(1).getGroup("people", 0);
+        assertThat(count(second, "list")).isOne();
+        assertThat(second.getGroup("list", 0).getGroup("element", 0).getInteger("x", 0)).isEqualTo(3);
+    }
+
+    @Test
+    void listWithNullStructElement(@TempDir Path dir) throws IOException {
+        FileSchema schema = FileSchema.builder("nested")
+                .list("people", RepetitionType.OPTIONAL, el -> el.struct(RepetitionType.OPTIONAL,
+                        s -> s.addColumn("x", PhysicalType.INT32, RepetitionType.REQUIRED)))
+                .build();
+
+        // One record whose middle element is a null struct rather than a struct with null fields.
+        List<Group> rows = writeAndRead(dir, schema, batch -> batch
+                .list("people", new int[] { 0, 3 })
+                .struct("people.list.element", Validity.ofNulls(new boolean[] { false, true, false }))
+                .ints("people.list.element.x", new int[] { 1, 0, 3 }));
+
+        Group list = rows.get(0).getGroup("people", 0);
+        assertThat(count(list, "list")).isEqualTo(3);
+        assertThat(list.getGroup("list", 0).getGroup("element", 0).getInteger("x", 0)).isEqualTo(1);
+        assertThat(count(list.getGroup("list", 1), "element")).as("middle element is a null struct").isZero();
+        assertThat(list.getGroup("list", 2).getGroup("element", 0).getInteger("x", 0)).isEqualTo(3);
+    }
+
+    // ==================== Maps ====================
+
+    @Test
+    void optionalMapOfIntToInt(@TempDir Path dir) throws IOException {
+        FileSchema schema = FileSchema.builder("nested")
+                .map("props", RepetitionType.OPTIONAL, PhysicalType.INT32,
+                        value -> value.primitive(PhysicalType.INT32, RepetitionType.OPTIONAL))
+                .build();
+
+        // Row 0: {1:10, 2:null}; row 1: {}; row 2: null; row 3: {3:30}.
+        List<Group> rows = writeAndRead(dir, schema, batch -> batch
+                .map("props", new int[] { 0, 2, 2, 2, 3 },
+                        Validity.ofNulls(new boolean[] { false, false, true, false }))
+                .ints("props.key_value.key", new int[] { 1, 2, 3 })
+                .ints("props.key_value.value", new int[] { 10, 0, 30 },
+                        new boolean[] { false, true, false }));
+
+        Map<Integer, Integer> first = new LinkedHashMap<>();
+        first.put(1, 10);
+        first.put(2, null);
+        assertThat(intMap(rows.get(0), "props")).isEqualTo(first);
+        assertThat(intMap(rows.get(1), "props")).isEmpty();
+        assertThat(intMap(rows.get(2), "props")).as("row 2 has no map").isNull();
+        assertThat(intMap(rows.get(3), "props")).isEqualTo(Map.of(3, 30));
+    }
+
+    @Test
+    void requiredMapWithStringKeys(@TempDir Path dir) throws IOException {
+        FileSchema schema = FileSchema.builder("nested")
+                .map("props", RepetitionType.REQUIRED, PhysicalType.BYTE_ARRAY,
+                        new LogicalType.StringType(),
+                        value -> value.primitive(PhysicalType.INT64, RepetitionType.REQUIRED))
+                .build();
+
+        List<Group> rows = writeAndRead(dir, schema, batch -> batch
+                .map("props", new int[] { 0, 2, 2 })
+                .bytes("props.key_value.key", new byte[][] { utf8("a"), utf8("b") })
+                .longs("props.key_value.value", new long[] { 1L, 2L }));
+
+        Group entries = rows.get(0).getGroup("props", 0);
+        assertThat(count(entries, "key_value")).isEqualTo(2);
+        assertThat(entries.getGroup("key_value", 0).getBinary("key", 0).getBytes()).isEqualTo(utf8("a"));
+        assertThat(entries.getGroup("key_value", 0).getLong("value", 0)).isEqualTo(1L);
+        assertThat(entries.getGroup("key_value", 1).getBinary("key", 0).getBytes()).isEqualTo(utf8("b"));
+        assertThat(entries.getGroup("key_value", 1).getLong("value", 0)).isEqualTo(2L);
+        assertThat(count(rows.get(1).getGroup("props", 0), "key_value")).as("row 1 is an empty map").isZero();
+    }
+
+    @Test
+    void mapOfIntToListOfInts(@TempDir Path dir) throws IOException {
+        FileSchema schema = FileSchema.builder("nested")
+                .map("m", RepetitionType.OPTIONAL, PhysicalType.INT32,
+                        value -> value.list(RepetitionType.OPTIONAL,
+                                el -> el.primitive(PhysicalType.INT32, RepetitionType.OPTIONAL)))
+                .build();
+
+        // Row 0: {1:[10,11], 2:[]}; row 1: {3:null}.
+        List<Group> rows = writeAndRead(dir, schema, batch -> batch
+                .map("m", new int[] { 0, 2, 3 })
+                .ints("m.key_value.key", new int[] { 1, 2, 3 })
+                .list("m.key_value.value", new int[] { 0, 2, 2, 2 },
+                        Validity.ofNulls(new boolean[] { false, false, true }))
+                .ints("m.key_value.value.list.element", new int[] { 10, 11 }));
+
+        Group first = rows.get(0).getGroup("m", 0);
+        assertThat(first.getGroup("key_value", 0).getInteger("key", 0)).isEqualTo(1);
+        assertThat(intList(first.getGroup("key_value", 0).getGroup("value", 0))).containsExactly(10, 11);
+        assertThat(first.getGroup("key_value", 1).getInteger("key", 0)).isEqualTo(2);
+        assertThat(intList(first.getGroup("key_value", 1).getGroup("value", 0))).isEmpty();
+
+        Group second = rows.get(1).getGroup("m", 0);
+        assertThat(second.getGroup("key_value", 0).getInteger("key", 0)).isEqualTo(3);
+        assertThat(count(second.getGroup("key_value", 0), "value")).as("row 1's value list is absent").isZero();
+    }
+
+    @Test
+    void mapOfIntToStruct(@TempDir Path dir) throws IOException {
+        FileSchema schema = FileSchema.builder("nested")
+                .map("m", RepetitionType.OPTIONAL, PhysicalType.INT32,
+                        value -> value.struct(RepetitionType.OPTIONAL, s -> s
+                                .addColumn("x", PhysicalType.INT32, RepetitionType.REQUIRED)))
+                .build();
+
+        // Row 0: {1:{x=10}, 2:null}.
+        List<Group> rows = writeAndRead(dir, schema, batch -> batch
+                .map("m", new int[] { 0, 2 })
+                .ints("m.key_value.key", new int[] { 1, 2 })
+                .struct("m.key_value.value", Validity.ofNulls(new boolean[] { false, true }))
+                .ints("m.key_value.value.x", new int[] { 10, 0 }));
+
+        Group entries = rows.get(0).getGroup("m", 0);
+        assertThat(entries.getGroup("key_value", 0).getGroup("value", 0).getInteger("x", 0)).isEqualTo(10);
+        assertThat(count(entries.getGroup("key_value", 1), "value")).as("second value is null").isZero();
+    }
+
+    // ==================== Boundaries ====================
+
+    @Test
+    void listsSurvivePageAndRowGroupBoundaries(@TempDir Path dir) throws IOException {
+        FileSchema schema = FileSchema.builder("nested")
+                .list("v", RepetitionType.OPTIONAL,
+                        el -> el.primitive(PhysicalType.INT32, RepetitionType.OPTIONAL))
+                .build();
+
+        // Records cycle through empty, absent, single and three-element lists, so every level
+        // combination recurs on both sides of every page and row-group boundary.
+        int records = 6_000;
+        int[] offsets = new int[records + 1];
+        boolean[] listNulls = new boolean[records];
+        List<Integer> flattened = new ArrayList<>();
+        for (int r = 0; r < records; r++) {
+            listNulls[r] = r % 4 == 2;
+            int entries = switch (r % 4) {
+                case 0 -> 0;
+                case 1 -> 1;
+                case 2 -> 0; // absent
+                default -> 3;
+            };
+            for (int e = 0; e < entries; e++) {
+                flattened.add(r + e);
+            }
+            offsets[r + 1] = flattened.size();
+        }
+        int[] elements = flattened.stream().mapToInt(Integer::intValue).toArray();
+        boolean[] elementNulls = new boolean[elements.length];
+        for (int e = 0; e < elements.length; e++) {
+            elementNulls[e] = e % 7 == 0;
+        }
+
+        WriterConfig config = WriterConfig.builder().pageTargetBytes(1024).rowGroupTargetBytes(4096).build();
+        Path file = write(dir, schema, config, batch -> batch
+                .list("v", offsets, Validity.ofNulls(listNulls))
+                .ints("v.list.element", elements, elementNulls));
+
+        ParquetMetadata footer = ParquetJavaReader.readFooter(file);
+        assertThat(footer.getBlocks()).as("row groups").hasSizeGreaterThan(1);
+        assertThat(ParquetJavaReader.readPages(file).dataPageCount()).as("data pages").isGreaterThan(1);
+
+        List<Group> rows = ParquetJavaReader.readGroups(file);
+        assertThat(rows).hasSize(records);
+        for (int r = 0; r < records; r++) {
+            List<Integer> actual = readIntList(rows.get(r), "v");
+            if (listNulls[r]) {
+                assertThat(actual).as("record %d is an absent list", r).isNull();
+                continue;
+            }
+            List<Integer> expected = new ArrayList<>();
+            for (int e = offsets[r]; e < offsets[r + 1]; e++) {
+                expected.add(elementNulls[e] ? null : elements[e]);
+            }
+            assertThat(actual).as("record %d", r).isEqualTo(expected);
+        }
+    }
+
+    // ==================== Helpers ====================
+
+    private List<Group> writeAndRead(Path dir, FileSchema schema, Consumer<ColumnBatch> filler) throws IOException {
+        return ParquetJavaReader.readGroups(write(dir, schema, WriterConfig.defaults(), filler));
+    }
+
+    private Path write(Path dir, FileSchema schema, WriterConfig config, Consumer<ColumnBatch> filler)
+            throws IOException {
+        Path file = dir.resolve("nested.parquet");
+        try (ParquetFileWriter writer = ParquetFileWriter.create(OutputFile.of(file), schema, config)) {
+            writer.writeBatch(filler);
+        }
+        return file;
+    }
+
+    /// How many instances of a field a group holds; zero means the field is absent, which is how
+    /// parquet-java represents a null leaf, a null `struct` instance and an absent list alike.
+    private static int count(Group group, String field) {
+        return group.getFieldRepetitionCount(field);
+    }
+
+    /// A row's `LIST` field as a nullable list of nullable `INT32`s, or `null` if the list itself
+    /// is absent.
+    private static List<Integer> readIntList(Group row, String field) {
+        return count(row, field) == 0 ? null : intList(row.getGroup(field, 0));
+    }
+
+    /// The entries of a canonical 3-level `LIST` group, a `null` entry for an absent element.
+    private static List<Integer> intList(Group list) {
+        List<Integer> values = new ArrayList<>();
+        for (int i = 0; i < count(list, "list"); i++) {
+            Group entry = list.getGroup("list", i);
+            values.add(count(entry, "element") == 0 ? null : entry.getInteger("element", 0));
+        }
+        return values;
+    }
+
+    private static List<List<Integer>> intLists(List<Group> rows, String field) {
+        List<List<Integer>> lists = new ArrayList<>(rows.size());
+        for (Group row : rows) {
+            lists.add(readIntList(row, field));
+        }
+        return lists;
+    }
+
+    /// A row's `MAP` field as an insertion-ordered map, a `null` mapped value for an absent one,
+    /// or `null` if the map itself is absent.
+    private static Map<Integer, Integer> intMap(Group row, String field) {
+        if (count(row, field) == 0) {
+            return null;
+        }
+        Group entries = row.getGroup(field, 0);
+        Map<Integer, Integer> map = new LinkedHashMap<>();
+        for (int i = 0; i < count(entries, "key_value"); i++) {
+            Group entry = entries.getGroup("key_value", i);
+            map.put(entry.getInteger("key", 0), count(entry, "value") == 0 ? null : entry.getInteger("value", 0));
+        }
+        return map;
+    }
+
+    private static byte[] utf8(String value) {
+        return value.getBytes(StandardCharsets.UTF_8);
+    }
+}


### PR DESCRIPTION
Closes #907. Stage 14 of [WRITER_SUPPORT.md](https://github.com/hardwood-hq/hardwood/blob/main/_designs/WRITER_SUPPORT.md); settled in the new `_designs/WRITER_INTEROP_GATE.md`.

## Why

Every check that read a Hardwood-written file was either Hardwood's own reader or DuckDB, and both are lenient in the same place. #901 is what that cost: a column chunk whose dictionary held one entry indexed it with a stream carrying no run header, which neither parquet-java nor Arrow C++ can decode — and both suites passed on it. Fixing the encoder pinned those bytes without closing the class, and every increment from here (the row-oriented layer, the remaining codecs, the delta encoders, page indexes, Bloom filters) multiplies the shapes that could carry the same kind of defect.

## The gate

parquet-java is the strict reader, hosted in `parquet-testing-runner`, which already carries it at test scope and runs on every PR — no new dependency, no new job.

It reads through the **Group record model** rather than the Avro one the read-direction comparison uses. Avro cannot represent `UUID`, `FLOAT16`, `INTERVAL` or the unsigned integer widths, so an Avro-based gate would have to drop parts of the matrix for reasons unrelated to conformance, and a gap excused that way still reads as coverage.

Four assertions per file, not one:

1. **It reads** — parquet-java materializes every row without throwing.
2. **Values agree** — compared against what was *written*, not against what Hardwood reads back.
3. **Metadata agrees** — the footer's `min` / `max` / `null_count` under *parquet-java's* comparator, which it derives from the annotation and `column_orders`. Stage 13b's sort orders finally have a second implementation checking them.
4. **The case covered what it claims** — the declared encodings pin that the case produced the dictionary / `PLAIN` fallback / plain-only chunk it exists for, and the layout cases walk parquet-java's page readers. Without this, a change to the writer's encoding choice or page sizing would silently empty an axis rather than fail it.

## Matrix

Floor: a single-entry dictionary per physical type, in every repetition shape — the #901 shape. Beyond that, one axis at a time against a representative base, every axis swept across all seven writable physical types.

| Class | Cases | Covers |
|---|---|---|
| `WriterInteropTest` | 84 | repetition / encoding / codec / layout axes |
| `WriterNestedInteropTest` | 12 | struct, list, map, incl. page and row-group boundaries |
| `WriterLogicalTypeInteropTest` | 26 | the full stage-13 annotation table, plus unsigned-integer and binary-`DECIMAL` order |

Supporting classes: `ParquetJavaReader` (Group rows, footer, page walk), `TypeFixture`, `InteropCase`.

Two axis values are deliberately degenerate and documented as such: `BOOLEAN` is never dictionary-encoded, so its dictionary cases are `PLAIN` cases; and the codec axis has only `UNCOMPRESSED` / `ZSTD` until stage 18 widens it.

## Acceptance

#907 asks for a test that fails against the writer as of the parent of the #901 fix. Reverting that encoder change turns **18 cases red** with `IllegalArgumentException: Reading past RLE/BitPacking stream` — the original symptom. Restored afterwards; `./mvnw verify` is green across all 13 modules.

## Delivery plan

The plan is resequenced in the same commit, because stage 14 *is* the gate only by virtue of that reordering. The remainder is now ordered by what gates **use** of the writer rather than by what widens it: the ergonomic layer (15), documentation (16) and object-store backend (17) precede codec and encoding breadth (18) and the encode-time optimizations (19–20). The gate leads that group because it is the only check on the shapes the increments after it multiply. `WRITER_INTEROP_GATE.md` carries the extension contract — which later increment extends which axis.