### PR TITLE
#963 Make the dive help overlay scrollable on a short terminal

### DIFF
--- a/cli/src/main/java/dev/hardwood/cli/dive/DiveApp.java
+++ b/cli/src/main/java/dev/hardwood/cli/dive/DiveApp.java
@@ -45,11 +45,13 @@ public final class DiveApp {
     private final ParquetModel model;
     private final NavigationStack stack;
     private boolean helpOpen;
+    private int helpScrollTop;
 
     public DiveApp(ParquetModel model) {
         this.model = model;
         this.stack = new NavigationStack(ScreenState.Overview.initial());
         this.helpOpen = false;
+        this.helpScrollTop = 0;
     }
 
     /// Runs the TUI loop until the user quits. Uses default backend + alternate screen.
@@ -99,11 +101,22 @@ public final class DiveApp {
         }
         if (!textInput && ke.code() == KeyCode.CHAR && ke.character() == '?') {
             helpOpen = !helpOpen;
+            if (helpOpen) {
+                helpScrollTop = 0;
+            }
             return Action.HANDLED;
         }
         if (helpOpen) {
             if (ke.isCancel()) {
                 helpOpen = false;
+                return Action.HANDLED;
+            }
+            if (Keys.isPageDown(ke)) {
+                helpScrollTop += 1;
+                return Action.HANDLED;
+            }
+            if (Keys.isPageUp(ke)) {
+                helpScrollTop = Math.max(0, helpScrollTop - 1);
                 return Action.HANDLED;
             }
             return Action.IGNORED;
@@ -182,7 +195,7 @@ public final class DiveApp {
             // Clear+paint restores full intensity inside its area.
             // Chrome (top bar, breadcrumb, keybar) stays unchanged.
             buffer.setStyle(regions.body(), Theme.dim());
-            HelpOverlay.render(buffer, area);
+            HelpOverlay.render(buffer, area, helpScrollTop);
         }
     }
 

--- a/cli/src/main/java/dev/hardwood/cli/dive/internal/HelpOverlay.java
+++ b/cli/src/main/java/dev/hardwood/cli/dive/internal/HelpOverlay.java
@@ -30,6 +30,10 @@ public final class HelpOverlay {
     }
 
     public static void render(Buffer buffer, Rect screenArea) {
+        render(buffer, screenArea, 0);
+    }
+
+    public static void render(Buffer buffer, Rect screenArea, int scrollTop) {
         int width = Math.min(60, screenArea.width() - 4);
         int descBudget = Math.max(1, (width - 2) - 20);
 
@@ -71,16 +75,29 @@ public final class HelpOverlay {
         int x = screenArea.left() + (screenArea.width() - width) / 2;
         int y = screenArea.top() + (screenArea.height() - height) / 2;
         Rect area = new Rect(x, y, width, height);
+
+        // A short terminal clips the line list; only the visible slice is drawn
+        // and the stored offset is clamped against the current content, so the
+        // last rows (version / close hint) stay reachable by paging down.
+        int viewport = Math.max(1, height - 2);
+        int maxScroll = Math.max(0, lines.size() - viewport);
+        int scroll = Math.max(0, Math.min(maxScroll, scrollTop));
+        int end = Math.min(lines.size(), scroll + viewport);
+
         // Wipe the area so the underlying screen doesn't bleed through cells
         // that the Paragraph doesn't paint.
         dev.tamboui.widgets.Clear.INSTANCE.render(area, buffer);
 
+        String title = " hardwood dive — help ";
+        if (end - scroll < lines.size()) {
+            title += "─ " + (scroll + 1) + "-" + end + "/" + lines.size() + " ";
+        }
         Block block = Block.builder()
-                .title(" hardwood dive — help ")
+                .title(title)
                 .borders(Borders.ALL)
                 .borderType(BorderType.ROUNDED)
                 .build();
-        Paragraph.builder().block(block).text(Text.from(lines)).left().build().render(area, buffer);
+        Paragraph.builder().block(block).text(Text.from(lines.subList(scroll, end))).left().build().render(area, buffer);
     }
 
     private static List<Line> kv(String key, String description, int descBudget) {

--- a/cli/src/test/java/dev/hardwood/cli/dive/DiveRenderTest.java
+++ b/cli/src/test/java/dev/hardwood/cli/dive/DiveRenderTest.java
@@ -325,6 +325,42 @@ class DiveRenderTest {
         assertThat(renderToString(buffer, screenArea)).contains("Press ? or Esc to close");
     }
 
+    /// On a short terminal the help overlay is taller than the viewport, so the
+    /// bottom-most rows — the build version and the close hint — are off-screen
+    /// until the user pages down. The top frame must say more content exists
+    /// rather than silently dropping it, and paging to the bottom must make those
+    /// last rows reachable. That is the exact failure mode of #963.
+    @Test
+    void helpOverlayCanReachItsBottomContentAtNarrowHeight() {
+        Rect screenArea = new Rect(0, 0, 80, 24);
+        DiveApp app = new DiveApp(model);
+
+        app.dispatchKey(new KeyEvent(KeyCode.CHAR, KeyModifiers.NONE, '?'));
+        assertThat(app.helpOpen()).isTrue();
+        Buffer buffer = Buffer.empty(screenArea);
+        app.renderOnce(buffer);
+
+        // At 24 rows the overlay is capped to the screen, so the trailing
+        // version / close-hint lines are not on screen yet — and the overlay
+        // must say so instead of pretending it fits.
+        assertThat(renderToString(buffer, screenArea)).doesNotContain(
+                "Press ? or Esc to close");
+        assertThat(renderToString(buffer, screenArea)).contains(
+                "hardwood dive — help");
+
+        // Page down until the last rows arrive; bounded so a regression that
+        // stops scrolling fails the test instead of hanging it.
+        int pageDowns = 0;
+        while (!renderToString(buffer, screenArea).contains("Press ? or Esc to close")) {
+            assertThat(++pageDowns).isLessThan(40);
+            app.dispatchKey(key(KeyCode.PAGE_DOWN));
+            app.renderOnce(buffer);
+        }
+
+        assertThat(renderToString(buffer, screenArea)).contains(
+                "Press ? or Esc to close");
+    }
+
     private static String renderToString(Buffer buffer, Rect screenArea) {
         StringBuilder sb = new StringBuilder();
         for (int y = 0; y < screenArea.height(); y++) {


### PR DESCRIPTION
## Summary

Fixes #963.

On a short terminal the help overlay's height is capped to the screen, so the
rows below the fold — the build version and the close hint — were silently
unreachable. The overlay now pages down/up through a clamped slice of the
keybindings, and the title carries a range marker when lines are hidden.

## Testing

- `helpOverlayCanReachItsBottomContentAtNarrowHeight` regression added (RED
  before the fix, GREEN after, Reverse-validated): 80×24 viewport; top frame
  does not advertise the close hint, and paging down makes it reachable.
- Dive suite: 173 tests pass (`DiveRenderTest` / `DiveStateTest` /
  `DiveAppTest`).
- Non-S3 CLI suite: 456 tests pass.
- S3 tests (Testcontainers / Docker) were not run in this environment.
- `docs/` unchanged — no user-facing API / CLI option was added or modified.

## Authorship

Hardwood is built with AI, not by AI. LLM assistance is welcome; submitting raw LLM output without understanding is not.
Neither are unattended agents opening pull requests.
See the contribution guide for more details.

- [x] This change is coming from a human who understands what it does and why, and can discuss it in review

## Checklist

- [ ] Build via `./mvnw clean verify` passes
- [x] The commit message is prefixed with the issue key ("#963 …")
- [x] Code changes are covered by tests
- [x] If this PR adds or changes user-facing behaviour, `docs/` has been updated
