### PR TITLE
#904 Fix group predicate resolution

### DIFF
--- a/core/src/main/java/dev/hardwood/internal/predicate/FilterPredicateResolver.java
+++ b/core/src/main/java/dev/hardwood/internal/predicate/FilterPredicateResolver.java
@@ -13,6 +13,7 @@ import java.time.Instant;
 import java.time.LocalTime;
 import java.util.List;
 
+import dev.hardwood.internal.schema.SchemaPathResolver;
 import dev.hardwood.metadata.ColumnOrder;
 import dev.hardwood.metadata.LogicalType;
 import dev.hardwood.metadata.PhysicalType;
@@ -239,64 +240,45 @@ public class FilterPredicateResolver {
     // ==================== Column resolution ====================
 
     /// Resolves a column name to its [ColumnSchema].
-    /// Group fields are rejected because filter predicates currently require leaf columns.
+    ///
+    /// Only leaf columns can carry a predicate. A name denoting a group — a struct, a `LIST`, or a
+    /// `MAP` — is rejected rather than resolved to one of the group's leaves, which would answer a
+    /// different question than the one that was asked.
     ///
     /// @return the resolved column schema
-    /// @throws IllegalArgumentException if the column is not found or does not resolve to a supported leaf column
+    /// @throws IllegalArgumentException if the column is not found, or names a group rather than a
+    ///         leaf column
     private static ColumnSchema resolveColumn(String columnName, FileSchema schema) {
         try {
             return schema.getColumn(columnName);
         }
         catch (IllegalArgumentException e) {
-            SchemaNode node = resolveSchemaNode(columnName, schema);
+            SchemaNode node = SchemaPathResolver.resolve(schema, columnName).node();
             if (node instanceof SchemaNode.GroupNode group) {
                 if (group.isList() || group.isMap() || group.maxRepetitionLevel() > 0) {
-                    throw new IllegalArgumentException(
-                            "Filter predicates do not support repeated columns. "
-                                    + "Column '" + columnName + "' is repeated.");
+                    throw repeatedColumnRejected(columnName);
                 }
-                else {
-                    throw new IllegalArgumentException(
-                            "Filter predicates require a leaf column. "
-                                    + "Column '" + columnName + "' is a group.");
-                }
+                throw new IllegalArgumentException(
+                        "Filter predicates require a leaf column. "
+                                + "Column '" + columnName + "' is a group.");
             }
             throw new IllegalArgumentException(
                     "Column '" + columnName + "' not found in schema", e);
         }
     }
 
-    private static SchemaNode resolveSchemaNode(String fieldPath, FileSchema schema) {
-        SchemaNode current = schema.getRootNode();
-        String[] parts = fieldPath.split("\\.");
-
-        for (String part : parts) {
-            if (!(current instanceof SchemaNode.GroupNode group)) {
-                return null;
-            }
-            SchemaNode next = null;
-            for (SchemaNode child : group.children()) {
-                if (child.name().equals(part)) {
-                    next = child;
-                    break;
-                }
-            }
-            if (next == null) {
-                return null;
-            }
-            current = next;
-        }
-        return current;
-    }
-
     // ==================== Type validation ====================
 
     private static void rejectRepeated(String columnName, ColumnSchema columnSchema) {
         if (columnSchema.maxRepetitionLevel() > 0) {
-            throw new IllegalArgumentException(
-                    "Filter predicates do not support repeated columns. "
-                    + "Column '" + columnName + "' is repeated.");
+            throw repeatedColumnRejected(columnName);
         }
+    }
+
+    private static IllegalArgumentException repeatedColumnRejected(String columnName) {
+        return new IllegalArgumentException(
+                "Filter predicates do not support repeated columns. "
+                        + "Column '" + columnName + "' is repeated.");
     }
 
     private static void validateType(String columnName, PhysicalType expectedType,

--- a/core/src/main/java/dev/hardwood/internal/predicate/FilterPredicateResolver.java
+++ b/core/src/main/java/dev/hardwood/internal/predicate/FilterPredicateResolver.java
@@ -36,6 +36,7 @@ import dev.hardwood.reader.FilterPredicate.Or;
 import dev.hardwood.reader.FilterPredicate.TimeColumnPredicate;
 import dev.hardwood.schema.ColumnSchema;
 import dev.hardwood.schema.FileSchema;
+import dev.hardwood.schema.SchemaNode;
 
 /// Resolves user-facing [FilterPredicate] into the internal [ResolvedPredicate] tree.
 ///
@@ -237,28 +238,55 @@ public class FilterPredicateResolver {
 
     // ==================== Column resolution ====================
 
-    /// Resolves a column name to its [ColumnSchema]. Tries exact name/path lookup first,
-    /// then falls back to matching by top-level field name (for nested/repeated columns).
+    /// Resolves a column name to its [ColumnSchema].
+    /// Group fields are rejected because filter predicates currently require leaf columns.
     ///
     /// @return the resolved column schema
-    /// @throws IllegalArgumentException if the column is not found
+    /// @throws IllegalArgumentException if the column is not found or does not resolve to a supported leaf column
     private static ColumnSchema resolveColumn(String columnName, FileSchema schema) {
         try {
             return schema.getColumn(columnName);
         }
         catch (IllegalArgumentException e) {
-            // Fall back to matching by top-level field name for nested/repeated columns
-            // (e.g. "scores" matches "scores.list.element")
-            int columnCount = schema.getColumnCount();
-            for (int i = 0; i < columnCount; i++) {
-                ColumnSchema col = schema.getColumn(i);
-                if (col.fieldPath().topLevelName().equals(columnName)) {
-                    return col;
+            SchemaNode node = resolveSchemaNode(columnName, schema);
+            if (node instanceof SchemaNode.GroupNode group) {
+                if (group.isList() || group.isMap() || group.maxRepetitionLevel() > 0) {
+                    throw new IllegalArgumentException(
+                            "Filter predicates do not support repeated columns. "
+                                    + "Column '" + columnName + "' is repeated.");
+                }
+                else {
+                    throw new IllegalArgumentException(
+                            "Filter predicates require a leaf column. "
+                                    + "Column '" + columnName + "' is a group.");
                 }
             }
             throw new IllegalArgumentException(
                     "Column '" + columnName + "' not found in schema", e);
         }
+    }
+
+    private static SchemaNode resolveSchemaNode(String fieldPath, FileSchema schema) {
+        SchemaNode current = schema.getRootNode();
+        String[] parts = fieldPath.split("\\.");
+
+        for (String part : parts) {
+            if (!(current instanceof SchemaNode.GroupNode group)) {
+                return null;
+            }
+            SchemaNode next = null;
+            for (SchemaNode child : group.children()) {
+                if (child.name().equals(part)) {
+                    next = child;
+                    break;
+                }
+            }
+            if (next == null) {
+                return null;
+            }
+            current = next;
+        }
+        return current;
     }
 
     // ==================== Type validation ====================

--- a/core/src/main/java/dev/hardwood/internal/schema/ProjectedSchema.java
+++ b/core/src/main/java/dev/hardwood/internal/schema/ProjectedSchema.java
@@ -199,49 +199,18 @@ public final class ProjectedSchema {
                                             List<Integer> includedOriginalIndices,
                                             List<Integer> includedFieldIndices,
                                             int[] originalToProjected) {
-        String[] parts = name.split("\\.");
-
-        // Find the top-level field
-        List<SchemaNode> children = schema.getRootNode().children();
-        SchemaNode current = null;
-        int topLevelFieldIndex = -1;
-
-        for (int i = 0; i < children.size(); i++) {
-            if (children.get(i).name().equals(parts[0])) {
-                current = children.get(i);
-                topLevelFieldIndex = i;
-                break;
-            }
+        SchemaPathResolver.Resolution resolution = SchemaPathResolver.resolve(schema, name);
+        if (resolution.blockedByPrimitive()) {
+            throw new IllegalArgumentException("Cannot navigate into primitive column: " + name);
         }
-
-        if (current == null) {
+        if (resolution.node() == null) {
             throw new IllegalArgumentException("Column not found: " + name);
         }
 
-        includedFieldIndices.add(topLevelFieldIndex);
-
-        // Navigate through the path
-        for (int p = 1; p < parts.length; p++) {
-            if (!(current instanceof SchemaNode.GroupNode group)) {
-                throw new IllegalArgumentException("Cannot navigate into primitive column: " + name);
-            }
-
-            SchemaNode found = null;
-            for (SchemaNode child : group.children()) {
-                if (child.name().equals(parts[p])) {
-                    found = child;
-                    break;
-                }
-            }
-
-            if (found == null) {
-                throw new IllegalArgumentException("Column not found: " + name);
-            }
-            current = found;
-        }
+        includedFieldIndices.add(resolution.topLevelChildIndex());
 
         // Collect all columns under this node
-        collectColumnsFromNode(current, includedOriginalIndices, originalToProjected);
+        collectColumnsFromNode(resolution.node(), includedOriginalIndices, originalToProjected);
     }
 
     /// Recursively collects all column indices under a schema node.

--- a/core/src/main/java/dev/hardwood/internal/schema/SchemaPathResolver.java
+++ b/core/src/main/java/dev/hardwood/internal/schema/SchemaPathResolver.java
@@ -1,0 +1,84 @@
+/*
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Copyright The original authors
+ *
+ *  Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package dev.hardwood.internal.schema;
+
+import java.util.List;
+
+import dev.hardwood.schema.FileSchema;
+import dev.hardwood.schema.SchemaNode;
+
+/// Resolves a dot-separated field path (e.g. `"address.city"`) against the [SchemaNode] tree.
+///
+/// [FileSchema#getColumn(String)] is keyed on leaf paths only, so a name denoting a group
+/// resolves to nothing there. This walker descends the node tree instead and can therefore stop
+/// on a group, which is what callers need in order to report *why* a name is not a usable leaf.
+///
+/// Path segments are compared in place, so no array is materialized for the path.
+public final class SchemaPathResolver {
+
+    private SchemaPathResolver() {
+    }
+
+    /// The outcome of walking a dot-separated path over a schema tree.
+    ///
+    /// @param node the node at the requested path, or `null` when the path names no node
+    /// @param topLevelChildIndex index of the path's first segment among the root's children,
+    ///        or `-1` when the root has no child of that name
+    /// @param blockedByPrimitive `true` when the walk stopped because a segment would have had to
+    ///        descend into a primitive column
+    public record Resolution(SchemaNode node, int topLevelChildIndex, boolean blockedByPrimitive) {
+    }
+
+    /// Resolves `path` against the root node of `schema`.
+    public static Resolution resolve(FileSchema schema, String path) {
+        return resolve(schema.getRootNode(), path);
+    }
+
+    /// Resolves `path` against `root`, one dot-separated segment per tree level.
+    public static Resolution resolve(SchemaNode.GroupNode root, String path) {
+        SchemaNode current = root;
+        int topLevelChildIndex = -1;
+        int start = 0;
+
+        while (true) {
+            if (!(current instanceof SchemaNode.GroupNode group)) {
+                return new Resolution(null, topLevelChildIndex, true);
+            }
+
+            int dot = path.indexOf('.', start);
+            int end = dot < 0 ? path.length() : dot;
+
+            int childIndex = indexOfChild(group, path, start, end);
+            if (childIndex < 0) {
+                return new Resolution(null, topLevelChildIndex, false);
+            }
+            if (topLevelChildIndex < 0) {
+                topLevelChildIndex = childIndex;
+            }
+            current = group.children().get(childIndex);
+
+            if (dot < 0) {
+                return new Resolution(current, topLevelChildIndex, false);
+            }
+            start = dot + 1;
+        }
+    }
+
+    /// Index of the child of `group` named by `path[start, end)`, or `-1` if there is none.
+    private static int indexOfChild(SchemaNode.GroupNode group, String path, int start, int end) {
+        int length = end - start;
+        List<SchemaNode> children = group.children();
+        for (int i = 0; i < children.size(); i++) {
+            String name = children.get(i).name();
+            if (name.length() == length && path.regionMatches(start, name, 0, length)) {
+                return i;
+            }
+        }
+        return -1;
+    }
+}

--- a/core/src/main/java/dev/hardwood/metadata/FieldPath.java
+++ b/core/src/main/java/dev/hardwood/metadata/FieldPath.java
@@ -36,8 +36,8 @@ public record FieldPath(List<String> elements) {
     /// Returns true if this path matches the given dotted name.
     ///
     /// A dotted name like `"address.zip"` matches the path `["address", "zip"]`.
-    /// A prefix match is allowed: `"address"` matches `["address", "zip"]`
-    /// (useful for filtering on a top-level field that contains nested columns).
+    /// A prefix match is allowed: `"address"` matches `["address", "zip"]`, so a group name
+    /// selects every leaf below it.
     ///
     /// @param dottedName a dot-separated field reference (e.g. `"address.zip"`)
     /// @return true if this path matches the dotted name

--- a/core/src/test/java/dev/hardwood/PredicatePushDownTest.java
+++ b/core/src/test/java/dev/hardwood/PredicatePushDownTest.java
@@ -542,6 +542,34 @@ class PredicatePushDownTest {
     }
 
     @Test
+    void testFilterOnMapColumnIsRejected() throws Exception {
+        // A MAP contains a repeated key_value group, so predicates on the MAP
+        // itself are unsupported and must be rejected as repeated.
+        Path mapFile = Paths.get("src/test/resources/map_struct_value_test.parquet");
+        try (ParquetFileReader reader = ParquetFileReader.open(InputFile.of(mapFile))) {
+            FilterPredicate filter = FilterPredicate.isNull("people");
+
+            assertThatThrownBy(() -> reader.buildRowReader().filter(filter).build())
+                    .isInstanceOf(IllegalArgumentException.class)
+                    .hasMessageContaining("repeated");
+        }
+    }
+
+    @Test
+    void testFilterOnMapValueGroupIsRejected() throws Exception {
+        // The MAP value group inherits a repetition level from the repeated
+        // key_value group, so filtering on the group must be rejected.
+        Path mapFile = Paths.get("src/test/resources/map_struct_value_test.parquet");
+        try (ParquetFileReader reader = ParquetFileReader.open(InputFile.of(mapFile))) {
+            FilterPredicate filter = FilterPredicate.isNull("people.key_value.value");
+
+            assertThatThrownBy(() -> reader.buildRowReader().filter(filter).build())
+                    .isInstanceOf(IllegalArgumentException.class)
+                    .hasMessageContaining("repeated");
+        }
+    }
+
+    @Test
     void testFilterOnFlatColumnFiltersRepeatedColumn() throws Exception {
         // Filter on flat "id" column, read all columns including repeated "scores"
         // id > 6 -> skip RG0 (id 1-3) and RG1 (id 4-6), keep RG2 (id 7-9)
@@ -608,6 +636,18 @@ class PredicatePushDownTest {
             try (RowReader rows = reader.buildRowReader().filter(filter).build()) {
                 assertThat(rows.hasNext()).isFalse();
             }
+        }
+    }
+
+    @Test
+    void testFilterOnGroupColumnIsRejected() throws Exception {
+        // Filtering on a group column should fail instead of resolving to a nested leaf.
+        try (ParquetFileReader reader = ParquetFileReader.open(InputFile.of(NESTED_FILE))) {
+            FilterPredicate filter = FilterPredicate.isNull("address");
+
+            assertThatThrownBy(() -> reader.buildRowReader().filter(filter).build())
+                    .isInstanceOf(IllegalArgumentException.class)
+                    .hasMessageContaining("group");
         }
     }
 

--- a/core/src/test/java/dev/hardwood/internal/predicate/FilterPredicateResolverTest.java
+++ b/core/src/test/java/dev/hardwood/internal/predicate/FilterPredicateResolverTest.java
@@ -311,6 +311,20 @@ class FilterPredicateResolverTest {
                 .hasMessageContaining("not found");
     }
 
+    @Test
+    void resolveNestedGroupColumnThrows() {
+        FileSchema schema = FileSchema.builder("root")
+                .struct("company", RepetitionType.OPTIONAL, company -> company
+                        .struct("address", RepetitionType.OPTIONAL, address -> address
+                                .addColumn("street", PhysicalType.BYTE_ARRAY, RepetitionType.OPTIONAL)))
+                .build();
+
+        assertThatThrownBy(() -> FilterPredicateResolver.resolve(
+                FilterPredicate.isNull("company.address"), schema))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("group");
+    }
+
     // ==================== Type validation ====================
 
     @Test

--- a/core/src/test/java/dev/hardwood/internal/predicate/FilterPredicateResolverTest.java
+++ b/core/src/test/java/dev/hardwood/internal/predicate/FilterPredicateResolverTest.java
@@ -325,6 +325,41 @@ class FilterPredicateResolverTest {
                 .hasMessageContaining("group");
     }
 
+    @Test
+    void resolveGroupWithRepeatedChildIsReportedAsGroup() {
+        // `address` is OPTIONAL and only its child is REPEATED, so the rejection must name the
+        // group rather than claim the column itself is repeated.
+        SchemaElement root = new SchemaElement("root", null, null, null, 1, null, null, null, null, null);
+        SchemaElement address = new SchemaElement("address", null, null, RepetitionType.OPTIONAL, 1,
+                null, null, null, null, null);
+        SchemaElement tags = new SchemaElement("tags", PhysicalType.INT32, null, RepetitionType.REPEATED,
+                null, null, null, null, null, null);
+        FileSchema schema = FileSchema.fromSchemaElements(List.of(root, address, tags));
+
+        assertThatThrownBy(() -> FilterPredicateResolver.resolve(
+                FilterPredicate.isNull("address"), schema))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("is a group")
+                .hasMessageNotContaining("repeated");
+    }
+
+    @Test
+    void resolveRepeatedGroupIsReportedAsRepeated() {
+        // A REPEATED group carries no LIST or MAP annotation, so it is caught by its own
+        // repetition level rather than by the annotation checks.
+        SchemaElement root = new SchemaElement("root", null, null, null, 1, null, null, null, null, null);
+        SchemaElement addresses = new SchemaElement("addresses", null, null, RepetitionType.REPEATED, 1,
+                null, null, null, null, null);
+        SchemaElement city = new SchemaElement("city", PhysicalType.BYTE_ARRAY, null,
+                RepetitionType.OPTIONAL, null, null, null, null, null, null);
+        FileSchema schema = FileSchema.fromSchemaElements(List.of(root, addresses, city));
+
+        assertThatThrownBy(() -> FilterPredicateResolver.resolve(
+                FilterPredicate.isNull("addresses"), schema))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("repeated");
+    }
+
     // ==================== Type validation ====================
 
     @Test

--- a/core/src/test/java/dev/hardwood/internal/schema/SchemaPathResolverTest.java
+++ b/core/src/test/java/dev/hardwood/internal/schema/SchemaPathResolverTest.java
@@ -1,0 +1,96 @@
+/*
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Copyright The original authors
+ *
+ *  Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package dev.hardwood.internal.schema;
+
+import org.junit.jupiter.api.Test;
+
+import dev.hardwood.metadata.PhysicalType;
+import dev.hardwood.metadata.RepetitionType;
+import dev.hardwood.schema.FileSchema;
+import dev.hardwood.schema.SchemaNode;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class SchemaPathResolverTest {
+
+    private static final FileSchema SCHEMA = FileSchema.builder("root")
+            .addColumn("id", PhysicalType.INT32, RepetitionType.REQUIRED)
+            .struct("address", RepetitionType.OPTIONAL, address -> address
+                    .addColumn("city", PhysicalType.BYTE_ARRAY, RepetitionType.OPTIONAL))
+            .list("scores", RepetitionType.OPTIONAL,
+                    element -> element.primitive(PhysicalType.INT32, RepetitionType.OPTIONAL))
+            .build();
+
+    @Test
+    void resolvesTopLevelLeaf() {
+        SchemaPathResolver.Resolution resolution = SchemaPathResolver.resolve(SCHEMA, "id");
+
+        assertThat(resolution.node()).isInstanceOf(SchemaNode.PrimitiveNode.class);
+        assertThat(resolution.node().name()).isEqualTo("id");
+        assertThat(resolution.topLevelChildIndex()).isZero();
+        assertThat(resolution.blockedByPrimitive()).isFalse();
+    }
+
+    @Test
+    void resolvesGroup() {
+        SchemaPathResolver.Resolution resolution = SchemaPathResolver.resolve(SCHEMA, "address");
+
+        assertThat(resolution.node()).isInstanceOf(SchemaNode.GroupNode.class);
+        assertThat(resolution.topLevelChildIndex()).isEqualTo(1);
+    }
+
+    @Test
+    void resolvesNestedLeaf() {
+        SchemaPathResolver.Resolution resolution = SchemaPathResolver.resolve(SCHEMA, "address.city");
+
+        assertThat(resolution.node()).isInstanceOf(SchemaNode.PrimitiveNode.class);
+        assertThat(resolution.node().name()).isEqualTo("city");
+        assertThat(resolution.topLevelChildIndex()).isEqualTo(1);
+    }
+
+    @Test
+    void resolvesThroughTheSyntheticListLevels() {
+        SchemaPathResolver.Resolution resolution = SchemaPathResolver.resolve(SCHEMA, "scores.list.element");
+
+        assertThat(resolution.node()).isInstanceOf(SchemaNode.PrimitiveNode.class);
+        assertThat(resolution.topLevelChildIndex()).isEqualTo(2);
+    }
+
+    @Test
+    void unknownTopLevelNameResolvesToNothing() {
+        SchemaPathResolver.Resolution resolution = SchemaPathResolver.resolve(SCHEMA, "nope");
+
+        assertThat(resolution.node()).isNull();
+        assertThat(resolution.topLevelChildIndex()).isEqualTo(-1);
+        assertThat(resolution.blockedByPrimitive()).isFalse();
+    }
+
+    @Test
+    void unknownNestedNameKeepsTheTopLevelIndex() {
+        SchemaPathResolver.Resolution resolution = SchemaPathResolver.resolve(SCHEMA, "address.nope");
+
+        assertThat(resolution.node()).isNull();
+        assertThat(resolution.topLevelChildIndex()).isEqualTo(1);
+        assertThat(resolution.blockedByPrimitive()).isFalse();
+    }
+
+    @Test
+    void descendingIntoALeafIsReportedSeparately() {
+        SchemaPathResolver.Resolution resolution = SchemaPathResolver.resolve(SCHEMA, "id.city");
+
+        assertThat(resolution.node()).isNull();
+        assertThat(resolution.topLevelChildIndex()).isZero();
+        assertThat(resolution.blockedByPrimitive()).isTrue();
+    }
+
+    @Test
+    void emptyAndTrailingDotPathsResolveToNothing() {
+        assertThat(SchemaPathResolver.resolve(SCHEMA, "").node()).isNull();
+        assertThat(SchemaPathResolver.resolve(SCHEMA, "address.").node()).isNull();
+    }
+}

--- a/docs/content/how-to/query-controls.md
+++ b/docs/content/how-to/query-controls.md
@@ -133,6 +133,11 @@ Filters work with all reader types: `RowReader`, `ColumnReader`, `AvroRowReader`
 
 ### Limitations
 
+- **Predicates apply to leaf columns only
+  ([#977](https://github.com/hardwood-hq/hardwood/issues/977)).** A name that denotes a group — a
+  struct, a `LIST`, or a `MAP` — is rejected with `IllegalArgumentException` at reader creation, as
+  is any leaf below a repeated group. Filter on a leaf instead: `isNull("address.city")` rather
+  than `isNull("address")`. Column projection accepts a group name; predicates do not.
 - **Record-level filtering only applies to flat schemas
   ([#222](https://github.com/hardwood-hq/hardwood/issues/222)).** When the schema contains
   nested columns (structs, lists, or maps), record-level filtering is not active. Row-group

--- a/docs/content/reference/query-controls.md
+++ b/docs/content/reference/query-controls.md
@@ -25,6 +25,7 @@ behavior of each control — predicate pushdown, projection, row limits, splits,
 | Physical types (comparison) | `int`, `long`, `float`, `double`, `boolean`, `String` |
 | Logical types (comparison) | `LocalDate`, `Instant`, `LocalTime`, `BigDecimal`, `UUID` |
 | Combinators | `and`, `or`, `not` (`and` / `or` accept varargs for three or more conditions) |
+| Column form | Leaf columns only, by name or dot-separated path (`address.city`); group, `LIST`, and `MAP` names and leaves below a repeated group are rejected |
 
 All predicates, including those wrapped in `not`, are pushed down to the statistics level for
 row-group and page skipping.


### PR DESCRIPTION
Fixes #904

## Authorship

Hardwood is built with AI, not by AI. LLM assistance is welcome; submitting raw LLM output without understanding is not.
Neither are unattended agents opening pull requests.
See the [contribution guide](https://github.com/hardwood-hq/hardwood/blob/main/CONTRIBUTING.md) for more details.
Check this box to confirm:

- [x] This change is coming from a human who understands what it does and why, and can discuss it in review

## Checklist

- [ ] Build via `./mvnw clean verify` passes
- [x] The commit message is prefixed with the issue key ("#123 Adding support for...")
- [x] Code changes are covered by tests
- [ ] If this PR adds or changes user-facing behaviour, `docs/` has been updated

## Verification

Docs were not updated because group predicates are not a supported or documented predicate surface.

All hardwood-core tests pass locally. The full `./mvnw clean verify` could not complete because Docker/Testcontainers is unavailable in the local environment.