### PR TITLE
#999 Fail the build when a new encoding is left half-wired

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -22,6 +22,38 @@ Every change should be linked to a GitHub issue. If one doesn't exist for what y
 - If your change adds or modifies a user-facing API (factory method, record, enum, configuration option, CLI option), update the documentation under `docs/content/` in the same PR.
 - Keep the public API surface small. Put anything that doesn't need to be user-facing in an `internal` package.
 
+## Adding an encoding
+
+An encoding is a read-side decoder, a write-side encoder, or both. Work through the table for the
+direction you are adding. Paths are relative to `core/src/main/java/dev/hardwood/`.
+
+### Read path
+
+| File | Change | Why |
+|---|---|---|
+| `metadata/Encoding.java` | Add the constant | The name a chunk's metadata reads back as |
+| `internal/thrift/ThriftEnumLookup.java` | Add it to `ENCODINGS`, at its Thrift index | Maps the value on the wire to that constant; without it the encoding reads back as `UNKNOWN` |
+| `internal/encoding/<Name>Decoder.java` | Implement `ValueDecoder` | Reads a page's values into the reader's primitive arrays |
+| `internal/reader/PageDecoder.java` | Add the case to `decodeTypedValues` | The reader's only dispatch point |
+
+### Write path
+
+| File | Change | Why |
+|---|---|---|
+| `writer/ColumnEncoding.java` | Add the policy | What a caller can name in `WriterConfig` |
+| `internal/writer/EncodingSupport.java` | Add it to `supports`, naming its legal physical types | The pairs the writer accepts, rejected at writer creation rather than at flush |
+| `internal/encoding/<Name>Encoder.java` | Implement the inverse of the decoder | Produces one page's value section |
+| `internal/writer/<Type>ValueEncoder.java` | Add the case to `encode`, in each type that may carry it | Each physical type encodes from its own value store |
+| `internal/writer/ColumnChunkBuffer.java` | Map the policy in `valueEncoding` | Names the encoding in the page header and `ColumnMetaData.encodings` |
+| `WriterEncodingPolicyTest`, `CoverageDomain`, `WriterInteropTest` | Restate the policy in each switch, and add it to the interop axis | Sweeps it over every legal type, the coverage domain, and the parquet-java interop axis |
+
+The write path is guarded by exhaustive switches, so the compiler names most of the rows above. The
+read path is not, so cover the decoder yourself — a round trip through the writer where Hardwood can
+write the encoding, and a `parquet-testing` fixture where it can only read it.
+
+Finally, update `docs/content/` for the public enums, and `ROADMAP.md` and `FORMAT_COVERAGE.md` for
+the capability itself. Nothing in the build checks those.
+
 ## Design docs for larger changes
 
 Larger changes — new features, refactorings that affect the system design — should start with a short Markdown document under `_designs_/` describing the intended end state. Open the design as a PR so it can be reviewed before implementation starts. Mark it complete once the work lands.

--- a/FORMAT_COVERAGE.md
+++ b/FORMAT_COVERAGE.md
@@ -94,14 +94,18 @@ All fields (column_idx, descending, nulls_first) ❌ — struct not read.
 | 10 | index_page_offset | ❌ | explicit skip; index pages superseded by Column Index |
 | 11 | dictionary_page_offset | ✅ | |
 | 12 | statistics | ✅ | row-group filtering |
-| 13 | encoding_stats | ❌ | dictionary/plain page mix not read |
+| 13 | encoding_stats | ✅ | on public record; dictionary row-group pruning (#105) and the CLI's data-page encoding column |
 | 14 | bloom_filter_offset | ✅ | shown in dive; filter body read & decoded (#669); used for `eq`/`in` row-group pruning (#105) |
 | 15 | bloom_filter_length | ✅ | shown in dive; #669 read path; #105 pushdown |
 | 16 | size_statistics | 🟡 | on public record, no functional consumer |
 | 17 | geospatial_statistics | ✅ | row-group filter evaluator (no per-page geospatial stats exist) |
 
 ### PageEncodingStats
-All fields (page_type, encoding, count) ❌ — struct not read.
+| id | field | status | notes |
+|----|-------|--------|-------|
+| 1 | page_type | ✅ | distinguishes a dictionary page from the data pages that index into it |
+| 2 | encoding | ✅ | an encoding this version does not recognize is reported as `Encoding.UNKNOWN` |
+| 3 | count | ✅ | a zero-count entry is ignored |
 
 ---
 
@@ -233,4 +237,4 @@ The ❌ rows cluster into a handful of capabilities, cross-referenced to ROADMAP
 - **Statistics completeness** — distinct_count, nan_count and the exactness flags are parsed but drive no filtering (#483).
 - **Declared sort order** — `sorting_columns`, `is_sorted`; ROADMAP 4.2.
 - **Column orders** — float total-order vs type-defined; #483.
-- **Deprecated / niche** — split-file `file_path` (surfaced, and reading such a chunk fails rather than decoding this file's bytes), index pages, encoding_stats, row-group ordinals: no planned support.
+- **Deprecated / niche** — split-file `file_path` (surfaced, and reading such a chunk fails rather than decoding this file's bytes), index pages, row-group ordinals: no planned support.

--- a/core/src/main/java/dev/hardwood/internal/thrift/ThriftEnumLookup.java
+++ b/core/src/main/java/dev/hardwood/internal/thrift/ThriftEnumLookup.java
@@ -72,20 +72,19 @@ class ThriftEnumLookup {
             ConvertedType.INTERVAL           // 21
     };
 
-    // Indexed by Thrift value (0-9), with gap at index 1
-    private static final Encoding[] ENCODINGS = new Encoding[10];
-
-    static {
-        ENCODINGS[0] = Encoding.PLAIN;
-        ENCODINGS[2] = Encoding.PLAIN_DICTIONARY;
-        ENCODINGS[3] = Encoding.RLE;
-        ENCODINGS[4] = Encoding.BIT_PACKED;
-        ENCODINGS[5] = Encoding.DELTA_BINARY_PACKED;
-        ENCODINGS[6] = Encoding.DELTA_LENGTH_BYTE_ARRAY;
-        ENCODINGS[7] = Encoding.DELTA_BYTE_ARRAY;
-        ENCODINGS[8] = Encoding.RLE_DICTIONARY;
-        ENCODINGS[9] = Encoding.BYTE_STREAM_SPLIT;
-    }
+    // Indexed by Thrift value (0-9); 1 is a hole the format left behind
+    private static final Encoding[] ENCODINGS = {
+            Encoding.PLAIN,                    // 0
+            null,                              // 1 - GROUP_VAR_INT, withdrawn by the format
+            Encoding.PLAIN_DICTIONARY,         // 2
+            Encoding.RLE,                      // 3
+            Encoding.BIT_PACKED,               // 4
+            Encoding.DELTA_BINARY_PACKED,      // 5
+            Encoding.DELTA_LENGTH_BYTE_ARRAY,  // 6
+            Encoding.DELTA_BYTE_ARRAY,         // 7
+            Encoding.RLE_DICTIONARY,           // 8
+            Encoding.BYTE_STREAM_SPLIT         // 9
+    };
 
     // Indexed by Thrift value (0-7)
     private static final CompressionCodec[] COMPRESSION_CODECS = {

--- a/core/src/test/java/dev/hardwood/internal/thrift/EncodingThriftMappingTest.java
+++ b/core/src/test/java/dev/hardwood/internal/thrift/EncodingThriftMappingTest.java
@@ -1,0 +1,74 @@
+/*
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Copyright The original authors
+ *
+ *  Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package dev.hardwood.internal.thrift;
+
+import java.util.EnumSet;
+import java.util.Set;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
+
+import dev.hardwood.metadata.Encoding;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/// [ThriftEnumLookup]'s encoding table, which is the one place a Thrift encoding value becomes an
+/// [Encoding] and back.
+///
+/// The write path exercises the table for every encoding it emits — `ColumnMetaDataWriter` and
+/// `PageHeaderWriter` both resolve one through [ThriftEnumLookup#thriftValue] — so a writable
+/// encoding missing from it fails there. What that leaves uncovered is an encoding Hardwood only
+/// reads: nothing in production asks for its Thrift value, so a missing or mis-indexed entry does
+/// not fail, it *degrades*, and the encoding reads back as [Encoding#UNKNOWN].
+///
+/// The round trip below closes that. It is driven by [Encoding#values()], so adding an encoding
+/// never means editing this file.
+class EncodingThriftMappingTest {
+
+    /// The one member that is not an encoding but a stand-in for the ones this release cannot
+    /// name. It has no Thrift value by construction, so it is excluded from the round trip and
+    /// pinned separately by [#unknownHasNoThriftValue].
+    private static final Set<Encoding> NOT_A_WIRE_VALUE = EnumSet.of(Encoding.UNKNOWN);
+
+    /// Every named encoding survives a trip through its Thrift value and back.
+    ///
+    /// A member missing from the table, or sitting at the wrong index, fails here rather than
+    /// silently reading back as [Encoding#UNKNOWN] or displacing its neighbour.
+    @ParameterizedTest
+    @EnumSource(Encoding.class)
+    void roundTripsThroughItsThriftValue(Encoding encoding) {
+        if (NOT_A_WIRE_VALUE.contains(encoding)) {
+            return;
+        }
+        int thriftValue = ThriftEnumLookup.thriftValue(encoding);
+        assertThat(thriftValue).as("Thrift value of %s", encoding).isNotNegative();
+        assertThat(ThriftEnumLookup.encoding(thriftValue))
+                .as("%s read back from Thrift value %d", encoding, thriftValue)
+                .isEqualTo(encoding);
+    }
+
+    /// [Encoding#UNKNOWN] stands for a value this release cannot name, so writing it out would
+    /// mean inventing one. Asking for its Thrift value is a defect, not a fallback.
+    @Test
+    void unknownHasNoThriftValue() {
+        assertThatThrownBy(() -> ThriftEnumLookup.thriftValue(Encoding.UNKNOWN))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("UNKNOWN");
+    }
+
+    /// Thrift value 1 is `GROUP_VAR_INT`, withdrawn by the format and never written. The table
+    /// carries it as an explicit hole, which must read as unrecognized rather than as whatever
+    /// member happens to sit beside it. A value past the table's end is the same question one step
+    /// further out, and `UnknownEncodingReadTest` settles that one on a real file.
+    @Test
+    void theWithdrawnGroupVarIntValueIsUnrecognized() {
+        assertThat(ThriftEnumLookup.encoding(1)).isEqualTo(Encoding.UNKNOWN);
+    }
+}

--- a/parquet-testing-runner/src/test/java/dev/hardwood/testing/CoverageDomain.java
+++ b/parquet-testing-runner/src/test/java/dev/hardwood/testing/CoverageDomain.java
@@ -265,25 +265,29 @@ final class CoverageDomain {
     /// The encodings a column of `type` can have on its data pages, over every policy legal for
     /// it. Every policy but [ColumnEncoding#AUTO] names one outright; `AUTO` reaches `PLAIN`
     /// always and `RLE_DICTIONARY` wherever a dictionary is possible at all.
+    ///
+    /// The mapping is a **switch expression** so that javac checks it for exhaustiveness. A switch
+    /// *statement* over an enum is not enhanced and so is not checked, which would let a policy
+    /// added to [ColumnEncoding] fall through this loop and contribute no cell — the whole domain
+    /// would then be silently short by that encoding, and the verdict would pass with it swept
+    /// nowhere. This is the one place the domain learns which encodings the writer can produce, so
+    /// an unmapped policy has to be a compile error rather than an empty set.
     static Set<Encoding> pageEncodings(PhysicalType type) {
         Set<Encoding> encodings = EnumSet.noneOf(Encoding.class);
         for (ColumnEncoding policy : ColumnEncoding.values()) {
             if (!EncodingSupport.supports(policy, type)) {
                 continue;
             }
-            switch (policy) {
-                case AUTO -> {
-                    encodings.add(Encoding.PLAIN);
-                    if (EncodingSupport.dictionaryCapable(type)) {
-                        encodings.add(Encoding.RLE_DICTIONARY);
-                    }
-                }
-                case PLAIN -> encodings.add(Encoding.PLAIN);
-                case DELTA_BINARY_PACKED -> encodings.add(Encoding.DELTA_BINARY_PACKED);
-                case DELTA_LENGTH_BYTE_ARRAY -> encodings.add(Encoding.DELTA_LENGTH_BYTE_ARRAY);
-                case DELTA_BYTE_ARRAY -> encodings.add(Encoding.DELTA_BYTE_ARRAY);
-                case BYTE_STREAM_SPLIT -> encodings.add(Encoding.BYTE_STREAM_SPLIT);
-            }
+            encodings.addAll(switch (policy) {
+                case AUTO -> EncodingSupport.dictionaryCapable(type)
+                        ? EnumSet.of(Encoding.PLAIN, Encoding.RLE_DICTIONARY)
+                        : EnumSet.of(Encoding.PLAIN);
+                case PLAIN -> EnumSet.of(Encoding.PLAIN);
+                case DELTA_BINARY_PACKED -> EnumSet.of(Encoding.DELTA_BINARY_PACKED);
+                case DELTA_LENGTH_BYTE_ARRAY -> EnumSet.of(Encoding.DELTA_LENGTH_BYTE_ARRAY);
+                case DELTA_BYTE_ARRAY -> EnumSet.of(Encoding.DELTA_BYTE_ARRAY);
+                case BYTE_STREAM_SPLIT -> EnumSet.of(Encoding.BYTE_STREAM_SPLIT);
+            });
         }
         return encodings;
     }


### PR DESCRIPTION
Closes #999.

Adding an encoding touches roughly a dozen places across the read and write paths. The write path is mostly guarded by non-exhaustive-switch compile errors and works well; two gaps let a new encoding reach `main` uncovered.

## The coverage domain dropped an unmapped policy

`CoverageDomain.pageEncodings` switched over `ColumnEncoding` with a **switch statement** and no `default`. A switch statement over an enum whose labels are all enum constants is not enhanced, so javac does not check it — a new policy fell through the loop and contributed no cell to `required()`.

That defeated the assertion exactly where it is supposed to bite. `WRITE_COVERAGE_ASSERTION.md` states the goal as "every combination the writer can produce is either produced by some test, or waived with a stated reason. A combination that is neither fails the build." It compounded with `WriterInteropTest.optionalEncodings()` being a hand-written `Stream.of(...)`: the axis is manual, and the automated backstop that should catch a manual omission opted itself out.

It is now a switch expression, so an unmapped policy is a compile error.

## The read path had no tripwire at all

Adding a member to `dev.hardwood.metadata.Encoding` compiled the entire project green — main and tests, every module. A missing `ThriftEnumLookup` entry degraded silently to `Encoding.UNKNOWN`.

`EncodingThriftMappingTest` closes most of that: it round-trips every member through its Thrift value, driven by `Encoding.values()` with no parallel list to maintain, so adding an encoding never means editing it.

Scoped honestly, it is a backstop rather than primary coverage. `ColumnMetaDataWriter` and `PageHeaderWriter` resolve every encoding the writer emits through the same table, so a *writable* encoding missing from it already fails in the writer tests. The gap it uniquely covers is an encoding Hardwood only reads — nothing in production asks for its Thrift value — plus a mis-indexed entry that would otherwise displace its neighbour.

## The lookup table is written like its neighbours now

It also converts `ENCODINGS` from an empty array filled by a static block to the array literal every other Thrift table in `ThriftEnumLookup` uses. The reason for the difference was the hole at Thrift value 1, `GROUP_VAR_INT`, which the format withdrew — but a literal carries a hole fine, and `null, // 1 - GROUP_VAR_INT, withdrawn by the format` states it outright where the static block could only imply it by leaving one index out of nine assignments.

It also retires a hazard rather than documenting one. `new Encoding[10]` kept the bound in one place and the entries in another, so an encoding added past the end compiled and then died in the static initializer. Taking the length from the entries deletes that step from adding an encoding, and the sentence about it from `CONTRIBUTING.md`.

**What the decoder does with an encoding stays unguarded, deliberately.** `PageDecoder.decodeTypedValues` dispatches through a throwing `default`, and the obvious gate — requiring each new member to be classified as decodable / not-implemented — would only assert that a hand-maintained list covers the enum. That gates a keystroke rather than a behaviour: a contributor could satisfy it by classifying an unimplemented encoding as decodable, and nothing would check the claim. A prompt is honest as prose and misleading as a green assertion, so it lives in `CONTRIBUTING.md` instead.

## Verified by breaking it

Both tripwires were checked by adding a dummy member and confirming they fire, not just that they pass on a healthy tree.

Dummy `Encoding.ALP`, before: entire build green. After:

```
EncodingThriftMappingTest.roundTripsThroughItsThriftValue ? IllegalArgument No Thrift value for encoding: ALP
```

Dummy `ColumnEncoding.FSST`, with every pre-existing compile tripwire satisfied — before: `parquet-testing-runner` test-compiled and the coverage verdict passed with the encoding swept nowhere. After:

```
CoverageDomain.java:[281,30] the switch expression does not cover all possible input values
```

## Also here

A `CONTRIBUTING.md` section on adding an encoding: two tables, read path and write path, listing the file to touch, the change, and what it is for. The one caveat worth carrying is on `PageDecoder` — nothing in the build reaches that dispatch, verified by adding a dummy `Encoding` member and watching the whole reactor stay green.

`FORMAT_COVERAGE.md` is corrected too: it still listed `encoding_stats` and `PageEncodingStats` as unread and filed the former under deprecated fields with no planned support. Both have had a consumer since dictionary row-group pruning landed.

## Build

`./mvnw verify` green across the reactor (`core` 2583 tests; `parquet-testing-runner` 929 plus the 5 coverage verdicts, still passing, so the `CoverageDomain` rewrite is behaviour-preserving).
