### PR TITLE
#999 Make PageDecoder's encoding dispatch exhaustive rather than defaulted

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -34,7 +34,7 @@ direction you are adding. Paths are relative to `core/src/main/java/dev/hardwood
 | `metadata/Encoding.java` | Add the constant | The name a chunk's metadata reads back as |
 | `internal/thrift/ThriftEnumLookup.java` | Add it to `ENCODINGS`, at its Thrift index | Maps the value on the wire to that constant; without it the encoding reads back as `UNKNOWN` |
 | `internal/encoding/<Name>Decoder.java` | Implement `ValueDecoder` | Reads a page's values into the reader's primitive arrays |
-| `internal/reader/PageDecoder.java` | Add the case to `decodeTypedValues` | The reader's only dispatch point |
+| `internal/reader/PageDecoder.java` | Add the case to `decodeTypedValues`, refusing the physical types the encoding is not defined over | The reader's only dispatch point; the compiler names the case but cannot name the types, and an undefined pair left unguarded decodes into a page of the wrong shape |
 
 ### Write path
 
@@ -47,9 +47,10 @@ direction you are adding. Paths are relative to `core/src/main/java/dev/hardwood
 | `internal/writer/ColumnChunkBuffer.java` | Map the policy in `valueEncoding` | Names the encoding in the page header and `ColumnMetaData.encodings` |
 | `WriterEncodingPolicyTest`, `CoverageDomain`, `WriterInteropTest` | Restate the policy in each switch, and add it to the interop axis | Sweeps it over every legal type, the coverage domain, and the parquet-java interop axis |
 
-The write path is guarded by exhaustive switches, so the compiler names most of the rows above. The
-read path is not, so cover the decoder yourself — a round trip through the writer where Hardwood can
-write the encoding, and a `parquet-testing` fixture where it can only read it.
+Both paths are guarded by exhaustive switches, so the compiler names most of the rows above; the
+Thrift table is the one row caught by a test rather than by the compiler. What nothing checks is
+whether the decoder is *correct*, so cover that yourself — a round trip through the writer where
+Hardwood can write the encoding, and a `parquet-testing` fixture where it can only read it.
 
 Finally, update `docs/content/` for the public enums, and `ROADMAP.md` and `FORMAT_COVERAGE.md` for
 the capability itself. Nothing in the build checks those.

--- a/core/src/main/java/dev/hardwood/internal/encoding/ByteStreamSplitDecoder.java
+++ b/core/src/main/java/dev/hardwood/internal/encoding/ByteStreamSplitDecoder.java
@@ -58,8 +58,8 @@ public class ByteStreamSplitDecoder implements ValueDecoder {
                 }
                 yield typeLength;
             }
-            default -> throw new UnsupportedOperationException(
-                    "BYTE_STREAM_SPLIT not supported for type: " + type);
+            default -> throw new IllegalArgumentException(
+                    "BYTE_STREAM_SPLIT is not defined over " + type);
         };
     }
 

--- a/core/src/main/java/dev/hardwood/internal/reader/PageDecoder.java
+++ b/core/src/main/java/dev/hardwood/internal/reader/PageDecoder.java
@@ -412,10 +412,10 @@ public class PageDecoder {
         PhysicalType type = column.type();
 
         // Try to decode into primitive arrays for supported type/encoding combinations
-        switch (encoding) {
+        return switch (encoding) {
             case PLAIN -> {
                 PlainDecoder decoder = new PlainDecoder(data, offset, type, column.typeLength());
-                return switch (type) {
+                yield switch (type) {
                     case INT64 -> {
                         long[] values = new long[numValues];
                         decoder.readLongs(values, definitionLevels, maxDefLevel);
@@ -450,7 +450,7 @@ public class PageDecoder {
             }
             case DELTA_BINARY_PACKED -> {
                 DeltaBinaryPackedDecoder decoder = new DeltaBinaryPackedDecoder(data, offset);
-                return switch (type) {
+                yield switch (type) {
                     case INT64 -> {
                         long[] values = new long[numValues];
                         decoder.readLongs(values, definitionLevels, maxDefLevel);
@@ -461,15 +461,22 @@ public class PageDecoder {
                         decoder.readInts(values, definitionLevels, maxDefLevel);
                         yield new Page.IntPage(values, definitionLevels, repetitionLevels, maxDefLevel, numValues);
                     }
-                    default -> throw new UnsupportedOperationException(
-                            "DELTA_BINARY_PACKED not supported for type: " + type);
+                    default -> throw undefinedOverType(Encoding.DELTA_BINARY_PACKED, type,
+                            PhysicalType.INT32, PhysicalType.INT64);
                 };
             }
             case BYTE_STREAM_SPLIT -> {
+                // The decoder derives its byte width from the physical type, so an undefined pair
+                // has to be refused before it is constructed — otherwise the width lookup, and not
+                // the format check, is what the file fails on.
+                if (type == PhysicalType.BOOLEAN || type == PhysicalType.BYTE_ARRAY
+                        || type == PhysicalType.INT96) {
+                    throw byteStreamSplitUndefinedOverType(type);
+                }
                 int numNonNullValues = countNonNullValues(numValues, definitionLevels);
                 ByteStreamSplitDecoder decoder = new ByteStreamSplitDecoder(
                         data, offset, numNonNullValues, type, column.typeLength());
-                return switch (type) {
+                yield switch (type) {
                     case INT64 -> {
                         long[] values = new long[numValues];
                         decoder.readLongs(values, definitionLevels, maxDefLevel);
@@ -495,8 +502,7 @@ public class PageDecoder {
                         decoder.readByteArrays(values, definitionLevels, maxDefLevel);
                         yield new Page.ByteArrayPage(values, definitionLevels, repetitionLevels, maxDefLevel, numValues);
                     }
-                    default -> throw new UnsupportedOperationException(
-                            "BYTE_STREAM_SPLIT not supported for type: " + type);
+                    default -> throw byteStreamSplitUndefinedOverType(type);
                 };
             }
             case RLE_DICTIONARY, PLAIN_DICTIONARY -> {
@@ -510,13 +516,16 @@ public class PageDecoder {
                 }
                 RleBitPackingHybridDecoder indexDecoder = new RleBitPackingHybridDecoder(data, offset, data.length - offset, bitWidth);
 
-                return dictionary.decodePage(indexDecoder, numValues, definitionLevels, repetitionLevels, maxDefLevel);
+                yield dictionary.decodePage(indexDecoder, numValues, definitionLevels, repetitionLevels, maxDefLevel);
             }
             case RLE -> {
-                // RLE encoding for boolean values uses bit-width of 1
+                // In the value position RLE carries booleans and nothing else; the format also
+                // gives it the level streams and dictionary indices, which do not come through
+                // here. Refusing another type is the format's position, not a decoder this
+                // release has yet to write.
                 if (type != PhysicalType.BOOLEAN) {
-                    throw new UnsupportedOperationException(
-                            "RLE encoding for non-boolean types not yet supported: " + type);
+                    throw new IOException(
+                            "RLE encodes only boolean values in a data page, not " + type);
                 }
 
                 // Read 4-byte length prefix (little-endian)
@@ -526,35 +535,78 @@ public class PageDecoder {
                 RleBitPackingHybridDecoder decoder = new RleBitPackingHybridDecoder(data, offset, rleLength, 1);
                 boolean[] values = new boolean[numValues];
                 decoder.readBooleans(values, definitionLevels, maxDefLevel);
-                return new Page.BooleanPage(values, definitionLevels, repetitionLevels, maxDefLevel, numValues);
+                yield new Page.BooleanPage(values, definitionLevels, repetitionLevels, maxDefLevel, numValues);
             }
             case DELTA_LENGTH_BYTE_ARRAY -> {
+                // The lengths are delta-encoded ahead of the bytes, so the values are byte arrays
+                // whatever the column claims; decoding an integer column's page this way would
+                // build a page of the wrong shape rather than fail.
+                if (type != PhysicalType.BYTE_ARRAY) {
+                    throw undefinedOverType(Encoding.DELTA_LENGTH_BYTE_ARRAY, type,
+                            PhysicalType.BYTE_ARRAY);
+                }
                 int numNonNullValues = countNonNullValues(numValues, definitionLevels);
                 DeltaLengthByteArrayDecoder decoder = new DeltaLengthByteArrayDecoder(data, offset);
                 decoder.initialize(numNonNullValues);
                 byte[][] values = new byte[numValues][];
                 decoder.readByteArrays(values, definitionLevels, maxDefLevel);
-                return new Page.ByteArrayPage(values, definitionLevels, repetitionLevels, maxDefLevel, numValues);
+                yield new Page.ByteArrayPage(values, definitionLevels, repetitionLevels, maxDefLevel, numValues);
             }
             case DELTA_BYTE_ARRAY -> {
+                if (type != PhysicalType.BYTE_ARRAY && type != PhysicalType.FIXED_LEN_BYTE_ARRAY) {
+                    throw undefinedOverType(Encoding.DELTA_BYTE_ARRAY, type,
+                            PhysicalType.BYTE_ARRAY, PhysicalType.FIXED_LEN_BYTE_ARRAY);
+                }
                 int numNonNullValues = countNonNullValues(numValues, definitionLevels);
                 DeltaByteArrayDecoder decoder = new DeltaByteArrayDecoder(data, offset);
                 decoder.initialize(numNonNullValues);
                 byte[][] values = new byte[numValues][];
                 decoder.readByteArrays(values, definitionLevels, maxDefLevel);
-                return new Page.ByteArrayPage(values, definitionLevels, repetitionLevels, maxDefLevel, numValues);
+                yield new Page.ByteArrayPage(values, definitionLevels, repetitionLevels, maxDefLevel, numValues);
             }
-            default -> throw new UnsupportedOperationException(
-                    "Encoding not yet supported: " + describeEncoding(encoding, encodingValue));
-        }
+            // BIT_PACKED encodes levels, never a page's values, so refusing it is the format's
+            // position rather than a decoder this release has yet to write.
+            case BIT_PACKED -> throw new IOException(
+                    "BIT_PACKED encodes levels and is not valid for a data page's values");
+            // UNKNOWN stands for every Thrift value this release cannot name, so on its own it
+            // does not say which encoding was met; the raw value does. This is the one refusal
+            // here that is a gap in this release rather than a malformed file, so it is the one
+            // that keeps UnsupportedOperationException.
+            case UNKNOWN -> throw new UnsupportedOperationException(
+                    "Encoding not yet supported: UNKNOWN (Thrift encoding value " + encodingValue + ")");
+        };
     }
 
-    /// Names an encoding for an error message. [Encoding#UNKNOWN] stands for every Thrift
-    /// value this release does not recognize, so on its own it does not say which encoding
-    /// was met; qualifying it with the raw value from the page header does.
-    private static String describeEncoding(Encoding encoding, int encodingValue) {
-        return encoding == Encoding.UNKNOWN
-                ? encoding + " (Thrift encoding value " + encodingValue + ")"
-                : encoding.toString();
+    /// Refusal for a page whose declared encoding is not defined over its column's physical type.
+    ///
+    /// The format names the physical types each encoding may carry, so such a page is a malformed
+    /// file rather than a gap in this release — which is why this is an [IOException] and not the
+    /// [UnsupportedOperationException] an unrecognized encoding raises. Decoding it anyway would
+    /// build a page of the wrong shape rather than fail: wrong in the values, and wrong in the
+    /// [Page] variant handed to the column reader.
+    ///
+    /// @param encoding the encoding the page declares
+    /// @param type the column's physical type
+    /// @param definedOver the physical types the format defines `encoding` over
+    /// @return the exception to throw
+    private static IOException undefinedOverType(Encoding encoding, PhysicalType type,
+            PhysicalType... definedOver) {
+        StringBuilder legalTypes = new StringBuilder();
+        for (PhysicalType candidate : definedOver) {
+            if (!legalTypes.isEmpty()) {
+                legalTypes.append(", ");
+            }
+            legalTypes.append(candidate);
+        }
+        return new IOException(encoding + " is not defined over " + type
+                + "; the format defines it over " + legalTypes + " only");
+    }
+
+    /// [#undefinedOverType] for `BYTE_STREAM_SPLIT`, whose legal types are named both before the
+    /// decoder is constructed and by the value switch that follows it.
+    private static IOException byteStreamSplitUndefinedOverType(PhysicalType type) {
+        return undefinedOverType(Encoding.BYTE_STREAM_SPLIT, type, PhysicalType.INT32,
+                PhysicalType.INT64, PhysicalType.FLOAT, PhysicalType.DOUBLE,
+                PhysicalType.FIXED_LEN_BYTE_ARRAY);
     }
 }

--- a/core/src/test/java/dev/hardwood/internal/reader/PageDecoderEncodingTest.java
+++ b/core/src/test/java/dev/hardwood/internal/reader/PageDecoderEncodingTest.java
@@ -1,0 +1,165 @@
+/*
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Copyright The original authors
+ *
+ *  Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package dev.hardwood.internal.reader;
+
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+import java.util.zip.CRC32;
+
+import org.junit.jupiter.api.Test;
+
+import dev.hardwood.internal.compression.DecompressorFactory;
+import dev.hardwood.internal.encoding.DeltaByteArrayEncoder;
+import dev.hardwood.internal.thrift.PageHeaderWriter;
+import dev.hardwood.internal.thrift.ThriftCompactWriter;
+import dev.hardwood.metadata.ColumnMetaData;
+import dev.hardwood.metadata.CompressionCodec;
+import dev.hardwood.metadata.Encoding;
+import dev.hardwood.metadata.FieldPath;
+import dev.hardwood.metadata.PhysicalType;
+import dev.hardwood.metadata.RepetitionType;
+import dev.hardwood.schema.ColumnSchema;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/// What [PageDecoder] does with a data page whose declared encoding its column cannot carry.
+///
+/// A file may say anything. An encoding is defined over some physical types and not others, so a
+/// page declaring one its column has no business carrying is a malformed file, and the decoder has
+/// to say so rather than decode the bytes into a page of the wrong shape — which is silently wrong
+/// twice over, once in the values and once in the [Page] variant handed to the column reader.
+/// Being a malformed file rather than a gap in this release, each of these is an [IOException];
+/// [java.lang.UnsupportedOperationException] is left to mean an encoding no decoder has been
+/// written for.
+class PageDecoderEncodingTest {
+
+    private static final int NUM_VALUES = 4;
+    private static final int FIXED_LENGTH = 4;
+
+    /// The byte-array delta encodings carry a length stream and then bytes, so their values are
+    /// byte arrays whatever the column's physical type is. Declared over an integer column they
+    /// used to decode into a `ByteArrayPage`, which is not the page an `INT32` column's reader
+    /// expects.
+    @Test
+    void rejectsDeltaLengthByteArrayOnAnIntegerColumn() {
+        assertThatThrownBy(() -> decode(Encoding.DELTA_LENGTH_BYTE_ARRAY, PhysicalType.INT32))
+                .isInstanceOf(IOException.class)
+                .hasMessageContaining("DELTA_LENGTH_BYTE_ARRAY")
+                .hasMessageContaining("INT32");
+    }
+
+    /// Unlike `DELTA_BYTE_ARRAY`, `DELTA_LENGTH_BYTE_ARRAY` is defined over `BYTE_ARRAY` alone:
+    /// its length stream is what a fixed-length column does not need and no writer emits. The two
+    /// guards must therefore not be made to agree.
+    @Test
+    void rejectsDeltaLengthByteArrayOnAFixedLengthColumn() {
+        assertThatThrownBy(() -> decode(Encoding.DELTA_LENGTH_BYTE_ARRAY, PhysicalType.FIXED_LEN_BYTE_ARRAY))
+                .isInstanceOf(IOException.class)
+                .hasMessageContaining("DELTA_LENGTH_BYTE_ARRAY")
+                .hasMessageContaining("FIXED_LEN_BYTE_ARRAY");
+    }
+
+    @Test
+    void rejectsDeltaByteArrayOnADoubleColumn() {
+        assertThatThrownBy(() -> decode(Encoding.DELTA_BYTE_ARRAY, PhysicalType.DOUBLE))
+                .isInstanceOf(IOException.class)
+                .hasMessageContaining("DELTA_BYTE_ARRAY")
+                .hasMessageContaining("DOUBLE");
+    }
+
+    /// `DELTA_BYTE_ARRAY` is defined over `FIXED_LEN_BYTE_ARRAY` as well, so that pair must not be
+    /// caught by the same guard — the suffix lengths are written even where the values are fixed
+    /// length by schema. Decoding a real page of them proves the guard lets the pair through,
+    /// which asserting that some exception was not raised would not.
+    @Test
+    void decodesDeltaByteArrayOnAFixedLengthColumn() throws Exception {
+        Page page = decode(Encoding.DELTA_BYTE_ARRAY, PhysicalType.FIXED_LEN_BYTE_ARRAY,
+                deltaByteArrayBody("aaaa", "aaab", "abcd", "abce"));
+
+        assertThat(page).isInstanceOf(Page.ByteArrayPage.class);
+        assertThat(Arrays.stream(((Page.ByteArrayPage) page).values())
+                .map(value -> new String(value, UTF_8))
+                .toList())
+                .containsExactly("aaaa", "aaab", "abcd", "abce");
+    }
+
+    /// `RLE` carries booleans in the value position, and the level streams and dictionary indices
+    /// elsewhere. An integer column claiming it is refused on the format's terms too, rather than
+    /// as something this release has not implemented.
+    @Test
+    void rejectsRleOnAnIntegerColumn() {
+        assertThatThrownBy(() -> decode(Encoding.RLE, PhysicalType.INT32))
+                .isInstanceOf(IOException.class)
+                .hasMessageContaining("RLE encodes only boolean values")
+                .hasMessageContaining("INT32");
+    }
+
+    /// `BYTE_STREAM_SPLIT` scatters the bytes of fixed-width values, so it has nothing to say
+    /// about a `BYTE_ARRAY` column. The refusal has to come before the decoder is built, since
+    /// the decoder's own byte-width lookup would otherwise fail first and on its own terms.
+    @Test
+    void rejectsByteStreamSplitOnAByteArrayColumn() {
+        assertThatThrownBy(() -> decode(Encoding.BYTE_STREAM_SPLIT, PhysicalType.BYTE_ARRAY))
+                .isInstanceOf(IOException.class)
+                .hasMessageContaining("BYTE_STREAM_SPLIT")
+                .hasMessageContaining("BYTE_ARRAY");
+    }
+
+    /// `BIT_PACKED` encodes levels; a page claiming it for its values is refused on the format's
+    /// terms, not as an encoding this release has not got round to.
+    @Test
+    void rejectsBitPackedAsAValueEncoding() {
+        assertThatThrownBy(() -> decode(Encoding.BIT_PACKED, PhysicalType.INT32))
+                .isInstanceOf(IOException.class)
+                .hasMessageContaining("BIT_PACKED encodes levels");
+    }
+
+    /// `DELTA_BYTE_ARRAY` for `values`, each of [#FIXED_LENGTH] bytes, in the layout the encoder
+    /// takes a chunk's values in.
+    private static byte[] deltaByteArrayBody(String... values) {
+        byte[] data = new byte[values.length * FIXED_LENGTH];
+        int[] offsets = new int[values.length + 1];
+        for (int i = 0; i < values.length; i++) {
+            byte[] bytes = values[i].getBytes(UTF_8);
+            System.arraycopy(bytes, 0, data, i * FIXED_LENGTH, FIXED_LENGTH);
+            offsets[i + 1] = (i + 1) * FIXED_LENGTH;
+        }
+        return DeltaByteArrayEncoder.encode(data, offsets, 0, values.length);
+    }
+
+    /// Decodes a minimal `DATA_PAGE` declaring `encoding` over a required column of `type`, its
+    /// body arbitrary: the refusals are all made before a value is read.
+    private static Page decode(Encoding encoding, PhysicalType type) throws Exception {
+        return decode(encoding, type, new byte[16]);
+    }
+
+    private static Page decode(Encoding encoding, PhysicalType type, byte[] body) throws Exception {
+        ColumnSchema column = new ColumnSchema(FieldPath.of("c"), type, RepetitionType.REQUIRED,
+                type == PhysicalType.FIXED_LEN_BYTE_ARRAY ? FIXED_LENGTH : null, 0, 0, 0, null);
+        ColumnMetaData metaData = new ColumnMetaData(type, List.of(encoding), FieldPath.of("c"),
+                CompressionCodec.UNCOMPRESSED, NUM_VALUES, 0, 0, Map.of(), 0, null, null, null,
+                null, null, List.of(), null);
+
+        CRC32 crc = new CRC32();
+        crc.update(body);
+        ThriftCompactWriter header = new ThriftCompactWriter();
+        PageHeaderWriter.writeDataPageV1(header, NUM_VALUES, body.length, body.length,
+                (int) crc.getValue(), encoding);
+        byte[] headerBytes = header.toByteArray();
+
+        ByteBuffer page = ByteBuffer.allocate(headerBytes.length + body.length);
+        page.put(headerBytes).put(body).flip();
+
+        return new PageDecoder(metaData, column, new DecompressorFactory(null)).decodePage(page, null);
+    }
+}


### PR DESCRIPTION
Follow-up to #999, which identified that the read path had no tripwire at all but closed only the Thrift-table half. This closes the other half — the decoder dispatch — structurally rather than with a test.

## The dispatch is exhaustive now

`PageDecoder.decodeTypedValues` was a switch **statement** with a `default` that rejected anything unhandled. An encoding added to `Encoding` compiled everywhere and surfaced only as an `UnsupportedOperationException` once a real file carried it.

Naming the unhandled members instead of defaulting makes it a switch **expression**, which javac checks for exhaustiveness. Adding a dummy member now fails the build:

```
PageDecoder.java:[415,16] the switch expression does not cover all possible input values
```

Leaving it a statement would not have worked: enum switch statements are not enhanced, so they are not exhaustiveness-checked — the same trap #999 fixed in `CoverageDomain`. Hence the `return` → `yield` on each arm, which is the whole of the mechanical change. The arms are otherwise untouched.

This is the cheaper of two approaches. The alternative collapsed the encoding-by-type grid into a decoder step and a page step, deduplicating 16 allocate-read-wrap blocks down to 6 — but at 122 lines across two files, introducing a megamorphic call site, and changing behaviour. It bought the same tripwire, so it is not in this PR; the deduplication is better done once FSST and ALP have shown what `ValueDecoder` actually needs.

## Each refusal says why

`BIT_PACKED` and `UNKNOWN` were sharing one message. They are different situations: `BIT_PACKED` encodes levels and is not a value encoding at all, which is the format's position rather than a decoder this release has yet to write, while `UNKNOWN` stands for every Thrift value this release cannot name and so needs qualifying with the raw value. `describeEncoding` went with them — with the two split, only `UNKNOWN` ever reached it and its other branch was dead.

## A fail-late fixed

The byte-array delta encodings had no legality check, unlike every other encoding here. Their values are byte arrays whatever the column claims, so a page declaring `DELTA_LENGTH_BYTE_ARRAY` over an `INT32` column decoded into a `ByteArrayPage` — wrong in the values, and wrong in the `Page` variant handed to the column reader.

`PageDecoderEncodingTest` is new and covers this. Three of its four cases fail against the decoder as it stands and pass with the guards; the fourth pins that `DELTA_BYTE_ARRAY` over `FIXED_LEN_BYTE_ARRAY` stays legal, so the guard does not overreach.

Malformed files only — no conformant writer emits these pairs — so the blast radius is small, but it is the fail-early rule either way.

## Docs

`CONTRIBUTING.md` said the read path was not compiler-guarded and told contributors to cover the decoder themselves. The first half is no longer true.

## Build

`./mvnw verify` green across the reactor: `core` 2633 tests, `parquet-testing-runner` 929 including the 430 real-file corpus comparisons, plus `s3`, `avro`, `cli`, `parquet-java-compat` and `integration-test`.
