### PR TITLE
#918 Add named SchemaElement factories

### DIFF
--- a/avro/src/test/java/dev/hardwood/avro/AvroRowReaderTest.java
+++ b/avro/src/test/java/dev/hardwood/avro/AvroRowReaderTest.java
@@ -159,9 +159,8 @@ class AvroRowReaderTest {
 
     @Test
     void wrongFixedWidthNamesRootField() {
-        SchemaElement root = new SchemaElement("root", null, null, null, 1, null, null, null, null, null);
-        SchemaElement value = new SchemaElement("value", PhysicalType.FIXED_LEN_BYTE_ARRAY, 4,
-                RepetitionType.REQUIRED, null, null, null, null, null, null);
+        SchemaElement root = SchemaElement.root("root", 1);
+        SchemaElement value = SchemaElement.fixedLengthPrimitive("value", 4, RepetitionType.REQUIRED);
         FileSchema schema = FileSchema.fromSchemaElements(List.of(root, value));
         AvroPlanNode plan = AvroSchemaConverter.plan(schema, ColumnProjection.all());
         RowReader rows = proxy(RowReader.class, values(
@@ -200,9 +199,9 @@ class AvroRowReaderTest {
 
     @Test
     void nonNullValueForNullLogicalTypeFailsAtRootField() {
-        SchemaElement root = new SchemaElement("root", null, null, null, 1, null, null, null, null, null);
-        SchemaElement value = new SchemaElement("value", PhysicalType.INT32, null,
-                RepetitionType.OPTIONAL, null, null, null, null, null, new NullType());
+        SchemaElement root = SchemaElement.root("root", 1);
+        SchemaElement value = SchemaElement.primitive("value", PhysicalType.INT32, RepetitionType.OPTIONAL,
+                new NullType());
         FileSchema schema = FileSchema.fromSchemaElements(List.of(root, value));
         AvroPlanNode plan = AvroSchemaConverter.plan(schema, ColumnProjection.all());
         RowReader rows = proxy(RowReader.class, values(
@@ -283,9 +282,9 @@ class AvroRowReaderTest {
     /// step cannot use.
     @Test
     void wrongRawTypeForUnsignedIntNamesRootField() {
-        SchemaElement root = new SchemaElement("root", null, null, null, 1, null, null, null, null, null);
-        SchemaElement count = new SchemaElement("count", PhysicalType.INT32, null,
-                RepetitionType.REQUIRED, null, null, null, null, null, new IntType(32, false));
+        SchemaElement root = SchemaElement.root("root", 1);
+        SchemaElement count = SchemaElement.primitive("count", PhysicalType.INT32, RepetitionType.REQUIRED,
+                new IntType(32, false));
         FileSchema schema = FileSchema.fromSchemaElements(List.of(root, count));
         AvroPlanNode plan = AvroSchemaConverter.plan(schema, ColumnProjection.all());
         RowReader rows = proxy(RowReader.class, values(
@@ -356,7 +355,7 @@ class AvroRowReaderTest {
             List<GenericRecord> records = readAll(reader);
             assertThat(records).isNotEmpty();
 
-            GenericRecord first = records.get(0);
+            GenericRecord first = records.getFirst();
             assertThat(first.get("id")).isEqualTo(1);
 
             Object addressObj = first.get("address");
@@ -379,7 +378,7 @@ class AvroRowReaderTest {
             List<GenericRecord> records = readAll(reader);
             assertThat(records).isNotEmpty();
 
-            GenericRecord first = records.get(0);
+            GenericRecord first = records.getFirst();
             assertThat(first.get("id")).isEqualTo(1);
 
             Object tags = first.get("tags");
@@ -401,7 +400,7 @@ class AvroRowReaderTest {
             List<GenericRecord> records = readAll(reader);
             assertThat(records).isNotEmpty();
 
-            GenericRecord first = records.get(0);
+            GenericRecord first = records.getFirst();
             Object attrs = first.get("attributes");
             assertThat(attrs).isInstanceOf(Map.class);
 
@@ -1436,29 +1435,23 @@ class AvroRowReaderTest {
     }
 
     private static FileSchema primitiveSchema(String name, PhysicalType type, RepetitionType repetition) {
-        SchemaElement root = new SchemaElement("root", null, null, null, 1, null, null, null, null, null);
-        SchemaElement value = new SchemaElement(name, type, null, repetition,
-                null, null, null, null, null, null);
+        SchemaElement root = SchemaElement.root("root", 1);
+        SchemaElement value = SchemaElement.primitive(name, type, repetition);
         return FileSchema.fromSchemaElements(List.of(root, value));
     }
 
     private static FileSchema nestedPrimitiveSchema() {
-        SchemaElement root = new SchemaElement("root", null, null, null, 1, null, null, null, null, null);
-        SchemaElement struct = new SchemaElement("record", null, null, RepetitionType.REQUIRED,
-                1, null, null, null, null, null);
-        SchemaElement value = new SchemaElement("value", PhysicalType.INT32, null,
-                RepetitionType.REQUIRED, null, null, null, null, null, null);
+        SchemaElement root = SchemaElement.root("root", 1);
+        SchemaElement struct = SchemaElement.group("record", RepetitionType.REQUIRED, 1);
+        SchemaElement value = SchemaElement.primitive("value", PhysicalType.INT32, RepetitionType.REQUIRED);
         return FileSchema.fromSchemaElements(List.of(root, struct, value));
     }
 
     private static FileSchema listStringSchema() {
-        SchemaElement root = new SchemaElement("root", null, null, null, 1, null, null, null, null, null);
-        SchemaElement list = new SchemaElement("items", null, null, RepetitionType.REQUIRED,
-                1, null, null, null, null, new ListType());
-        SchemaElement repeated = new SchemaElement("list", null, null, RepetitionType.REPEATED,
-                1, null, null, null, null, null);
-        SchemaElement element = new SchemaElement("element", PhysicalType.BYTE_ARRAY, null,
-                RepetitionType.REQUIRED, null, null, null, null, null,
+        SchemaElement root = SchemaElement.root("root", 1);
+        SchemaElement list = SchemaElement.group("items", RepetitionType.REQUIRED, 1, new ListType());
+        SchemaElement repeated = SchemaElement.group("list", RepetitionType.REPEATED, 1);
+        SchemaElement element = SchemaElement.primitive("element", PhysicalType.BYTE_ARRAY, RepetitionType.REQUIRED,
                 new StringType());
         return FileSchema.fromSchemaElements(List.of(root, list, repeated, element));
     }
@@ -1466,42 +1459,30 @@ class AvroRowReaderTest {
     /// `list<null>` — every element is null in a well-formed file, so the `NULL` arm of
     /// the element switch is only reachable when the accessors and the plan disagree.
     private static FileSchema listOfNullSchema() {
-        SchemaElement root = new SchemaElement("root", null, null, null, 1, null, null, null, null, null);
-        SchemaElement list = new SchemaElement("nulls", null, null, RepetitionType.REQUIRED,
-                1, null, null, null, null, new ListType());
-        SchemaElement repeated = new SchemaElement("list", null, null, RepetitionType.REPEATED,
-                1, null, null, null, null, null);
-        SchemaElement element = new SchemaElement("element", PhysicalType.INT32, null,
-                RepetitionType.OPTIONAL, null, null, null, null, null, new NullType());
+        SchemaElement root = SchemaElement.root("root", 1);
+        SchemaElement list = SchemaElement.group("nulls", RepetitionType.REQUIRED, 1, new ListType());
+        SchemaElement repeated = SchemaElement.group("list", RepetitionType.REPEATED, 1);
+        SchemaElement element = SchemaElement.primitive("element", PhysicalType.INT32, RepetitionType.OPTIONAL, new NullType());
         return FileSchema.fromSchemaElements(List.of(root, list, repeated, element));
     }
 
     /// `map<string, null>` — the map counterpart of [#listOfNullSchema].
     private static FileSchema mapOfNullSchema() {
-        SchemaElement root = new SchemaElement("root", null, null, null, 1, null, null, null, null, null);
-        SchemaElement map = new SchemaElement("attributes", null, null, RepetitionType.REQUIRED,
-                1, null, null, null, null, new MapType());
-        SchemaElement keyValue = new SchemaElement("key_value", null, null, RepetitionType.REPEATED,
-                2, null, null, null, null, null);
-        SchemaElement key = new SchemaElement("key", PhysicalType.BYTE_ARRAY, null,
-                RepetitionType.REQUIRED, null, null, null, null, null, new StringType());
-        SchemaElement value = new SchemaElement("value", PhysicalType.INT32, null,
-                RepetitionType.OPTIONAL, null, null, null, null, null, new NullType());
+        SchemaElement root = SchemaElement.root("root", 1);
+        SchemaElement map = SchemaElement.group("attributes", RepetitionType.REQUIRED, 1, new MapType());
+        SchemaElement keyValue = SchemaElement.group("key_value", RepetitionType.REPEATED, 2);
+        SchemaElement key = SchemaElement.primitive("key", PhysicalType.BYTE_ARRAY, RepetitionType.REQUIRED, new StringType());
+        SchemaElement value = SchemaElement.primitive("value", PhysicalType.INT32, RepetitionType.OPTIONAL,
+                new NullType());
         return FileSchema.fromSchemaElements(List.of(root, map, keyValue, key, value));
     }
 
     private static FileSchema mapStringSchema() {
-        SchemaElement root = new SchemaElement("root", null, null, null, 1, null, null, null, null, null);
-        SchemaElement map = new SchemaElement("attributes", null, null, RepetitionType.REQUIRED,
-                1, null, null, null, null, new MapType());
-        SchemaElement keyValue = new SchemaElement("key_value", null, null, RepetitionType.REPEATED,
-                2, null, null, null, null, null);
-        SchemaElement key = new SchemaElement("key", PhysicalType.BYTE_ARRAY, null,
-                RepetitionType.REQUIRED, null, null, null, null, null,
-                new StringType());
-        SchemaElement value = new SchemaElement("value", PhysicalType.BYTE_ARRAY, null,
-                RepetitionType.REQUIRED, null, null, null, null, null,
-                new StringType());
+        SchemaElement root = SchemaElement.root("root", 1);
+        SchemaElement map = SchemaElement.group("attributes", RepetitionType.REQUIRED, 1, new MapType());
+        SchemaElement keyValue = SchemaElement.group("key_value", RepetitionType.REPEATED, 2);
+        SchemaElement key = SchemaElement.primitive("key", PhysicalType.BYTE_ARRAY, RepetitionType.REQUIRED, new StringType());
+        SchemaElement value = SchemaElement.primitive("value", PhysicalType.BYTE_ARRAY, RepetitionType.REQUIRED, new StringType());
         return FileSchema.fromSchemaElements(List.of(root, map, keyValue, key, value));
     }
 

--- a/avro/src/test/java/dev/hardwood/avro/internal/AvroSchemaConverterTest.java
+++ b/avro/src/test/java/dev/hardwood/avro/internal/AvroSchemaConverterTest.java
@@ -91,11 +91,11 @@ class AvroSchemaConverterTest {
     /// that the reader cannot fill, since the list accessors serve the group's leaf.
     @Test
     void rejectsGroupCarryingAnUnrecognisedAnnotation() {
-        SchemaElement root = root("root", 1);
+        SchemaElement rootElement = root("root", 1);
         SchemaElement legacy = new SchemaElement("legacy", null, null, RepetitionType.OPTIONAL,
                 1, ConvertedType.MAP_KEY_VALUE, null, null, null, null);
         SchemaElement leaf = primitive("v", PhysicalType.INT32, RepetitionType.REQUIRED);
-        FileSchema schema = FileSchema.fromSchemaElements(List.of(root, legacy, leaf));
+        FileSchema schema = FileSchema.fromSchemaElements(List.of(rootElement, legacy, leaf));
 
         assertThatThrownBy(() -> AvroSchemaConverter.plan(schema, ColumnProjection.all()))
                 .isInstanceOf(IllegalArgumentException.class)
@@ -105,9 +105,9 @@ class AvroSchemaConverterTest {
 
     @Test
     void rejectsNonStringKeyedMapNestedInStruct() {
-        SchemaElement root = root("root", 1);
+        SchemaElement rootElement = root("root", 1);
         SchemaElement holder = group("holder", RepetitionType.OPTIONAL, 1);
-        List<SchemaElement> elements = new ArrayList<>(List.of(root, holder));
+        List<SchemaElement> elements = new ArrayList<>(List.of(rootElement, holder));
         elements.addAll(intKeyedMap("nested"));
 
         assertRejectsMap(FileSchema.fromSchemaElements(elements), "holder.nested", "INT32");
@@ -115,10 +115,10 @@ class AvroSchemaConverterTest {
 
     @Test
     void rejectsNonStringKeyedMapUsedAsListElement() {
-        SchemaElement root = root("root", 1);
+        SchemaElement rootElement = root("root", 1);
         SchemaElement items = group("items", RepetitionType.OPTIONAL, 1, new LogicalType.ListType());
         SchemaElement list = group("list", RepetitionType.REPEATED, 1);
-        List<SchemaElement> elements = new ArrayList<>(List.of(root, items, list));
+        List<SchemaElement> elements = new ArrayList<>(List.of(rootElement, items, list));
         elements.addAll(intKeyedMap("element"));
 
         assertRejectsMap(FileSchema.fromSchemaElements(elements), "items.element", "INT32");
@@ -126,12 +126,12 @@ class AvroSchemaConverterTest {
 
     @Test
     void rejectsNonStringKeyedMapUsedAsMapValue() {
-        SchemaElement root = root("root", 1);
+        SchemaElement rootElement = root("root", 1);
         SchemaElement outer = group("outer", RepetitionType.OPTIONAL, 1, new LogicalType.MapType());
         SchemaElement outerKv = group("key_value", RepetitionType.REPEATED, 2);
         SchemaElement outerKey = primitive("key", PhysicalType.BYTE_ARRAY, RepetitionType.REQUIRED,
                 new LogicalType.StringType());
-        List<SchemaElement> elements = new ArrayList<>(List.of(root, outer, outerKv, outerKey));
+        List<SchemaElement> elements = new ArrayList<>(List.of(rootElement, outer, outerKv, outerKey));
         elements.addAll(intKeyedMap("value"));
 
         assertRejectsMap(FileSchema.fromSchemaElements(elements), "outer.value", "INT32");
@@ -237,7 +237,7 @@ class AvroSchemaConverterTest {
     /// A Variant group and an ordinary group of the identical two-byte-field shape,
     /// side by side.
     private static FileSchema variantAndOrdinarySchema() {
-        SchemaElement root = root("root", 2);
+        SchemaElement rootElement = root("root", 2);
         SchemaElement variant = group("variant_record", RepetitionType.OPTIONAL, 2, new LogicalType.VariantType(1));
         SchemaElement variantMetadata = primitive("metadata", PhysicalType.BYTE_ARRAY, RepetitionType.REQUIRED);
         SchemaElement variantValue = primitive("value", PhysicalType.BYTE_ARRAY, RepetitionType.REQUIRED);
@@ -246,7 +246,7 @@ class AvroSchemaConverterTest {
         SchemaElement ordinaryValue = primitive("value", PhysicalType.BYTE_ARRAY, RepetitionType.REQUIRED);
 
         return FileSchema.fromSchemaElements(List.of(
-                root, variant, variantMetadata, variantValue,
+                rootElement, variant, variantMetadata, variantValue,
                 ordinary, ordinaryMetadata, ordinaryValue));
     }
 
@@ -255,10 +255,10 @@ class AvroSchemaConverterTest {
     /// the Avro spec forbids.
     @Test
     void nullLogicalTypeBecomesBareAvroNull() {
-        SchemaElement root = root("root", 1);
+        SchemaElement rootElement = root("root", 1);
         SchemaElement nothing = primitive("nothing", PhysicalType.INT32, RepetitionType.OPTIONAL,
                 new LogicalType.NullType());
-        FileSchema schema = FileSchema.fromSchemaElements(List.of(root, nothing));
+        FileSchema schema = FileSchema.fromSchemaElements(List.of(rootElement, nothing));
 
         Schema avroSchema = convert(schema);
         Schema.Field field = avroSchema.getField("nothing");
@@ -273,9 +273,9 @@ class AvroSchemaConverterTest {
 
     @Test
     void rejectsListWithoutElementDuringPlanning() {
-        SchemaElement root = root("root", 1);
+        SchemaElement rootElement = root("root", 1);
         SchemaElement list = group("items", RepetitionType.OPTIONAL, 0, new LogicalType.ListType());
-        FileSchema schema = FileSchema.fromSchemaElements(List.of(root, list));
+        FileSchema schema = FileSchema.fromSchemaElements(List.of(rootElement, list));
 
         assertThatThrownBy(() -> AvroSchemaConverter.plan(schema, ColumnProjection.all()))
                 .isInstanceOf(IllegalArgumentException.class)
@@ -285,12 +285,12 @@ class AvroSchemaConverterTest {
 
     @Test
     void keyOnlyMapBecomesMapOfBareNull() {
-        SchemaElement root = root("root", 1);
+        SchemaElement rootElement = root("root", 1);
         SchemaElement map = group("attributes", RepetitionType.OPTIONAL, 1, new LogicalType.MapType());
         SchemaElement keyValue = group("key_value", RepetitionType.REPEATED, 1);
         SchemaElement key = primitive("key", PhysicalType.BYTE_ARRAY, RepetitionType.REQUIRED,
                 new LogicalType.StringType());
-        FileSchema schema = FileSchema.fromSchemaElements(List.of(root, map, keyValue, key));
+        FileSchema schema = FileSchema.fromSchemaElements(List.of(rootElement, map, keyValue, key));
 
         AvroPlanNode plan = AvroSchemaConverter.plan(schema, ColumnProjection.all());
         Schema mapSchema = pickMapBranch(plan.avro().getField("attributes").schema());
@@ -303,11 +303,11 @@ class AvroSchemaConverterTest {
     /// in the other order this map converts to `map<null>` and only fails per value.
     @Test
     void rejectsKeyOnlyMapWhoseKeyIsNotAString() {
-        SchemaElement root = root("root", 1);
+        SchemaElement rootElement = root("root", 1);
         SchemaElement map = group("attributes", RepetitionType.OPTIONAL, 1, new LogicalType.MapType());
         SchemaElement keyValue = group("key_value", RepetitionType.REPEATED, 1);
         SchemaElement key = primitive("key", PhysicalType.INT32, RepetitionType.REQUIRED);
-        FileSchema schema = FileSchema.fromSchemaElements(List.of(root, map, keyValue, key));
+        FileSchema schema = FileSchema.fromSchemaElements(List.of(rootElement, map, keyValue, key));
 
         assertThatThrownBy(() -> AvroSchemaConverter.plan(schema, ColumnProjection.all()))
                 .isInstanceOf(IllegalArgumentException.class)
@@ -319,10 +319,10 @@ class AvroSchemaConverterTest {
     /// structs stay distinguishable.
     @Test
     void namesTheDottedPathWhenANestedListHasNoElement() {
-        SchemaElement root = root("root", 1);
+        SchemaElement rootElement = root("root", 1);
         SchemaElement holder = group("holder", RepetitionType.OPTIONAL, 1);
         SchemaElement list = group("items", RepetitionType.OPTIONAL, 0, new LogicalType.ListType());
-        FileSchema schema = FileSchema.fromSchemaElements(List.of(root, holder, list));
+        FileSchema schema = FileSchema.fromSchemaElements(List.of(rootElement, holder, list));
 
         assertThatThrownBy(() -> AvroSchemaConverter.plan(schema, ColumnProjection.all()))
                 .isInstanceOf(IllegalArgumentException.class)
@@ -333,12 +333,12 @@ class AvroSchemaConverterTest {
     /// `array<union [null, null]>`.
     @Test
     void listOfNullElementsBecomesArrayOfBareNull() {
-        SchemaElement root = root("root", 1);
+        SchemaElement rootElement = root("root", 1);
         SchemaElement listGroup = group("nulls", RepetitionType.OPTIONAL, 1, new LogicalType.ListType());
         SchemaElement listInner = group("list", RepetitionType.REPEATED, 1);
         SchemaElement element = primitive("element", PhysicalType.INT32, RepetitionType.OPTIONAL,
                 new LogicalType.NullType());
-        FileSchema schema = FileSchema.fromSchemaElements(List.of(root, listGroup, listInner, element));
+        FileSchema schema = FileSchema.fromSchemaElements(List.of(rootElement, listGroup, listInner, element));
 
         Schema avroSchema = convert(schema);
         Schema listField = pickArrayBranch(avroSchema.getField("nulls").schema());
@@ -351,14 +351,14 @@ class AvroSchemaConverterTest {
     /// `map<union [null, null]>`.
     @Test
     void mapWithNullValuesBecomesMapOfBareNull() {
-        SchemaElement root = root("root", 1);
+        SchemaElement rootElement = root("root", 1);
         SchemaElement mapGroup = group("m", RepetitionType.OPTIONAL, 1, new LogicalType.MapType());
         SchemaElement kv = group("key_value", RepetitionType.REPEATED, 2);
         SchemaElement key = primitive("key", PhysicalType.BYTE_ARRAY, RepetitionType.REQUIRED,
                 new LogicalType.StringType());
         SchemaElement value = primitive("value", PhysicalType.INT32, RepetitionType.OPTIONAL,
                 new LogicalType.NullType());
-        FileSchema schema = FileSchema.fromSchemaElements(List.of(root, mapGroup, kv, key, value));
+        FileSchema schema = FileSchema.fromSchemaElements(List.of(rootElement, mapGroup, kv, key, value));
 
         Schema avroSchema = convert(schema);
         Schema mapField = pickMapBranch(avroSchema.getField("m").schema());
@@ -410,14 +410,14 @@ class AvroSchemaConverterTest {
 
     private static FileSchema buildVariantSchema(boolean includeTypedValue) {
         int varChildren = includeTypedValue ? 3 : 2;
-        SchemaElement root = root("root", 1);
+        SchemaElement rootElement = root("root", 1);
         SchemaElement var = group("var", RepetitionType.OPTIONAL, varChildren, new LogicalType.VariantType(1));
         SchemaElement metadata = primitive("metadata", PhysicalType.BYTE_ARRAY, RepetitionType.REQUIRED);
         SchemaElement value = primitive("value", PhysicalType.BYTE_ARRAY, RepetitionType.REQUIRED);
         if (!includeTypedValue) {
-            return FileSchema.fromSchemaElements(List.of(root, var, metadata, value));
+            return FileSchema.fromSchemaElements(List.of(rootElement, var, metadata, value));
         }
         SchemaElement typedValue = primitive("typed_value", PhysicalType.INT64, RepetitionType.OPTIONAL);
-        return FileSchema.fromSchemaElements(List.of(root, var, metadata, value, typedValue));
+        return FileSchema.fromSchemaElements(List.of(rootElement, var, metadata, value, typedValue));
     }
 }

--- a/avro/src/test/java/dev/hardwood/avro/internal/AvroSchemaConverterTest.java
+++ b/avro/src/test/java/dev/hardwood/avro/internal/AvroSchemaConverterTest.java
@@ -21,6 +21,9 @@ import dev.hardwood.metadata.SchemaElement;
 import dev.hardwood.schema.ColumnProjection;
 import dev.hardwood.schema.FileSchema;
 
+import static dev.hardwood.metadata.SchemaElement.group;
+import static dev.hardwood.metadata.SchemaElement.primitive;
+import static dev.hardwood.metadata.SchemaElement.root;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
@@ -88,11 +91,10 @@ class AvroSchemaConverterTest {
     /// that the reader cannot fill, since the list accessors serve the group's leaf.
     @Test
     void rejectsGroupCarryingAnUnrecognisedAnnotation() {
-        SchemaElement root = new SchemaElement("root", null, null, null, 1, null, null, null, null, null);
+        SchemaElement root = root("root", 1);
         SchemaElement legacy = new SchemaElement("legacy", null, null, RepetitionType.OPTIONAL,
                 1, ConvertedType.MAP_KEY_VALUE, null, null, null, null);
-        SchemaElement leaf = new SchemaElement("v", PhysicalType.INT32, null,
-                RepetitionType.REQUIRED, null, null, null, null, null, null);
+        SchemaElement leaf = primitive("v", PhysicalType.INT32, RepetitionType.REQUIRED);
         FileSchema schema = FileSchema.fromSchemaElements(List.of(root, legacy, leaf));
 
         assertThatThrownBy(() -> AvroSchemaConverter.plan(schema, ColumnProjection.all()))
@@ -103,7 +105,7 @@ class AvroSchemaConverterTest {
 
     @Test
     void rejectsNonStringKeyedMapNestedInStruct() {
-        SchemaElement root = group("root", null, 1);
+        SchemaElement root = root("root", 1);
         SchemaElement holder = group("holder", RepetitionType.OPTIONAL, 1);
         List<SchemaElement> elements = new ArrayList<>(List.of(root, holder));
         elements.addAll(intKeyedMap("nested"));
@@ -113,9 +115,8 @@ class AvroSchemaConverterTest {
 
     @Test
     void rejectsNonStringKeyedMapUsedAsListElement() {
-        SchemaElement root = group("root", null, 1);
-        SchemaElement items = annotatedGroup("items", RepetitionType.OPTIONAL, 1,
-                new LogicalType.ListType());
+        SchemaElement root = root("root", 1);
+        SchemaElement items = group("items", RepetitionType.OPTIONAL, 1, new LogicalType.ListType());
         SchemaElement list = group("list", RepetitionType.REPEATED, 1);
         List<SchemaElement> elements = new ArrayList<>(List.of(root, items, list));
         elements.addAll(intKeyedMap("element"));
@@ -125,12 +126,11 @@ class AvroSchemaConverterTest {
 
     @Test
     void rejectsNonStringKeyedMapUsedAsMapValue() {
-        SchemaElement root = group("root", null, 1);
-        SchemaElement outer = annotatedGroup("outer", RepetitionType.OPTIONAL, 1,
-                new LogicalType.MapType());
+        SchemaElement root = root("root", 1);
+        SchemaElement outer = group("outer", RepetitionType.OPTIONAL, 1, new LogicalType.MapType());
         SchemaElement outerKv = group("key_value", RepetitionType.REPEATED, 2);
-        SchemaElement outerKey = new SchemaElement("key", PhysicalType.BYTE_ARRAY, null,
-                RepetitionType.REQUIRED, null, null, null, null, null, new LogicalType.StringType());
+        SchemaElement outerKey = primitive("key", PhysicalType.BYTE_ARRAY, RepetitionType.REQUIRED,
+                new LogicalType.StringType());
         List<SchemaElement> elements = new ArrayList<>(List.of(root, outer, outerKv, outerKey));
         elements.addAll(intKeyedMap("value"));
 
@@ -143,11 +143,11 @@ class AvroSchemaConverterTest {
     @Test
     void acceptsEveryMapKeyAvroRendersAsString() {
         assertMapConverts(mapKeyedBy(
-                primitive("key", PhysicalType.BYTE_ARRAY, null, new LogicalType.StringType())));
+                convertedPrimitive("key", PhysicalType.BYTE_ARRAY, null, new LogicalType.StringType())));
         assertMapConverts(mapKeyedBy(
-                primitive("key", PhysicalType.BYTE_ARRAY, null, new LogicalType.EnumType())));
+                convertedPrimitive("key", PhysicalType.BYTE_ARRAY, null, new LogicalType.EnumType())));
         assertMapConverts(mapKeyedBy(
-                primitive("key", PhysicalType.BYTE_ARRAY, null, new LogicalType.JsonType())));
+                convertedPrimitive("key", PhysicalType.BYTE_ARRAY, null, new LogicalType.JsonType())));
     }
 
     /// Writers predating the logical-type union annotate string keys with the legacy
@@ -156,7 +156,7 @@ class AvroSchemaConverterTest {
     @Test
     void acceptsMapKeyCarryingOnlyTheLegacyUtf8ConvertedType() {
         assertMapConverts(mapKeyedBy(
-                primitive("key", PhysicalType.BYTE_ARRAY, ConvertedType.UTF8, null)));
+                convertedPrimitive("key", PhysicalType.BYTE_ARRAY, ConvertedType.UTF8, null)));
     }
 
     /// An unannotated `BYTE_ARRAY` key holds arbitrary bytes. Decoding those as UTF-8
@@ -165,7 +165,7 @@ class AvroSchemaConverterTest {
     /// dropping the other. Reject instead of mangling.
     @Test
     void rejectsUnannotatedBinaryMapKey() {
-        assertRejectsMap(mapKeyedBy(primitive("key", PhysicalType.BYTE_ARRAY, null, null)),
+        assertRejectsMap(mapKeyedBy(convertedPrimitive("key", PhysicalType.BYTE_ARRAY, null, null)),
                 "m", "BYTE_ARRAY with no logical annotation");
     }
 
@@ -173,7 +173,7 @@ class AvroSchemaConverterTest {
     /// text — the string accessor would hand back mojibake.
     @Test
     void rejectsUuidMapKey() {
-        assertRejectsMap(mapKeyedBy(primitive("key", PhysicalType.FIXED_LEN_BYTE_ARRAY,
+        assertRejectsMap(mapKeyedBy(convertedPrimitive("key", PhysicalType.FIXED_LEN_BYTE_ARRAY,
                 null, new LogicalType.UuidType())), "m", "UUID");
     }
 
@@ -182,13 +182,12 @@ class AvroSchemaConverterTest {
     @Test
     void rejectsMapWithGroupKey() {
         List<SchemaElement> elements = List.of(
-                group("root", null, 1),
-                annotatedGroup("m", RepetitionType.OPTIONAL, 1, new LogicalType.MapType()),
+                root("root", 1),
+                group("m", RepetitionType.OPTIONAL, 1, new LogicalType.MapType()),
                 group("key_value", RepetitionType.REPEATED, 2),
                 group("key", RepetitionType.REQUIRED, 1),
-                primitive("part", PhysicalType.INT32, null, null),
-                new SchemaElement("value", PhysicalType.INT64, null,
-                        RepetitionType.OPTIONAL, null, null, null, null, null, null));
+                convertedPrimitive("part", PhysicalType.INT32, null, null),
+                primitive("value", PhysicalType.INT64, RepetitionType.OPTIONAL));
 
         assertRejectsMap(FileSchema.fromSchemaElements(elements), "m", "group 'key'");
     }
@@ -209,60 +208,42 @@ class AvroSchemaConverterTest {
     }
 
     private static List<SchemaElement> intKeyedMap(String name) {
-        return keyedMap(name, primitive("key", PhysicalType.INT32, null, null));
+        return keyedMap(name, convertedPrimitive("key", PhysicalType.INT32, null, null));
     }
 
     /// A `map<?, int64>` whose key element is given, so key handling can be varied
     /// without restating the surrounding MAP / `key_value` shape.
     private static List<SchemaElement> keyedMap(String name, SchemaElement key) {
         return List.of(
-                annotatedGroup(name, RepetitionType.OPTIONAL, 1, new LogicalType.MapType()),
+                group(name, RepetitionType.OPTIONAL, 1, new LogicalType.MapType()),
                 group("key_value", RepetitionType.REPEATED, 2),
                 key,
-                new SchemaElement("value", PhysicalType.INT64, null,
-                        RepetitionType.OPTIONAL, null, null, null, null, null, null));
+                primitive("value", PhysicalType.INT64, RepetitionType.OPTIONAL));
     }
 
     /// A single-field schema whose field `m` is a `map<?, int64>` with the given key.
     private static FileSchema mapKeyedBy(SchemaElement key) {
-        List<SchemaElement> elements = new ArrayList<>(List.of(group("root", null, 1)));
+        List<SchemaElement> elements = new ArrayList<>(List.of(root("root", 1)));
         elements.addAll(keyedMap("m", key));
         return FileSchema.fromSchemaElements(elements);
     }
 
-    private static SchemaElement primitive(String name, PhysicalType type,
+    private static SchemaElement convertedPrimitive(String name, PhysicalType type,
             ConvertedType convertedType, LogicalType logicalType) {
         return new SchemaElement(name, type, null, RepetitionType.REQUIRED, null,
                 convertedType, null, null, null, logicalType);
     }
 
-    private static SchemaElement group(String name, RepetitionType repetition, int children) {
-        return new SchemaElement(name, null, null, repetition, children,
-                null, null, null, null, null);
-    }
-
-    private static SchemaElement annotatedGroup(String name, RepetitionType repetition, int children,
-            LogicalType logicalType) {
-        return new SchemaElement(name, null, null, repetition, children,
-                null, null, null, null, logicalType);
-    }
-
     /// A Variant group and an ordinary group of the identical two-byte-field shape,
     /// side by side.
     private static FileSchema variantAndOrdinarySchema() {
-        SchemaElement root = new SchemaElement("root", null, null, null, 2, null, null, null, null, null);
-        SchemaElement variant = new SchemaElement("variant_record", null, null, RepetitionType.OPTIONAL,
-                2, null, null, null, null, new LogicalType.VariantType(1));
-        SchemaElement variantMetadata = new SchemaElement("metadata", PhysicalType.BYTE_ARRAY, null,
-                RepetitionType.REQUIRED, null, null, null, null, null, null);
-        SchemaElement variantValue = new SchemaElement("value", PhysicalType.BYTE_ARRAY, null,
-                RepetitionType.REQUIRED, null, null, null, null, null, null);
-        SchemaElement ordinary = new SchemaElement("ordinary_record", null, null, RepetitionType.OPTIONAL,
-                2, null, null, null, null, null);
-        SchemaElement ordinaryMetadata = new SchemaElement("metadata", PhysicalType.BYTE_ARRAY, null,
-                RepetitionType.REQUIRED, null, null, null, null, null, null);
-        SchemaElement ordinaryValue = new SchemaElement("value", PhysicalType.BYTE_ARRAY, null,
-                RepetitionType.REQUIRED, null, null, null, null, null, null);
+        SchemaElement root = root("root", 2);
+        SchemaElement variant = group("variant_record", RepetitionType.OPTIONAL, 2, new LogicalType.VariantType(1));
+        SchemaElement variantMetadata = primitive("metadata", PhysicalType.BYTE_ARRAY, RepetitionType.REQUIRED);
+        SchemaElement variantValue = primitive("value", PhysicalType.BYTE_ARRAY, RepetitionType.REQUIRED);
+        SchemaElement ordinary = group("ordinary_record", RepetitionType.OPTIONAL, 2);
+        SchemaElement ordinaryMetadata = primitive("metadata", PhysicalType.BYTE_ARRAY, RepetitionType.REQUIRED);
+        SchemaElement ordinaryValue = primitive("value", PhysicalType.BYTE_ARRAY, RepetitionType.REQUIRED);
 
         return FileSchema.fromSchemaElements(List.of(
                 root, variant, variantMetadata, variantValue,
@@ -274,9 +255,9 @@ class AvroSchemaConverterTest {
     /// the Avro spec forbids.
     @Test
     void nullLogicalTypeBecomesBareAvroNull() {
-        SchemaElement root = new SchemaElement("root", null, null, null, 1, null, null, null, null, null);
-        SchemaElement nothing = new SchemaElement("nothing", PhysicalType.INT32, null,
-                RepetitionType.OPTIONAL, null, null, null, null, null, new LogicalType.NullType());
+        SchemaElement root = root("root", 1);
+        SchemaElement nothing = primitive("nothing", PhysicalType.INT32, RepetitionType.OPTIONAL,
+                new LogicalType.NullType());
         FileSchema schema = FileSchema.fromSchemaElements(List.of(root, nothing));
 
         Schema avroSchema = convert(schema);
@@ -292,9 +273,8 @@ class AvroSchemaConverterTest {
 
     @Test
     void rejectsListWithoutElementDuringPlanning() {
-        SchemaElement root = new SchemaElement("root", null, null, null, 1, null, null, null, null, null);
-        SchemaElement list = new SchemaElement("items", null, null, RepetitionType.OPTIONAL,
-                0, null, null, null, null, new LogicalType.ListType());
+        SchemaElement root = root("root", 1);
+        SchemaElement list = group("items", RepetitionType.OPTIONAL, 0, new LogicalType.ListType());
         FileSchema schema = FileSchema.fromSchemaElements(List.of(root, list));
 
         assertThatThrownBy(() -> AvroSchemaConverter.plan(schema, ColumnProjection.all()))
@@ -305,13 +285,11 @@ class AvroSchemaConverterTest {
 
     @Test
     void keyOnlyMapBecomesMapOfBareNull() {
-        SchemaElement root = new SchemaElement("root", null, null, null, 1, null, null, null, null, null);
-        SchemaElement map = new SchemaElement("attributes", null, null, RepetitionType.OPTIONAL,
-                1, null, null, null, null, new LogicalType.MapType());
-        SchemaElement keyValue = new SchemaElement("key_value", null, null, RepetitionType.REPEATED,
-                1, null, null, null, null, null);
-        SchemaElement key = new SchemaElement("key", PhysicalType.BYTE_ARRAY, null,
-                RepetitionType.REQUIRED, null, null, null, null, null, new LogicalType.StringType());
+        SchemaElement root = root("root", 1);
+        SchemaElement map = group("attributes", RepetitionType.OPTIONAL, 1, new LogicalType.MapType());
+        SchemaElement keyValue = group("key_value", RepetitionType.REPEATED, 1);
+        SchemaElement key = primitive("key", PhysicalType.BYTE_ARRAY, RepetitionType.REQUIRED,
+                new LogicalType.StringType());
         FileSchema schema = FileSchema.fromSchemaElements(List.of(root, map, keyValue, key));
 
         AvroPlanNode plan = AvroSchemaConverter.plan(schema, ColumnProjection.all());
@@ -325,13 +303,10 @@ class AvroSchemaConverterTest {
     /// in the other order this map converts to `map<null>` and only fails per value.
     @Test
     void rejectsKeyOnlyMapWhoseKeyIsNotAString() {
-        SchemaElement root = new SchemaElement("root", null, null, null, 1, null, null, null, null, null);
-        SchemaElement map = new SchemaElement("attributes", null, null, RepetitionType.OPTIONAL,
-                1, null, null, null, null, new LogicalType.MapType());
-        SchemaElement keyValue = new SchemaElement("key_value", null, null, RepetitionType.REPEATED,
-                1, null, null, null, null, null);
-        SchemaElement key = new SchemaElement("key", PhysicalType.INT32, null,
-                RepetitionType.REQUIRED, null, null, null, null, null, null);
+        SchemaElement root = root("root", 1);
+        SchemaElement map = group("attributes", RepetitionType.OPTIONAL, 1, new LogicalType.MapType());
+        SchemaElement keyValue = group("key_value", RepetitionType.REPEATED, 1);
+        SchemaElement key = primitive("key", PhysicalType.INT32, RepetitionType.REQUIRED);
         FileSchema schema = FileSchema.fromSchemaElements(List.of(root, map, keyValue, key));
 
         assertThatThrownBy(() -> AvroSchemaConverter.plan(schema, ColumnProjection.all()))
@@ -344,11 +319,9 @@ class AvroSchemaConverterTest {
     /// structs stay distinguishable.
     @Test
     void namesTheDottedPathWhenANestedListHasNoElement() {
-        SchemaElement root = new SchemaElement("root", null, null, null, 1, null, null, null, null, null);
-        SchemaElement holder = new SchemaElement("holder", null, null, RepetitionType.OPTIONAL,
-                1, null, null, null, null, null);
-        SchemaElement list = new SchemaElement("items", null, null, RepetitionType.OPTIONAL,
-                0, null, null, null, null, new LogicalType.ListType());
+        SchemaElement root = root("root", 1);
+        SchemaElement holder = group("holder", RepetitionType.OPTIONAL, 1);
+        SchemaElement list = group("items", RepetitionType.OPTIONAL, 0, new LogicalType.ListType());
         FileSchema schema = FileSchema.fromSchemaElements(List.of(root, holder, list));
 
         assertThatThrownBy(() -> AvroSchemaConverter.plan(schema, ColumnProjection.all()))
@@ -360,13 +333,11 @@ class AvroSchemaConverterTest {
     /// `array<union [null, null]>`.
     @Test
     void listOfNullElementsBecomesArrayOfBareNull() {
-        SchemaElement root = new SchemaElement("root", null, null, null, 1, null, null, null, null, null);
-        SchemaElement listGroup = new SchemaElement("nulls", null, null, RepetitionType.OPTIONAL,
-                1, null, null, null, null, new LogicalType.ListType());
-        SchemaElement listInner = new SchemaElement("list", null, null, RepetitionType.REPEATED,
-                1, null, null, null, null, null);
-        SchemaElement element = new SchemaElement("element", PhysicalType.INT32, null,
-                RepetitionType.OPTIONAL, null, null, null, null, null, new LogicalType.NullType());
+        SchemaElement root = root("root", 1);
+        SchemaElement listGroup = group("nulls", RepetitionType.OPTIONAL, 1, new LogicalType.ListType());
+        SchemaElement listInner = group("list", RepetitionType.REPEATED, 1);
+        SchemaElement element = primitive("element", PhysicalType.INT32, RepetitionType.OPTIONAL,
+                new LogicalType.NullType());
         FileSchema schema = FileSchema.fromSchemaElements(List.of(root, listGroup, listInner, element));
 
         Schema avroSchema = convert(schema);
@@ -380,15 +351,13 @@ class AvroSchemaConverterTest {
     /// `map<union [null, null]>`.
     @Test
     void mapWithNullValuesBecomesMapOfBareNull() {
-        SchemaElement root = new SchemaElement("root", null, null, null, 1, null, null, null, null, null);
-        SchemaElement mapGroup = new SchemaElement("m", null, null, RepetitionType.OPTIONAL,
-                1, null, null, null, null, new LogicalType.MapType());
-        SchemaElement kv = new SchemaElement("key_value", null, null, RepetitionType.REPEATED,
-                2, null, null, null, null, null);
-        SchemaElement key = new SchemaElement("key", PhysicalType.BYTE_ARRAY, null,
-                RepetitionType.REQUIRED, null, null, null, null, null, new LogicalType.StringType());
-        SchemaElement value = new SchemaElement("value", PhysicalType.INT32, null,
-                RepetitionType.OPTIONAL, null, null, null, null, null, new LogicalType.NullType());
+        SchemaElement root = root("root", 1);
+        SchemaElement mapGroup = group("m", RepetitionType.OPTIONAL, 1, new LogicalType.MapType());
+        SchemaElement kv = group("key_value", RepetitionType.REPEATED, 2);
+        SchemaElement key = primitive("key", PhysicalType.BYTE_ARRAY, RepetitionType.REQUIRED,
+                new LogicalType.StringType());
+        SchemaElement value = primitive("value", PhysicalType.INT32, RepetitionType.OPTIONAL,
+                new LogicalType.NullType());
         FileSchema schema = FileSchema.fromSchemaElements(List.of(root, mapGroup, kv, key, value));
 
         Schema avroSchema = convert(schema);
@@ -441,18 +410,14 @@ class AvroSchemaConverterTest {
 
     private static FileSchema buildVariantSchema(boolean includeTypedValue) {
         int varChildren = includeTypedValue ? 3 : 2;
-        SchemaElement root = new SchemaElement("root", null, null, null, 1, null, null, null, null, null);
-        SchemaElement var = new SchemaElement("var", null, null, RepetitionType.OPTIONAL,
-                varChildren, null, null, null, null, new LogicalType.VariantType(1));
-        SchemaElement metadata = new SchemaElement("metadata", PhysicalType.BYTE_ARRAY, null,
-                RepetitionType.REQUIRED, null, null, null, null, null, null);
-        SchemaElement value = new SchemaElement("value", PhysicalType.BYTE_ARRAY, null,
-                RepetitionType.REQUIRED, null, null, null, null, null, null);
+        SchemaElement root = root("root", 1);
+        SchemaElement var = group("var", RepetitionType.OPTIONAL, varChildren, new LogicalType.VariantType(1));
+        SchemaElement metadata = primitive("metadata", PhysicalType.BYTE_ARRAY, RepetitionType.REQUIRED);
+        SchemaElement value = primitive("value", PhysicalType.BYTE_ARRAY, RepetitionType.REQUIRED);
         if (!includeTypedValue) {
             return FileSchema.fromSchemaElements(List.of(root, var, metadata, value));
         }
-        SchemaElement typedValue = new SchemaElement("typed_value", PhysicalType.INT64, null,
-                RepetitionType.OPTIONAL, null, null, null, null, null, null);
+        SchemaElement typedValue = primitive("typed_value", PhysicalType.INT64, RepetitionType.OPTIONAL);
         return FileSchema.fromSchemaElements(List.of(root, var, metadata, value, typedValue));
     }
 }

--- a/cli/src/test/java/dev/hardwood/cli/internal/LevelSummaryTest.java
+++ b/cli/src/test/java/dev/hardwood/cli/internal/LevelSummaryTest.java
@@ -228,9 +228,8 @@ class LevelSummaryTest {
     @Test
     void unannotatedRepeatedFieldLabelsTheEmptyBucketWithItsOwnName() {
         FileSchema schema = FileSchema.fromSchemaElements(List.of(
-                new SchemaElement("root", null, null, RepetitionType.REQUIRED, 1, null, null, null, null, null),
-                new SchemaElement("tags", PhysicalType.INT32, null, RepetitionType.REPEATED, null,
-                        null, null, null, null, null)));
+                SchemaElement.group("root", RepetitionType.REQUIRED, 1),
+                SchemaElement.primitive("tags", PhysicalType.INT32, RepetitionType.REPEATED)));
         ColumnSchema tags = column(schema, "tags");
 
         assertThat(LevelSummary.definitionLabels(schema, tags))

--- a/core/src/main/java/dev/hardwood/metadata/SchemaElement.java
+++ b/core/src/main/java/dev/hardwood/metadata/SchemaElement.java
@@ -12,9 +12,8 @@ package dev.hardwood.metadata;
 /// @param name column or group name
 /// @param type physical type of this element, or `null` for group nodes
 /// @param typeLength byte length of the values for [PhysicalType#FIXED_LEN_BYTE_ARRAY]; for any other
-///         physical type, it denotes the maximum bit length used to store a value; or, `null` when the field is absent
-/// @param repetitionType repetition level (required, optional, or repeated), or `null` when the field is
-///         absent, which a root element may be
+///         physical type, it denotes the maximum bit length used to store a value; or, `null` otherwise
+/// @param repetitionType repetition level (required, optional, or repeated)
 /// @param numChildren number of child elements for group nodes, or `null` for primitive nodes
 /// @param convertedType legacy converted type annotation, or `null` if absent
 /// @param scale decimal scale (number of digits after the decimal point), or `null` if not a decimal

--- a/core/src/main/java/dev/hardwood/metadata/SchemaElement.java
+++ b/core/src/main/java/dev/hardwood/metadata/SchemaElement.java
@@ -11,8 +11,10 @@ package dev.hardwood.metadata;
 ///
 /// @param name column or group name
 /// @param type physical type of this element, or `null` for group nodes
-/// @param typeLength fixed byte length for [PhysicalType#FIXED_LEN_BYTE_ARRAY] columns, or `null` otherwise
-/// @param repetitionType repetition level (required, optional, or repeated)
+/// @param typeLength byte length of the values for [PhysicalType#FIXED_LEN_BYTE_ARRAY]; for any other
+///         physical type, it denotes the maximum bit length used to store a value; or, `null` when the field is absent
+/// @param repetitionType repetition level (required, optional, or repeated), or `null` when the field is
+///         absent, which a root element may be
 /// @param numChildren number of child elements for group nodes, or `null` for primitive nodes
 /// @param convertedType legacy converted type annotation, or `null` if absent
 /// @param scale decimal scale (number of digits after the decimal point), or `null` if not a decimal
@@ -32,6 +34,134 @@ public record SchemaElement(
         Integer precision,
         Integer fieldId,
         LogicalType logicalType) {
+
+    /// Creates a root group element.
+    ///
+    /// @param name        group name; the root group is named `"schema"` by convention
+    /// @param numChildren number of child elements, zero or more
+    /// @return the group element
+    /// @throws IllegalArgumentException if `numChildren` is negative
+    public static SchemaElement root(String name, int numChildren) {
+        return group(name, null, numChildren, null);
+    }
+
+    /// Creates a group element.
+    ///
+    /// @param name group name
+    /// @param repetitionType repetition level
+    /// @param numChildren number of child elements, zero or more
+    /// @return the group element
+    /// @throws IllegalArgumentException if `numChildren` is negative
+    public static SchemaElement group(String name, RepetitionType repetitionType, int numChildren) {
+        return group(name, repetitionType, numChildren, null);
+    }
+
+    /// Creates a group element.
+    ///
+    /// @param name group name
+    /// @param repetitionType nullable repetition level
+    /// @param numChildren number of child elements, zero or more
+    /// @param logicalType logical type annotation, or `null` for none
+    /// @return the group element
+    /// @throws IllegalArgumentException if `numChildren` is negative
+    public static SchemaElement group(String name, RepetitionType repetitionType, int numChildren,
+            LogicalType logicalType) {
+        if (numChildren < 0) {
+            String s = "Group " + name + " requires a child count of zero or more, not " + numChildren;
+            throw new IllegalArgumentException(s);
+        }
+        return new SchemaElement(name, null, null, repetitionType, numChildren, null, null, null, null, logicalType);
+    }
+
+    /// Creates a primitive element
+    ///
+    /// @param name column name
+    /// @param type physical type
+    /// @param repetitionType nullable repetition level
+    /// @return the primitive element
+    /// @throws IllegalArgumentException if `type` is `null`, or is
+    ///         [PhysicalType#FIXED_LEN_BYTE_ARRAY], which needs a width
+    public static SchemaElement primitive(String name, PhysicalType type, RepetitionType repetitionType) {
+        return primitive(name, type, repetitionType, null);
+    }
+
+    /// Creates a primitive element.
+    ///
+    /// @param name column name
+    /// @param type physical type
+    /// @param repetitionType nullable repetition level
+    /// @param logicalType nullable logical type annotation
+    /// @return the primitive element
+    /// @throws IllegalArgumentException if `type` is `null`, or is
+    ///         [PhysicalType#FIXED_LEN_BYTE_ARRAY], which needs a width
+    public static SchemaElement primitive(String name, PhysicalType type, RepetitionType repetitionType,
+            LogicalType logicalType) {
+        if (type == null) {
+            throw new IllegalArgumentException(
+                    "Primitive element " + name + " requires a physical type; a null type denotes a group");
+        }
+        if (type == PhysicalType.FIXED_LEN_BYTE_ARRAY) {
+            throw new IllegalArgumentException("FIXED_LEN_BYTE_ARRAY column " + name
+                    + " requires a positive type length; use fixedLengthPrimitive instead");
+        }
+        return new SchemaElement(name, type, null, repetitionType, null, null, null, null, null, logicalType);
+    }
+
+    /// Creates a [PhysicalType#FIXED_LEN_BYTE_ARRAY] element.
+    ///
+    /// @param name column name
+    /// @param typeLength fixed byte length: must be positive
+    /// @param repetitionType nullable repetition level
+    /// @return the fixed-length primitive element
+    /// @throws IllegalArgumentException if `typeLength` is not positive
+    public static SchemaElement fixedLengthPrimitive(String name, int typeLength, RepetitionType repetitionType) {
+        return fixedLengthPrimitive(name, typeLength, repetitionType, null);
+    }
+
+    /// Creates a [PhysicalType#FIXED_LEN_BYTE_ARRAY] element.
+    ///
+    /// @param name column name
+    /// @param typeLength fixed byte length: must be positive
+    /// @param repetitionType nullable repetition level
+    /// @param logicalType nullable logical type annotation
+    /// @return the fixed-length primitive element
+    /// @throws IllegalArgumentException if `typeLength` is not positive
+    public static SchemaElement fixedLengthPrimitive(String name, int typeLength, RepetitionType repetitionType,
+            LogicalType logicalType) {
+        if (typeLength <= 0) {
+            String s = "FIXED_LEN_BYTE_ARRAY column " + name + " requires a positive type length, not " + typeLength;
+            throw new IllegalArgumentException(s);
+        }
+        return new SchemaElement(name, PhysicalType.FIXED_LEN_BYTE_ARRAY, typeLength, repetitionType, null, null, null,
+                null, null, logicalType);
+    }
+
+    /// Returns a copy of this element carrying `typeLength`.
+    ///
+    /// The field has two meanings, one per physical type. For
+    /// [PhysicalType#FIXED_LEN_BYTE_ARRAY] it is the byte length of every value, which
+    /// [#fixedLengthPrimitive] sets directly. For every other physical type it is the
+    /// maximum bit length used to store a value, and this method is the only way to set it:
+    ///
+    /// ```java
+    /// // a low-cardinality INT32 whose values fit in 3 bits
+    /// primitive("tag", PhysicalType.INT32, RepetitionType.REQUIRED).withTypeLength(3)
+    /// ```
+    ///
+    /// @param typeLength the byte length or the maximum bit length, one or more
+    /// @return a copy of this element with `typeLength` set
+    /// @throws IllegalArgumentException if `typeLength` is not positive, or this element is a group
+    public SchemaElement withTypeLength(int typeLength) {
+        if (typeLength <= 0) {
+            String s = "Column " + name + " requires a positive type length, not " + typeLength;
+            throw new IllegalArgumentException(s);
+        }
+        if (isGroup()) {
+            throw new IllegalArgumentException("Group " + name + " cannot carry a type length");
+        }
+        return new SchemaElement(name, type, typeLength, repetitionType, numChildren, convertedType, scale, precision,
+                fieldId, logicalType);
+    }
 
     /// Returns `true` if this element is a group node (has no physical type).
     public boolean isGroup() {

--- a/core/src/main/java/dev/hardwood/metadata/SchemaElement.java
+++ b/core/src/main/java/dev/hardwood/metadata/SchemaElement.java
@@ -34,23 +34,23 @@ public record SchemaElement(
         Integer fieldId,
         LogicalType logicalType) {
 
-    /// Creates a root group element.
+    /// Creates a root group element, which carries no repetition.
     ///
     /// @param name        group name; the root group is named `"schema"` by convention
     /// @param numChildren number of child elements, zero or more
     /// @return the group element
     /// @throws IllegalArgumentException if `numChildren` is negative
     public static SchemaElement root(String name, int numChildren) {
-        return group(name, null, numChildren, null);
+        return groupElement(name, null, numChildren, null);
     }
 
     /// Creates a group element.
     ///
     /// @param name group name
-    /// @param repetitionType repetition level
+    /// @param repetitionType repetition level; only the root element may omit it, via [#root]
     /// @param numChildren number of child elements, zero or more
     /// @return the group element
-    /// @throws IllegalArgumentException if `numChildren` is negative
+    /// @throws IllegalArgumentException if `repetitionType` is `null` or `numChildren` is negative
     public static SchemaElement group(String name, RepetitionType repetitionType, int numChildren) {
         return group(name, repetitionType, numChildren, null);
     }
@@ -58,16 +58,22 @@ public record SchemaElement(
     /// Creates a group element.
     ///
     /// @param name group name
-    /// @param repetitionType nullable repetition level
+    /// @param repetitionType repetition level; only the root element may omit it, via [#root]
     /// @param numChildren number of child elements, zero or more
     /// @param logicalType logical type annotation, or `null` for none
     /// @return the group element
-    /// @throws IllegalArgumentException if `numChildren` is negative
+    /// @throws IllegalArgumentException if `repetitionType` is `null` or `numChildren` is negative
     public static SchemaElement group(String name, RepetitionType repetitionType, int numChildren,
             LogicalType logicalType) {
+        requireRepetition(name, repetitionType);
+        return groupElement(name, repetitionType, numChildren, logicalType);
+    }
+
+    private static SchemaElement groupElement(String name, RepetitionType repetitionType, int numChildren,
+            LogicalType logicalType) {
         if (numChildren < 0) {
-            String s = "Group " + name + " requires a child count of zero or more, not " + numChildren;
-            throw new IllegalArgumentException(s);
+            throw new IllegalArgumentException(
+                    "Group " + name + " requires a child count of zero or more, not " + numChildren);
         }
         return new SchemaElement(name, null, null, repetitionType, numChildren, null, null, null, null, logicalType);
     }
@@ -76,9 +82,9 @@ public record SchemaElement(
     ///
     /// @param name column name
     /// @param type physical type
-    /// @param repetitionType nullable repetition level
+    /// @param repetitionType repetition level
     /// @return the primitive element
-    /// @throws IllegalArgumentException if `type` is `null`, or is
+    /// @throws IllegalArgumentException if `repetitionType` is `null`, or `type` is `null` or is
     ///         [PhysicalType#FIXED_LEN_BYTE_ARRAY], which needs a width
     public static SchemaElement primitive(String name, PhysicalType type, RepetitionType repetitionType) {
         return primitive(name, type, repetitionType, null);
@@ -88,13 +94,14 @@ public record SchemaElement(
     ///
     /// @param name column name
     /// @param type physical type
-    /// @param repetitionType nullable repetition level
+    /// @param repetitionType repetition level
     /// @param logicalType nullable logical type annotation
     /// @return the primitive element
-    /// @throws IllegalArgumentException if `type` is `null`, or is
+    /// @throws IllegalArgumentException if `repetitionType` is `null`, or `type` is `null` or is
     ///         [PhysicalType#FIXED_LEN_BYTE_ARRAY], which needs a width
     public static SchemaElement primitive(String name, PhysicalType type, RepetitionType repetitionType,
             LogicalType logicalType) {
+        requireRepetition(name, repetitionType);
         if (type == null) {
             throw new IllegalArgumentException(
                     "Primitive element " + name + " requires a physical type; a null type denotes a group");
@@ -110,9 +117,9 @@ public record SchemaElement(
     ///
     /// @param name column name
     /// @param typeLength fixed byte length: must be positive
-    /// @param repetitionType nullable repetition level
+    /// @param repetitionType repetition level
     /// @return the fixed-length primitive element
-    /// @throws IllegalArgumentException if `typeLength` is not positive
+    /// @throws IllegalArgumentException if `repetitionType` is `null` or `typeLength` is not positive
     public static SchemaElement fixedLengthPrimitive(String name, int typeLength, RepetitionType repetitionType) {
         return fixedLengthPrimitive(name, typeLength, repetitionType, null);
     }
@@ -121,45 +128,26 @@ public record SchemaElement(
     ///
     /// @param name column name
     /// @param typeLength fixed byte length: must be positive
-    /// @param repetitionType nullable repetition level
+    /// @param repetitionType repetition level
     /// @param logicalType nullable logical type annotation
     /// @return the fixed-length primitive element
-    /// @throws IllegalArgumentException if `typeLength` is not positive
+    /// @throws IllegalArgumentException if `repetitionType` is `null` or `typeLength` is not positive
     public static SchemaElement fixedLengthPrimitive(String name, int typeLength, RepetitionType repetitionType,
             LogicalType logicalType) {
+        requireRepetition(name, repetitionType);
         if (typeLength <= 0) {
-            String s = "FIXED_LEN_BYTE_ARRAY column " + name + " requires a positive type length, not " + typeLength;
-            throw new IllegalArgumentException(s);
+            throw new IllegalArgumentException(
+                    "FIXED_LEN_BYTE_ARRAY column " + name + " requires a positive type length, not " + typeLength);
         }
         return new SchemaElement(name, PhysicalType.FIXED_LEN_BYTE_ARRAY, typeLength, repetitionType, null, null, null,
                 null, null, logicalType);
     }
 
-    /// Returns a copy of this element carrying `typeLength`.
-    ///
-    /// The field has two meanings, one per physical type. For
-    /// [PhysicalType#FIXED_LEN_BYTE_ARRAY] it is the byte length of every value, which
-    /// [#fixedLengthPrimitive] sets directly. For every other physical type it is the
-    /// maximum bit length used to store a value, and this method is the only way to set it:
-    ///
-    /// ```java
-    /// // a low-cardinality INT32 whose values fit in 3 bits
-    /// primitive("tag", PhysicalType.INT32, RepetitionType.REQUIRED).withTypeLength(3)
-    /// ```
-    ///
-    /// @param typeLength the byte length or the maximum bit length, one or more
-    /// @return a copy of this element with `typeLength` set
-    /// @throws IllegalArgumentException if `typeLength` is not positive, or this element is a group
-    public SchemaElement withTypeLength(int typeLength) {
-        if (typeLength <= 0) {
-            String s = "Column " + name + " requires a positive type length, not " + typeLength;
-            throw new IllegalArgumentException(s);
+    private static void requireRepetition(String name, RepetitionType repetitionType) {
+        if (repetitionType == null) {
+            throw new IllegalArgumentException(
+                    "Element " + name + " requires a repetition level; only the root element may omit it");
         }
-        if (isGroup()) {
-            throw new IllegalArgumentException("Group " + name + " cannot carry a type length");
-        }
-        return new SchemaElement(name, type, typeLength, repetitionType, numChildren, convertedType, scale, precision,
-                fieldId, logicalType);
     }
 
     /// Returns `true` if this element is a group node (has no physical type).

--- a/core/src/main/java/dev/hardwood/schema/FileSchema.java
+++ b/core/src/main/java/dev/hardwood/schema/FileSchema.java
@@ -143,8 +143,7 @@ public class FileSchema {
     /// followed by each node in pre-order, groups carrying their child count.
     public List<SchemaElement> toSchemaElements() {
         List<SchemaElement> elements = new ArrayList<>(columns.size() + 1);
-        elements.add(new SchemaElement(name, null, null, rootNode.repetitionType(),
-                rootNode.children().size(), null, null, null, null, null));
+        elements.add(SchemaElement.group(name, rootNode.repetitionType(), rootNode.children().size()));
         appendElements(rootNode.children(), elements);
         return elements;
     }
@@ -596,8 +595,7 @@ public class FileSchema {
                 throw new IllegalArgumentException("Schema must have at least one column");
             }
             List<SchemaElement> elements = new ArrayList<>();
-            elements.add(new SchemaElement(name, null, null, RepetitionType.REQUIRED, content.children.size(),
-                    null, null, null, null, null));
+            elements.add(SchemaElement.group(name, RepetitionType.REQUIRED, content.children.size()));
             flatten(content.children, elements);
             return fromSchemaElements(elements);
         }
@@ -907,22 +905,19 @@ public class FileSchema {
             switch (node) {
                 case BuilderLeaf leaf -> out.add(leafElement(leaf));
                 case BuilderStruct group -> {
-                    out.add(new SchemaElement(group.name(), null, null, group.repetition(),
-                            group.children().size(), null, null, null, null, null));
+                    out.add(SchemaElement.group(group.name(), group.repetition(), group.children().size()));
                     flatten(group.children(), out);
                 }
                 case BuilderList list -> {
                     out.add(new SchemaElement(list.name(), null, null, list.repetition(), 1,
                             ConvertedType.LIST, null, null, null, new LogicalType.ListType()));
-                    out.add(new SchemaElement("list", null, null, RepetitionType.REPEATED, 1,
-                            null, null, null, null, null));
+                    out.add(SchemaElement.group("list", RepetitionType.REPEATED, 1));
                     flatten(List.of(list.element()), out);
                 }
                 case BuilderMap map -> {
                     out.add(new SchemaElement(map.name(), null, null, map.repetition(), 1,
                             ConvertedType.MAP, null, null, null, new LogicalType.MapType()));
-                    out.add(new SchemaElement("key_value", null, null, RepetitionType.REPEATED, 2,
-                            null, null, null, null, null));
+                    out.add(SchemaElement.group("key_value", RepetitionType.REPEATED, 2));
                     out.add(leafElement(map.key()));
                     flatten(List.of(map.value()), out);
                 }

--- a/core/src/test/java/dev/hardwood/FilterPredicateTest.java
+++ b/core/src/test/java/dev/hardwood/FilterPredicateTest.java
@@ -665,9 +665,8 @@ class FilterPredicateTest {
 
     @Test
     void uuidPredicateOnNonUuidColumnThrows() {
-        SchemaElement root = new SchemaElement("root", null, null, null, 1, null, null, null, null, null);
-        SchemaElement col = new SchemaElement("col", PhysicalType.FIXED_LEN_BYTE_ARRAY, 16,
-                RepetitionType.REQUIRED, null, null, null, null, null, null);
+        SchemaElement root = SchemaElement.root("root", 1);
+        SchemaElement col = SchemaElement.fixedLengthPrimitive("col", 16, RepetitionType.REQUIRED);
         FileSchema schema = FileSchema.fromSchemaElements(List.of(root, col));
 
         assertThatThrownBy(() -> FilterPredicateResolver.resolve(
@@ -1376,9 +1375,8 @@ class FilterPredicateTest {
     }
 
     private static FileSchema createUuidSchema() {
-        SchemaElement root = new SchemaElement("root", null, null, null, 1, null, null, null, null, null);
-        SchemaElement col = new SchemaElement("col", PhysicalType.FIXED_LEN_BYTE_ARRAY, 16,
-                RepetitionType.REQUIRED, null, null, null, null, null, new LogicalType.UuidType());
+        SchemaElement root = SchemaElement.root("root", 1);
+        SchemaElement col = SchemaElement.fixedLengthPrimitive("col", 16, RepetitionType.REQUIRED, new LogicalType.UuidType());
         return FileSchema.fromSchemaElements(List.of(root, col));
     }
 
@@ -1392,14 +1390,14 @@ class FilterPredicateTest {
 
     private static FileSchema createSchemaForType(PhysicalType type) {
         // Root element + one column
-        SchemaElement root = new SchemaElement("root", null, null, null, 1, null, null, null, null, null);
-        SchemaElement col = new SchemaElement("col", type, null, RepetitionType.REQUIRED, null, null, null, null, null, null);
+        SchemaElement root = SchemaElement.root("root", 1);
+        SchemaElement col = SchemaElement.primitive("col", type, RepetitionType.REQUIRED);
         return FileSchema.fromSchemaElements(List.of(root, col));
     }
 
     private static FileSchema createSchemaForType(PhysicalType type, LogicalType logicalType) {
-        SchemaElement root = new SchemaElement("root", null, null, null, 1, null, null, null, null, null);
-        SchemaElement col = new SchemaElement("col", type, null, RepetitionType.REQUIRED, null, null, null, null, null, logicalType);
+        SchemaElement root = SchemaElement.root("root", 1);
+        SchemaElement col = SchemaElement.primitive("col", type, RepetitionType.REQUIRED, logicalType);
         return FileSchema.fromSchemaElements(List.of(root, col));
     }
 

--- a/core/src/test/java/dev/hardwood/internal/predicate/BatchFilterCompilerTest.java
+++ b/core/src/test/java/dev/hardwood/internal/predicate/BatchFilterCompilerTest.java
@@ -35,8 +35,7 @@ class BatchFilterCompilerTest {
     }
 
     private static FileSchema schema(SchemaElement... columns) {
-        SchemaElement root = new SchemaElement("root", null, null, null, columns.length,
-                null, null, null, null, null);
+        SchemaElement root = SchemaElement.root("root", columns.length);
         SchemaElement[] elements = new SchemaElement[columns.length + 1];
         elements[0] = root;
         System.arraycopy(columns, 0, elements, 1, columns.length);
@@ -44,7 +43,7 @@ class BatchFilterCompilerTest {
     }
 
     private static SchemaElement leaf(String name, PhysicalType type) {
-        return new SchemaElement(name, type, null, RepetitionType.OPTIONAL, null, null, null, null, null, null);
+        return SchemaElement.primitive(name, type, RepetitionType.OPTIONAL);
     }
 
     private static FileSchema longDoubleSchema() {
@@ -167,11 +166,9 @@ class BatchFilterCompilerTest {
         void leafOnNonTopLevelPath_returnsNull() {
             // A nested struct: root -> nest (group, 1 child) -> id (INT64).
             // The leaf column has fieldPath ["nest", "id"] — not top-level.
-            SchemaElement root = new SchemaElement("root", null, null, null, 1, null, null, null, null, null);
-            SchemaElement nest = new SchemaElement("nest", null, null, RepetitionType.OPTIONAL, 1,
-                    null, null, null, null, null);
-            SchemaElement id = new SchemaElement("id", PhysicalType.INT64, null, RepetitionType.OPTIONAL,
-                    null, null, null, null, null, null);
+            SchemaElement root = SchemaElement.root("root", 1);
+            SchemaElement nest = SchemaElement.group("nest", RepetitionType.OPTIONAL, 1);
+            SchemaElement id = SchemaElement.primitive("id", PhysicalType.INT64, RepetitionType.OPTIONAL);
             FileSchema schema = FileSchema.fromSchemaElements(List.of(root, nest, id));
             ResolvedPredicate predicate = new ResolvedPredicate.LongPredicate(0, Operator.GT, 5L);
             assertNull(BatchFilterCompiler.tryCompile(predicate, schema, IntUnaryOperator.identity()));

--- a/core/src/test/java/dev/hardwood/internal/predicate/DrainSideOracleTest.java
+++ b/core/src/test/java/dev/hardwood/internal/predicate/DrainSideOracleTest.java
@@ -445,18 +445,12 @@ class DrainSideOracleTest {
             this.scoreNulls = scoreNulls;
             this.flags = flags;
             this.flagNulls = flagNulls;
-            SchemaElement root = new SchemaElement("root", null, null, null, 5,
-                    null, null, null, null, null);
-            SchemaElement c1 = new SchemaElement("id", PhysicalType.INT64, null,
-                    RepetitionType.OPTIONAL, null, null, null, null, null, null);
-            SchemaElement c2 = new SchemaElement("value", PhysicalType.DOUBLE, null,
-                    RepetitionType.OPTIONAL, null, null, null, null, null, null);
-            SchemaElement c3 = new SchemaElement("tag", PhysicalType.INT32, null,
-                    RepetitionType.OPTIONAL, null, null, null, null, null, null);
-            SchemaElement c4 = new SchemaElement("score", PhysicalType.FLOAT, null,
-                    RepetitionType.OPTIONAL, null, null, null, null, null, null);
-            SchemaElement c5 = new SchemaElement("flag", PhysicalType.BOOLEAN, null,
-                    RepetitionType.OPTIONAL, null, null, null, null, null, null);
+            SchemaElement root = SchemaElement.root("root", 5);
+            SchemaElement c1 = SchemaElement.primitive("id", PhysicalType.INT64, RepetitionType.OPTIONAL);
+            SchemaElement c2 = SchemaElement.primitive("value", PhysicalType.DOUBLE, RepetitionType.OPTIONAL);
+            SchemaElement c3 = SchemaElement.primitive("tag", PhysicalType.INT32, RepetitionType.OPTIONAL);
+            SchemaElement c4 = SchemaElement.primitive("score", PhysicalType.FLOAT, RepetitionType.OPTIONAL);
+            SchemaElement c5 = SchemaElement.primitive("flag", PhysicalType.BOOLEAN, RepetitionType.OPTIONAL);
             this.schema = FileSchema.fromSchemaElements(List.of(root, c1, c2, c3, c4, c5));
             this.projection = ProjectedSchema.create(schema, ColumnProjection.all());
         }

--- a/core/src/test/java/dev/hardwood/internal/predicate/FilterPredicateResolverTest.java
+++ b/core/src/test/java/dev/hardwood/internal/predicate/FilterPredicateResolverTest.java
@@ -472,7 +472,7 @@ class FilterPredicateResolverTest {
 
     private static FileSchema schemaWithLogicalType(String columnName, PhysicalType type,
             Integer typeLength, LogicalType logicalType) {
-        SchemaElement root = new SchemaElement("root", null, null, null, 1, null, null, null, null, null);
+        SchemaElement root = SchemaElement.root("root", 1);
         SchemaElement col = new SchemaElement(columnName, type, typeLength, RepetitionType.REQUIRED,
                 null, null, null, null, null, logicalType);
         return FileSchema.fromSchemaElements(List.of(root, col));

--- a/core/src/test/java/dev/hardwood/internal/predicate/RecordFilterCompilerTest.java
+++ b/core/src/test/java/dev/hardwood/internal/predicate/RecordFilterCompilerTest.java
@@ -334,18 +334,15 @@ class RecordFilterCompilerTest {
     }
 
     private static FileSchema schema(String name, PhysicalType type) {
-        SchemaElement root = new SchemaElement("root", null, null, null, 1, null, null, null, null, null);
-        SchemaElement col = new SchemaElement(name, type, null, RepetitionType.OPTIONAL,
-                null, null, null, null, null, null);
+        SchemaElement root = SchemaElement.root("root", 1);
+        SchemaElement col = SchemaElement.primitive(name, type, RepetitionType.OPTIONAL);
         return FileSchema.fromSchemaElements(List.of(root, col));
     }
 
     private static FileSchema twoIntSchema(String name1, String name2) {
-        SchemaElement root = new SchemaElement("root", null, null, null, 2, null, null, null, null, null);
-        SchemaElement col1 = new SchemaElement(name1, PhysicalType.INT32, null, RepetitionType.REQUIRED,
-                null, null, null, null, null, null);
-        SchemaElement col2 = new SchemaElement(name2, PhysicalType.INT32, null, RepetitionType.REQUIRED,
-                null, null, null, null, null, null);
+        SchemaElement root = SchemaElement.root("root", 2);
+        SchemaElement col1 = SchemaElement.primitive(name1, PhysicalType.INT32, RepetitionType.REQUIRED);
+        SchemaElement col2 = SchemaElement.primitive(name2, PhysicalType.INT32, RepetitionType.REQUIRED);
         return FileSchema.fromSchemaElements(List.of(root, col1, col2));
     }
 

--- a/core/src/test/java/dev/hardwood/internal/predicate/RecordFilterIndexedTest.java
+++ b/core/src/test/java/dev/hardwood/internal/predicate/RecordFilterIndexedTest.java
@@ -165,40 +165,31 @@ class RecordFilterIndexedTest {
     }
 
     private static FileSchema twoLongSchema(String n1, String n2) {
-        SchemaElement root = new SchemaElement("root", null, null, null, 2, null, null, null, null, null);
-        SchemaElement c1 = new SchemaElement(n1, PhysicalType.INT64, null, RepetitionType.OPTIONAL,
-                null, null, null, null, null, null);
-        SchemaElement c2 = new SchemaElement(n2, PhysicalType.INT64, null, RepetitionType.OPTIONAL,
-                null, null, null, null, null, null);
+        SchemaElement root = SchemaElement.root("root", 2);
+        SchemaElement c1 = SchemaElement.primitive(n1, PhysicalType.INT64, RepetitionType.OPTIONAL);
+        SchemaElement c2 = SchemaElement.primitive(n2, PhysicalType.INT64, RepetitionType.OPTIONAL);
         return FileSchema.fromSchemaElements(List.of(root, c1, c2));
     }
 
     private static FileSchema twoIntSchema(String n1, String n2) {
-        SchemaElement root = new SchemaElement("root", null, null, null, 2, null, null, null, null, null);
-        SchemaElement c1 = new SchemaElement(n1, PhysicalType.INT32, null, RepetitionType.OPTIONAL,
-                null, null, null, null, null, null);
-        SchemaElement c2 = new SchemaElement(n2, PhysicalType.INT32, null, RepetitionType.OPTIONAL,
-                null, null, null, null, null, null);
+        SchemaElement root = SchemaElement.root("root", 2);
+        SchemaElement c1 = SchemaElement.primitive(n1, PhysicalType.INT32, RepetitionType.OPTIONAL);
+        SchemaElement c2 = SchemaElement.primitive(n2, PhysicalType.INT32, RepetitionType.OPTIONAL);
         return FileSchema.fromSchemaElements(List.of(root, c1, c2));
     }
 
     private static FileSchema twoDoubleSchema(String n1, String n2) {
-        SchemaElement root = new SchemaElement("root", null, null, null, 2, null, null, null, null, null);
-        SchemaElement c1 = new SchemaElement(n1, PhysicalType.DOUBLE, null, RepetitionType.OPTIONAL,
-                null, null, null, null, null, null);
-        SchemaElement c2 = new SchemaElement(n2, PhysicalType.DOUBLE, null, RepetitionType.OPTIONAL,
-                null, null, null, null, null, null);
+        SchemaElement root = SchemaElement.root("root", 2);
+        SchemaElement c1 = SchemaElement.primitive(n1, PhysicalType.DOUBLE, RepetitionType.OPTIONAL);
+        SchemaElement c2 = SchemaElement.primitive(n2, PhysicalType.DOUBLE, RepetitionType.OPTIONAL);
         return FileSchema.fromSchemaElements(List.of(root, c1, c2));
     }
 
     private static FileSchema threeLongSchema(String n1, String n2, String n3) {
-        SchemaElement root = new SchemaElement("root", null, null, null, 3, null, null, null, null, null);
-        SchemaElement c1 = new SchemaElement(n1, PhysicalType.INT64, null, RepetitionType.OPTIONAL,
-                null, null, null, null, null, null);
-        SchemaElement c2 = new SchemaElement(n2, PhysicalType.INT64, null, RepetitionType.OPTIONAL,
-                null, null, null, null, null, null);
-        SchemaElement c3 = new SchemaElement(n3, PhysicalType.INT64, null, RepetitionType.OPTIONAL,
-                null, null, null, null, null, null);
+        SchemaElement root = SchemaElement.root("root", 3);
+        SchemaElement c1 = SchemaElement.primitive(n1, PhysicalType.INT64, RepetitionType.OPTIONAL);
+        SchemaElement c2 = SchemaElement.primitive(n2, PhysicalType.INT64, RepetitionType.OPTIONAL);
+        SchemaElement c3 = SchemaElement.primitive(n3, PhysicalType.INT64, RepetitionType.OPTIONAL);
         return FileSchema.fromSchemaElements(List.of(root, c1, c2, c3));
     }
 

--- a/core/src/test/java/dev/hardwood/internal/thrift/RepeatedPathCacheTest.java
+++ b/core/src/test/java/dev/hardwood/internal/thrift/RepeatedPathCacheTest.java
@@ -124,11 +124,9 @@ class RepeatedPathCacheTest {
 
     private static List<SchemaElement> schemaElements(List<String> paths) {
         List<SchemaElement> elements = new ArrayList<>();
-        elements.add(new SchemaElement("schema", null, null, RepetitionType.REQUIRED, paths.size(),
-                null, null, null, null, null));
+        elements.add(SchemaElement.group("schema", RepetitionType.REQUIRED, paths.size()));
         for (String path : paths) {
-            elements.add(new SchemaElement(path.replace('.', '_'), PhysicalType.DOUBLE, null,
-                    RepetitionType.REQUIRED, null, null, null, null, null, null));
+            elements.add(SchemaElement.primitive(path.replace('.', '_'), PhysicalType.DOUBLE, RepetitionType.REQUIRED));
         }
         return elements;
     }

--- a/core/src/test/java/dev/hardwood/metadata/SchemaElementFactoryTest.java
+++ b/core/src/test/java/dev/hardwood/metadata/SchemaElementFactoryTest.java
@@ -185,8 +185,8 @@ class SchemaElementFactoryTest {
                 .hasMessageContaining("token");
     }
 
-    /// Record equality proves the factories match the constructor. This proves the rest of
-    /// the system accepts what they build.
+    /// Record equality proves the factories match the constructor. The round trip also
+    /// preserves the logical annotations, including their legacy converted-type forms.
     @Test
     void factoryBuiltElementsRoundTripThroughFileSchema() {
         List<SchemaElement> elements = List.of(
@@ -199,8 +199,8 @@ class SchemaElementFactoryTest {
         FileSchema schema = FileSchema.fromSchemaElements(elements);
 
         assertThat(schema.getName()).isEqualTo("root");
-        // The root comes back with the REQUIRED that fromSchemaElements reads into an absent
-        // repetition; every other element survives the trip unchanged.
+        // The root comes back with REQUIRED because fromSchemaElements defaults an absent
+        // root repetition; logical annotations also gain their legacy converted-type forms.
         assertThat(schema.toSchemaElements()).containsExactly(
                 new SchemaElement("root", null, null, RepetitionType.REQUIRED, 3, null, null, null, null, null),
                 new SchemaElement("items", null, null, RepetitionType.OPTIONAL, 1, ConvertedType.LIST, null, null,

--- a/core/src/test/java/dev/hardwood/metadata/SchemaElementFactoryTest.java
+++ b/core/src/test/java/dev/hardwood/metadata/SchemaElementFactoryTest.java
@@ -1,0 +1,211 @@
+/*
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Copyright The original authors
+ *
+ *  Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package dev.hardwood.metadata;
+
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+
+import dev.hardwood.schema.FileSchema;
+
+import static dev.hardwood.metadata.SchemaElement.fixedLengthPrimitive;
+import static dev.hardwood.metadata.SchemaElement.group;
+import static dev.hardwood.metadata.SchemaElement.primitive;
+import static dev.hardwood.metadata.SchemaElement.root;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class SchemaElementFactoryTest {
+
+    @Test
+    void groupEqualsCanonicalConstruction() {
+        assertThat(group("address", RepetitionType.OPTIONAL, 3))
+                .isEqualTo(new SchemaElement("address", null, null, RepetitionType.OPTIONAL, 3, null, null, null, null,
+                        null));
+    }
+
+    @Test
+    void annotatedGroupEqualsCanonicalConstruction() {
+        LogicalType listType = new LogicalType.ListType();
+        assertThat(group("items", RepetitionType.OPTIONAL, 1, listType))
+                .isEqualTo(new SchemaElement("items", null, null, RepetitionType.OPTIONAL, 1, null, null, null, null,
+                        listType));
+    }
+
+    @Test
+    void primitiveEqualsCanonicalConstruction() {
+        assertThat(primitive("zip", PhysicalType.INT32, RepetitionType.OPTIONAL))
+                .isEqualTo(new SchemaElement("zip", PhysicalType.INT32, null, RepetitionType.OPTIONAL, null, null, null,
+                        null, null, null));
+    }
+
+    @Test
+    void annotatedPrimitiveEqualsCanonicalConstruction() {
+        LogicalType stringType = new LogicalType.StringType();
+        assertThat(primitive("city", PhysicalType.BYTE_ARRAY, RepetitionType.OPTIONAL, stringType))
+                .isEqualTo(new SchemaElement("city", PhysicalType.BYTE_ARRAY, null, RepetitionType.OPTIONAL, null, null,
+                        null, null, null, stringType));
+    }
+
+    @Test
+    void fixedLengthPrimitiveEqualsCanonicalConstruction() {
+        assertThat(fixedLengthPrimitive("token", 4, RepetitionType.OPTIONAL))
+                .isEqualTo(new SchemaElement("token", PhysicalType.FIXED_LEN_BYTE_ARRAY, 4, RepetitionType.OPTIONAL,
+                        null, null, null, null, null, null));
+    }
+
+    @Test
+    void annotatedFixedLengthPrimitiveEqualsCanonicalConstruction() {
+        LogicalType uuidType = new LogicalType.UuidType();
+        assertThat(fixedLengthPrimitive("id", 16, RepetitionType.REQUIRED, uuidType))
+                .isEqualTo(new SchemaElement("id", PhysicalType.FIXED_LEN_BYTE_ARRAY, 16, RepetitionType.REQUIRED, null,
+                        null, null, null, null, uuidType));
+    }
+
+    @Test
+    void groupIsAGroupAndPrimitivesArePrimitive() {
+        assertThat(group("g", RepetitionType.OPTIONAL, 0).isGroup()).isTrue();
+        assertThat(group("g", RepetitionType.OPTIONAL, 0).isPrimitive()).isFalse();
+        assertThat(primitive("p", PhysicalType.INT32, RepetitionType.OPTIONAL).isPrimitive()).isTrue();
+        assertThat(primitive("p", PhysicalType.INT32, RepetitionType.OPTIONAL).isGroup()).isFalse();
+        assertThat(fixedLengthPrimitive("f", 4, RepetitionType.OPTIONAL).isPrimitive()).isTrue();
+        assertThat(fixedLengthPrimitive("f", 4, RepetitionType.OPTIONAL).isGroup()).isFalse();
+    }
+
+    /// A root element carries no repetition. `RecordFilterMicroBenchmark` and many fixtures
+    /// build one that way, and `FileSchema.fromSchemaElements` defaults it to `REQUIRED`.
+    @Test
+    void groupKeepsANullRepetition() {
+        SchemaElement root = root("root", 4);
+
+        assertThat(root.repetitionType()).isNull();
+        assertThat(root).isEqualTo(new SchemaElement("root", null, null, null, 4, null, null, null, null, null));
+    }
+
+    /// `type_length` on a non-FLBA column is the maximum bit length of a value, which the
+    /// primitive factories cannot express. `withTypeLength` is the only way to set it.
+    @Test
+    void withTypeLengthSetsTheMaximumBitLength() {
+        assertThat(primitive("tag", PhysicalType.INT32, RepetitionType.REQUIRED).withTypeLength(3))
+                .isEqualTo(new SchemaElement("tag", PhysicalType.INT32, 3, RepetitionType.REQUIRED, null, null, null,
+                        null, null, null));
+    }
+
+    @Test
+    void withTypeLengthKeepsEveryOtherComponent() {
+        LogicalType stringType = new LogicalType.StringType();
+        SchemaElement annotated = primitive("city", PhysicalType.BYTE_ARRAY, RepetitionType.OPTIONAL, stringType);
+
+        assertThat(annotated.withTypeLength(12))
+                .isEqualTo(new SchemaElement("city", PhysicalType.BYTE_ARRAY, 12, RepetitionType.OPTIONAL, null, null,
+                        null, null, null, stringType));
+    }
+
+    @Test
+    void withTypeLengthReplacesAFixedWidth() {
+        assertThat(fixedLengthPrimitive("token", 4, RepetitionType.OPTIONAL).withTypeLength(8))
+                .isEqualTo(fixedLengthPrimitive("token", 8, RepetitionType.OPTIONAL));
+    }
+
+    @Test
+    void withTypeLengthRejectsAGroupAndANonPositiveLength() {
+        assertThatThrownBy(() -> group("g", RepetitionType.OPTIONAL, 1).withTypeLength(4))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("cannot carry a type length");
+        assertThatThrownBy(() -> primitive("p", PhysicalType.INT32, RepetitionType.REQUIRED).withTypeLength(0))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("positive type length");
+    }
+
+    @Test
+    void aNullLogicalTypeMatchesTheShorterOverload() {
+        assertThat(group("g", RepetitionType.OPTIONAL, 2, null)).isEqualTo(group("g", RepetitionType.OPTIONAL, 2));
+        assertThat(primitive("p", PhysicalType.INT64, RepetitionType.REQUIRED, null))
+                .isEqualTo(primitive("p", PhysicalType.INT64, RepetitionType.REQUIRED));
+        assertThat(fixedLengthPrimitive("f", 8, RepetitionType.REQUIRED, null))
+                .isEqualTo(fixedLengthPrimitive("f", 8, RepetitionType.REQUIRED));
+    }
+
+    /// The record accepts a null name, and so does the read path: a footer missing Thrift
+    /// field 4 decodes to a null-named element that `FileSchema.toSchemaElements()` writes
+    /// back out. A factory that rejected null would stop that round trip.
+    @Test
+    void everyFactoryAcceptsANullName() {
+        assertThat(group(null, RepetitionType.REQUIRED, 1))
+                .isEqualTo(new SchemaElement(null, null, null, RepetitionType.REQUIRED, 1, null, null, null, null,
+                        null));
+        assertThat(primitive(null, PhysicalType.INT32, RepetitionType.REQUIRED))
+                .isEqualTo(new SchemaElement(null, PhysicalType.INT32, null, RepetitionType.REQUIRED, null, null, null,
+                        null, null, null));
+        assertThat(fixedLengthPrimitive(null, 4, RepetitionType.REQUIRED))
+                .isEqualTo(new SchemaElement(null, PhysicalType.FIXED_LEN_BYTE_ARRAY, 4, RepetitionType.REQUIRED, null,
+                        null, null, null, null, null));
+    }
+
+    @Test
+    void primitiveRejectsANullType() {
+        assertThatThrownBy(() -> primitive("value", null, RepetitionType.OPTIONAL))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("value")
+                .hasMessageContaining("null type denotes a group");
+    }
+
+    @Test
+    void primitiveRejectsFixedLenByteArray() {
+        assertThatThrownBy(() -> primitive("token", PhysicalType.FIXED_LEN_BYTE_ARRAY, RepetitionType.OPTIONAL))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("token")
+                .hasMessageContaining("fixedLengthPrimitive");
+    }
+
+    @Test
+    void groupRejectsANegativeChildCount() {
+        assertThatThrownBy(() -> group("address", RepetitionType.OPTIONAL, -1))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("address");
+    }
+
+    @Test
+    void groupAcceptsNoChildren() {
+        assertThat(group("empty", RepetitionType.OPTIONAL, 0).numChildren()).isZero();
+    }
+
+    @Test
+    void fixedLengthPrimitiveRejectsANonPositiveWidth() {
+        assertThatThrownBy(() -> fixedLengthPrimitive("token", 0, RepetitionType.OPTIONAL))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("token");
+        assertThatThrownBy(() -> fixedLengthPrimitive("token", -4, RepetitionType.OPTIONAL))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("token");
+    }
+
+    /// Record equality proves the factories match the constructor. This proves the rest of
+    /// the system accepts what they build.
+    @Test
+    void factoryBuiltElementsRoundTripThroughFileSchema() {
+        List<SchemaElement> elements = List.of(
+                root("root", 3),
+                group("items", RepetitionType.OPTIONAL, 1, new LogicalType.ListType()),
+                primitive("element", PhysicalType.INT32, RepetitionType.REQUIRED),
+                primitive("name", PhysicalType.BYTE_ARRAY, RepetitionType.OPTIONAL, new LogicalType.StringType()),
+                fixedLengthPrimitive("id", 16, RepetitionType.REQUIRED, new LogicalType.UuidType()));
+
+        FileSchema schema = FileSchema.fromSchemaElements(elements);
+
+        assertThat(schema.getName()).isEqualTo("root");
+        // The root comes back with the REQUIRED that fromSchemaElements reads into an absent
+        // repetition; every other element survives the trip unchanged.
+        assertThat(schema.toSchemaElements()).containsExactly(
+                new SchemaElement("root", null, null, RepetitionType.REQUIRED, 3, null, null, null, null, null),
+                elements.get(1),
+                elements.get(2),
+                elements.get(3),
+                elements.get(4));
+    }
+}

--- a/core/src/test/java/dev/hardwood/metadata/SchemaElementFactoryTest.java
+++ b/core/src/test/java/dev/hardwood/metadata/SchemaElementFactoryTest.java
@@ -80,46 +80,31 @@ class SchemaElementFactoryTest {
     /// A root element carries no repetition. `RecordFilterMicroBenchmark` and many fixtures
     /// build one that way, and `FileSchema.fromSchemaElements` defaults it to `REQUIRED`.
     @Test
-    void groupKeepsANullRepetition() {
-        SchemaElement root = root("root", 4);
+    void rootKeepsANullRepetition() {
+        SchemaElement rootElement = root("root", 4);
 
-        assertThat(root.repetitionType()).isNull();
-        assertThat(root).isEqualTo(new SchemaElement("root", null, null, null, 4, null, null, null, null, null));
+        assertThat(rootElement.repetitionType()).isNull();
+        assertThat(rootElement).isEqualTo(new SchemaElement("root", null, null, null, 4, null, null, null, null, null));
     }
 
-    /// `type_length` on a non-FLBA column is the maximum bit length of a value, which the
-    /// primitive factories cannot express. `withTypeLength` is the only way to set it.
+    /// Only the root element may omit `repetition_type`; every other element must carry one,
+    /// so the non-root factories reject a null rather than let `fromSchemaElements` silently
+    /// default it to `OPTIONAL`.
     @Test
-    void withTypeLengthSetsTheMaximumBitLength() {
-        assertThat(primitive("tag", PhysicalType.INT32, RepetitionType.REQUIRED).withTypeLength(3))
-                .isEqualTo(new SchemaElement("tag", PhysicalType.INT32, 3, RepetitionType.REQUIRED, null, null, null,
-                        null, null, null));
-    }
-
-    @Test
-    void withTypeLengthKeepsEveryOtherComponent() {
-        LogicalType stringType = new LogicalType.StringType();
-        SchemaElement annotated = primitive("city", PhysicalType.BYTE_ARRAY, RepetitionType.OPTIONAL, stringType);
-
-        assertThat(annotated.withTypeLength(12))
-                .isEqualTo(new SchemaElement("city", PhysicalType.BYTE_ARRAY, 12, RepetitionType.OPTIONAL, null, null,
-                        null, null, null, stringType));
-    }
-
-    @Test
-    void withTypeLengthReplacesAFixedWidth() {
-        assertThat(fixedLengthPrimitive("token", 4, RepetitionType.OPTIONAL).withTypeLength(8))
-                .isEqualTo(fixedLengthPrimitive("token", 8, RepetitionType.OPTIONAL));
-    }
-
-    @Test
-    void withTypeLengthRejectsAGroupAndANonPositiveLength() {
-        assertThatThrownBy(() -> group("g", RepetitionType.OPTIONAL, 1).withTypeLength(4))
+    void everyNonRootFactoryRejectsANullRepetition() {
+        assertThatThrownBy(() -> group("g", null, 1))
                 .isInstanceOf(IllegalArgumentException.class)
-                .hasMessageContaining("cannot carry a type length");
-        assertThatThrownBy(() -> primitive("p", PhysicalType.INT32, RepetitionType.REQUIRED).withTypeLength(0))
+                .hasMessageContaining("g")
+                .hasMessageContaining("requires a repetition level");
+        assertThatThrownBy(() -> group("g", null, 1, new LogicalType.ListType()))
                 .isInstanceOf(IllegalArgumentException.class)
-                .hasMessageContaining("positive type length");
+                .hasMessageContaining("requires a repetition level");
+        assertThatThrownBy(() -> primitive("p", PhysicalType.INT32, null))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("requires a repetition level");
+        assertThatThrownBy(() -> fixedLengthPrimitive("f", 4, null))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("requires a repetition level");
     }
 
     @Test

--- a/core/src/test/java/dev/hardwood/metadata/SchemaElementFactoryTest.java
+++ b/core/src/test/java/dev/hardwood/metadata/SchemaElementFactoryTest.java
@@ -203,9 +203,11 @@ class SchemaElementFactoryTest {
         // repetition; every other element survives the trip unchanged.
         assertThat(schema.toSchemaElements()).containsExactly(
                 new SchemaElement("root", null, null, RepetitionType.REQUIRED, 3, null, null, null, null, null),
-                elements.get(1),
+                new SchemaElement("items", null, null, RepetitionType.OPTIONAL, 1, ConvertedType.LIST, null, null,
+                        null, new LogicalType.ListType()),
                 elements.get(2),
-                elements.get(3),
+                new SchemaElement("name", PhysicalType.BYTE_ARRAY, null, RepetitionType.OPTIONAL, null,
+                        ConvertedType.UTF8, null, null, null, new LogicalType.StringType()),
                 elements.get(4));
     }
 }

--- a/core/src/test/java/dev/hardwood/schema/FileSchemaBuildTest.java
+++ b/core/src/test/java/dev/hardwood/schema/FileSchemaBuildTest.java
@@ -15,6 +15,9 @@ import dev.hardwood.metadata.PhysicalType;
 import dev.hardwood.metadata.RepetitionType;
 import dev.hardwood.metadata.SchemaElement;
 
+import static dev.hardwood.metadata.SchemaElement.group;
+import static dev.hardwood.metadata.SchemaElement.primitive;
+import static dev.hardwood.metadata.SchemaElement.root;
 import static org.assertj.core.api.Assertions.assertThat;
 
 /// Characterization test for [FileSchema#fromSchemaElements]: pins the exact
@@ -27,14 +30,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 /// once a group's whole subtree has been consumed (the invariant behind the
 /// `columnIndex` ⇄ `ColumnChunk`-order coupling the reader relies on).
 class FileSchemaBuildTest {
-
-    private static SchemaElement group(String name, RepetitionType rep, int numChildren) {
-        return new SchemaElement(name, null, null, rep, numChildren, null, null, null, null, null);
-    }
-
-    private static SchemaElement prim(String name, PhysicalType type, RepetitionType rep) {
-        return new SchemaElement(name, type, null, rep, null, null, null, null, null, null);
-    }
 
     private static void assertColumn(ColumnSchema c, String path, int index, int maxDef, int maxRep) {
         assertThat(c.fieldPath().toString()).isEqualTo(path);
@@ -65,19 +60,19 @@ class FileSchemaBuildTest {
     @Test
     void leafOrderingIndicesAndLevels() {
         List<SchemaElement> elements = List.of(
-                group("user", null, 6),
-                prim("id", PhysicalType.INT64, RepetitionType.REQUIRED),
-                prim("name", PhysicalType.BYTE_ARRAY, RepetitionType.OPTIONAL),
+                root("user", 6),
+                primitive("id", PhysicalType.INT64, RepetitionType.REQUIRED),
+                primitive("name", PhysicalType.BYTE_ARRAY, RepetitionType.OPTIONAL),
                 group("address", RepetitionType.OPTIONAL, 3),
-                prim("street", PhysicalType.BYTE_ARRAY, RepetitionType.OPTIONAL),
+                primitive("street", PhysicalType.BYTE_ARRAY, RepetitionType.OPTIONAL),
                 group("geo", RepetitionType.OPTIONAL, 2),
-                prim("lat", PhysicalType.DOUBLE, RepetitionType.OPTIONAL),
-                prim("lon", PhysicalType.DOUBLE, RepetitionType.REQUIRED),
-                prim("zip", PhysicalType.INT32, RepetitionType.OPTIONAL),
-                prim("scores", PhysicalType.INT32, RepetitionType.REPEATED),
+                primitive("lat", PhysicalType.DOUBLE, RepetitionType.OPTIONAL),
+                primitive("lon", PhysicalType.DOUBLE, RepetitionType.REQUIRED),
+                primitive("zip", PhysicalType.INT32, RepetitionType.OPTIONAL),
+                primitive("scores", PhysicalType.INT32, RepetitionType.REPEATED),
                 group("tags", RepetitionType.REPEATED, 1),
-                prim("value", PhysicalType.BYTE_ARRAY, RepetitionType.REQUIRED),
-                prim("footer", PhysicalType.INT32, RepetitionType.REQUIRED));
+                primitive("value", PhysicalType.BYTE_ARRAY, RepetitionType.REQUIRED),
+                primitive("footer", PhysicalType.INT32, RepetitionType.REQUIRED));
 
         FileSchema schema = FileSchema.fromSchemaElements(elements);
 
@@ -98,19 +93,19 @@ class FileSchemaBuildTest {
     @Test
     void treeStructureMirrorsNesting() {
         List<SchemaElement> elements = List.of(
-                group("user", null, 6),
-                prim("id", PhysicalType.INT64, RepetitionType.REQUIRED),
-                prim("name", PhysicalType.BYTE_ARRAY, RepetitionType.OPTIONAL),
+                root("user", 6),
+                primitive("id", PhysicalType.INT64, RepetitionType.REQUIRED),
+                primitive("name", PhysicalType.BYTE_ARRAY, RepetitionType.OPTIONAL),
                 group("address", RepetitionType.OPTIONAL, 3),
-                prim("street", PhysicalType.BYTE_ARRAY, RepetitionType.OPTIONAL),
+                primitive("street", PhysicalType.BYTE_ARRAY, RepetitionType.OPTIONAL),
                 group("geo", RepetitionType.OPTIONAL, 2),
-                prim("lat", PhysicalType.DOUBLE, RepetitionType.OPTIONAL),
-                prim("lon", PhysicalType.DOUBLE, RepetitionType.REQUIRED),
-                prim("zip", PhysicalType.INT32, RepetitionType.OPTIONAL),
-                prim("scores", PhysicalType.INT32, RepetitionType.REPEATED),
+                primitive("lat", PhysicalType.DOUBLE, RepetitionType.OPTIONAL),
+                primitive("lon", PhysicalType.DOUBLE, RepetitionType.REQUIRED),
+                primitive("zip", PhysicalType.INT32, RepetitionType.OPTIONAL),
+                primitive("scores", PhysicalType.INT32, RepetitionType.REPEATED),
                 group("tags", RepetitionType.REPEATED, 1),
-                prim("value", PhysicalType.BYTE_ARRAY, RepetitionType.REQUIRED),
-                prim("footer", PhysicalType.INT32, RepetitionType.REQUIRED));
+                primitive("value", PhysicalType.BYTE_ARRAY, RepetitionType.REQUIRED),
+                primitive("footer", PhysicalType.INT32, RepetitionType.REQUIRED));
 
         List<SchemaNode> top = FileSchema.fromSchemaElements(elements).getRootNode().children();
 

--- a/core/src/test/java/dev/hardwood/schema/FileSchemaConvertedTypeTest.java
+++ b/core/src/test/java/dev/hardwood/schema/FileSchemaConvertedTypeTest.java
@@ -38,8 +38,7 @@ class FileSchemaConvertedTypeTest {
 
     private static ColumnSchema resolveColumn(
             PhysicalType type, ConvertedType convertedType, Integer scale, Integer precision) {
-        SchemaElement root = new SchemaElement(
-                ROOT, null, null, RepetitionType.REQUIRED, 1, null, null, null, null, null);
+        SchemaElement root = SchemaElement.group(ROOT, RepetitionType.REQUIRED, 1);
         SchemaElement leaf = new SchemaElement(
                 COLUMN, type, null, RepetitionType.OPTIONAL, null, convertedType, scale, precision, null, null);
         FileSchema schema = FileSchema.fromSchemaElements(List.of(root, leaf));
@@ -175,8 +174,7 @@ class FileSchemaConvertedTypeTest {
 
     @Test
     void modernLogicalTypeWinsOverConvertedType() {
-        SchemaElement root = new SchemaElement(
-                ROOT, null, null, RepetitionType.REQUIRED, 1, null, null, null, null, null);
+        SchemaElement root = SchemaElement.group(ROOT, RepetitionType.REQUIRED, 1);
         // converted_type=UTF8, but logical type is explicitly an Int, logical type must win.
         LogicalType.IntType modern = new LogicalType.IntType(32, false);
         SchemaElement leaf = new SchemaElement(

--- a/core/src/test/java/dev/hardwood/schema/FileSchemaFlattenTest.java
+++ b/core/src/test/java/dev/hardwood/schema/FileSchemaFlattenTest.java
@@ -19,6 +19,7 @@ import static dev.hardwood.metadata.SchemaElement.fixedLengthPrimitive;
 import static dev.hardwood.metadata.SchemaElement.primitive;
 import static dev.hardwood.metadata.SchemaElement.root;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 /// Characterization test for [FileSchema#toSchemaElements], the footer-write path
 /// [dev.hardwood.writer.ParquetFileWriter] calls: pins what survives a round trip
@@ -72,25 +73,16 @@ class FileSchemaFlattenTest {
         assertThat(column.typeLength()).isEqualTo(3);
     }
 
-    /// Documents a known fault, not intended behavior. `Builder.map` takes the key's physical
-    /// type but no byte length, so a `FIXED_LEN_BYTE_ARRAY` key cannot be given one, and
-    /// `build()` accepts it. The resulting `key` element has no width, which no reader can
-    /// decode. The fix is to reject the key type in `map`, and this assertion inverts when it
-    /// lands.
+    /// `Builder.map` rejects a `FIXED_LEN_BYTE_ARRAY` key because the builder has no
+    /// key-width parameter.
     @Test
-    void mapWithFixedWidthKeyBuildsAKeyWithNoByteLength() {
-        FileSchema schema = FileSchema.builder("schema")
+    void mapWithFixedWidthKeyRequiresAByteLength() {
+        assertThatThrownBy(() -> FileSchema.builder("schema")
                 .map("m", RepetitionType.OPTIONAL, PhysicalType.FIXED_LEN_BYTE_ARRAY,
                         value -> value.primitive(PhysicalType.INT32, RepetitionType.REQUIRED))
-                .build();
-
-        SchemaElement key = schema.toSchemaElements().stream()
-                .filter(element -> "key".equals(element.name()))
-                .findFirst()
-                .orElseThrow();
-
-        assertThat(key.type()).isEqualTo(PhysicalType.FIXED_LEN_BYTE_ARRAY);
-        assertThat(key.typeLength()).isNull();
+                .build())
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("FIXED_LEN_BYTE_ARRAY column key requires a positive type length");
     }
 
     @Test

--- a/core/src/test/java/dev/hardwood/schema/FileSchemaFlattenTest.java
+++ b/core/src/test/java/dev/hardwood/schema/FileSchemaFlattenTest.java
@@ -1,0 +1,103 @@
+/*
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Copyright The original authors
+ *
+ *  Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package dev.hardwood.schema;
+
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+
+import dev.hardwood.metadata.PhysicalType;
+import dev.hardwood.metadata.RepetitionType;
+import dev.hardwood.metadata.SchemaElement;
+
+import static dev.hardwood.metadata.SchemaElement.fixedLengthPrimitive;
+import static dev.hardwood.metadata.SchemaElement.primitive;
+import static dev.hardwood.metadata.SchemaElement.root;
+import static org.assertj.core.api.Assertions.assertThat;
+
+/// Characterization test for [FileSchema#toSchemaElements], the footer-write path
+/// [dev.hardwood.writer.ParquetFileWriter] calls: pins what survives a round trip
+/// through [FileSchema#fromSchemaElements] and back.
+///
+/// `type_length` carries both of the meanings parquet.thrift gives it: the byte length
+/// of a `FIXED_LEN_BYTE_ARRAY` value, and the maximum bit length of a value of any other
+/// physical type. Both are optional in the footer, so all four combinations reach the
+/// reader and each one has to come back out unchanged.
+class FileSchemaFlattenTest {
+
+    private static SchemaElement onlyColumnOf(SchemaElement column) {
+        FileSchema schema = FileSchema.fromSchemaElements(List.of(root("schema", 1), column));
+        List<SchemaElement> flattened = schema.toSchemaElements();
+        assertThat(flattened).hasSize(2);
+        return flattened.get(1);
+    }
+
+    @Test
+    void fixedWidthColumnKeepsItsByteLength() {
+        SchemaElement column = onlyColumnOf(fixedLengthPrimitive("digest", 16, RepetitionType.REQUIRED));
+
+        assertThat(column.type()).isEqualTo(PhysicalType.FIXED_LEN_BYTE_ARRAY);
+        assertThat(column.typeLength()).isEqualTo(16);
+    }
+
+    /// `type_length` is optional in the footer, so a `FIXED_LEN_BYTE_ARRAY` element can
+    /// arrive without one. Flattening reproduces the element as it was read, so rewriting
+    /// such a file fails on the column's own contents rather than on an unboxed null.
+    @Test
+    void fixedWidthColumnWithNoByteLengthSurvivesFlattening() {
+        SchemaElement noWidth = new SchemaElement("digest", PhysicalType.FIXED_LEN_BYTE_ARRAY, null,
+                RepetitionType.REQUIRED, null, null, null, null, null, null);
+
+        SchemaElement column = onlyColumnOf(noWidth);
+
+        assertThat(column.type()).isEqualTo(PhysicalType.FIXED_LEN_BYTE_ARRAY);
+        assertThat(column.typeLength()).isNull();
+    }
+
+    /// A non-FLBA element may carry a `type_length`, which the format defines as the
+    /// maximum bit length of a value. It does not affect decoding, and it survives the
+    /// round trip.
+    @Test
+    void maximumBitLengthOfIntColumnSurvivesFlattening() {
+        SchemaElement tag = primitive("tag", PhysicalType.INT32, RepetitionType.REQUIRED).withTypeLength(3);
+
+        SchemaElement column = onlyColumnOf(tag);
+
+        assertThat(column.type()).isEqualTo(PhysicalType.INT32);
+        assertThat(column.typeLength()).isEqualTo(3);
+    }
+
+    /// Documents a known fault, not intended behavior. `Builder.map` takes the key's physical
+    /// type but no byte length, so a `FIXED_LEN_BYTE_ARRAY` key cannot be given one, and
+    /// `build()` accepts it. The resulting `key` element has no width, which no reader can
+    /// decode. The fix is to reject the key type in `map`, and this assertion inverts when it
+    /// lands.
+    @Test
+    void mapWithFixedWidthKeyBuildsAKeyWithNoByteLength() {
+        FileSchema schema = FileSchema.builder("schema")
+                .map("m", RepetitionType.OPTIONAL, PhysicalType.FIXED_LEN_BYTE_ARRAY,
+                        value -> value.primitive(PhysicalType.INT32, RepetitionType.REQUIRED))
+                .build();
+
+        SchemaElement key = schema.toSchemaElements().stream()
+                .filter(element -> "key".equals(element.name()))
+                .findFirst()
+                .orElseThrow();
+
+        assertThat(key.type()).isEqualTo(PhysicalType.FIXED_LEN_BYTE_ARRAY);
+        assertThat(key.typeLength()).isNull();
+    }
+
+    @Test
+    void columnWithNoTypeLengthStaysWithout() {
+        SchemaElement column = onlyColumnOf(primitive("id", PhysicalType.INT64, RepetitionType.REQUIRED));
+
+        assertThat(column.type()).isEqualTo(PhysicalType.INT64);
+        assertThat(column.typeLength()).isNull();
+    }
+}

--- a/core/src/test/java/dev/hardwood/schema/FileSchemaFlattenTest.java
+++ b/core/src/test/java/dev/hardwood/schema/FileSchemaFlattenTest.java
@@ -47,8 +47,8 @@ class FileSchemaFlattenTest {
     }
 
     /// `type_length` is optional in the footer, so a `FIXED_LEN_BYTE_ARRAY` element can
-    /// arrive without one. Flattening reproduces the element as it was read, so rewriting
-    /// such a file fails on the column's own contents rather than on an unboxed null.
+    /// arrive without one. Flattening preserves the missing width; a later writer validation
+    /// rejects the schema before it can write values.
     @Test
     void fixedWidthColumnWithNoByteLengthSurvivesFlattening() {
         SchemaElement noWidth = new SchemaElement("digest", PhysicalType.FIXED_LEN_BYTE_ARRAY, null,

--- a/core/src/test/java/dev/hardwood/schema/FileSchemaFlattenTest.java
+++ b/core/src/test/java/dev/hardwood/schema/FileSchemaFlattenTest.java
@@ -61,11 +61,13 @@ class FileSchemaFlattenTest {
     }
 
     /// A non-FLBA element may carry a `type_length`, which the format defines as the
-    /// maximum bit length of a value. It does not affect decoding, and it survives the
+    /// maximum bit length of a value. The primitive factories do not express it, so the
+    /// canonical constructor builds it. It does not affect decoding, and it survives the
     /// round trip.
     @Test
     void maximumBitLengthOfIntColumnSurvivesFlattening() {
-        SchemaElement tag = primitive("tag", PhysicalType.INT32, RepetitionType.REQUIRED).withTypeLength(3);
+        SchemaElement tag = new SchemaElement("tag", PhysicalType.INT32, 3, RepetitionType.REQUIRED, null, null, null,
+                null, null, null);
 
         SchemaElement column = onlyColumnOf(tag);
 

--- a/core/src/test/java/dev/hardwood/schema/VariantSchemaTest.java
+++ b/core/src/test/java/dev/hardwood/schema/VariantSchemaTest.java
@@ -24,15 +24,13 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 class VariantSchemaTest {
 
     private static SchemaElement primChild(String name, PhysicalType type) {
-        return new SchemaElement(name, type, null, RepetitionType.REQUIRED,
-                null, null, null, null, null, null);
+        return SchemaElement.primitive(name, type, RepetitionType.REQUIRED);
     }
 
     @Test
     void groupNodeRoundTripsVariantAnnotation() {
-        SchemaElement root = new SchemaElement("root", null, null, null, 1, null, null, null, null, null);
-        SchemaElement variant = new SchemaElement("v", null, null, RepetitionType.OPTIONAL, 2,
-                null, null, null, null, new LogicalType.VariantType(1));
+        SchemaElement root = SchemaElement.root("root", 1);
+        SchemaElement variant = SchemaElement.group("v", RepetitionType.OPTIONAL, 2, new LogicalType.VariantType(1));
         SchemaElement metadata = primChild("metadata", PhysicalType.BYTE_ARRAY);
         SchemaElement value = primChild("value", PhysicalType.BYTE_ARRAY);
 
@@ -46,13 +44,11 @@ class VariantSchemaTest {
 
     @Test
     void variantGroupWithTypedValueIsAccepted() {
-        SchemaElement root = new SchemaElement("root", null, null, null, 1, null, null, null, null, null);
-        SchemaElement variant = new SchemaElement("v", null, null, RepetitionType.OPTIONAL, 3,
-                null, null, null, null, new LogicalType.VariantType(1));
+        SchemaElement root = SchemaElement.root("root", 1);
+        SchemaElement variant = SchemaElement.group("v", RepetitionType.OPTIONAL, 3, new LogicalType.VariantType(1));
         SchemaElement metadata = primChild("metadata", PhysicalType.BYTE_ARRAY);
         SchemaElement value = primChild("value", PhysicalType.BYTE_ARRAY);
-        SchemaElement typedValue = new SchemaElement("typed_value", PhysicalType.INT64, null,
-                RepetitionType.OPTIONAL, null, null, null, null, null, null);
+        SchemaElement typedValue = SchemaElement.primitive("typed_value", PhysicalType.INT64, RepetitionType.OPTIONAL);
 
         FileSchema schema = FileSchema.fromSchemaElements(List.of(root, variant, metadata, value, typedValue));
         SchemaNode.GroupNode variantNode = (SchemaNode.GroupNode) schema.getRootNode().children().get(0);
@@ -62,9 +58,8 @@ class VariantSchemaTest {
 
     @Test
     void variantGroupMissingValueChildIsRejected() {
-        SchemaElement root = new SchemaElement("root", null, null, null, 1, null, null, null, null, null);
-        SchemaElement variant = new SchemaElement("v", null, null, RepetitionType.OPTIONAL, 1,
-                null, null, null, null, new LogicalType.VariantType(1));
+        SchemaElement root = SchemaElement.root("root", 1);
+        SchemaElement variant = SchemaElement.group("v", RepetitionType.OPTIONAL, 1, new LogicalType.VariantType(1));
         SchemaElement metadata = primChild("metadata", PhysicalType.BYTE_ARRAY);
 
         assertThatThrownBy(() -> FileSchema.fromSchemaElements(List.of(root, variant, metadata)))
@@ -74,9 +69,8 @@ class VariantSchemaTest {
 
     @Test
     void variantGroupWithWrongChildNameIsRejected() {
-        SchemaElement root = new SchemaElement("root", null, null, null, 1, null, null, null, null, null);
-        SchemaElement variant = new SchemaElement("v", null, null, RepetitionType.OPTIONAL, 2,
-                null, null, null, null, new LogicalType.VariantType(1));
+        SchemaElement root = SchemaElement.root("root", 1);
+        SchemaElement variant = SchemaElement.group("v", RepetitionType.OPTIONAL, 2, new LogicalType.VariantType(1));
         SchemaElement metadata = primChild("metadata", PhysicalType.BYTE_ARRAY);
         SchemaElement misnamed = primChild("payload", PhysicalType.BYTE_ARRAY);
 
@@ -87,9 +81,8 @@ class VariantSchemaTest {
 
     @Test
     void variantGroupWithWrongPhysicalTypeIsRejected() {
-        SchemaElement root = new SchemaElement("root", null, null, null, 1, null, null, null, null, null);
-        SchemaElement variant = new SchemaElement("v", null, null, RepetitionType.OPTIONAL, 2,
-                null, null, null, null, new LogicalType.VariantType(1));
+        SchemaElement root = SchemaElement.root("root", 1);
+        SchemaElement variant = SchemaElement.group("v", RepetitionType.OPTIONAL, 2, new LogicalType.VariantType(1));
         SchemaElement metadata = primChild("metadata", PhysicalType.BYTE_ARRAY);
         SchemaElement wrongType = primChild("value", PhysicalType.INT32);
 
@@ -106,9 +99,8 @@ class VariantSchemaTest {
 
     @Test
     void plainStructUnchangedByNewAnnotation() {
-        SchemaElement root = new SchemaElement("root", null, null, null, 1, null, null, null, null, null);
-        SchemaElement addr = new SchemaElement("addr", null, null, RepetitionType.OPTIONAL, 1,
-                null, null, null, null, null);
+        SchemaElement root = SchemaElement.root("root", 1);
+        SchemaElement addr = SchemaElement.group("addr", RepetitionType.OPTIONAL, 1);
         SchemaElement zip = primChild("zip", PhysicalType.INT32);
 
         FileSchema schema = FileSchema.fromSchemaElements(List.of(root, addr, zip));

--- a/docs/content/reference/schema-element.md
+++ b/docs/content/reference/schema-element.md
@@ -11,21 +11,21 @@
 -->
 # SchemaElement
 
-`dev.hardwood.metadata.SchemaElement` is one entry in the flat, depth-first schema list stored in a Parquet file footer. It maps one to one onto the Thrift `SchemaElement` in the Parquet format.
+`dev.hardwood.metadata.SchemaElement` represents one element in the flat schema list in a Parquet footer. The list uses depth-first order.
 
-`FileSchema.fromSchemaElements(List<SchemaElement>)` turns such a list into a schema tree. `FileSchema.toSchemaElements()` turns it back.
+`FileSchema.fromSchemaElements(List<SchemaElement>)` builds a schema tree from this list. `FileSchema.toSchemaElements()` creates the list again.
 
 !!! note
 
-    To build a schema for writing, use [`FileSchema.builder(String)`](../how-to/metadata.md) instead. It validates the whole schema and computes child counts for you. Use `SchemaElement` when you work with footer metadata directly.
+    Use [`FileSchema.builder(String)`](../how-to/metadata.md) to build a schema for writing. The builder checks the complete schema and calculates child counts. Use `SchemaElement` when you work with footer metadata.
 
 ## Factories
 
-Static factories cover the common element kinds. Each one sets only the components that its kind uses.
+The static factories build the common element kinds. Each factory sets the fields for its kind.
 
 | Factory | Builds |
 |---|---|
-| `root(name, numChildren)` | the root group, which has no repetition |
+| `root(name, numChildren)` | the root group, with no repetition |
 | `group(name, repetition, numChildren)` | a group |
 | `group(name, repetition, numChildren, logicalType)` | a group with a logical type |
 | `primitive(name, type, repetition)` | a primitive column |
@@ -43,41 +43,46 @@ List<SchemaElement> elements = List.of(
 FileSchema schema = FileSchema.fromSchemaElements(elements);
 ```
 
-### Repetition
+## Repetition
 
-The root element has no repetition, and every other element has one. `root` builds the first case, and `group` and the primitive factories take the repetition for the second.
+A valid root has no repetition. Other valid elements have a repetition value.
 
-A footer that breaks this rule still reads. `fromSchemaElements` supplies a missing repetition, `REQUIRED` for a root and `OPTIONAL` for any other element.
+`root` sets the root repetition to `null`. The group and primitive factories take the repetition value as an argument.
 
-`name` may be `null`. Valid Parquet footers carry a name because the Thrift field is required.
-Malformed or truncated metadata can still produce a null name; the factories pass it through
-without a check.
+`fromSchemaElements` accepts a missing repetition value. It uses `REQUIRED` for the root and `OPTIONAL` for other elements.
 
-### Type length
+## Name
 
-`typeLength` has two meanings, one per physical type:
+A valid Parquet footer has a name for each schema element. The Thrift field is required.
 
-| Physical type | Meaning | How to set it |
-|---|---|---|
-| `FIXED_LEN_BYTE_ARRAY` | byte length of every value | `fixedLengthPrimitive` |
-| any other | maximum bit length used to store a value | `withTypeLength(int)` |
+A malformed or truncated footer can omit the name. The reader then creates an element with `name == null`. The factories pass a null name through without a check.
 
-`withTypeLength` returns a copy of an element with the field set:
+## Type length
+
+`typeLength` has a different meaning for each physical type:
+
+| Physical type | Meaning |
+|---|---|
+| `FIXED_LEN_BYTE_ARRAY` | the byte length of each value |
+| any other physical type | the maximum bit length needed to store any value |
+
+Use `fixedLengthPrimitive` to create an `FIXED_LEN_BYTE_ARRAY` (called FLBA henceforth) column with its byte length. Use `withTypeLength(int)` to set or replace `typeLength` on a primitive element.
 
 ```java
-// a low-cardinality INT32 whose values fit in 3 bits
-primitive("tag", PhysicalType.INT32, RepetitionType.REQUIRED).withTypeLength(3)
+// An INT32 column with a maximum bit length of 3 - all values of this column can be stored with 3 bits.
+SchemaElement tag = primitive("tag", PhysicalType.INT32, RepetitionType.REQUIRED)
+        .withTypeLength(3);
 ```
 
-The field is optional in both cases. A column of any type can leave it out.
+`typeLength` can be `null` in raw footer metadata. A writer must provide a positive length for an FLBA column. A data reader also needs this length to decode FLBA values.
 
-`fixedLengthPrimitive` sets the physical type to `FIXED_LEN_BYTE_ARRAY` itself, so it takes no `PhysicalType`. It takes the width **second**. `FileSchema.Builder.addColumn` takes the width last.
+`fixedLengthPrimitive` sets the physical type to `FIXED_LEN_BYTE_ARRAY`. It takes the width as its second argument. `FileSchema.Builder.addColumn` takes the width as its fourth argument.
 
-`primitive` rejects `FIXED_LEN_BYTE_ARRAY`, because that type needs a width. Use `fixedLengthPrimitive` for it.
+`primitive` rejects `FIXED_LEN_BYTE_ARRAY`. Use `fixedLengthPrimitive` for that type.
 
-### Errors
+## Errors
 
-Every factory throws `IllegalArgumentException` for these:
+The factories throw `IllegalArgumentException` for these inputs:
 
 | Condition | Factory |
 |---|---|
@@ -87,23 +92,26 @@ Every factory throws `IllegalArgumentException` for these:
 | `typeLength` is zero or less | `fixedLengthPrimitive`, `withTypeLength` |
 | the element is a group | `withTypeLength` |
 
-A factory checks only one element. Rules that span the whole list stay in `fromSchemaElements`. For example, a root that declares two children followed by only one element fails there, not in the factory.
+A factory checks one element. Rules for the complete list stay in `fromSchemaElements`. The method consumes the list in depth-first order and builds the schema tree.
 
 ## Canonical constructor
 
-The record constructor takes all ten components in Hardwood record-component order:
+The record constructor takes the components in Hardwood record-component order:
 
 ```java
-new SchemaElement(name, type, typeLength, repetitionType, numChildren,
-        convertedType, scale, precision, fieldId, logicalType);
+new SchemaElement(name, type, typeLength, repetitionType, 
+                  numChildren, convertedType, scale, precision, 
+                  fieldId, logicalType);
 ```
 
-Use it for metadata the factories do not cover. No factory sets `convertedType`, `scale`, `precision`, or `fieldId`, so these cases need the constructor:
+Use the constructor when the factories do not cover the metadata. The factories do not set `convertedType`, `scale`, `precision`, or `fieldId`.
 
-- a legacy `ConvertedType` annotation, such as `ConvertedType.LIST` or `ConvertedType.MAP`
-- a decimal, which carries `scale` and `precision`
-- a Thrift `fieldId`
-- a full element decoded from a footer, where every component must survive
+Use the constructor for:
+
+- a legacy `ConvertedType` annotation, such as `ConvertedType.LIST` or `ConvertedType.MAP`;
+- legacy decimal metadata with `scale` and `precision`;
+- a Thrift `fieldId`;
+- a complete element decoded from a footer.
 
 ## Node kind
 
@@ -112,4 +120,4 @@ Use it for metadata the factories do not cover. No factory sets `convertedType`,
 | `isGroup()` | `type` is `null` |
 | `isPrimitive()` | `type` is not `null` |
 
-A `null` physical type is what marks an element as a group. This is why `primitive` rejects a `null` type: it would build a group.
+A null physical type marks a group. `primitive` rejects a null type because it would create a group.

--- a/docs/content/reference/schema-element.md
+++ b/docs/content/reference/schema-element.md
@@ -1,0 +1,115 @@
+<!--
+
+     SPDX-License-Identifier: CC-BY-SA-4.0
+
+     Copyright The original authors
+
+     Licensed under the Creative Commons Attribution-ShareAlike 4.0 International License;
+     you may not use this file except in compliance with the License.
+     You may obtain a copy of the License at https://creativecommons.org/licenses/by-sa/4.0/
+
+-->
+# SchemaElement
+
+`dev.hardwood.metadata.SchemaElement` is one entry in the flat, depth-first schema list stored in a Parquet file footer. It maps one to one onto the Thrift `SchemaElement` in the Parquet format.
+
+`FileSchema.fromSchemaElements(List<SchemaElement>)` turns such a list into a schema tree. `FileSchema.toSchemaElements()` turns it back.
+
+!!! note
+
+    To build a schema for writing, use [`FileSchema.builder(String)`](../how-to/metadata.md) instead. It validates the whole schema and computes child counts for you. Use `SchemaElement` when you work with footer metadata directly.
+
+## Factories
+
+Static factories cover the common element kinds. Each one sets only the components that its kind uses.
+
+| Factory | Builds |
+|---|---|
+| `root(name, numChildren)` | the root group, which has no repetition |
+| `group(name, repetition, numChildren)` | a group |
+| `group(name, repetition, numChildren, logicalType)` | a group with a logical type |
+| `primitive(name, type, repetition)` | a primitive column |
+| `primitive(name, type, repetition, logicalType)` | a primitive column with a logical type |
+| `fixedLengthPrimitive(name, typeLength, repetition)` | a `FIXED_LEN_BYTE_ARRAY` column |
+| `fixedLengthPrimitive(name, typeLength, repetition, logicalType)` | a `FIXED_LEN_BYTE_ARRAY` column with a logical type |
+
+```java
+List<SchemaElement> elements = List.of(
+        root("schema", 3),
+        primitive("id", PhysicalType.INT64, RepetitionType.REQUIRED),
+        primitive("name", PhysicalType.BYTE_ARRAY, RepetitionType.OPTIONAL, new LogicalType.StringType()),
+        fixedLengthPrimitive("uuid", 16, RepetitionType.REQUIRED, new LogicalType.UuidType()));
+
+FileSchema schema = FileSchema.fromSchemaElements(elements);
+```
+
+### Repetition
+
+The root element has no repetition, and every other element has one. `root` builds the first case, and `group` and the primitive factories take the repetition for the second.
+
+A footer that breaks this rule still reads. `fromSchemaElements` supplies a missing repetition, `REQUIRED` for a root and `OPTIONAL` for any other element.
+
+### Name
+
+`name` may be `null`. The factories pass it through without a check. A footer always carries a name, because the Thrift field is required, so a `null` name comes from code rather than from a file.
+
+### Type length
+
+`typeLength` has two meanings, one per physical type:
+
+| Physical type | Meaning | How to set it |
+|---|---|---|
+| `FIXED_LEN_BYTE_ARRAY` | byte length of every value | `fixedLengthPrimitive` |
+| any other | maximum bit length used to store a value | `withTypeLength(int)` |
+
+`withTypeLength` returns a copy of an element with the field set:
+
+```java
+// a low-cardinality INT32 whose values fit in 3 bits
+primitive("tag", PhysicalType.INT32, RepetitionType.REQUIRED).withTypeLength(3)
+```
+
+The field is optional in both cases. A column of any type can leave it out.
+
+`fixedLengthPrimitive` sets the physical type to `FIXED_LEN_BYTE_ARRAY` itself, so it takes no `PhysicalType`. It takes the width **second**. `FileSchema.Builder.addColumn` takes the width last.
+
+`primitive` rejects `FIXED_LEN_BYTE_ARRAY`, because that type needs a width. Use `fixedLengthPrimitive` for it.
+
+### Errors
+
+Every factory throws `IllegalArgumentException` for these:
+
+| Condition | Factory |
+|---|---|
+| `type` is `null` | `primitive` |
+| `type` is `FIXED_LEN_BYTE_ARRAY` | `primitive` |
+| `numChildren` is negative | `group`, `root` |
+| `typeLength` is zero or less | `fixedLengthPrimitive`, `withTypeLength` |
+| the element is a group | `withTypeLength` |
+
+A factory checks only one element. Rules that span the whole list stay in `fromSchemaElements`. For example, a root that declares two children followed by only one element fails there, not in the factory.
+
+## Canonical constructor
+
+The record constructor takes all ten components in Thrift field order:
+
+```java
+new SchemaElement(name, type, typeLength, repetitionType, numChildren,
+        convertedType, scale, precision, fieldId, logicalType);
+```
+
+Use it for metadata the factories do not cover. No factory sets `convertedType`, `scale`, `precision`, or `fieldId`, so these cases need the constructor:
+
+- a legacy `ConvertedType` annotation, such as `ConvertedType.LIST` or `ConvertedType.MAP`
+- a decimal, which carries `scale` and `precision`
+- a Thrift `fieldId`
+- a full element decoded from a footer, where every component must survive
+
+## Node kind
+
+| Method | Returns `true` when |
+|---|---|
+| `isGroup()` | `type` is `null` |
+| `isPrimitive()` | `type` is not `null` |
+
+A `null` physical type is what marks an element as a group. This is why `primitive` rejects a `null` type: it would build a group.

--- a/docs/content/reference/schema-element.md
+++ b/docs/content/reference/schema-element.md
@@ -34,6 +34,10 @@ The static factories build the common element kinds. Each factory sets the field
 | `fixedLengthPrimitive(name, typeLength, repetition, logicalType)` | a `FIXED_LEN_BYTE_ARRAY` column with a logical type |
 
 ```java
+import static dev.hardwood.metadata.SchemaElement.fixedLengthPrimitive;
+import static dev.hardwood.metadata.SchemaElement.primitive;
+import static dev.hardwood.metadata.SchemaElement.root;
+
 List<SchemaElement> elements = List.of(
         root("schema", 3),
         primitive("id", PhysicalType.INT64, RepetitionType.REQUIRED),
@@ -45,11 +49,11 @@ FileSchema schema = FileSchema.fromSchemaElements(elements);
 
 ## Repetition
 
-A valid root has no repetition. Other valid elements have a repetition value.
+The Parquet format leaves `repetition_type` unset on the root element and requires it on every other element.
 
-`root` sets the root repetition to `null`. The group and primitive factories take the repetition value as an argument.
+`root` builds the root element with no repetition. The group and primitive factories require a non-null repetition value and reject a null one.
 
-`fromSchemaElements` accepts a missing repetition value. It uses `REQUIRED` for the root and `OPTIONAL` for other elements.
+`fromSchemaElements` accepts an element with no repetition value, as a footer may carry one. It uses `REQUIRED` for the root and `OPTIONAL` for other elements. `FileSchema.toSchemaElements()` writes `REQUIRED` for the root of a schema built with `FileSchema.builder(String)`.
 
 ## Name
 
@@ -66,19 +70,17 @@ A malformed or truncated footer can omit the name. The reader then creates an el
 | `FIXED_LEN_BYTE_ARRAY` | the byte length of each value |
 | any other physical type | the maximum bit length needed to store any value |
 
-Use `fixedLengthPrimitive` to create an `FIXED_LEN_BYTE_ARRAY` (called FLBA henceforth) column with its byte length. Use `withTypeLength(int)` to set or replace `typeLength` on a primitive element.
+`fixedLengthPrimitive` sets the physical type to `FIXED_LEN_BYTE_ARRAY` and takes the byte length as its second argument. `primitive` rejects `FIXED_LEN_BYTE_ARRAY`.
+
+The maximum bit length has no factory. Use the canonical constructor for it:
 
 ```java
 // An INT32 column with a maximum bit length of 3 - all values of this column can be stored with 3 bits.
-SchemaElement tag = primitive("tag", PhysicalType.INT32, RepetitionType.REQUIRED)
-        .withTypeLength(3);
+SchemaElement tag = new SchemaElement("tag", PhysicalType.INT32, 3, RepetitionType.REQUIRED,
+        null, null, null, null, null, null);
 ```
 
-`typeLength` can be `null` in raw footer metadata. A writer must provide a positive length for an FLBA column. A data reader also needs this length to decode FLBA values.
-
-`fixedLengthPrimitive` sets the physical type to `FIXED_LEN_BYTE_ARRAY`. It takes the width as its second argument. `FileSchema.Builder.addColumn` takes the width as its fourth argument.
-
-`primitive` rejects `FIXED_LEN_BYTE_ARRAY`. Use `fixedLengthPrimitive` for that type.
+`typeLength` can be `null` in raw footer metadata. A writer must provide a positive length for a `FIXED_LEN_BYTE_ARRAY` column. A data reader also needs this length to decode its values.
 
 ## Errors
 
@@ -86,11 +88,11 @@ The factories throw `IllegalArgumentException` for these inputs:
 
 | Condition | Factory |
 |---|---|
+| `repetition` is `null` | `group`, `primitive`, `fixedLengthPrimitive` |
 | `type` is `null` | `primitive` |
 | `type` is `FIXED_LEN_BYTE_ARRAY` | `primitive` |
 | `numChildren` is negative | `group`, `root` |
-| `typeLength` is zero or less | `fixedLengthPrimitive`, `withTypeLength` |
-| the element is a group | `withTypeLength` |
+| `typeLength` is zero or less | `fixedLengthPrimitive` |
 
 A factory checks one element. Rules for the complete list stay in `fromSchemaElements`. The method consumes the list in depth-first order and builds the schema tree.
 
@@ -111,6 +113,8 @@ Use the constructor for:
 - a legacy `ConvertedType` annotation, such as `ConvertedType.LIST` or `ConvertedType.MAP`;
 - legacy decimal metadata with `scale` and `precision`;
 - a Thrift `fieldId`;
+- a `typeLength` on a column that is not `FIXED_LEN_BYTE_ARRAY`;
+- an element with no repetition value that is not the root;
 - a complete element decoded from a footer.
 
 ## Node kind

--- a/docs/content/reference/schema-element.md
+++ b/docs/content/reference/schema-element.md
@@ -49,9 +49,9 @@ The root element has no repetition, and every other element has one. `root` buil
 
 A footer that breaks this rule still reads. `fromSchemaElements` supplies a missing repetition, `REQUIRED` for a root and `OPTIONAL` for any other element.
 
-### Name
-
-`name` may be `null`. The factories pass it through without a check. A footer always carries a name, because the Thrift field is required, so a `null` name comes from code rather than from a file.
+`name` may be `null`. Valid Parquet footers carry a name because the Thrift field is required.
+Malformed or truncated metadata can still produce a null name; the factories pass it through
+without a check.
 
 ### Type length
 

--- a/docs/content/reference/schema-element.md
+++ b/docs/content/reference/schema-element.md
@@ -91,7 +91,7 @@ A factory checks only one element. Rules that span the whole list stay in `fromS
 
 ## Canonical constructor
 
-The record constructor takes all ten components in Thrift field order:
+The record constructor takes all ten components in Hardwood record-component order:
 
 ```java
 new SchemaElement(name, type, typeLength, repetitionType, numChildren,

--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -46,6 +46,7 @@ nav:
     - Query Controls: reference/query-controls.md
     - S3: reference/s3.md
     - Error Handling: reference/error-handling.md
+    - SchemaElement: reference/schema-element.md
     - CLI: reference/cli.md
     - Package Structure: reference/packages.md
     - API (JavaDoc): /api/latest/

--- a/performance-testing/micro-benchmarks/src/main/java/dev/hardwood/benchmarks/RecordFilterMicroBenchmark.java
+++ b/performance-testing/micro-benchmarks/src/main/java/dev/hardwood/benchmarks/RecordFilterMicroBenchmark.java
@@ -53,6 +53,9 @@ import dev.hardwood.row.StructAccessor;
 import dev.hardwood.schema.ColumnProjection;
 import dev.hardwood.schema.FileSchema;
 
+import static dev.hardwood.metadata.SchemaElement.primitive;
+import static dev.hardwood.metadata.SchemaElement.root;
+
 /// Predicate evaluation micro-benchmark, isolated from any I/O.
 ///
 /// Measures the per-row cost of `RecordFilterCompiler.compile` + `RowMatcher.test`
@@ -200,15 +203,11 @@ public class RecordFilterMicroBenchmark {
     /// Schema with four flat columns: id (INT64), value (DOUBLE), tag (INT32),
     /// flag (BOOLEAN). All required.
     private static FileSchema buildSchema() {
-        SchemaElement root = new SchemaElement("root", null, null, null, 4, null, null, null, null, null);
-        SchemaElement id = new SchemaElement("id", PhysicalType.INT64, null, RepetitionType.REQUIRED,
-                null, null, null, null, null, null);
-        SchemaElement value = new SchemaElement("value", PhysicalType.DOUBLE, null, RepetitionType.REQUIRED,
-                null, null, null, null, null, null);
-        SchemaElement tag = new SchemaElement("tag", PhysicalType.INT32, null, RepetitionType.REQUIRED,
-                null, null, null, null, null, null);
-        SchemaElement flag = new SchemaElement("flag", PhysicalType.BOOLEAN, null, RepetitionType.REQUIRED,
-                null, null, null, null, null, null);
+        SchemaElement root = root("root", 4);
+        SchemaElement id = primitive("id", PhysicalType.INT64, RepetitionType.REQUIRED);
+        SchemaElement value = primitive("value", PhysicalType.DOUBLE, RepetitionType.REQUIRED);
+        SchemaElement tag = primitive("tag", PhysicalType.INT32, RepetitionType.REQUIRED);
+        SchemaElement flag = primitive("flag", PhysicalType.BOOLEAN, RepetitionType.REQUIRED);
         return FileSchema.fromSchemaElements(List.of(root, id, value, tag, flag));
     }
 

--- a/performance-testing/micro-benchmarks/src/main/java/dev/hardwood/benchmarks/RecordFilterMicroBenchmark.java
+++ b/performance-testing/micro-benchmarks/src/main/java/dev/hardwood/benchmarks/RecordFilterMicroBenchmark.java
@@ -203,12 +203,12 @@ public class RecordFilterMicroBenchmark {
     /// Schema with four flat columns: id (INT64), value (DOUBLE), tag (INT32),
     /// flag (BOOLEAN). All required.
     private static FileSchema buildSchema() {
-        SchemaElement root = root("root", 4);
+        SchemaElement rootElement = root("root", 4);
         SchemaElement id = primitive("id", PhysicalType.INT64, RepetitionType.REQUIRED);
         SchemaElement value = primitive("value", PhysicalType.DOUBLE, RepetitionType.REQUIRED);
         SchemaElement tag = primitive("tag", PhysicalType.INT32, RepetitionType.REQUIRED);
         SchemaElement flag = primitive("flag", PhysicalType.BOOLEAN, RepetitionType.REQUIRED);
-        return FileSchema.fromSchemaElements(List.of(root, id, value, tag, flag));
+        return FileSchema.fromSchemaElements(List.of(rootElement, id, value, tag, flag));
     }
 
     private static StructAccessor[] buildRows(int n, long seed) {


### PR DESCRIPTION
Closes #918

## Refactor - adding named factories
`SchemaElement` has lengthy constructor in which nearly all fields are nullable:
```java
record SchemaElement(
        String name,
        PhysicalType type,
        Integer typeLength,
        RepetitionType repetitionType,
        Integer numChildren,
        ConvertedType convertedType,
        Integer scale,
        Integer precision,
        Integer fieldId,
        LogicalType logicalType) {}
```

Creating synthetic `SchemaElement`s in tests involve long chain of `null`s that are hard to read, and may hide semantics (`PhysicalType` is null -> group, `PhysicalType` and `RepetitionType` null -> root) - hence, adding named factory methods that ease reading of code.

Example: 
- group creation:
    ```java
    new SchemaElement("items", null, null, RepetitionType.OPTIONAL,
                        1, null, null, null, 
                        null, new LogicalType.ListType());
    ```
    becomes
    ```java
    SchemaElement.group("items", RepetitionType.OPTIONAL, 1, new LogicalType.ListType());
    ```

It mostly impact tests; dynamic `typeLength` and converted/legacy metadata continue to use the canonical constructor.

## Verification
```text
./mvnw -pl core,avro,cli -am test
./mvnw verify
./mvnw -Pperformance-test -pl performance-testing/micro-benchmarks test-compile
```

## Follow-up issues found
A few issues are found - these are NOT regressions.
  - #965 
  - #966 
  - #967 

## Authorship
- [x] This change is coming from a human who understands what it does and why, and can discuss it in review

## Checklist
- [x] Build via `mvn verify` passes
- [x] The commit message is prefixed with the issue key (`#918 ...`)
- [x] Code changes are covered by tests
- [x] If this PR adds or changes user-facing behaviour, `docs/` has been updated
