### PR TITLE
#1008 Unify the navigation and cursor model across dive

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -83,6 +83,8 @@ Labels are not mutually exclusive — a TUI bug should get `bug` + `cli` + `dive
 
 When changing visual styling in the `hardwood dive` TUI (any code under `cli/src/main/java/dev/hardwood/cli/dive/`), follow the visual-hierarchy decision tree in [_designs/DIVE_THEME.md](_designs/DIVE_THEME.md). Style spans through one of `Theme.primary()` / `Theme.accent()` / `Theme.selection()` / `Theme.dim()`, or leave them at default fg via `Style.EMPTY`. Direct use of `Color.*` constants or literal `Style.EMPTY.bold()` / `Style.EMPTY.fg(...)` outside `Theme.java` is a smell — review against the decision tree before introducing any.
 
+Navigation keys and the `▶` marker follow the two rules in [_designs/DIVE_NAVIGATION_MODEL.md](_designs/DIVE_NAVIGATION_MODEL.md): every key moves the cursor, stopping on every row, and `▶` marks what `Enter` can act on while colour marks the cursor. Route a row-shaped pane through `CursorPane` and a document-shaped one through `ScrollPane` rather than handling the keys in the screen — every pane that deviated from the rules had hand-rolled them.
+
 List-shaped screens must build `Row` objects only for the visible viewport, never for the whole collection. Use `RowWindow.bottomPinned(selection, total, viewport)` to derive the slice and pass `window.selectionInWindow()` to `TableState.select(...)`. Building rows for the entire list is invisible on small inputs but turns navigation O(N) on dictionaries with hundreds of thousands of entries, page lists with thousands of pages, or wide-schema files. See [_designs/DIVE_LIST_VIEWPORT_VIRTUALIZATION.md](_designs/DIVE_LIST_VIEWPORT_VIRTUALIZATION.md).
 
 # Code Reviews

--- a/_designs/DIVE_NAVIGATION_MODEL.md
+++ b/_designs/DIVE_NAVIGATION_MODEL.md
@@ -1,0 +1,187 @@
+# Design: dive navigation and cursor model
+
+**Status: Implemented.** Tracking issue: #1008.
+
+## Goal
+
+One navigation model across every pane of `hardwood dive`, so that a key
+pressed on any screen does what it did on the previous screen, and so that
+a reviewer has a rule to check new screens against.
+
+Two rules cover it: one for what the keys move, one for what the markers
+mean.
+
+## Rule 1 — keys
+
+`↑`/`↓`, `PgUp`/`PgDn` (aliased `Shift+↑`/`Shift+↓`) and `g`/`G` are **one
+axis at three strides**: one unit, one viewport, all the way. They never act
+on different things within the same pane.
+
+What a "unit" is depends on the pane, and a pane is exactly one kind:
+
+- **Cursor pane** — the unit is a row. State holds an index into the
+  content; the scroll offset exists only to keep that index on screen. Every
+  pane a reader can focus is one of these, whether or not `Enter` does
+  anything in it: a cursor is where you are, not what you can do, and a pane
+  worth reading is worth walking through. The list screens, the menus, the
+  facts panes, the record modal.
+- **Scroll pane** — the unit is a line. State holds an offset into the
+  content; there is no cursor and `Enter` means nothing. The modals and the
+  help overlay: an overlay is dismissed rather than navigated, so a position
+  in it would not survive to be worth keeping.
+
+The split is what a reader does with the pane, not what the content happens
+to contain. A facts pane with nothing actionable still gets a cursor,
+because `↑` should mean the same thing on it as on the pane beside it.
+
+Where a screen has both kinds, `Tab` switches focus between them, so `↑`/`↓`
+changes meaning only after an explicit move.
+
+**The cursor stops on every row.** It never skips rows that `Enter` cannot
+act on: a row that is not actionable is still worth reading, and skipping it
+puts content out of reach of the only keys that reach content.
+
+The cursor is a line index wherever a pane's rows are not uniform — the
+footer body, the facts panes, the record modal — so the lines between the
+ones `Enter` acts on are visited like any other, headings and blanks
+included. Which lines are inert is a rendering detail, and a cursor that
+knew about it would need the rule to carry an exception again.
+
+> Every key moves the cursor. Only the size of the step varies.
+
+## Rule 2 — markers
+
+- **Colour marks the cursor.** The cursor row is styled `Theme.selection()`.
+  That is the only signal of where the cursor is.
+- **`▶` marks actionability.** It is drawn on the cursor row whenever that
+  row is actionable, and on other rows only where it distinguishes them —
+  that is, where the pane holds some row `Enter` cannot act on.
+
+The cursor row's marker is orange like the rest of that row, since the
+selection style covers the whole row. A pane whose rows are uniformly
+actionable therefore shows a single caret travelling with the cursor rather
+than a column of identical ones. Absence is only required to be unambiguous
+on the cursor row, which is the only row `Enter` applies to, and there it
+always is.
+
+The marker occupies two cells, `"▶ "` or `"  "`, so text starts at the same
+column whether or not a row is actionable.
+
+The keybar stays consistent with this: `Keys.Hints` already lists `Enter`
+only when it is live on the current row.
+
+Together with Rule 1 this makes a non-actionable row legible rather than
+merely reachable — the cursor can rest on it, and the missing `▶` says why
+`Enter` does nothing.
+
+`Schema` carries two markers in two columns, and they stay separate: the
+actionability caret first, per the rule above, then the tree's `▶`/`▼`
+marking whether a group is collapsed or expanded. Leaf rows leave the tree
+column blank. Every schema row is actionable, so the first column holds a
+single caret that travels with the cursor.
+
+## Conformance
+
+Panes already conforming: Row groups, Column chunks, Pages, Offset index,
+Column index, Dictionary, File indexes, Row-group indexes,
+Column-across-row-groups, Data preview table, Column chunk detail facts
+pane, and the Overview and Row group detail menus.
+
+The remaining work, in the order it should land:
+
+### 1. Cursor panes whose viewport does not follow the cursor
+
+Both move the cursor correctly and then render from row zero, so the cursor
+leaves the screen and never comes back.
+
+- **Schema** — `ScreenState.Schema` has no scroll offset. Add one and adopt
+  `RowWindow.bottomPinned`, per
+  [DIVE_LIST_VIEWPORT_VIRTUALIZATION.md](DIVE_LIST_VIEWPORT_VIRTUALIZATION.md);
+  this is the only list screen still building rows for the whole collection.
+- **Overview facts pane** — `ScreenState.Overview` has no scroll offset for
+  the key/value list. Add one, window the pane, then add `PgUp`/`PgDn` and
+  `g`/`G`, which only become meaningful once the offset exists.
+
+### 2. Scroll panes missing strides
+
+- **Pages header, Dictionary value and Column index min/max modals** —
+  accept only `Esc` / `Enter`, so content past the modal viewport cannot be
+  reached. The Dictionary modal additionally places the whole value in a
+  single unwrapped line inside a fixed 16-row box, clipping anything wider
+  than the modal; it exists to show values too long for the table row.
+
+- **Row group detail facts pane** — no scrolling at all; content below the
+  fold is unreachable on a short terminal. Add a scroll offset and mirror
+  `ColumnChunkDetailScreen.scrollFacts`.
+- **Key/value modal** — recognises only `Shift+↑`/`Shift+↓`, with a
+  hard-coded stride of 10 and no `g`/`G`. Route through `Keys.isPageUp` /
+  `Keys.isPageDown`, take the stride from `Keys.viewportStride()`, add
+  `g`/`G`.
+- **Help overlay** — silently truncated on short terminals. Either make it
+  a scroll pane or guarantee it fits.
+
+### 3. Cursor panes that skip rows
+
+- **Record modal** — the cursor stops only on expandable fields and the body
+  scrolls on a second axis to compensate. Restore a cursor that stops on
+  every line, put `PgUp`/`PgDn` back on the cursor, add `g`/`G`. The modal
+  geometry stays; the independent scroll offset becomes a slave of the
+  cursor.
+- **Column chunk detail "Drill into" menu** — the cursor skips disabled
+  items. Let it rest on them; the absent `▶` tells the reader why `Enter`
+  does nothing.
+
+### 4. Footer
+
+Replace the anchor cursor with a line cursor that stops on every line, so
+the lines above the topmost anchor can be reached at all. The separate
+scroll offset and the render-time reconciliation that fights it both go
+away; opening the screen still puts the cursor on the first anchor.
+
+### 5. Markers
+
+Replace `.highlightSymbol("▶ ")` on the ten list screens, and the
+hand-rolled equivalent in the Overview facts pane and the two "Drill into"
+menus, with a marker driven by per-row actionability.
+
+`Schema` replaces its `▸` cursor prefix with the standard `▶` caret in its
+own column, ahead of the tree marker, and styles the whole cursor row
+`Theme.selection()` rather than the name span alone.
+
+The record modal reserves one cell for its marker where every other screen
+reserves two, so its caret abuts the field name. Widening it to `"▶ "` /
+`"  "` also shifts `continuationIndent` and `valueBudget`, which both encode
+the one-cell width.
+
+### 6. Shared mechanisms
+
+Every pane that renders through the shared table path obeys both rules, and
+every pane that deviates hand-rolls its own paragraph. The two rules should
+therefore be two pieces of shared code, with no third path:
+
+- **`CursorPane`** — the three strides over rows, the `RowWindow` slice, the
+  actionability marker column and the three standard keybar hints. A screen
+  supplies a row count, an actionability predicate, cell content, and the
+  effect of `Enter`. `Footer` overrides the finest stride; nothing else
+  needs to.
+- **`ScrollPane`** — the three strides over lines, plus wrapping. Promoted
+  out of `ColumnChunkDetailScreen.scrollFacts`, which is currently the only
+  correct implementation of it and is private to one screen.
+
+This is what the existing virtualization rule already demonstrates:
+`RowWindow` is shared, every screen that uses it is correct, and `Schema`,
+which does not, is the one that is broken.
+
+### 7. Documentation
+
+CLAUDE.md's Dive TUI section gains a pointer to this document, next to the
+existing theme and virtualization rules.
+
+The help overlay lists `PgDn`/`PgUp` under "Data preview", implying it is
+specific to that screen when it works on every pane that scrolls. Move it to
+"Navigation", document Footer's second axis, and list the key/value modal's
+keys.
+
+## Open decisions
+
+None outstanding.

--- a/cli/src/main/java/dev/hardwood/cli/dive/DiveApp.java
+++ b/cli/src/main/java/dev/hardwood/cli/dive/DiveApp.java
@@ -27,6 +27,7 @@ import dev.hardwood.cli.dive.internal.RowGroupDetailScreen;
 import dev.hardwood.cli.dive.internal.RowGroupIndexesScreen;
 import dev.hardwood.cli.dive.internal.RowGroupsScreen;
 import dev.hardwood.cli.dive.internal.SchemaScreen;
+import dev.hardwood.cli.dive.internal.ScrollPane;
 import dev.hardwood.cli.dive.internal.Theme;
 import dev.tamboui.buffer.Buffer;
 import dev.tamboui.layout.Rect;
@@ -45,6 +46,13 @@ public final class DiveApp {
     private final ParquetModel model;
     private final NavigationStack stack;
     private boolean helpOpen;
+
+    /// Scroll offset into the help overlay, and the line count the last
+    /// frame produced — the overlay wraps to the terminal width, so its
+    /// length is not known until it has been rendered once.
+    private int helpScroll;
+
+    private int helpLineCount;
 
     public DiveApp(ParquetModel model) {
         this.model = model;
@@ -99,11 +107,19 @@ public final class DiveApp {
         }
         if (!textInput && ke.code() == KeyCode.CHAR && ke.character() == '?') {
             helpOpen = !helpOpen;
+            helpScroll = 0;
             return Action.HANDLED;
         }
         if (helpOpen) {
             if (ke.isCancel()) {
                 helpOpen = false;
+                return Action.HANDLED;
+            }
+            // The overlay is longer than a short terminal can show, so it
+            // scrolls like any other document pane while it has the keys.
+            int next = ScrollPane.scroll(ke, helpScroll, helpLineCount, Keys.viewportStride());
+            if (next != ScrollPane.UNHANDLED) {
+                helpScroll = next;
                 return Action.HANDLED;
             }
             return Action.IGNORED;
@@ -172,6 +188,11 @@ public final class DiveApp {
         int kbHeight = Chrome.keybarHeight(screenKeys, globalKeys, area.width());
         Chrome.Regions regions = Chrome.split(area, kbHeight);
 
+        // Data preview loads exactly the rows its body can paint, so the
+        // page has to be fitted before the body is rendered rather than
+        // after — otherwise the frame the screen is entered on is short.
+        DataPreviewScreen.fitToViewport(model, stack, regions.body());
+
         Chrome.renderTopBar(buffer, regions.topBar(), model);
         Chrome.renderBreadcrumb(buffer, regions.breadcrumb(), stack, model);
         renderBody(buffer, regions.body());
@@ -182,7 +203,8 @@ public final class DiveApp {
             // Clear+paint restores full intensity inside its area.
             // Chrome (top bar, breadcrumb, keybar) stays unchanged.
             buffer.setStyle(regions.body(), Theme.dim());
-            HelpOverlay.render(buffer, area);
+            helpLineCount = HelpOverlay.lineCount(area);
+            HelpOverlay.render(buffer, area, helpScroll);
         }
     }
 
@@ -212,7 +234,7 @@ public final class DiveApp {
             case ScreenState.Overview s -> OverviewScreen.keybarKeys(s, model);
             case ScreenState.Schema s -> SchemaScreen.keybarKeys(s, model);
             case ScreenState.RowGroups s -> RowGroupsScreen.keybarKeys(s, model);
-            case ScreenState.RowGroupDetail s -> RowGroupDetailScreen.keybarKeys(s);
+            case ScreenState.RowGroupDetail s -> RowGroupDetailScreen.keybarKeys(s, model);
             case ScreenState.RowGroupIndexes s -> RowGroupIndexesScreen.keybarKeys(s, model);
             case ScreenState.ColumnChunks s -> ColumnChunksScreen.keybarKeys(s, model);
             case ScreenState.ColumnChunkDetail s -> ColumnChunkDetailScreen.keybarKeys(s, model);

--- a/cli/src/main/java/dev/hardwood/cli/dive/ScreenState.java
+++ b/cli/src/main/java/dev/hardwood/cli/dive/ScreenState.java
@@ -21,8 +21,13 @@ public sealed interface ScreenState {
     /// is the line offset into the modal contents — used when the formatted
     /// value (e.g. an Arrow hex dump) overflows the modal viewport.
     record Overview(Pane focus, int menuSelection, int kvSelection,
-                    boolean kvModalOpen, int kvModalScroll)
+                    boolean kvModalOpen, int kvModalScroll, int factsTop)
             implements ScreenState {
+        public Overview(Pane focus, int menuSelection, int kvSelection,
+                        boolean kvModalOpen, int kvModalScroll) {
+            this(focus, menuSelection, kvSelection, kvModalOpen, kvModalScroll, 0);
+        }
+
         public enum Pane { FACTS, MENU }
 
         /// Default state: menu pane focused, selection at 0, no KV interaction.
@@ -31,7 +36,8 @@ public sealed interface ScreenState {
         }
     }
 
-    /// Expandable tree of schema nodes. `selection` is the visible-row index;
+    /// Expandable tree of schema nodes. `selection` is the visible-row index
+    /// and `scrollTop` the absolute index of the first row on screen;
     /// `expanded` tracks which group paths are currently expanded. `filter` is
     /// the live search substring (empty = show the tree); `searching` toggles
     /// inline filter-edit mode via `/`.
@@ -39,13 +45,19 @@ public sealed interface ScreenState {
             int selection,
             java.util.Set<String> expanded,
             String filter,
-            boolean searching) implements ScreenState {
+            boolean searching,
+            int scrollTop) implements ScreenState {
         public Schema {
             expanded = java.util.Set.copyOf(expanded);
         }
 
+        public Schema(int selection, java.util.Set<String> expanded, String filter,
+                      boolean searching) {
+            this(selection, expanded, filter, searching, 0);
+        }
+
         public static Schema initial() {
-            return new Schema(0, java.util.Set.of(), "", false);
+            return new Schema(0, java.util.Set.of(), "", false, 0);
         }
     }
 
@@ -61,8 +73,17 @@ public sealed interface ScreenState {
 
     /// Two-pane overview of one row group: facts (left) + drill menu (right)
     /// leading to Column chunks and Indexes-for-this-RG.
-    record RowGroupDetail(int rowGroupIndex, Pane focus, int menuSelection)
+    record RowGroupDetail(int rowGroupIndex, Pane focus, int menuSelection, int scrollTop,
+                          int factsTop)
             implements ScreenState {
+        public RowGroupDetail(int rowGroupIndex, Pane focus, int menuSelection) {
+            this(rowGroupIndex, focus, menuSelection, 0, 0);
+        }
+
+        public RowGroupDetail(int rowGroupIndex, Pane focus, int menuSelection, int scrollTop) {
+            this(rowGroupIndex, focus, menuSelection, scrollTop, 0);
+        }
+
         public enum Pane { FACTS, MENU }
     }
 
@@ -93,11 +114,16 @@ public sealed interface ScreenState {
     /// the bottom of an ordinary terminal on a nested column, so it scrolls
     /// with the facts pane focused rather than dropping the tail.
     record ColumnChunkDetail(int rowGroupIndex, int columnIndex, Pane focus, int menuSelection,
-                              boolean logicalTypes, boolean levels, int scrollTop)
+                              boolean logicalTypes, boolean levels, int scrollTop, int factsTop)
             implements ScreenState {
         public ColumnChunkDetail(int rowGroupIndex, int columnIndex, Pane focus, int menuSelection,
                                  boolean logicalTypes, boolean levels) {
-            this(rowGroupIndex, columnIndex, focus, menuSelection, logicalTypes, levels, 0);
+            this(rowGroupIndex, columnIndex, focus, menuSelection, logicalTypes, levels, 0, 0);
+        }
+
+        public ColumnChunkDetail(int rowGroupIndex, int columnIndex, Pane focus, int menuSelection,
+                                 boolean logicalTypes, boolean levels, int scrollTop) {
+            this(rowGroupIndex, columnIndex, focus, menuSelection, logicalTypes, levels, scrollTop, 0);
         }
 
         public enum Pane { FACTS, MENU }
@@ -107,11 +133,16 @@ public sealed interface ScreenState {
     /// `logicalTypes` controls whether stats columns render via logical type
     /// (default) or raw physical-type form — toggled with `t`.
     record Pages(int rowGroupIndex, int columnIndex, int selection, boolean modalOpen,
-                 boolean logicalTypes, int scrollTop)
+                 boolean logicalTypes, int scrollTop, int modalScroll)
             implements ScreenState {
         public Pages(int rowGroupIndex, int columnIndex, int selection, boolean modalOpen,
                      boolean logicalTypes) {
-            this(rowGroupIndex, columnIndex, selection, modalOpen, logicalTypes, 0);
+            this(rowGroupIndex, columnIndex, selection, modalOpen, logicalTypes, 0, 0);
+        }
+
+        public Pages(int rowGroupIndex, int columnIndex, int selection, boolean modalOpen,
+                     boolean logicalTypes, int scrollTop) {
+            this(rowGroupIndex, columnIndex, selection, modalOpen, logicalTypes, scrollTop, 0);
         }
     }
 
@@ -130,11 +161,19 @@ public sealed interface ScreenState {
             boolean searching,
             boolean logicalTypes,
             boolean modalOpen,
-            int scrollTop) implements ScreenState {
+            int scrollTop,
+            int modalScroll) implements ScreenState {
         public ColumnIndexView(int rowGroupIndex, int columnIndex, int selection,
                                 String filter, boolean searching, boolean logicalTypes,
                                 boolean modalOpen) {
-            this(rowGroupIndex, columnIndex, selection, filter, searching, logicalTypes, modalOpen, 0);
+            this(rowGroupIndex, columnIndex, selection, filter, searching, logicalTypes, modalOpen, 0, 0);
+        }
+
+        public ColumnIndexView(int rowGroupIndex, int columnIndex, int selection,
+                                String filter, boolean searching, boolean logicalTypes,
+                                boolean modalOpen, int scrollTop) {
+            this(rowGroupIndex, columnIndex, selection, filter, searching, logicalTypes,
+                    modalOpen, scrollTop, 0);
         }
     }
 
@@ -151,11 +190,20 @@ public sealed interface ScreenState {
     /// `Anchor#OFFSET`, `Anchor#DICTIONARY` — so ↑/↓ cycle between them
     /// and Enter always drills. Body content is scrolled separately with
     /// `PgDn` / `PgUp`; `scroll` is the line offset into the body content.
-    record Footer(Anchor cursor, int scroll) implements ScreenState {
-        public enum Anchor { COLUMN, OFFSET, DICTIONARY }
+    /// The footer body is a document with a few drillable anchors in it.
+    /// `cursorRow` indexes the rows the cursor stops on — the facts, not the
+    /// section headings and blanks between them. The window is derived from
+    /// it, so there is no scroll offset to keep.
+    record Footer(int cursorRow, int windowTop) implements ScreenState {
+        public Footer(int cursorRow) {
+            this(cursorRow, 0);
+        }
 
+        /// Where the cursor starts before the file is consulted. Screens open
+        /// this through `FooterScreen.initialState`, which puts it on the
+        /// first anchor the file actually has.
         public static Footer initial() {
-            return new Footer(Anchor.COLUMN, 0);
+            return new Footer(0, 0);
         }
     }
 
@@ -198,12 +246,20 @@ public sealed interface ScreenState {
             boolean searching,
             boolean loadConfirmed,
             boolean logicalTypes,
-            int scrollTop) implements ScreenState {
+            int scrollTop,
+            int modalScroll) implements ScreenState {
         public DictionaryView(int rowGroupIndex, int columnIndex, int selection,
                               boolean modalOpen, String filter, boolean searching,
                               boolean loadConfirmed, boolean logicalTypes) {
             this(rowGroupIndex, columnIndex, selection, modalOpen, filter, searching,
-                    loadConfirmed, logicalTypes, 0);
+                    loadConfirmed, logicalTypes, 0, 0);
+        }
+
+        public DictionaryView(int rowGroupIndex, int columnIndex, int selection,
+                              boolean modalOpen, String filter, boolean searching,
+                              boolean loadConfirmed, boolean logicalTypes, int scrollTop) {
+            this(rowGroupIndex, columnIndex, selection, modalOpen, filter, searching,
+                    loadConfirmed, logicalTypes, scrollTop, 0);
         }
     }
 

--- a/cli/src/main/java/dev/hardwood/cli/dive/internal/ColumnAcrossRowGroupsScreen.java
+++ b/cli/src/main/java/dev/hardwood/cli/dive/internal/ColumnAcrossRowGroupsScreen.java
@@ -45,36 +45,14 @@ public final class ColumnAcrossRowGroupsScreen {
         ScreenState.ColumnAcrossRowGroups state = (ScreenState.ColumnAcrossRowGroups) stack.top();
         int count = model.rowGroupCount();
         boolean logical = state.logicalTypes();
-        if (Keys.isStepUp(event)) {
-            stack.replaceTop(moved(state, Math.max(0, state.selection() - 1), logical));
-            return true;
-        }
-        if (Keys.isStepDown(event)) {
-            stack.replaceTop(moved(state, Math.min(count - 1, state.selection() + 1), logical));
-            return true;
-        }
-        if (Keys.isPageDown(event) && count > 0) {
-            stack.replaceTop(moved(state,
-                    Math.min(count - 1, state.selection() + Keys.viewportStride()), logical));
-            return true;
-        }
-        if (Keys.isPageUp(event) && count > 0) {
-            stack.replaceTop(moved(state,
-                    Math.max(0, state.selection() - Keys.viewportStride()), logical));
-            return true;
-        }
-        if (Keys.isJumpTop(event) && count > 0) {
-            stack.replaceTop(moved(state, 0, logical));
-            return true;
-        }
-        if (Keys.isJumpBottom(event) && count > 0) {
-            stack.replaceTop(moved(state, count - 1, logical));
+        int next = CursorPane.select(event, state.selection(), count);
+        if (next != CursorPane.UNHANDLED) {
+            stack.replaceTop(moved(state, next, logical));
             return true;
         }
         if (event.isConfirm() && count > 0) {
-            stack.push(new ScreenState.ColumnChunkDetail(
-                    state.selection(), state.columnIndex(),
-                    ScreenState.ColumnChunkDetail.Pane.MENU, 0, state.logicalTypes(), false));
+            stack.push(ColumnChunkDetailScreen.initialState(
+                    model, state.selection(), state.columnIndex(), state.logicalTypes()));
             return true;
         }
         if (event.code() == dev.tamboui.tui.event.KeyCode.CHAR && event.character() == 't'
@@ -143,8 +121,7 @@ public final class ColumnAcrossRowGroupsScreen {
         Block block = Block.builder()
                 .title(" " + truncateLeft(col.fieldPath().toString(), 40)
                         + " · RG "
-                        + Plurals.rangeOf(state.selection(), model.rowGroupCount(),
-                                Keys.viewportStride())
+                        + Plurals.rangeOf(window, model.rowGroupCount())
                         + typeMode + " ")
                 .borders(Borders.ALL)
                 .borderType(BorderType.ROUNDED)
@@ -178,9 +155,7 @@ public final class ColumnAcrossRowGroupsScreen {
         ColumnSchema col = model.schema().getColumn(state.columnIndex());
         boolean hasLogical = col.logicalType() != null;
         return new Keys.Hints()
-                .add(count > 1, "[↑↓] move")
-                .add(count > Keys.viewportStride(), "[PgDn/PgUp or Shift+↓↑] page")
-                .add(count > 1, "[g/G] first/last")
+                .add(true, CursorPane.hints(count))
                 .add(count > 0, "[Enter] open")
                 .add(hasLogical, "[t] logical types")
                 .add(true, "[Esc] back")

--- a/cli/src/main/java/dev/hardwood/cli/dive/internal/ColumnChunkDetailScreen.java
+++ b/cli/src/main/java/dev/hardwood/cli/dive/internal/ColumnChunkDetailScreen.java
@@ -62,6 +62,21 @@ public final class ColumnChunkDetailScreen {
     private ColumnChunkDetailScreen() {
     }
 
+    /// The state to push when drilling into a chunk: the menu focused, with
+    /// the cursor on the first entry `Enter` can act on.
+    ///
+    /// Chosen here rather than corrected on each keypress — a screen that
+    /// re-snapped the cursor every event would drag it straight back off any
+    /// disabled entry the reader moved onto.
+    public static ScreenState.ColumnChunkDetail initialState(ParquetModel model, int rowGroupIndex,
+                                                             int columnIndex, boolean logicalTypes) {
+        ScreenState.ColumnChunkDetail entry = new ScreenState.ColumnChunkDetail(
+                rowGroupIndex, columnIndex, ScreenState.ColumnChunkDetail.Pane.MENU, 0,
+                logicalTypes, false);
+        int first = firstEnabledIndex(MenuItem.values(), model, entry);
+        return first <= 0 ? entry : state(entry, first);
+    }
+
     public static boolean handle(KeyEvent event, ParquetModel model, NavigationStack stack) {
         ScreenState.ColumnChunkDetail state = (ScreenState.ColumnChunkDetail) stack.top();
         if (event.isFocusNext() || event.isFocusPrevious()) {
@@ -92,30 +107,9 @@ public final class ColumnChunkDetailScreen {
             return scrollFacts(event, model, stack, state);
         }
         MenuItem[] items = MenuItem.values();
-        // Snap an out-of-place selection to the first enabled item — covers
-        // the initial entry where menuSelection is 0 (PAGES) and (in
-        // principle) any later state where the chunk shape has changed.
-        if (!itemEnabled(items[state.menuSelection()], model, state)) {
-            int first = firstEnabledIndex(items, model, state);
-            if (first >= 0 && first != state.menuSelection()) {
-                state = state(state, first);
-                stack.replaceTop(state);
-            }
-        }
-        if (event.isUp()) {
-            int prev = previousEnabledIndex(items, model, state, state.menuSelection());
-            if (prev < 0) {
-                return false;
-            }
-            stack.replaceTop(state(state, prev));
-            return true;
-        }
-        if (event.isDown()) {
-            int next = nextEnabledIndex(items, model, state, state.menuSelection());
-            if (next < 0) {
-                return false;
-            }
-            stack.replaceTop(state(state, next));
+        int selected = CursorPane.select(event, state.menuSelection(), items.length);
+        if (selected != CursorPane.UNHANDLED) {
+            stack.replaceTop(state(state, selected));
             return true;
         }
         if (event.isConfirm()) {
@@ -149,16 +143,8 @@ public final class ColumnChunkDetailScreen {
     public static String keybarKeys(ScreenState.ColumnChunkDetail state, ParquetModel model) {
         boolean onMenu = state.focus() == ScreenState.ColumnChunkDetail.Pane.MENU;
         MenuItem[] items = MenuItem.values();
-        int enabledCount = 0;
-        boolean currentEnabled = false;
-        for (int i = 0; i < items.length; i++) {
-            if (itemEnabled(items[i], model, state)) {
-                enabledCount++;
-                if (i == state.menuSelection()) {
-                    currentEnabled = true;
-                }
-            }
-        }
+        boolean currentEnabled = state.menuSelection() < items.length
+                && itemEnabled(items[state.menuSelection()], model, state);
         ColumnSchema col = model.schema().getColumn(state.columnIndex());
         boolean hasLogical = col.logicalType() != null;
         ColumnMetaData cmd = model.chunk(state.rowGroupIndex(), state.columnIndex()).metaData();
@@ -167,13 +153,14 @@ public final class ColumnChunkDetailScreen {
         // rows are shown outright and the key would toggle nothing.
         LevelSummary summary = LevelSummary.of(model.schema(), col, cmd);
         boolean hasLevels = hasHistogram(summary);
-        // Advertised only where it does something: the facts pane scrolls only
-        // when it has more lines than the viewport can hold.
-        boolean canScroll = !onMenu && factsLineCount(model, state) > Keys.viewportStride();
+        // The scroll fragment is empty unless the facts pane overflows, so it
+        // contributes nothing while the menu has focus or the content fits.
+        boolean canScroll = !onMenu;
         return new Keys.Hints()
                 .add(true, "[Tab] pane")
-                .add(onMenu && enabledCount > 1, "[↑↓] move")
-                .add(canScroll, "[↑↓] scroll")
+                .add(onMenu, CursorPane.hints(items.length))
+                .add(canScroll, factsLines(model, state, LevelSummary.MINIMUM_WIDTH)
+                        .hints(Keys.viewportStride()))
                 .add(onMenu && currentEnabled, "[Enter] open")
                 .add(hasLevels, "[l] levels")
                 .add(hasLogical, "[t] logical types")
@@ -187,50 +174,48 @@ public final class ColumnChunkDetailScreen {
                 state.logicalTypes(), state.levels(), state.scrollTop());
     }
 
+    /// Repaints the cursor line in the selection colour. Nothing in a facts
+    /// pane is actionable, so the cursor carries no marker — the colour alone
+    /// is the reader's place in the pane.
+    private static List<Line> withCursor(List<Line> window, int offset, boolean focused) {
+        if (!focused || offset < 0 || offset >= window.size()) {
+            return window;
+        }
+        List<Line> painted = new ArrayList<>(window);
+        StringBuilder text = new StringBuilder();
+        for (Span span : window.get(offset).spans()) {
+            text.append(span.content());
+        }
+        painted.set(offset, Line.from(new Span(text.toString(), Theme.selection())));
+        return painted;
+    }
+
     private static boolean isPlainChar(KeyEvent event, char character) {
         return event.code() == KeyCode.CHAR && event.character() == character
                 && !event.hasCtrl() && !event.hasAlt();
     }
 
-    /// Scrolls the facts pane, which is the only thing ↑/↓ can mean while it
-    /// has focus — the menu is not being navigated. The pane runs to about
-    /// forty lines on a nested column with its levels shown, so without this
-    /// the tail is simply dropped.
+    /// Moves the facts cursor, which is what the navigation keys mean while
+    /// the pane has focus — the menu is not being navigated. The pane runs to
+    /// about forty lines on a nested column with its levels shown.
     ///
-    /// The stored offset is clamped against the *current* content before it is
-    /// adjusted, so collapsing the levels while scrolled past their end does
-    /// not leave a stale offset that swallows the next few keypresses.
+    /// Nothing here is actionable, so the cursor carries no marker; it is the
+    /// reader's place in the pane, and it moves on the same keys as every
+    /// other focusable pane in dive.
     private static boolean scrollFacts(KeyEvent event, ParquetModel model, NavigationStack stack,
                                        ScreenState.ColumnChunkDetail state) {
-        int viewport = Keys.viewportStride();
-        int maxScroll = Math.max(0, factsLineCount(model, state) - viewport);
-        int current = Math.min(state.scrollTop(), maxScroll);
-        int next;
-        if (Keys.isStepUp(event)) {
-            next = Math.max(0, current - 1);
-        }
-        else if (Keys.isStepDown(event)) {
-            next = Math.min(maxScroll, current + 1);
-        }
-        else if (Keys.isPageUp(event)) {
-            next = Math.max(0, current - viewport);
-        }
-        else if (Keys.isPageDown(event)) {
-            next = Math.min(maxScroll, current + viewport);
-        }
-        else if (Keys.isJumpTop(event)) {
-            next = 0;
-        }
-        else if (Keys.isJumpBottom(event)) {
-            next = maxScroll;
-        }
-        else {
+        int next = factsLines(model, state, LevelSummary.MINIMUM_WIDTH)
+                .select(event, state.scrollTop(), Keys.viewportStride());
+        if (next == CursorPane.UNHANDLED) {
             return false;
         }
         if (next != state.scrollTop()) {
             stack.replaceTop(new ScreenState.ColumnChunkDetail(
                     state.rowGroupIndex(), state.columnIndex(), state.focus(), state.menuSelection(),
-                    state.logicalTypes(), state.levels(), next));
+                    state.logicalTypes(), state.levels(), next,
+                    factsLines(model, state, LevelSummary.MINIMUM_WIDTH)
+                            .windowTopAfterMove(state.factsTop(), state.scrollTop(), next,
+                                    Keys.viewportStride())));
         }
         return true;
     }
@@ -245,25 +230,6 @@ public final class ColumnChunkDetailScreen {
         return -1;
     }
 
-    private static int nextEnabledIndex(MenuItem[] items, ParquetModel model,
-                                         ScreenState.ColumnChunkDetail state, int from) {
-        for (int i = from + 1; i < items.length; i++) {
-            if (itemEnabled(items[i], model, state)) {
-                return i;
-            }
-        }
-        return -1;
-    }
-
-    private static int previousEnabledIndex(MenuItem[] items, ParquetModel model,
-                                             ScreenState.ColumnChunkDetail state, int from) {
-        for (int i = from - 1; i >= 0; i--) {
-            if (itemEnabled(items[i], model, state)) {
-                return i;
-            }
-        }
-        return -1;
-    }
 
     private static boolean itemEnabled(MenuItem item, ParquetModel model, ScreenState.ColumnChunkDetail state) {
         ColumnChunk chunk = model.chunk(state.rowGroupIndex(), state.columnIndex());
@@ -280,11 +246,11 @@ public final class ColumnChunkDetailScreen {
     /// this does not depend on the width the lines are later built at — which
     /// is what lets key handling size a scroll against content it has not
     /// rendered.
-    private static int factsLineCount(ParquetModel model, ScreenState.ColumnChunkDetail state) {
-        return factsLines(model, state, LevelSummary.MINIMUM_WIDTH).size();
+    private static int factsRowCount(ParquetModel model, ScreenState.ColumnChunkDetail state) {
+        return factsLines(model, state, LevelSummary.MINIMUM_WIDTH).rowCount();
     }
 
-    private static List<Line> factsLines(ParquetModel model, ScreenState.ColumnChunkDetail state,
+    private static Document factsLines(ParquetModel model, ScreenState.ColumnChunkDetail state,
                                          int innerWidth) {
         ColumnChunk chunk = model.chunk(state.rowGroupIndex(), state.columnIndex());
         ColumnMetaData cmd = chunk.metaData();
@@ -292,20 +258,22 @@ public final class ColumnChunkDetailScreen {
         Statistics stats = cmd.statistics();
 
         LevelSummary summary = LevelSummary.of(model.schema(), col, cmd);
-        List<Line> lines = new ArrayList<>();
+        Document.Builder lines = Document.builder();
 
-        lines.add(group("Identity"));
-        lines.addAll(pathLines(Sizes.columnPath(cmd)));
-        lines.add(fact("Column idx", String.valueOf(col.columnIndex())));
-        lines.add(fact("Physical", cmd.type().name()));
-        lines.add(fact("Logical", col.logicalType() != null ? col.logicalType().toString() : "—"));
+        lines.decoration(group("Identity"));
+        for (Line pathLine : pathLines(Sizes.columnPath(cmd))) {
+            lines.row(pathLine);
+        }
+        lines.row(fact("Column idx", String.valueOf(col.columnIndex())));
+        lines.row(fact("Physical", cmd.type().name()));
+        lines.row(fact("Logical", col.logicalType() != null ? col.logicalType().toString() : "—"));
 
-        lines.add(Line.empty());
-        lines.add(group("Storage"));
-        lines.add(fact("Compressed", Sizes.format(cmd.totalCompressedSize())
+        lines.blank();
+        lines.decoration(group("Storage"));
+        lines.row(fact("Compressed", Sizes.format(cmd.totalCompressedSize())
                 + compressionQualifier(cmd)));
-        lines.add(fact("Uncompressed", Sizes.format(cmd.totalUncompressedSize())));
-        lines.add(fact("Codec", cmd.codec().name()));
+        lines.row(fact("Uncompressed", Sizes.format(cmd.totalUncompressedSize())));
+        lines.row(fact("Codec", cmd.codec().name()));
         // What the data pages actually use, which is the same figure
         // `hardwood inspect columns` prints. The chunk's declared list follows
         // only where `encoding_stats` made the two say different things: it
@@ -313,51 +281,57 @@ public final class ColumnChunkDetailScreen {
         // its own it cannot show a dictionary abandoned partway through.
         long dictionaryEntries = model.dictionaryEntries(state.rowGroupIndex(), state.columnIndex());
         long dictionaryValues = summary.hasPresentValues() ? summary.presentValues() : cmd.numValues();
-        lines.add(fact("Encoding",
+        lines.row(fact("Encoding",
                 Encodings.label(Encodings.dataPages(cmd), dictionaryEntries, dictionaryValues, "—")
                         + dictionaryQualifier(dictionaryEntries, dictionaryValues)));
         if (Encodings.hasEncodingStats(cmd)) {
-            lines.add(fact("Chunk encodings", cmd.encodings().stream()
+            lines.row(fact("Chunk encodings", cmd.encodings().stream()
                     .map(Enum::name)
                     .collect(Collectors.joining(", "))));
         }
         appendStorageStatistics(lines, summary, cmd, model, state);
 
-        lines.add(Line.empty());
-        lines.add(group("Content"));
+        lines.blank();
+        lines.decoration(group("Content"));
         appendContent(lines, cmd, stats, col, summary, state);
 
-        lines.add(Line.empty());
+        lines.blank();
         appendLevels(lines, summary, innerWidth, state);
 
-        lines.add(Line.empty());
-        lines.add(group("Layout"));
-        lines.add(fact("Data offset", Fmt.fmt("%,d", cmd.dataPageOffset())));
-        lines.add(fact("Dict offset", cmd.dictionaryPageOffset() != null
+        lines.blank();
+        lines.decoration(group("Layout"));
+        lines.row(fact("Data offset", Fmt.fmt("%,d", cmd.dataPageOffset())));
+        lines.row(fact("Dict offset", cmd.dictionaryPageOffset() != null
                 ? Fmt.fmt("%,d", cmd.dictionaryPageOffset())
                 : "—"));
-        lines.add(fact("Column index offset", chunk.columnIndexOffset() != null
+        lines.row(fact("Column index offset", chunk.columnIndexOffset() != null
                 ? Fmt.fmt("%,d", chunk.columnIndexOffset())
                 : "—"));
-        lines.add(fact("Offset index offset", chunk.offsetIndexOffset() != null
+        lines.row(fact("Offset index offset", chunk.offsetIndexOffset() != null
                 ? Fmt.fmt("%,d", chunk.offsetIndexOffset())
                 : "—"));
-        return lines;
+        return lines.build();
     }
 
     private static void renderFactsPane(Buffer buffer, Rect area, ParquetModel model, ScreenState.ColumnChunkDetail state) {
         boolean focused = state.focus() == ScreenState.ColumnChunkDetail.Pane.FACTS;
         // Two border columns and the one-space inset every row is rendered with.
-        List<Line> lines = factsLines(model, state, Math.max(0, area.width() - 3));
+        Document facts = factsLines(model, state, Math.max(0, area.width() - 3));
 
         int viewport = Math.max(1, area.height() - 2);
         Keys.observeViewport(viewport);
-        int maxScroll = Math.max(0, lines.size() - viewport);
-        int scroll = Math.max(0, Math.min(maxScroll, state.scrollTop()));
-        int end = Math.min(lines.size(), scroll + viewport);
+        int cursorLine = Math.max(0, facts.lineOfRow(state.scrollTop()));
+        RowWindow window = RowWindow.from(
+                facts.windowTop(state.factsTop(), state.scrollTop(), viewport),
+                cursorLine, facts.lineCount(), viewport);
+        int scroll = window.start();
+        int end = window.end();
 
-        Block block = paneBlock(paneTitle(model, state, scroll, end, lines.size()), focused);
-        Paragraph.builder().block(block).text(Text.from(lines.subList(scroll, end)))
+        Block block = paneBlock(paneTitle(model, state, scroll, end, facts.lineCount()), focused);
+        Paragraph.builder()
+                .block(block)
+                .text(Text.from(withCursor(facts.lines().subList(scroll, end),
+                        cursorLine - scroll, focused)))
                 .left().build().render(area, buffer);
     }
 
@@ -378,13 +352,13 @@ public final class ColumnChunkDetailScreen {
     /// whose input the file does not record are dropped rather than shown as
     /// `—`: scaffolding a flat column with rows that can never be filled costs
     /// more lines than it explains.
-    private static void appendStorageStatistics(List<Line> lines, LevelSummary summary, ColumnMetaData cmd,
+    private static void appendStorageStatistics(Document.Builder lines, LevelSummary summary, ColumnMetaData cmd,
                                                 ParquetModel model, ScreenState.ColumnChunkDetail state) {
         if (!summary.hasSizeStatistics()) {
-            lines.add(advisory("Size statistics", "— (not written)"));
+            lines.row(advisory("Size statistics", "— (not written)"));
         }
         else {
-            lines.add(fact("Size statistics", coverage(model, state)));
+            lines.row(fact("Size statistics", coverage(model, state)));
         }
         if (summary.hasUnencoded()) {
             // The length-prefix parenthetical needs the present-value count; a
@@ -401,11 +375,11 @@ public final class ColumnChunkDetailScreen {
                 }
                 note.append('+').append(Sizes.format(summary.lengthPrefixBytes())).append(" lengths");
             }
-            lines.add(fact("Unencoded", Sizes.format(summary.unencodedBytes())
+            lines.row(fact("Unencoded", Sizes.format(summary.unencodedBytes())
                     + qualifier(note.toString())));
         }
         if (summary.hasAvgValueSize()) {
-            lines.add(fact("Avg value size", Sizes.format(Math.round(summary.avgValueSize()))));
+            lines.row(fact("Avg value size", Sizes.format(Math.round(summary.avgValueSize()))));
         }
     }
 
@@ -418,32 +392,32 @@ public final class ColumnChunkDetailScreen {
     /// describe rather than standing as rows of their own: each is a property
     /// of the count beside it, and a bare `2.64` on its own line reads as an
     /// independent fact with no scale.
-    private static void appendContent(List<Line> lines, ColumnMetaData cmd, Statistics stats, ColumnSchema col,
+    private static void appendContent(Document.Builder lines, ColumnMetaData cmd, Statistics stats, ColumnSchema col,
                                       LevelSummary summary, ScreenState.ColumnChunkDetail state) {
         boolean repeated = summary.maxRepetitionLevel() > 0;
         if (repeated && summary.hasRecords()) {
-            lines.add(fact("Records", Fmt.fmt("%,d", summary.records())));
+            lines.row(fact("Records", Fmt.fmt("%,d", summary.records())));
         }
-        lines.add(fact("Values", Fmt.fmt("%,d", cmd.numValues())
+        lines.row(fact("Values", Fmt.fmt("%,d", cmd.numValues())
                 + (repeated && summary.hasAvgFanOut()
                         ? qualifier(Fmt.fmt("%.2f per record", summary.avgFanOut()))
                         : "")));
         if (summary.maxDefinitionLevel() > 0 && summary.hasPresentValues()) {
-            lines.add(fact("Present", Fmt.fmt("%,d", summary.presentValues())
+            lines.row(fact("Present", Fmt.fmt("%,d", summary.presentValues())
                     + share(summary.presentValues(), cmd.numValues())));
         }
         long nulls = summary.nullCount(stats);
-        lines.add(fact("Nulls", nulls >= 0
+        lines.row(fact("Nulls", nulls >= 0
                 ? Fmt.fmt("%,d", nulls) + share(nulls, cmd.numValues())
                 : "—"));
         if (summary.hasAvgListLength()) {
-            lines.add(fact("Avg list length", Fmt.fmt("%.2f", summary.avgListLength())
+            lines.row(fact("Avg list length", Fmt.fmt("%.2f", summary.avgListLength())
                     + qualifier("non-empty")));
         }
-        lines.add(fact("Min", stats != null ? formatStatValue(stats.minValue(), col, state.logicalTypes()) : "—"));
-        lines.add(fact("Max", stats != null ? formatStatValue(stats.maxValue(), col, state.logicalTypes()) : "—"));
+        lines.row(fact("Min", stats != null ? formatStatValue(stats.minValue(), col, state.logicalTypes()) : "—"));
+        lines.row(fact("Max", stats != null ? formatStatValue(stats.maxValue(), col, state.logicalTypes()) : "—"));
         if (summary.mismatch() != null) {
-            lines.add(Line.from(
+            lines.row(Line.from(
                     new Span(" ⚠ " + padRight("Declared vs actual", 20), Theme.error()),
                     new Span(summary.mismatch(), Theme.error())));
         }
@@ -453,20 +427,20 @@ public final class ColumnChunkDetailScreen {
     /// both degrade to one `—` row each there is nothing to collapse, so they
     /// are shown outright rather than hidden behind a key that reveals two
     /// lines of explanation.
-    private static void appendLevels(List<Line> lines, LevelSummary summary, int innerWidth,
+    private static void appendLevels(Document.Builder lines, LevelSummary summary, int innerWidth,
                                      ScreenState.ColumnChunkDetail state) {
         if (!hasHistogram(summary)) {
-            lines.add(advisory("Def levels", definitionLevelsAbsent(summary)));
-            lines.add(advisory("Rep levels", repetitionLevelsAbsent(summary)));
+            lines.row(advisory("Def levels", definitionLevelsAbsent(summary)));
+            lines.row(advisory("Rep levels", repetitionLevelsAbsent(summary)));
             return;
         }
         if (!state.levels()) {
-            lines.add(advisory("Levels", "[l] to show"));
+            lines.row(advisory("Levels", "[l] to show"));
             return;
         }
         appendLevelBlock(lines, "Def levels", summary.definitionLevels(),
                 summary.maxDefinitionLevel(), definitionLevelsAbsent(summary), innerWidth);
-        lines.add(Line.empty());
+        lines.blank();
         appendLevelBlock(lines, "Rep levels", summary.repetitionLevels(),
                 summary.maxRepetitionLevel(), repetitionLevelsAbsent(summary), innerWidth);
     }
@@ -522,17 +496,17 @@ public final class ColumnChunkDetailScreen {
         return summary.maxRepetitionLevel() == 0 ? "— (not repeated)" : "— (not written)";
     }
 
-    private static void appendLevelBlock(List<Line> lines, String label, List<LevelSummary.LevelRow> rows,
+    private static void appendLevelBlock(Document.Builder lines, String label, List<LevelSummary.LevelRow> rows,
                                          int maxLevel, String absent, int innerWidth) {
         if (rows.isEmpty()) {
-            lines.add(advisory(label, absent));
+            lines.row(advisory(label, absent));
             return;
         }
         // A populated block is a section, not a fact: its caption sits at the
         // group indent so the level rows below read as its children.
-        lines.add(group(label + " (max " + maxLevel + ")"));
+        lines.decoration(group(label + " (max " + maxLevel + ")"));
         for (String row : LevelSummary.renderLevels(rows, innerWidth)) {
-            lines.add(Line.from(new Span(" " + row, Style.EMPTY)));
+            lines.row(Line.from(new Span(" " + row, Style.EMPTY)));
         }
     }
 
@@ -560,22 +534,14 @@ public final class ColumnChunkDetailScreen {
         Block block = paneBlock(" Drill into ", focused);
         List<Line> lines = new ArrayList<>();
         MenuItem[] items = MenuItem.values();
-        // First-render snap: if state.menuSelection() points at a disabled
-        // item, paint the cursor on the first enabled item so the user
-        // sees a usable affordance immediately. handle() persists the
-        // snap into state on the next event.
-        int effectiveSelection = state.menuSelection();
-        if (!itemEnabled(items[effectiveSelection], model, state)) {
-            int first = firstEnabledIndex(items, model, state);
-            if (first >= 0) {
-                effectiveSelection = first;
-            }
-        }
         for (int i = 0; i < items.length; i++) {
             MenuItem item = items[i];
             boolean enabled = itemEnabled(item, model, state);
-            boolean selected = focused && i == effectiveSelection && enabled;
-            String cursor = selected ? "▶ " : "  ";
+            boolean selected = focused && i == state.menuSelection();
+            // Menu entries a chunk does not have — a column index it was
+            // written without, say — stay on screen and keep their fact, but
+            // lose the marker that says Enter goes somewhere.
+            String cursor = CursorPane.marker(enabled, selected, true);
             Style labelStyle = selected
                     ? Theme.selection()
                     : Theme.primary();

--- a/cli/src/main/java/dev/hardwood/cli/dive/internal/ColumnChunksScreen.java
+++ b/cli/src/main/java/dev/hardwood/cli/dive/internal/ColumnChunksScreen.java
@@ -38,33 +38,14 @@ public final class ColumnChunksScreen {
     public static boolean handle(KeyEvent event, ParquetModel model, NavigationStack stack) {
         ScreenState.ColumnChunks state = (ScreenState.ColumnChunks) stack.top();
         int count = model.rowGroup(state.rowGroupIndex()).columns().size();
-        if (Keys.isStepUp(event)) {
-            stack.replaceTop(moved(state, Math.max(0, state.selection() - 1)));
-            return true;
-        }
-        if (Keys.isStepDown(event)) {
-            stack.replaceTop(moved(state, Math.min(count - 1, state.selection() + 1)));
-            return true;
-        }
-        if (Keys.isPageDown(event) && count > 0) {
-            stack.replaceTop(moved(state, Math.min(count - 1, state.selection() + Keys.viewportStride())));
-            return true;
-        }
-        if (Keys.isPageUp(event) && count > 0) {
-            stack.replaceTop(moved(state, Math.max(0, state.selection() - Keys.viewportStride())));
-            return true;
-        }
-        if (Keys.isJumpTop(event) && count > 0) {
-            stack.replaceTop(moved(state, 0));
-            return true;
-        }
-        if (Keys.isJumpBottom(event) && count > 0) {
-            stack.replaceTop(moved(state, count - 1));
+        int next = CursorPane.select(event, state.selection(), count);
+        if (next != CursorPane.UNHANDLED) {
+            stack.replaceTop(moved(state, next));
             return true;
         }
         if (event.isConfirm() && count > 0) {
-            stack.push(new ScreenState.ColumnChunkDetail(state.rowGroupIndex(), state.selection(),
-                    ScreenState.ColumnChunkDetail.Pane.MENU, 0, true, false));
+            stack.push(ColumnChunkDetailScreen.initialState(
+                    model, state.rowGroupIndex(), state.selection(), true));
             return true;
         }
         return false;
@@ -100,9 +81,7 @@ public final class ColumnChunksScreen {
                 .style(Theme.accent().bold());
         Block block = Block.builder()
                 .title(" RG #" + state.rowGroupIndex() + " column chunks "
-                        + Plurals.rangeOf(state.selection(),
-                                model.rowGroup(state.rowGroupIndex()).columns().size(),
-                                Keys.viewportStride()) + " ")
+                        + Plurals.rangeOf(window, model.rowGroup(state.rowGroupIndex()).columns().size()) + " ")
                 .borders(Borders.ALL)
                 .borderType(BorderType.ROUNDED)
                 .build();
@@ -130,9 +109,7 @@ public final class ColumnChunksScreen {
     public static String keybarKeys(ScreenState.ColumnChunks state, ParquetModel model) {
         int count = model.rowGroup(state.rowGroupIndex()).columns().size();
         return new Keys.Hints()
-                .add(count > 1, "[↑↓] move")
-                .add(count > Keys.viewportStride(), "[PgDn/PgUp or Shift+↓↑] page")
-                .add(count > 1, "[g/G] first/last")
+                .add(true, CursorPane.hints(count))
                 .add(count > 0, "[Enter] open")
                 .add(true, "[Esc] back")
                 .build();

--- a/cli/src/main/java/dev/hardwood/cli/dive/internal/ColumnIndexScreen.java
+++ b/cli/src/main/java/dev/hardwood/cli/dive/internal/ColumnIndexScreen.java
@@ -16,6 +16,7 @@ import dev.hardwood.cli.dive.ParquetModel;
 import dev.hardwood.cli.dive.ScreenState;
 import dev.hardwood.cli.internal.Fmt;
 import dev.hardwood.cli.internal.IndexValueFormatter;
+import dev.hardwood.cli.internal.Strings;
 import dev.hardwood.metadata.ColumnIndex;
 import dev.hardwood.schema.ColumnSchema;
 import dev.tamboui.buffer.Buffer;
@@ -70,7 +71,18 @@ public final class ColumnIndexScreen {
                 stack.replaceTop(withModal(state, false));
                 return true;
             }
-            return false;
+            int next = ScrollPane.scroll(event, state.modalScroll(),
+                    modalLineCount(model, state), Keys.viewportStride());
+            if (next == ScrollPane.UNHANDLED) {
+                return false;
+            }
+            if (next != state.modalScroll()) {
+                stack.replaceTop(new ScreenState.ColumnIndexView(
+                        state.rowGroupIndex(), state.columnIndex(), state.selection(),
+                        state.filter(), state.searching(), state.logicalTypes(),
+                        state.modalOpen(), state.scrollTop(), next));
+            }
+            return true;
         }
         if (state.searching()) {
             return handleSearching(event, state, stack);
@@ -85,32 +97,9 @@ public final class ColumnIndexScreen {
         }
         ColumnSchema col = model.schema().getColumn(state.columnIndex());
         List<Integer> filtered = filteredPages(ci, col, state.filter());
-        if (Keys.isPageDown(event)) {
-            int max = filtered.isEmpty() ? 0 : filtered.size() - 1;
-            stack.replaceTop(with(state, Math.min(max, state.selection() + Keys.viewportStride()),
-                    state.filter(), false));
-            return true;
-        }
-        if (Keys.isPageUp(event)) {
-            stack.replaceTop(with(state, Math.max(0, state.selection() - Keys.viewportStride()),
-                    state.filter(), false));
-            return true;
-        }
-        if (Keys.isStepUp(event)) {
-            stack.replaceTop(with(state, Math.max(0, state.selection() - 1), state.filter(), false));
-            return true;
-        }
-        if (Keys.isStepDown(event)) {
-            int max = filtered.isEmpty() ? 0 : filtered.size() - 1;
-            stack.replaceTop(with(state, Math.min(max, state.selection() + 1), state.filter(), false));
-            return true;
-        }
-        if (Keys.isJumpTop(event) && !filtered.isEmpty()) {
-            stack.replaceTop(with(state, 0, state.filter(), false));
-            return true;
-        }
-        if (Keys.isJumpBottom(event) && !filtered.isEmpty()) {
-            stack.replaceTop(with(state, filtered.size() - 1, state.filter(), false));
+        int selected = CursorPane.select(event, state.selection(), filtered.size());
+        if (selected != CursorPane.UNHANDLED) {
+            stack.replaceTop(with(state, selected, state.filter(), false));
             return true;
         }
         // Open the full Min/Max modal on Enter only when at least one of the
@@ -187,6 +176,13 @@ public final class ColumnIndexScreen {
         // Build Row objects only for the visible window — see RowWindow.
         RowWindow window = RowWindow.from(state.scrollTop(), state.selection(),
                 filtered.size(), area.height() - 5);
+        // Enter opens the full min/max only for pages whose bounds the row
+        // had to truncate, so the marker column carries a fact here rather
+        // than repeating the cursor.
+        boolean mixed = false;
+        for (int i = window.start(); i < window.end() && !mixed; i++) {
+            mixed = !isExpandable(ci, filtered.get(i), col, state.logicalTypes());
+        }
         List<Row> rows = new ArrayList<>(window.size());
         for (int i = window.start(); i < window.end(); i++) {
             int idx = filtered.get(i);
@@ -194,17 +190,18 @@ public final class ColumnIndexScreen {
                     ? Fmt.fmt("%,d", ci.nullCounts()[idx])
                     : "—";
             rows.add(Row.from(
-                    String.valueOf(idx),
+                    CursorPane.marker(isExpandable(ci, idx, col, state.logicalTypes()),
+                            i == state.selection(), mixed) + idx,
                     ci.nullPages()[idx] ? "yes" : "no",
                     nulls,
                     formatStat(ci.minValues().get(idx), col, state.logicalTypes()),
                     formatStat(ci.maxValues().get(idx), col, state.logicalTypes())));
         }
-        Row header = Row.from("#", "Null page", "Nulls", "Min", "Max").style(Theme.accent().bold());
+        Row header = Row.from("  #", "Null page", "Nulls", "Min", "Max").style(Theme.accent().bold());
         String typeMode = state.logicalTypes() ? "" : " · physical";
         Block block = Block.builder()
                 .title(" Column index "
-                        + Plurals.rangeOf(state.selection(), filtered.size(), Keys.viewportStride())
+                        + Plurals.rangeOf(window, filtered.size())
                         + (state.filter().isEmpty()
                                 ? ""
                                 : " · " + Plurals.format(ci.getPageCount(), "page", "pages") + " total")
@@ -215,14 +212,14 @@ public final class ColumnIndexScreen {
         Table table = Table.builder()
                 .header(header)
                 .rows(rows)
-                .widths(new Constraint.Length(5),
+                .widths(new Constraint.Length(7),
                         new Constraint.Length(10),
                         new Constraint.Length(10),
                         new Constraint.Fill(1),
                         new Constraint.Fill(1))
                 .columnSpacing(2)
                 .block(block)
-                .highlightSymbol("▶ ")
+                .highlightSymbol("")
                 .highlightStyle(Theme.selection())
                 .build();
         TableState tableState = new TableState();
@@ -236,37 +233,60 @@ public final class ColumnIndexScreen {
             buffer.setStyle(area, Theme.dim());
             renderMinMaxModal(buffer, area, idx,
                     ci.minValues().get(idx), ci.maxValues().get(idx),
-                    col, state.logicalTypes());
+                    col, state.logicalTypes(), state.modalScroll());
         }
     }
 
     private static void renderMinMaxModal(Buffer buffer, Rect screenArea, int pageIndex,
                                           byte[] minBytes, byte[] maxBytes,
-                                          ColumnSchema col, boolean logical) {
-        // Modal has space — bypass the per-string 20-char cap.
-        String min = minBytes == null ? "—" : IndexValueFormatter.format(minBytes, col, logical, false);
-        String max = maxBytes == null ? "—" : IndexValueFormatter.format(maxBytes, col, logical, false);
-
-        int width = Math.min(100, screenArea.width() - 4);
-        int height = Math.min(screenArea.height() - 2, 8);
-        int x = screenArea.left() + (screenArea.width() - width) / 2;
-        int y = screenArea.top() + (screenArea.height() - height) / 2;
-        Rect modal = new Rect(x, y, width, height);
-        dev.tamboui.widgets.Clear.INSTANCE.render(modal, buffer);
-
-        List<Line> lines = new ArrayList<>();
-        lines.add(Line.from(new Span(" Min ", Theme.primary()), Span.raw(min)));
-        lines.add(Line.from(new Span(" Max ", Theme.primary()), Span.raw(max)));
-        lines.add(Line.empty());
+                                          ColumnSchema col, boolean logical, int scroll) {
+        Rect area = ScrollPane.modalArea(screenArea, 100, screenArea.height());
         boolean hasLogical = col.logicalType() != null;
-        String hint = " Esc / Enter close" + (hasLogical ? " · t logical types" : "");
-        lines.add(Line.from(new Span(hint, Theme.dim())));
-        Block block = Block.builder()
-                .title(" Page #" + pageIndex + " min / max ")
-                .borders(Borders.ALL)
-                .borderType(BorderType.ROUNDED)
-                .build();
-        Paragraph.builder().block(block).text(Text.from(lines)).left().build().render(modal, buffer);
+        ScrollPane.renderModal(buffer, area, "Page #" + pageIndex + " min / max",
+                minMaxLines(minBytes, maxBytes, col, logical, ScrollPane.modalWidth(area)), scroll,
+                "Esc / Enter close" + (hasLogical ? " · t logical types" : ""));
+    }
+
+    /// Line count of the open modal at the width the last frame wrapped to,
+    /// so the key handler and the renderer agree on how far it can scroll.
+    private static int modalLineCount(ParquetModel model, ScreenState.ColumnIndexView state) {
+        ColumnIndex ci = model.columnIndex(state.rowGroupIndex(), state.columnIndex());
+        if (ci == null) {
+            return 0;
+        }
+        ColumnSchema col = model.schema().getColumn(state.columnIndex());
+        List<Integer> filtered = filteredPages(ci, col, state.filter());
+        if (filtered.isEmpty()) {
+            return 0;
+        }
+        int idx = filtered.get(Math.min(state.selection(), filtered.size() - 1));
+        return minMaxLines(ci.minValues().get(idx), ci.maxValues().get(idx),
+                col, state.logicalTypes(), Keys.modalWidth()).size();
+    }
+
+    /// The modal's content, wrapped to its width. Min and max are arbitrary
+    /// values — a long UTF-8 string bound ran off the right edge of the modal
+    /// that exists to show it in full.
+    private static List<Line> minMaxLines(byte[] minBytes, byte[] maxBytes, ColumnSchema col,
+                                          boolean logical, int width) {
+        List<Line> lines = new ArrayList<>();
+        appendBound(lines, "Min", minBytes, col, logical, width);
+        appendBound(lines, "Max", maxBytes, col, logical, width);
+        return lines;
+    }
+
+    private static void appendBound(List<Line> lines, String label, byte[] bytes, ColumnSchema col,
+                                    boolean logical, int width) {
+        // Modal has space — bypass the per-string 20-char cap.
+        String value = bytes == null ? "—" : IndexValueFormatter.format(bytes, col, logical, false);
+        // The label occupies the first five cells; continuation lines are
+        // indented to match so a wrapped value reads as one field.
+        List<String> wrapped = Strings.hardWrap(value, Math.max(1, width - 5));
+        for (int i = 0; i < wrapped.size(); i++) {
+            lines.add(i == 0
+                    ? Line.from(new Span(" " + label + " ", Theme.primary()), Span.raw(wrapped.get(i)))
+                    : Line.from(Span.raw("      " + wrapped.get(i))));
+        }
     }
 
     public static String keybarKeys(ScreenState.ColumnIndexView state, ParquetModel model) {
@@ -275,7 +295,7 @@ public final class ColumnIndexScreen {
         }
         ColumnIndex ci = model.columnIndex(state.rowGroupIndex(), state.columnIndex());
         ColumnSchema col = model.schema().getColumn(state.columnIndex());
-        java.util.List<Integer> filtered = filteredPages(ci, col, state.filter());
+        List<Integer> filtered = filteredPages(ci, col, state.filter());
         int count = filtered.size();
         boolean hasLogical = col.logicalType() != null;
         // Enter opens the modal only when the selected row's Min or Max
@@ -288,9 +308,7 @@ public final class ColumnIndexScreen {
             canExpand = min.endsWith("…") || max.endsWith("…");
         }
         return new Keys.Hints()
-                .add(count > 1, "[↑↓] move")
-                .add(count > Keys.viewportStride(), "[PgDn/PgUp or Shift+↓↑] page")
-                .add(count > 1, "[g/G] first/last")
+                .add(true, CursorPane.hints(count))
                 .add(canExpand, "[Enter] view min/max")
                 .add(count > 0, "[/] search")
                 .add(hasLogical, "[t] logical types")
@@ -359,6 +377,14 @@ public final class ColumnIndexScreen {
     /// value ourselves so an `…` suffix is visible when truncation
     /// happened — users then know the modal will reveal more on Enter.
     private static final int CELL_MAX = 24;
+
+    /// Whether `Enter` would do anything on this page: the modal only earns
+    /// its place when a bound was truncated to fit the cell budget, which
+    /// `formatStat` signals with a trailing ellipsis.
+    private static boolean isExpandable(ColumnIndex ci, int page, ColumnSchema col, boolean logical) {
+        return formatStat(ci.minValues().get(page), col, logical).endsWith("…")
+                || formatStat(ci.maxValues().get(page), col, logical).endsWith("…");
+    }
 
     private static String formatStat(byte[] bytes, ColumnSchema col, boolean logical) {
         if (bytes == null) {

--- a/cli/src/main/java/dev/hardwood/cli/dive/internal/CursorPane.java
+++ b/cli/src/main/java/dev/hardwood/cli/dive/internal/CursorPane.java
@@ -1,0 +1,104 @@
+/*
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Copyright The original authors
+ *
+ *  Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package dev.hardwood.cli.dive.internal;
+
+import dev.tamboui.tui.event.KeyEvent;
+
+/// Navigation for a pane whose content is a list of rows: every list screen,
+/// every menu, and the record modal. A cursor selects one row and the
+/// viewport follows it, so the three strides all move the cursor — `↑`/`↓`
+/// by a row, `PgUp`/`PgDn` by a viewport, `g`/`G` to the ends.
+///
+/// The cursor stops on every row, including rows `Enter` cannot act on. A
+/// row that is not actionable is still worth reading, and skipping it puts
+/// content out of reach of the only keys that reach content — which is what
+/// the marker is for: see [Rows#marker(boolean)].
+///
+/// Screens hold the selection in their [dev.hardwood.cli.dive.ScreenState]
+/// and pass it back on every keypress; nothing is retained between calls.
+/// Turning a new selection into a scroll offset is the screen's own job, via
+/// [RowWindow#adjustTop(int,int,int)], because only the screen knows which
+/// state record to rebuild.
+public final class CursorPane {
+
+    /// Returned by [#select(KeyEvent,int,int)] when the event does not move
+    /// the cursor, so the caller can let it fall through to the rest of its
+    /// handler.
+    public static final int UNHANDLED = -1;
+
+    private CursorPane() {
+    }
+
+    /// The row to select after `event`, clamped to `count`, or [#UNHANDLED]
+    /// if `event` does not move the cursor. A navigation key on a cursor
+    /// already against its end returns the unchanged selection: it is
+    /// handled, it simply has nowhere to go.
+    ///
+    /// An empty list has nothing to select, so every key is [#UNHANDLED]
+    /// there and screens do not each need to guard on the count.
+    public static int select(KeyEvent event, int selection, int count) {
+        if (count <= 0) {
+            return UNHANDLED;
+        }
+        int current = Math.max(0, Math.min(selection, count - 1));
+        int stride = Keys.viewportStride();
+        if (Keys.isStepUp(event)) {
+            return Math.max(0, current - 1);
+        }
+        if (Keys.isStepDown(event)) {
+            return Math.min(count - 1, current + 1);
+        }
+        if (Keys.isPageUp(event)) {
+            return Math.max(0, current - stride);
+        }
+        if (Keys.isPageDown(event)) {
+            return Math.min(count - 1, current + stride);
+        }
+        if (Keys.isJumpTop(event)) {
+            return 0;
+        }
+        if (Keys.isJumpBottom(event)) {
+            return count - 1;
+        }
+        return UNHANDLED;
+    }
+
+    /// The two cells a row reserves for its actionability marker.
+    ///
+    /// `▶` marks what `Enter` can act on; the cursor is marked by colour, not
+    /// by the glyph. It is drawn on the cursor row whenever that row is
+    /// actionable, and on other rows only when `mixed` — when the pane holds
+    /// some row `Enter` cannot act on, and the marker therefore distinguishes
+    /// one row from another. A pane whose rows are uniformly actionable shows
+    /// a single marker travelling with the cursor rather than a column of
+    /// identical ones.
+    ///
+    /// A pane whose rows are uniformly actionable can leave this to the
+    /// table's own highlight symbol, which draws on the cursor row already.
+    public static String marker(boolean actionable, boolean cursor, boolean mixed) {
+        return actionable && (cursor || mixed) ? MARKER : NO_MARKER;
+    }
+
+    /// The marker glyph and the blank that keeps unmarked rows aligned with
+    /// marked ones.
+    public static final String MARKER = "▶ ";
+
+    public static final String NO_MARKER = "  ";
+
+    /// The keybar fragment for a list of `count` rows: the movement keys that
+    /// have somewhere to go. Screens append their own `Enter` and per-screen
+    /// bindings around it so the wording of the movement keys is stated in
+    /// one place.
+    public static String hints(int count) {
+        return new Keys.Hints()
+                .add(count > 1, "[↑↓] move")
+                .add(count > Keys.viewportStride(), "[PgDn/PgUp or Shift+↓↑] page")
+                .add(count > 1, "[g/G] first/last")
+                .build();
+    }
+}

--- a/cli/src/main/java/dev/hardwood/cli/dive/internal/DataPreviewScreen.java
+++ b/cli/src/main/java/dev/hardwood/cli/dive/internal/DataPreviewScreen.java
@@ -12,6 +12,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 
+import dev.hardwood.cli.dive.NavigationStack;
 import dev.hardwood.cli.dive.ParquetModel;
 import dev.hardwood.cli.dive.ScreenState;
 import dev.hardwood.cli.internal.Fmt;
@@ -72,16 +73,6 @@ public final class DataPreviewScreen {
 
     public static boolean handle(KeyEvent event, ParquetModel model, dev.hardwood.cli.dive.NavigationStack stack) {
         ScreenState.DataPreview state = (ScreenState.DataPreview) stack.top();
-        // Auto-resize the page to match the current viewport. The first
-        // render after initialState observes the available rows; on the
-        // first subsequent event we re-load to fill the actual viewport.
-        // Skip while a modal is open — the modal owns the screen.
-        if (state.modalRow() < 0 && Keys.hasObservedViewport()
-                && state.pageSize() != Keys.viewportStride()) {
-            state = loadPage(model, state.firstRow(), Keys.viewportStride(),
-                    state.columnScroll(), state.logicalTypes());
-            stack.replaceTop(state);
-        }
         long total = model.facts().totalRows();
         if (state.modalRow() >= 0) {
             return handleModal(event, state, stack, model);
@@ -177,11 +168,37 @@ public final class DataPreviewScreen {
         return false;
     }
 
+    /// Re-loads the page so it fills `body`, if it does not already.
+    ///
+    /// How many rows the screen shows is a fact about the frame, not about
+    /// the state that arrived, and a page sized for some other viewport
+    /// leaves the bottom of this one blank. Called before the body is
+    /// painted, so the screen is full on the frame it is entered on rather
+    /// than on the one after the first keypress.
+    ///
+    /// Does nothing while the record modal is open: the modal owns the
+    /// screen, and re-loading underneath it would move the row it is showing.
+    public static void fitToViewport(ParquetModel model, NavigationStack stack, Rect body) {
+        if (!(stack.top() instanceof ScreenState.DataPreview state) || state.modalRow() >= 0) {
+            return;
+        }
+        int viewport = viewportRows(body);
+        if (state.pageSize() == viewport) {
+            return;
+        }
+        stack.replaceTop(loadPage(model, state.firstRow(), viewport,
+                state.columnScroll(), state.logicalTypes()));
+    }
+
+    /// Block borders (top + bottom) and the header row are 3 cells of chrome
+    /// around the data rows.
+    private static int viewportRows(Rect body) {
+        return Math.max(1, body.height() - 3);
+    }
+
     public static void render(Buffer buffer, Rect area, ParquetModel model, ScreenState.DataPreview state) {
         Keys.observeDataPreviewArea(area.width(), area.height());
-        // Block borders (top + bottom) + header row = 3 cells of chrome
-        // around the data rows.
-        Keys.observeViewport(area.height() - 3);
+        Keys.observeViewport(viewportRows(area));
         Keys.observeViewportWidth(area.width());
         int columnCount = state.columnNames().size();
         ColumnWindow window = columnWindow(state, area.width());
@@ -251,15 +268,22 @@ public final class DataPreviewScreen {
         int maxKeyWidth = geometry.maxKeyWidth();
         int valueBudget = geometry.valueBudget();
         int viewport = geometry.viewportLines();
-        String continuationIndent = " ".repeat(1 + maxKeyWidth + 3);
+        String continuationIndent = " ".repeat(2 + maxKeyWidth + 3);
 
         // Build the full body as a flat line list. ownership[i] = the line
         // index where field i's key line starts; continuation lines for an
         // expanded field belong to that same field.
         int[] ownership = new int[names.size()];
+        // Enter expands only fields with more to show than the row fits, so
+        // the marker column says which ones those are.
+        boolean mixed = false;
+        for (int i = 0; i < names.size() && !mixed; i++) {
+            mixed = !isExpandableField(state, i, geometry);
+        }
         List<Line> all = new ArrayList<>();
         for (int i = 0; i < names.size(); i++) {
             String name = names.get(i);
+            String marker = CursorPane.marker(isExpandableField(state, i, geometry), false, mixed);
             String pad = " ".repeat(maxKeyWidth - name.length());
             boolean isExpanded = state.expandedColumns().contains(i);
             String value = i < values.size() ? values.get(i) : "";
@@ -267,7 +291,7 @@ public final class DataPreviewScreen {
             if (isExpanded) {
                 List<String> wrapped = expandedValueLines(state, i, geometry);
                 all.add(Line.from(
-                        new Span(" " + name + pad + " : ", Theme.primary()),
+                        new Span(marker + name + pad + " : ", Theme.primary()),
                         Span.raw(wrapped.get(0))));
                 for (int k = 1; k < wrapped.size(); k++) {
                     all.add(Line.from(Span.raw(continuationIndent + wrapped.get(k))));
@@ -275,20 +299,17 @@ public final class DataPreviewScreen {
             }
             else {
                 all.add(Line.from(
-                        new Span(" " + name + pad + " : ", Theme.primary()),
+                        new Span(marker + name + pad + " : ", Theme.primary()),
                         Span.raw(truncate(value, valueBudget))));
             }
         }
 
         int totalLines = all.size();
         int cursorLine = Math.max(0, Math.min(state.modalCursorLine(), totalLines - 1));
-        // The cursor exists to point at something Enter can act on. With no
-        // expandable field there is nothing to point at, so the modal becomes
-        // a static info display that PgDn/PgUp scrolls.
         boolean canExpandAny = hasExpandableField(state, geometry);
         int fieldIdx = fieldForLine(state, cursorLine, geometry);
         boolean focusExpandable = canExpandAny && isExpandableField(state, fieldIdx, geometry);
-        if (canExpandAny && cursorLine < all.size()) {
+        if (cursorLine < all.size()) {
             int fieldFirstLine = ownership[fieldIdx];
             String name = names.get(fieldIdx);
             String pad = " ".repeat(maxKeyWidth - name.length());
@@ -305,8 +326,8 @@ public final class DataPreviewScreen {
                     shown = truncate(value, valueBudget);
                 }
                 all.set(cursorLine, Line.from(
-                        new Span((focusExpandable ? "▶" : " ") + name + pad + " : ",
-                                selectionStyle),
+                        new Span(CursorPane.marker(focusExpandable, true, mixed)
+                                + name + pad + " : ", selectionStyle),
                         new Span(shown, selectionStyle)));
             }
             else if (isExpanded) {
@@ -324,13 +345,13 @@ public final class DataPreviewScreen {
 
         List<Line> lines = new ArrayList<>(all.subList(scroll, end));
         lines.add(Line.empty());
-        // Hint is tiered: drop "↑↓ field" when no other expandable field can
-        // be reached; drop "PgDn/PgUp scroll" when the body already fits;
-        // drop "Enter expand" when the focused field has nothing more to
-        // show and "e/c all" when no field does; include "t logical types"
-        // only when at least one column has a logical type.
-        boolean canNavigate = previousExpandableLine(state, cursorLine, geometry) >= 0
-                || nextExpandableLine(state, cursorLine, geometry) >= 0;
+        // Hint is tiered: drop "↑↓ move" and "g/G first/last" on a
+        // single-line body; drop "PgDn/PgUp page" when the body already fits
+        // and there is nothing to page to; drop "Enter expand"
+        // when the focused field has nothing more to show and "e/c all" when
+        // no field does; include "t logical types" only when at least one
+        // column has a logical type.
+        boolean canNavigate = totalLines > 1;
         boolean canScroll = totalLines > viewport;
         boolean anyLogical = false;
         for (SchemaNode child : model.schema().getRootNode().children()) {
@@ -347,10 +368,15 @@ public final class DataPreviewScreen {
             segments.add(" ↑ " + scroll + " lines above");
         }
         if (canNavigate) {
-            segments.add("↑↓ field");
+            segments.add("↑↓ move");
         }
         if (canScroll) {
-            segments.add("PgDn/PgUp scroll");
+            segments.add("PgDn/PgUp page");
+        }
+        if (canNavigate) {
+            // g/G move the cursor, so they act whenever there is more than
+            // one line — whether or not the body has to scroll.
+            segments.add("g/G first/last");
         }
         if (focusExpandable) {
             segments.add("Enter expand");
@@ -390,7 +416,9 @@ public final class DataPreviewScreen {
         for (String name : names) {
             maxKeyWidth = Math.max(maxKeyWidth, name.length());
         }
-        int valueBudget = Math.max(8, width - 2 - 1 - maxKeyWidth - 3 - 1);
+        // Two borders, the two-cell actionability marker, the key, " : ",
+        // and a trailing cell.
+        int valueBudget = Math.max(8, width - 2 - 2 - maxKeyWidth - 3 - 1);
         int viewportLines = Math.max(1, height - 4);
         return new ModalGeometry(width, height, maxKeyWidth, valueBudget, viewportLines);
     }
@@ -457,12 +485,11 @@ public final class DataPreviewScreen {
     private static boolean handleModal(KeyEvent event, ScreenState.DataPreview state,
                                        dev.hardwood.cli.dive.NavigationStack stack,
                                        ParquetModel model) {
-        // ↑/↓ step between the fields Enter can expand, skipping the ones it
-        // can't at every terminal size; PgDn/PgUp scroll the body so content
-        // the cursor never stops on is still readable. Enter toggles the
-        // field under the cursor; e / c expand / collapse all fields. Esc
-        // closes the modal. Row stepping is intentionally absent — the user
-        // picks another row from the table after closing.
+        // The cursor walks every line, so a long expanded value is crossed
+        // with PgDn rather than a field at a time. Enter toggles the field
+        // owning the line under the cursor; e / c expand / collapse all
+        // fields. Esc closes the modal. Row stepping is intentionally absent
+        // — the user picks another row from the table after closing.
         if (event.isCancel()) {
             stack.replaceTop(withModalRow(state, -1));
             return true;
@@ -513,48 +540,14 @@ public final class DataPreviewScreen {
                     state.expandedColumns(), state.modalCursorLine(), state.modalScroll()));
             return true;
         }
-        // Paging is checked before stepping because `isPageDown` / `isPageUp`
-        // also match Shift+↓/↑, which `event.isDown()` / `isUp()` would claim.
-        if (Keys.isPageDown(event)) {
-            return scrollModal(state, stack, totalLines, geometry, geometry.viewportLines());
-        }
-        if (Keys.isPageUp(event)) {
-            return scrollModal(state, stack, totalLines, geometry, -geometry.viewportLines());
-        }
-        if (Keys.isStepUp(event)) {
-            int previous = previousExpandableLine(state, state.modalCursorLine(), geometry);
-            if (previous < 0) {
-                return false;
-            }
-            stack.replaceTop(withCursorLine(state, previous, totalLines, geometry));
-            return true;
-        }
-        if (Keys.isStepDown(event)) {
-            int next = nextExpandableLine(state, state.modalCursorLine(), geometry);
-            if (next < 0) {
-                return false;
-            }
-            stack.replaceTop(withCursorLine(state, next, totalLines, geometry));
+        int selected = CursorPane.select(event, state.modalCursorLine(), totalLines);
+        if (selected != CursorPane.UNHANDLED) {
+            stack.replaceTop(withCursorLine(state, selected, totalLines, geometry));
             return true;
         }
         return false;
     }
 
-    /// Scrolls the modal body by `delta` lines without moving the cursor.
-    /// Returns `false` when the body is already against that end, so the
-    /// keypress reads as unhandled rather than as a no-op redraw.
-    private static boolean scrollModal(ScreenState.DataPreview state,
-                                       dev.hardwood.cli.dive.NavigationStack stack,
-                                       int totalLines, ModalGeometry geometry, int delta) {
-        int max = maxScroll(totalLines, geometry);
-        int current = Math.max(0, Math.min(state.modalScroll(), max));
-        int next = Math.max(0, Math.min(max, current + delta));
-        if (next == current) {
-            return false;
-        }
-        stack.replaceTop(withModalScroll(state, next));
-        return true;
-    }
 
     /// Total displayable lines in the modal body given `expandedColumns` —
     /// one per collapsed field, plus extra continuation lines for each
@@ -650,33 +643,6 @@ public final class DataPreviewScreen {
         String collapsed = truncate(field < values.size() ? values.get(field) : "",
                 geometry.valueBudget());
         return wrapped.size() > 1 || !wrapped.get(0).equals(collapsed);
-    }
-
-    /// First line of the nearest expandable field before `from`, or `-1` when
-    /// there is none. `↑` skips over fields Enter can do nothing with at every
-    /// terminal size; reading past them is `PgUp`'s job, not the cursor's.
-    private static int previousExpandableLine(
-            ScreenState.DataPreview state, int from, ModalGeometry geometry) {
-        int currentField = fieldForLine(state, from, geometry);
-        for (int field = currentField - 1; field >= 0; field--) {
-            if (isExpandableField(state, field, geometry)) {
-                return firstLineForField(state, state.expandedColumns(), field, geometry);
-            }
-        }
-        return -1;
-    }
-
-    /// First line of the nearest expandable field after `from`, or `-1` when
-    /// there is none. See [#previousExpandableLine].
-    private static int nextExpandableLine(
-            ScreenState.DataPreview state, int from, ModalGeometry geometry) {
-        int currentField = fieldForLine(state, from, geometry);
-        for (int field = currentField + 1; field < state.columnNames().size(); field++) {
-            if (isExpandableField(state, field, geometry)) {
-                return firstLineForField(state, state.expandedColumns(), field, geometry);
-            }
-        }
-        return -1;
     }
 
     /// Largest first-visible-line the body can scroll to.

--- a/cli/src/main/java/dev/hardwood/cli/dive/internal/DictionaryScreen.java
+++ b/cli/src/main/java/dev/hardwood/cli/dive/internal/DictionaryScreen.java
@@ -18,6 +18,7 @@ import dev.hardwood.cli.dive.ParquetModel;
 import dev.hardwood.cli.dive.ScreenState;
 import dev.hardwood.cli.internal.Fmt;
 import dev.hardwood.cli.internal.RowValueFormatter;
+import dev.hardwood.cli.internal.Strings;
 import dev.hardwood.internal.reader.Dictionary;
 import dev.hardwood.schema.ColumnSchema;
 import dev.tamboui.buffer.Buffer;
@@ -110,7 +111,18 @@ public final class DictionaryScreen {
                 stack.replaceTop(with(state, state.selection(), false, state.filter(), false));
                 return true;
             }
-            return false;
+            int next = ScrollPane.scroll(event, state.modalScroll(),
+                    modalLineCount(model, state), Keys.viewportStride());
+            if (next == ScrollPane.UNHANDLED) {
+                return false;
+            }
+            if (next != state.modalScroll()) {
+                stack.replaceTop(new ScreenState.DictionaryView(
+                        state.rowGroupIndex(), state.columnIndex(), state.selection(),
+                        state.modalOpen(), state.filter(), state.searching(),
+                        state.loadConfirmed(), state.logicalTypes(), state.scrollTop(), next));
+            }
+            return true;
         }
         if (event.code() == KeyCode.CHAR && event.character() == '/') {
             stack.replaceTop(with(state, 0, false, state.filter(), true));
@@ -119,35 +131,9 @@ public final class DictionaryScreen {
         Dictionary dict = loadDictionary(model, state);
         ColumnSchema col = model.schema().getColumn(state.columnIndex());
         FilterIndex filtered = filteredIndices(dict, col, state.filter(), state.logicalTypes());
-        // Plain Up/Down step one entry; PgDn/PgUp (and the Shift+↓/↑ Mac
-        // chord since most macOS laptops have no dedicated PgDn/PgUp keys)
-        // move Keys.viewportStride() entries via the shared helper.
-        if (Keys.isPageDown(event)) {
-            int max = filtered.isEmpty() ? 0 : filtered.size() - 1;
-            stack.replaceTop(with(state, Math.min(max, state.selection() + Keys.viewportStride()),
-                    false, state.filter(), false));
-            return true;
-        }
-        if (Keys.isPageUp(event)) {
-            stack.replaceTop(with(state, Math.max(0, state.selection() - Keys.viewportStride()),
-                    false, state.filter(), false));
-            return true;
-        }
-        if (Keys.isStepUp(event)) {
-            stack.replaceTop(with(state, Math.max(0, state.selection() - 1), false, state.filter(), false));
-            return true;
-        }
-        if (Keys.isStepDown(event)) {
-            int max = filtered.isEmpty() ? 0 : filtered.size() - 1;
-            stack.replaceTop(with(state, Math.min(max, state.selection() + 1), false, state.filter(), false));
-            return true;
-        }
-        if (Keys.isJumpTop(event) && !filtered.isEmpty()) {
-            stack.replaceTop(with(state, 0, false, state.filter(), false));
-            return true;
-        }
-        if (Keys.isJumpBottom(event) && !filtered.isEmpty()) {
-            stack.replaceTop(with(state, filtered.size() - 1, false, state.filter(), false));
+        int selected = CursorPane.select(event, state.selection(), filtered.size());
+        if (selected != CursorPane.UNHANDLED) {
+            stack.replaceTop(with(state, selected, false, state.filter(), false));
             return true;
         }
         if (event.isConfirm() && !filtered.isEmpty()) {
@@ -216,18 +202,23 @@ public final class DictionaryScreen {
         // why list screens must do this.
         int total = filtered.size();
         RowWindow window = RowWindow.from(state.scrollTop(), state.selection(), total, area.height() - 4);
+        // Enter opens the full value only for entries the row had to
+        // truncate, so the marker column carries a fact here rather than
+        // repeating the cursor.
+        boolean mixed = hasUnexpandableEntry(dict, col, filtered, window, state.logicalTypes());
         List<Row> rows = new ArrayList<>(window.size());
         for (int i = window.start(); i < window.end(); i++) {
             int idx = filtered.at(i);
             rows.add(Row.from(
-                    "[" + idx + "]",
+                    CursorPane.marker(isExpandable(dict, idx, col, state.logicalTypes()),
+                            i == state.selection(), mixed) + "[" + idx + "]",
                     formatValue(dict, idx, col, VALUE_PREVIEW_MAX, state.logicalTypes())));
         }
-        Row header = Row.from("#", "Value").style(Theme.accent().bold());
+        Row header = Row.from("  #", "Value").style(Theme.accent().bold());
         String typeMode = state.logicalTypes() ? "" : " · physical";
         Block block = Block.builder()
                 .title(" Dictionary entries "
-                        + Plurals.rangeOf(state.selection(), total, Keys.viewportStride())
+                        + Plurals.rangeOf(window, total)
                         + (state.filter().isEmpty()
                                 ? ""
                                 : " · " + Plurals.format(dict.size(), "entry", "entries") + " total")
@@ -238,10 +229,10 @@ public final class DictionaryScreen {
         Table table = Table.builder()
                 .header(header)
                 .rows(rows)
-                .widths(new Constraint.Length(8), new Constraint.Fill(1))
+                .widths(new Constraint.Length(10), new Constraint.Fill(1))
                 .columnSpacing(2)
                 .block(block)
-                .highlightSymbol("▶ ")
+                .highlightSymbol("")
                 .highlightStyle(Theme.selection())
                 .build();
         TableState tableState = new TableState();
@@ -253,7 +244,8 @@ public final class DictionaryScreen {
         if (state.modalOpen() && !filtered.isEmpty()) {
             int dictIdx = filtered.at(Math.min(state.selection(), filtered.size() - 1));
             buffer.setStyle(area, Theme.dim());
-            renderValueModal(buffer, area, dict, col, dictIdx, state.logicalTypes());
+            renderValueModal(buffer, area, dict, col, dictIdx, state.logicalTypes(),
+                    state.modalScroll());
         }
     }
 
@@ -270,9 +262,7 @@ public final class DictionaryScreen {
         }
         boolean hasLogical = col.logicalType() != null;
         return new Keys.Hints()
-                .add(count > 1, "[↑↓] move")
-                .add(count > Keys.viewportStride(), "[PgDn/PgUp or Shift+↓↑] page")
-                .add(count > 1, "[g/G] first/last")
+                .add(true, CursorPane.hints(count))
                 .add(canExpand, "[Enter] view full value")
                 .add(dict != null, "[/] search")
                 .add(hasLogical, "[t] logical types")
@@ -375,6 +365,34 @@ public final class DictionaryScreen {
                 : model.dictionary(state.rowGroupIndex(), state.columnIndex());
     }
 
+    /// Whether `Enter` would do anything on this entry: the modal only earns
+    /// its place when the row had to truncate the value.
+    private static boolean isExpandable(Dictionary dict, int index, ColumnSchema col,
+                                        boolean useLogicalType) {
+        return fullValue(dict, index, col, useLogicalType).length() > VALUE_PREVIEW_MAX;
+    }
+
+    /// Whether the rows on screen include an entry `Enter` cannot open, and
+    /// the marker column therefore distinguishes rows rather than repeating
+    /// the cursor.
+    ///
+    /// Measured over the window rather than the whole dictionary: a file can
+    /// carry hundreds of thousands of entries and per-keystroke work has to
+    /// stay proportional to the viewport. The cost is that the column can
+    /// come and go while scrolling a dictionary whose entries straddle the
+    /// preview width — the cursor's own marker is unaffected, since it does
+    /// not depend on this.
+    private static boolean hasUnexpandableEntry(Dictionary dict, ColumnSchema col,
+                                                FilterIndex filtered, RowWindow window,
+                                                boolean useLogicalType) {
+        for (int i = window.start(); i < window.end(); i++) {
+            if (!isExpandable(dict, filtered.at(i), col, useLogicalType)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
     private static String formatValue(Dictionary dict, int index, ColumnSchema col, int max,
                                       boolean useLogicalType) {
         String full = fullValue(dict, index, col, useLogicalType);
@@ -438,28 +456,40 @@ public final class DictionaryScreen {
     }
 
     private static void renderValueModal(Buffer buffer, Rect screenArea, Dictionary dict, ColumnSchema col,
-                                         int index, boolean useLogicalType) {
-        int width = Math.min(80, screenArea.width() - 4);
-        int height = Math.min(16, screenArea.height() - 2);
-        int x = screenArea.left() + (screenArea.width() - width) / 2;
-        int y = screenArea.top() + (screenArea.height() - height) / 2;
-        Rect area = new Rect(x, y, width, height);
-        dev.tamboui.widgets.Clear.INSTANCE.render(area, buffer);
-
-        String full = fullValue(dict, index, col, useLogicalType);
-        List<Line> lines = new ArrayList<>();
-        lines.add(Line.empty());
-        lines.add(Line.from(Span.raw(" " + full)));
-        lines.add(Line.empty());
+                                         int index, boolean useLogicalType, int scroll) {
+        Rect area = ScrollPane.modalArea(screenArea, 80, 16);
         boolean hasLogical = col.logicalType() != null;
-        String hint = " Esc / Enter close" + (hasLogical ? " · t logical types" : "");
-        lines.add(Line.from(new Span(hint, Theme.dim())));
+        ScrollPane.renderModal(buffer, area, "Entry #" + index,
+                modalLines(fullValue(dict, index, col, useLogicalType), area), scroll,
+                "Esc / Enter close" + (hasLogical ? " · t logical types" : ""));
+    }
 
-        Block block = Block.builder()
-                .title(" Entry #" + index + " ")
-                .borders(Borders.ALL)
-                .borderType(BorderType.ROUNDED)
-                .build();
-        Paragraph.builder().block(block).text(Text.from(lines)).left().build().render(area, buffer);
+    /// The modal's content, wrapped to its width. A dictionary entry can be
+    /// an arbitrarily long string, and the modal exists precisely to show
+    /// values the table row had to truncate, so it must wrap rather than run
+    /// off the right edge.
+    /// Line count of the open modal at the width the last frame wrapped to,
+    /// so the key handler and the renderer agree on how far it can scroll.
+    private static int modalLineCount(ParquetModel model, ScreenState.DictionaryView state) {
+        Dictionary dict = needsConfirmation(model, state) ? null : loadDictionary(model, state);
+        if (dict == null) {
+            return 0;
+        }
+        ColumnSchema col = model.schema().getColumn(state.columnIndex());
+        FilterIndex filtered = filteredIndices(dict, col, state.filter(), state.logicalTypes());
+        if (filtered.isEmpty()) {
+            return 0;
+        }
+        int index = filtered.at(Math.min(state.selection(), filtered.size() - 1));
+        return Strings.hardWrap(fullValue(dict, index, col, state.logicalTypes()),
+                Keys.modalWidth()).size();
+    }
+
+    private static List<Line> modalLines(String full, Rect area) {
+        List<Line> lines = new ArrayList<>();
+        for (String wrapped : Strings.hardWrap(full, ScrollPane.modalWidth(area))) {
+            lines.add(Line.from(Span.raw(" " + wrapped)));
+        }
+        return lines;
     }
 }

--- a/cli/src/main/java/dev/hardwood/cli/dive/internal/Document.java
+++ b/cli/src/main/java/dev/hardwood/cli/dive/internal/Document.java
@@ -1,0 +1,190 @@
+/*
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Copyright The original authors
+ *
+ *  Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package dev.hardwood.cli.dive.internal;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import dev.tamboui.text.Line;
+import dev.tamboui.tui.event.KeyEvent;
+
+/// The content of a pane whose rows are not uniform — a facts pane, the
+/// footer body — as the lines it paints plus which of them are rows.
+///
+/// A section heading and the blank above it are decoration: they are painted,
+/// they are read, and the cursor does not stop on them, because there is
+/// nothing there to be at. Modelling that here rather than in each pane's key
+/// handler keeps [CursorPane] free of any notion of which lines are inert —
+/// the pane says so as it builds them, where it knows.
+///
+/// The cursor is an index into [#rowCount()], not into the lines, so a pane
+/// holding one navigates with [CursorPane#select(dev.tamboui.tui.event.KeyEvent,int,int)]
+/// exactly as a list screen does.
+public final class Document {
+
+    private final List<Line> lines;
+
+    /// Line index of each row, ascending. The cursor indexes into this.
+    private final int[] rowLines;
+
+    private Document(List<Line> lines, int[] rowLines) {
+        this.lines = List.copyOf(lines);
+        this.rowLines = rowLines;
+    }
+
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    public List<Line> lines() {
+        return lines;
+    }
+
+    public int lineCount() {
+        return lines.size();
+    }
+
+    /// How many rows the cursor can occupy. Zero for a document that is all
+    /// decoration, which navigates as nothing rather than as a single row.
+    public int rowCount() {
+        return rowLines.length;
+    }
+
+    /// The line row `index` occupies, clamped, or `-1` when there are no rows.
+    public int lineOfRow(int index) {
+        if (rowLines.length == 0) {
+            return -1;
+        }
+        return rowLines[Math.max(0, Math.min(index, rowLines.length - 1))];
+    }
+
+    /// The row to select after `event`, or [CursorPane#UNHANDLED] if `event`
+    /// does not move the cursor.
+    ///
+    /// The three strides are the same ones every pane uses, but a document's
+    /// rows and its lines are not the same count: paging by rows would carry
+    /// the cursor much further than a screenful whenever headings and blanks
+    /// sit between them. `PgDn` therefore moves a viewport of *lines* and
+    /// lands on the row nearest where that puts it.
+    public int select(KeyEvent event, int cursorRow, int viewportLines) {
+        if (rowLines.length == 0) {
+            return CursorPane.UNHANDLED;
+        }
+        int current = Math.max(0, Math.min(cursorRow, rowLines.length - 1));
+        if (Keys.isPageUp(event)) {
+            return rowNear(lineOfRow(current) - Math.max(1, viewportLines));
+        }
+        if (Keys.isPageDown(event)) {
+            return rowNear(lineOfRow(current) + Math.max(1, viewportLines));
+        }
+        return CursorPane.select(event, current, rowLines.length);
+    }
+
+    /// The row whose line is nearest `line`, clamped to the document.
+    private int rowNear(int line) {
+        int best = 0;
+        int bestDistance = Integer.MAX_VALUE;
+        for (int i = 0; i < rowLines.length; i++) {
+            int distance = Math.abs(rowLines[i] - line);
+            if (distance < bestDistance) {
+                bestDistance = distance;
+                best = i;
+            }
+        }
+        return best;
+    }
+
+    /// The keybar fragment for this document at `viewportLines` high.
+    ///
+    /// Stated here rather than by each pane so that every document screen
+    /// advertises the same keys on the same terms: paging is offered when the
+    /// content is taller than the pane, which is a fact about lines, while
+    /// stepping and jumping are offered when there is more than one row.
+    public String hints(int viewportLines) {
+        return new Keys.Hints()
+                .add(rowCount() > 1, "[↑↓] move")
+                .add(lineCount() > Math.max(1, viewportLines), "[PgDn/PgUp or Shift+↓↑] page")
+                .add(rowCount() > 1, "[g/G] first/last")
+                .build();
+    }
+
+    /// Where the window should start to show row `cursorRow`, given where it
+    /// started last frame.
+    ///
+    /// The window slides the least it can, as it does on the list screens:
+    /// moving the cursor up walks it to the top of the window before the
+    /// content underneath moves. Recomputing the top from the cursor instead
+    /// pins the cursor to the bottom row, so every step up drags the whole
+    /// pane with it.
+    ///
+    /// Row zero pins the window to the first line so that any decoration
+    /// above it — a leading section heading — is not stranded off the top,
+    /// which the cursor could not reach to bring back.
+    public int windowTop(int prevTop, int cursorRow, int viewport) {
+        if (cursorRow <= 0) {
+            return 0;
+        }
+        return RowWindow.adjustTop(prevTop, lineOfRow(cursorRow), viewport);
+    }
+
+    /// Where the window should start after the cursor moves from `fromRow` to
+    /// `toRow`.
+    ///
+    /// The stored top is reconciled against `fromRow` before the move,
+    /// because a state built before this pane first rendered — entering the
+    /// screen — carries a top computed from whatever viewport the previous
+    /// pane had. The frame the reader is looking at was drawn from the
+    /// reconciled value, so moving from the stored one would step the body to
+    /// catch up.
+    public int windowTopAfterMove(int prevTop, int fromRow, int toRow, int viewport) {
+        return windowTop(windowTop(prevTop, fromRow, viewport), toRow, viewport);
+    }
+
+    /// The row at `line`, or `-1` when that line is decoration. Panes use this
+    /// to decide what `Enter` acts on.
+    public int rowAtLine(int line) {
+        for (int i = 0; i < rowLines.length; i++) {
+            if (rowLines[i] == line) {
+                return i;
+            }
+        }
+        return -1;
+    }
+
+    /// Accumulates lines, recording which are rows. Callers add a line as a
+    /// row when the cursor should stop on it and as decoration otherwise.
+    public static final class Builder {
+        private final List<Line> lines = new ArrayList<>();
+        private final List<Integer> rows = new ArrayList<>();
+
+        /// A line the cursor stops on.
+        public Builder row(Line line) {
+            rows.add(lines.size());
+            lines.add(line);
+            return this;
+        }
+
+        /// A line the cursor passes over: a heading, a blank, a continuation.
+        public Builder decoration(Line line) {
+            lines.add(line);
+            return this;
+        }
+
+        public Builder blank() {
+            return decoration(Line.empty());
+        }
+
+        public Document build() {
+            int[] rowLines = new int[rows.size()];
+            for (int i = 0; i < rowLines.length; i++) {
+                rowLines[i] = rows.get(i);
+            }
+            return new Document(lines, rowLines);
+        }
+    }
+}

--- a/cli/src/main/java/dev/hardwood/cli/dive/internal/FileIndexesScreen.java
+++ b/cli/src/main/java/dev/hardwood/cli/dive/internal/FileIndexesScreen.java
@@ -49,28 +49,9 @@ public final class FileIndexesScreen {
         ScreenState.FileIndexes state = (ScreenState.FileIndexes) stack.top();
         List<Entry> entries = entries(model, state.kind());
         int count = entries.size();
-        if (Keys.isStepUp(event) && count > 0) {
-            stack.replaceTop(moved(state, Math.max(0, state.selection() - 1)));
-            return true;
-        }
-        if (Keys.isStepDown(event) && count > 0) {
-            stack.replaceTop(moved(state, Math.min(count - 1, state.selection() + 1)));
-            return true;
-        }
-        if (Keys.isPageDown(event) && count > 0) {
-            stack.replaceTop(moved(state, Math.min(count - 1, state.selection() + Keys.viewportStride())));
-            return true;
-        }
-        if (Keys.isPageUp(event) && count > 0) {
-            stack.replaceTop(moved(state, Math.max(0, state.selection() - Keys.viewportStride())));
-            return true;
-        }
-        if (Keys.isJumpTop(event) && count > 0) {
-            stack.replaceTop(moved(state, 0));
-            return true;
-        }
-        if (Keys.isJumpBottom(event) && count > 0) {
-            stack.replaceTop(moved(state, count - 1));
+        int next = CursorPane.select(event, state.selection(), count);
+        if (next != CursorPane.UNHANDLED) {
+            stack.replaceTop(moved(state, next));
             return true;
         }
         if (event.isConfirm() && count > 0) {
@@ -168,7 +149,7 @@ public final class FileIndexesScreen {
                     new Constraint.Length(14),
                     new Constraint.Length(10));
         };
-        String range = Plurals.rangeOf(state.selection(), entries.size(), Keys.viewportStride());
+        String range = Plurals.rangeOf(window, entries.size());
         String title = switch (state.kind()) {
             case COLUMN -> " All column indexes " + range + " ";
             case OFFSET -> " All offset indexes " + range + " ";
@@ -198,9 +179,7 @@ public final class FileIndexesScreen {
     public static String keybarKeys(ScreenState.FileIndexes state, ParquetModel model) {
         int count = entries(model, state.kind()).size();
         return new Keys.Hints()
-                .add(count > 1, "[↑↓] move")
-                .add(count > Keys.viewportStride(), "[PgDn/PgUp or Shift+↓↑] page")
-                .add(count > 1, "[g/G] first/last")
+                .add(true, CursorPane.hints(count))
                 .add(count > 0, "[Enter] open")
                 .add(true, "[Esc] back")
                 .build();

--- a/cli/src/main/java/dev/hardwood/cli/dive/internal/FooterScreen.java
+++ b/cli/src/main/java/dev/hardwood/cli/dive/internal/FooterScreen.java
@@ -45,70 +45,31 @@ public final class FooterScreen {
     private FooterScreen() {
     }
 
+    /// The state to push when opening the screen: the cursor on the first
+    /// anchor that goes somewhere, so a file missing the section we would
+    /// otherwise land on does not start on a dead line.
+    ///
+    /// Chosen here rather than corrected on each keypress — a screen that
+    /// re-snapped the cursor every event would drag it back to an anchor the
+    /// moment the reader moved off one.
+    public static ScreenState.Footer initialState(ParquetModel model) {
+        FooterBody body = bodyAndAnchors(model);
+        int row = Math.max(0, body.document().rowAtLine(firstEnabledAnchorLine(body)));
+        return new ScreenState.Footer(row);
+    }
+
     public static boolean handle(KeyEvent event, ParquetModel model, NavigationStack stack) {
         ScreenState.Footer state = (ScreenState.Footer) stack.top();
         FooterBody body = bodyAndAnchors(model);
-        // Snap an out-of-place cursor to the first enabled anchor so a file
-        // missing the section we entered on (e.g. no column indexes) doesn't
-        // sit on a dead anchor.
-        if (!isEnabled(state.cursor(), body)) {
-            ScreenState.Footer.Anchor first = firstEnabledAnchor(body);
-            if (first != null && first != state.cursor()) {
-                state = new ScreenState.Footer(first, state.scroll());
-                stack.replaceTop(state);
-            }
-        }
-        int total = body.lines().size();
-        int viewport = Keys.viewportStride();
-        int maxScroll = Math.max(0, total - viewport);
-        // ↑/↓ cycle the cursor through the drillable anchors that are
-        // actually populated. Anchors whose count is zero (e.g. a file
-        // without dictionaries) are skipped so the cursor doesn't land on
-        // a non-actionable line. PgDn / PgUp scroll the body for reading
-        // other sections.
-        if (Keys.isStepUp(event)) {
-            ScreenState.Footer.Anchor prev = previousEnabledAnchor(state.cursor(), body);
-            if (prev == null) {
-                return false;
-            }
-            stack.replaceTop(new ScreenState.Footer(prev, state.scroll()));
-            return true;
-        }
-        if (Keys.isStepDown(event)) {
-            ScreenState.Footer.Anchor next = nextEnabledAnchor(state.cursor(), body);
-            if (next == null) {
-                return false;
-            }
-            stack.replaceTop(new ScreenState.Footer(next, state.scroll()));
-            return true;
-        }
-        if (Keys.isPageDown(event)) {
-            stack.replaceTop(new ScreenState.Footer(state.cursor(),
-                    Math.min(maxScroll, state.scroll() + viewport)));
-            return true;
-        }
-        if (Keys.isPageUp(event)) {
-            stack.replaceTop(new ScreenState.Footer(state.cursor(),
-                    Math.max(0, state.scroll() - viewport)));
-            return true;
-        }
-        if (Keys.isJumpTop(event)) {
-            stack.replaceTop(new ScreenState.Footer(state.cursor(), 0));
-            return true;
-        }
-        if (Keys.isJumpBottom(event)) {
-            stack.replaceTop(new ScreenState.Footer(state.cursor(), maxScroll));
+        int selected = body.document().select(event, state.cursorRow(), Keys.viewportStride());
+        if (selected != CursorPane.UNHANDLED) {
+            stack.replaceTop(new ScreenState.Footer(selected,
+                    body.document().windowTopAfterMove(state.windowTop(), state.cursorRow(),
+                            selected, Keys.viewportStride())));
             return true;
         }
         if (event.isConfirm()) {
-            ScreenState.FileIndexes.Kind kind = switch (state.cursor()) {
-                case COLUMN -> body.columnIndexCount() > 0
-                        ? ScreenState.FileIndexes.Kind.COLUMN : null;
-                case OFFSET -> body.offsetIndexCount() > 0
-                        ? ScreenState.FileIndexes.Kind.OFFSET : null;
-                case DICTIONARY -> body.dictionaryCount() > 0
-                        ? ScreenState.FileIndexes.Kind.DICTIONARY : null;
-            };
+            ScreenState.FileIndexes.Kind kind = kindAt(cursorLine(state, body), body);
             if (kind != null) {
                 stack.push(new ScreenState.FileIndexes(kind, 0));
                 return true;
@@ -117,56 +78,79 @@ public final class FooterScreen {
         return false;
     }
 
+    /// The body line the cursor is on. The state holds a row index; the
+    /// rows are the lines `↑`/`↓` stop on, which excludes the section
+    /// headings and the blanks between them.
+    private static int cursorLine(ScreenState.Footer state, FooterBody body) {
+        return Math.max(0, body.document().lineOfRow(state.cursorRow()));
+    }
+
+    /// The screen `Enter` opens from `line`, or null when the line is not an
+    /// anchor or its section is empty.
+    private static ScreenState.FileIndexes.Kind kindAt(int line, FooterBody body) {
+        if (line == body.columnIndexLine() && body.columnIndexCount() > 0) {
+            return ScreenState.FileIndexes.Kind.COLUMN;
+        }
+        if (line == body.offsetIndexLine() && body.offsetIndexCount() > 0) {
+            return ScreenState.FileIndexes.Kind.OFFSET;
+        }
+        if (line == body.dictionaryLine() && body.dictionaryCount() > 0) {
+            return ScreenState.FileIndexes.Kind.DICTIONARY;
+        }
+        return null;
+    }
+
+    private static boolean isAnchorLine(int line, FooterBody body) {
+        return kindAt(line, body) != null;
+    }
+
+    private static int firstEnabledAnchorLine(FooterBody body) {
+        int best = -1;
+        for (int line : anchorLines(body)) {
+            if (line >= 0 && (best < 0 || line < best)) {
+                best = line;
+            }
+        }
+        return best;
+    }
+
+    /// Body lines carrying an anchor `Enter` can act on, `-1` where the file
+    /// has none of that kind.
+    private static int[] anchorLines(FooterBody body) {
+        return new int[] {
+            body.columnIndexCount() > 0 ? body.columnIndexLine() : -1,
+            body.offsetIndexCount() > 0 ? body.offsetIndexLine() : -1,
+            body.dictionaryCount() > 0 ? body.dictionaryLine() : -1,
+        };
+    }
+
     public static void render(Buffer buffer, Rect area, ParquetModel model, ScreenState.Footer state) {
         // Block borders only — the in-body scroll hint was dropped earlier
         // in favor of the keybar carrying that information, so the body
         // chrome is just 2 rows (top + bottom border).
         Keys.observeViewport(area.height() - 2);
         FooterBody body = bodyAndAnchors(model);
-        // On the first render after entering the screen, state.cursor() may
-        // point to an anchor the file doesn't actually have (the initial
-        // value is COLUMN). Snap the rendered cursor to the first enabled
-        // anchor so the marker shows up immediately; handle() will fix up
-        // state on the next event.
-        ScreenState.Footer.Anchor effective = state.cursor();
-        if (!isEnabled(effective, body)) {
-            ScreenState.Footer.Anchor first = firstEnabledAnchor(body);
-            if (first != null) {
-                effective = first;
-            }
-        }
+        int cursorLine = cursorLine(state, body);
         List<Line> all = body.lines();
         int viewport = Math.max(1, area.height() - 2);
-        int total = all.size();
-        int maxScroll = Math.max(0, total - viewport);
-        int cursorLine = switch (effective) {
-            case COLUMN -> body.columnIndexLine();
-            case OFFSET -> body.offsetIndexLine();
-            case DICTIONARY -> body.dictionaryLine();
-        };
-        int scroll = Math.max(0, Math.min(maxScroll, state.scroll()));
-        // Auto-scroll to keep the cursor anchor visible.
-        if (cursorLine >= 0) {
-            if (cursorLine < scroll) {
-                scroll = cursorLine;
-            }
-            else if (cursorLine >= scroll + viewport) {
-                scroll = Math.max(0, cursorLine - viewport + 1);
-            }
-        }
-        int end = Math.min(total, scroll + viewport);
+        RowWindow window = RowWindow.from(
+                body.document().windowTop(state.windowTop(), state.cursorRow(), viewport),
+                cursorLine, all.size(), viewport);
+        int scroll = window.start();
 
-        // Always paint both anchors with the ▶ marker so they're discoverable
-        // without hovering. The currently-selected one renders in accent
-        // colour; the inactive one is bold-only.
-        List<Line> lines = new ArrayList<>(all.subList(scroll, end));
+        // Every anchor Enter can act on is marked, so they are discoverable
+        // without arrowing onto each one; the cursor is the coloured line.
+        List<Line> lines = new ArrayList<>(all.subList(scroll, window.end()));
         styleAnchor(lines, all, scroll, body.columnIndexLine(),
-                effective == ScreenState.Footer.Anchor.COLUMN, body.columnIndexCount() > 0);
+                cursorLine == body.columnIndexLine(), body.columnIndexCount() > 0);
         styleAnchor(lines, all, scroll, body.offsetIndexLine(),
-                effective == ScreenState.Footer.Anchor.OFFSET, body.offsetIndexCount() > 0);
+                cursorLine == body.offsetIndexLine(), body.offsetIndexCount() > 0);
         styleAnchor(lines, all, scroll, body.dictionaryLine(),
-                effective == ScreenState.Footer.Anchor.DICTIONARY, body.dictionaryCount() > 0);
-
+                cursorLine == body.dictionaryLine(), body.dictionaryCount() > 0);
+        // The cursor is coloured wherever it is, not only on the anchors:
+        // painting it on three of thirty lines left it invisible everywhere
+        // else, so the reader could not see what the arrows were moving.
+        styleCursor(lines, all, scroll, cursorLine, kindAt(cursorLine, body) == null);
 
         Block block = Block.builder()
                 .title(" Footer & indexes ")
@@ -176,9 +160,26 @@ public final class FooterScreen {
         Paragraph.builder().block(block).text(Text.from(lines)).left().build().render(area, buffer);
     }
 
+    /// Paints the cursor on a line the anchors did not already claim: the
+    /// selection colour, and no marker, since `Enter` does nothing here.
+    private static void styleCursor(List<Line> visible, List<Line> all, int scroll,
+                                    int cursorLine, boolean paint) {
+        if (!paint || cursorLine < 0) {
+            return;
+        }
+        int offset = cursorLine - scroll;
+        if (offset < 0 || offset >= visible.size()) {
+            return;
+        }
+        visible.set(offset, Line.from(
+                new Span(renderLine(all.get(cursorLine)), Theme.selection())));
+    }
+
+    /// Paints one anchor line: `▶` when `Enter` can act on it, and the
+    /// selection colour when it is the line the cursor is on.
     private static void styleAnchor(List<Line> visible, List<Line> all, int scroll,
-                                    int absoluteLine, boolean active, boolean enabled) {
-        if (absoluteLine < 0 || !active) {
+                                    int absoluteLine, boolean cursor, boolean enabled) {
+        if (absoluteLine < 0) {
             return;
         }
         int offset = absoluteLine - scroll;
@@ -186,12 +187,10 @@ public final class FooterScreen {
             return;
         }
         String text = renderLine(all.get(absoluteLine));
+        // The body indents its rows by one cell, which the marker takes over.
         String marker = enabled ? "▶" : " ";
         String shown = text.startsWith(" ") ? marker + text.substring(1) : marker + text;
-        Style style = enabled
-                ? Theme.selection()
-                : Theme.primary();
-        visible.set(offset, Line.from(new Span(shown, style)));
+        visible.set(offset, Line.from(new Span(shown, cursor ? Theme.selection() : Theme.primary())));
     }
 
     private static String renderLine(Line line) {
@@ -205,59 +204,22 @@ public final class FooterScreen {
     /// Body content plus indices of the drill-target lines so Enter can
     /// be context-aware without recomputing the layout.
     private record FooterBody(
-            List<Line> lines,
+            Document document,
             int columnIndexLine,
             int columnIndexCount,
             int offsetIndexLine,
             int offsetIndexCount,
             int dictionaryLine,
             int dictionaryCount) {
-    }
 
-    private static boolean isEnabled(ScreenState.Footer.Anchor anchor, FooterBody body) {
-        return switch (anchor) {
-            case COLUMN -> body.columnIndexCount() > 0;
-            case OFFSET -> body.offsetIndexCount() > 0;
-            case DICTIONARY -> body.dictionaryCount() > 0;
-        };
-    }
-
-    private static ScreenState.Footer.Anchor nextEnabledAnchor(
-            ScreenState.Footer.Anchor from, FooterBody body) {
-        ScreenState.Footer.Anchor[] all = ScreenState.Footer.Anchor.values();
-        for (int i = from.ordinal() + 1; i < all.length; i++) {
-            if (isEnabled(all[i], body)) {
-                return all[i];
-            }
+        List<Line> lines() {
+            return document.lines();
         }
-        return null;
-    }
-
-    private static ScreenState.Footer.Anchor previousEnabledAnchor(
-            ScreenState.Footer.Anchor from, FooterBody body) {
-        ScreenState.Footer.Anchor[] all = ScreenState.Footer.Anchor.values();
-        for (int i = from.ordinal() - 1; i >= 0; i--) {
-            if (isEnabled(all[i], body)) {
-                return all[i];
-            }
-        }
-        return null;
-    }
-
-    /// First enabled anchor, or null if no anchor is drillable on this file.
-    /// Used to choose a sensible cursor on entry so the screen doesn't open
-    /// pointing at an unavailable section.
-    private static ScreenState.Footer.Anchor firstEnabledAnchor(FooterBody body) {
-        for (ScreenState.Footer.Anchor a : ScreenState.Footer.Anchor.values()) {
-            if (isEnabled(a, body)) {
-                return a;
-            }
-        }
-        return null;
     }
 
     private static FooterBody bodyAndAnchors(ParquetModel model) {
-        List<Line> lines = bodyLines(model);
+        Document body = bodyLines(model);
+        List<Line> lines = body.lines();
         FooterStats stats = computeStats(model);
         int columnIndexLine = -1;
         int offsetIndexLine = -1;
@@ -274,100 +236,84 @@ public final class FooterScreen {
                 dictionaryLine = i;
             }
         }
-        return new FooterBody(lines, columnIndexLine, stats.columnIndexCount(),
+        return new FooterBody(body, columnIndexLine, stats.columnIndexCount(),
                 offsetIndexLine, stats.offsetIndexCount(),
                 dictionaryLine, stats.dictionaryCount());
     }
 
-    private static List<Line> bodyLines(ParquetModel model) {
+    private static Document bodyLines(ParquetModel model) {
         FooterStats stats = computeStats(model);
         long fileSize = model.fileSizeBytes();
         long footerTrailerOffset = fileSize - FOOTER_TRAILER_BYTES;
 
-        List<Line> lines = new ArrayList<>();
+        Document.Builder lines = Document.builder();
 
-        lines.add(Line.from(new Span(" File layout ", Theme.accent().bold())));
-        lines.add(fact("  File size", Sizes.dualFormat(fileSize)));
-        lines.add(fact("  Format version", String.valueOf(model.metadata().version())));
-        lines.add(fact("  Created by",
+        lines.decoration(Line.from(new Span(" File layout ", Theme.accent().bold())));
+        lines.row(fact("  File size", Sizes.dualFormat(fileSize)));
+        lines.row(fact("  Format version", String.valueOf(model.metadata().version())));
+        lines.row(fact("  Created by",
                 model.facts().createdBy() != null ? model.facts().createdBy() : "unknown"));
-        lines.add(fact("  Footer trailer offset", Fmt.fmt("%,d", footerTrailerOffset)));
-        lines.add(fact("  Trailer bytes", String.valueOf(FOOTER_TRAILER_BYTES)));
+        lines.row(fact("  Footer trailer offset", Fmt.fmt("%,d", footerTrailerOffset)));
+        lines.row(fact("  Trailer bytes", String.valueOf(FOOTER_TRAILER_BYTES)));
         if (stats.minDataOffset() < Long.MAX_VALUE) {
-            lines.add(fact("  Data region",
+            lines.row(fact("  Data region",
                     Fmt.fmt("%,d .. %,d  (%s)",
                             stats.minDataOffset(), stats.maxDataEnd(),
                             Sizes.format(stats.maxDataEnd() - stats.minDataOffset()))));
-            lines.add(fact("  Footer + indexes",
+            lines.row(fact("  Footer + indexes",
                     Sizes.dualFormat(footerAndIndexBytes(model))));
         }
 
-        lines.add(Line.empty());
-        lines.add(Line.from(new Span(" Encodings ", Theme.accent().bold())));
+        lines.blank();
+        lines.decoration(Line.from(new Span(" Encodings ", Theme.accent().bold())));
         for (Map.Entry<Encoding, Integer> e : stats.encodingHistogram().entrySet()) {
-            lines.add(fact("  " + e.getKey().name(),
+            lines.row(fact("  " + e.getKey().name(),
                     Plurals.format(e.getValue(), "chunk", "chunks")));
         }
 
-        lines.add(Line.empty());
-        lines.add(Line.from(new Span(" Codecs ", Theme.accent().bold())));
+        lines.blank();
+        lines.decoration(Line.from(new Span(" Codecs ", Theme.accent().bold())));
         for (Map.Entry<CompressionCodec, Integer> e : stats.codecHistogram().entrySet()) {
             int pct = stats.totalChunks() == 0 ? 0
                     : (int) Math.round(100.0 * e.getValue() / stats.totalChunks());
-            lines.add(fact("  " + e.getKey().name(),
+            lines.row(fact("  " + e.getKey().name(),
                     Plurals.format(e.getValue(), "chunk", "chunks") + "  (" + pct + "%)"));
         }
 
-        lines.add(Line.empty());
-        lines.add(Line.from(new Span(" Page indexes ", Theme.accent().bold())));
-        lines.add(fact("  Column indexes",
+        lines.blank();
+        lines.decoration(Line.from(new Span(" Page indexes ", Theme.accent().bold())));
+        lines.row(fact("  Column indexes",
                 Sizes.dualFormat(stats.columnIndexBytes()) + "  ("
                         + coverage(stats.columnIndexCount(), stats.totalChunks()) + ")"));
-        lines.add(fact("  Offset indexes",
+        lines.row(fact("  Offset indexes",
                 Sizes.dualFormat(stats.offsetIndexBytes()) + "  ("
                         + coverage(stats.offsetIndexCount(), stats.totalChunks()) + ")"));
 
-        lines.add(Line.empty());
-        lines.add(Line.from(new Span(" Bloom filters ", Theme.accent().bold())));
-        lines.add(fact("  Bloom filters",
+        lines.blank();
+        lines.decoration(Line.from(new Span(" Bloom filters ", Theme.accent().bold())));
+        lines.row(fact("  Bloom filters",
                 Sizes.dualFormat(stats.bloomFilterBytes()) + "  ("
                         + coverage(stats.bloomFilterCount(), stats.totalChunks()) + ")"));
 
-        lines.add(Line.empty());
-        lines.add(Line.from(new Span(" Dictionary ", Theme.accent().bold())));
-        lines.add(fact("  With dictionary",
+        lines.blank();
+        lines.decoration(Line.from(new Span(" Dictionary ", Theme.accent().bold())));
+        lines.row(fact("  With dictionary",
                 coverage(stats.dictionaryCount(), stats.totalChunks())));
 
-        lines.add(Line.empty());
-        lines.add(Line.from(new Span(" Aggregate ", Theme.accent().bold())));
-        lines.add(fact("  Compressed data", Sizes.dualFormat(model.facts().compressedBytes())));
-        lines.add(fact("  Uncompressed data", Sizes.dualFormat(model.facts().uncompressedBytes())));
-        lines.add(fact("  Compression", Sizes.compression(model.facts().compressedBytes(),
+        lines.blank();
+        lines.decoration(Line.from(new Span(" Aggregate ", Theme.accent().bold())));
+        lines.row(fact("  Compressed data", Sizes.dualFormat(model.facts().compressedBytes())));
+        lines.row(fact("  Uncompressed data", Sizes.dualFormat(model.facts().uncompressedBytes())));
+        lines.row(fact("  Compression", Sizes.compression(model.facts().compressedBytes(),
                 model.facts().uncompressedBytes(), "—")));
-        return lines;
+        return lines.build();
     }
 
     public static String keybarKeys(ScreenState.Footer state, ParquetModel model) {
         FooterBody body = bodyAndAnchors(model);
-        int enabledAnchors = 0;
-        for (ScreenState.Footer.Anchor a : ScreenState.Footer.Anchor.values()) {
-            if (isEnabled(a, body)) {
-                enabledAnchors++;
-            }
-        }
-        // The render path auto-snaps the visible cursor to the first enabled
-        // anchor when state.cursor() points at a disabled section, and so
-        // does handle() on the next event. The keybar should mirror that:
-        // [Enter] open is available whenever ANY anchor is drillable, not
-        // only when state.cursor() (which may be the stale default COLUMN)
-        // happens to land on an enabled section.
-        int total = body.lines().size();
-        boolean overflows = total > Keys.viewportStride();
         return new Keys.Hints()
-                .add(enabledAnchors > 1, "[↑↓] pick anchor")
-                .add(enabledAnchors > 0, "[Enter] open")
-                .add(overflows, "[PgDn/PgUp or Shift+↓↑] scroll")
-                .add(overflows, "[g/G] top/bottom")
+                .add(true, body.document().hints(Keys.viewportStride()))
+                .add(kindAt(cursorLine(state, body), body) != null, "[Enter] open")
                 .add(true, "[Esc] back")
                 .build();
     }

--- a/cli/src/main/java/dev/hardwood/cli/dive/internal/HelpOverlay.java
+++ b/cli/src/main/java/dev/hardwood/cli/dive/internal/HelpOverlay.java
@@ -17,11 +17,6 @@ import dev.tamboui.layout.Rect;
 import dev.tamboui.style.Style;
 import dev.tamboui.text.Line;
 import dev.tamboui.text.Span;
-import dev.tamboui.text.Text;
-import dev.tamboui.widgets.block.Block;
-import dev.tamboui.widgets.block.BorderType;
-import dev.tamboui.widgets.block.Borders;
-import dev.tamboui.widgets.paragraph.Paragraph;
 
 /// Modal dialog listing all keybindings. Rendered on top of the active screen when
 /// the user presses `?`; dismissed with `Esc` or `?` again.
@@ -30,18 +25,43 @@ public final class HelpOverlay {
     private HelpOverlay() {
     }
 
-    public static void render(Buffer buffer, Rect screenArea) {
-        int width = Math.min(60, screenArea.width() - 4);
+    public static void render(Buffer buffer, Rect screenArea, int scroll) {
+        List<Line> lines = lines(screenArea);
+        Rect area = ScrollPane.modalArea(screenArea, WIDTH, lines.size() + 4);
+        ScrollPane.renderModal(buffer, area, "hardwood dive — help", lines, scroll,
+                "Press ? or Esc to close");
+    }
+
+    /// Line count at this screen size, so the key handler knows how far the
+    /// overlay can scroll.
+    public static int lineCount(Rect screenArea) {
+        return lines(screenArea).size();
+    }
+
+    /// Widest the overlay is allowed to get. Narrow enough to read, wide
+    /// enough for the longest description without wrapping every row.
+    private static final int WIDTH = 60;
+
+    private static List<Line> lines(Rect screenArea) {
+        int width = Math.min(WIDTH, Math.max(1, screenArea.width() - 4));
         int descBudget = Math.max(1, (width - 2) - 20);
 
         List<Line> lines = new ArrayList<>();
+        // First, not last: this is where a TUI user finds out which build
+        // they are on, and the overlay is longer than a short terminal shows.
+        lines.add(Line.from(new Span("Version: " + Version.getVersion(), Theme.dim())));
+        lines.add(Line.empty());
         lines.add(Line.from(new Span("Navigation", Theme.accent().bold())));
-        lines.addAll(kv("↑ / ↓", "move selection", descBudget));
-        lines.addAll(kv("g / G", "jump to first / last row", descBudget));
+        lines.addAll(kv("↑ / ↓", "move one row or line", descBudget));
+        lines.addAll(kv("PgDn / PgUp", "move one screenful (Shift+↓/↑ on macOS)", descBudget));
+        lines.addAll(kv("g / G", "jump to first / last", descBudget));
         lines.addAll(kv("Enter", "drill into selected item", descBudget));
         lines.addAll(kv("Esc / Backspace", "go back one level", descBudget));
         lines.addAll(kv("Tab / Shift-Tab", "switch focused pane", descBudget));
         lines.addAll(kv("o", "return to Overview", descBudget));
+        lines.add(Line.empty());
+        lines.addAll(kv("▶", "Enter does something on this row", descBudget));
+        lines.addAll(kv("colour", "where the cursor is", descBudget));
         lines.add(Line.empty());
         lines.add(Line.from(new Span("Schema tree", Theme.accent().bold())));
         lines.addAll(kv("→ / Enter", "expand group · drill leaf", descBudget));
@@ -58,30 +78,10 @@ public final class HelpOverlay {
         lines.addAll(kv("q / Ctrl-C", "quit", descBudget));
         lines.add(Line.empty());
         lines.add(Line.from(new Span("Data preview", Theme.accent().bold())));
-        lines.addAll(kv("PgDn / PgUp", "page forward / back (Shift+↓/↑ on macOS)", descBudget));
         lines.addAll(kv("← / →", "scroll visible columns", descBudget));
-        lines.addAll(kv("g / G", "jump to first / last row of file", descBudget));
-        lines.add(Line.empty());
-        lines.add(Line.from(new Span("Version: " + Version.getVersion(), Theme.dim())));
-        lines.add(Line.from(new Span("Press ? or Esc to close", Theme.dim())));
-
-        // Height is derived from the produced line count (plus 2 for the borders)
-        // so the overlay grows with the wrapped content. Capped to the screen so
-        // we don't draw outside the buffer.
-        int height = Math.min(lines.size() + 2, screenArea.height() - 2);
-        int x = screenArea.left() + (screenArea.width() - width) / 2;
-        int y = screenArea.top() + (screenArea.height() - height) / 2;
-        Rect area = new Rect(x, y, width, height);
-        // Wipe the area so the underlying screen doesn't bleed through cells
-        // that the Paragraph doesn't paint.
-        dev.tamboui.widgets.Clear.INSTANCE.render(area, buffer);
-
-        Block block = Block.builder()
-                .title(" hardwood dive — help ")
-                .borders(Borders.ALL)
-                .borderType(BorderType.ROUNDED)
-                .build();
-        Paragraph.builder().block(block).text(Text.from(lines)).left().build().render(area, buffer);
+        lines.addAll(kv("Enter", "open / expand the record field", descBudget));
+        lines.addAll(kv("e / c", "expand / collapse all fields", descBudget));
+        return lines;
     }
 
     private static List<Line> kv(String key, String description, int descBudget) {

--- a/cli/src/main/java/dev/hardwood/cli/dive/internal/Keys.java
+++ b/cli/src/main/java/dev/hardwood/cli/dive/internal/Keys.java
@@ -99,6 +99,21 @@ public final class Keys {
         return observedViewportRows > 0 ? observedViewportRows : PAGE_STRIDE;
     }
 
+    /// Content width of the modal the last frame rendered. Modals wrap their
+    /// content, so the key handler needs the same width the renderer used to
+    /// agree with it on the line count.
+    private static int observedModalWidth = -1;
+
+    /// Called by [ScrollPane#renderModal] with the width it wrapped to.
+    public static void observeModalWidth(int columns) {
+        observedModalWidth = Math.max(1, columns);
+    }
+
+    /// Most recently observed modal content width, or a pre-render fallback.
+    public static int modalWidth() {
+        return observedModalWidth > 0 ? observedModalWidth : DEFAULT_VIEWPORT_COLUMNS;
+    }
+
     /// Records the terminal width used by horizontally scrolling screens.
     public static void observeViewportWidth(int columns) {
         observedViewportColumns = Math.max(1, columns);
@@ -107,13 +122,6 @@ public final class Keys {
     /// Most recently observed terminal width, or a pre-render fallback.
     public static int viewportWidth() {
         return observedViewportColumns > 0 ? observedViewportColumns : DEFAULT_VIEWPORT_COLUMNS;
-    }
-
-    /// True iff a screen has rendered and recorded a viewport size — used
-    /// by Data preview to gate viewport-driven page resizing so unit tests
-    /// that supply an explicit page size aren't overridden.
-    public static boolean hasObservedViewport() {
-        return observedViewportRows > 0;
     }
 
     /// Called by Data preview's `render` to record the area it was drawn into.
@@ -140,6 +148,7 @@ public final class Keys {
     public static void resetObservedGeometry() {
         observedViewportRows = -1;
         observedViewportColumns = -1;
+        observedModalWidth = -1;
         observedDataPreviewWidth = -1;
         observedDataPreviewHeight = -1;
     }
@@ -149,11 +158,15 @@ public final class Keys {
     /// lists exactly the keys that have a meaningful effect in the current
     /// screen state. Callers should phrase enablement at the
     /// "would-pressing-this-do-something-visible" level.
+    ///
+    /// An empty binding is dropped rather than separated, so a fragment
+    /// produced elsewhere — [ScrollPane#hints(int,int)], say — can be added
+    /// unconditionally and contribute nothing when it is empty.
     public static final class Hints {
         private final StringBuilder sb = new StringBuilder();
 
         public Hints add(boolean enabled, String binding) {
-            if (enabled) {
+            if (enabled && !binding.isEmpty()) {
                 if (!sb.isEmpty()) {
                     sb.append("  ");
                 }

--- a/cli/src/main/java/dev/hardwood/cli/dive/internal/OffsetIndexScreen.java
+++ b/cli/src/main/java/dev/hardwood/cli/dive/internal/OffsetIndexScreen.java
@@ -43,28 +43,9 @@ public final class OffsetIndexScreen {
         ScreenState.OffsetIndexView state = (ScreenState.OffsetIndexView) stack.top();
         OffsetIndex oi = model.offsetIndex(state.rowGroupIndex(), state.columnIndex());
         int count = oi != null ? oi.pageLocations().size() : 0;
-        if (Keys.isStepUp(event)) {
-            stack.replaceTop(moved(state, Math.max(0, state.selection() - 1)));
-            return true;
-        }
-        if (Keys.isStepDown(event)) {
-            stack.replaceTop(moved(state, Math.min(count - 1, state.selection() + 1)));
-            return true;
-        }
-        if (Keys.isPageDown(event) && count > 0) {
-            stack.replaceTop(moved(state, Math.min(count - 1, state.selection() + Keys.viewportStride())));
-            return true;
-        }
-        if (Keys.isPageUp(event) && count > 0) {
-            stack.replaceTop(moved(state, Math.max(0, state.selection() - Keys.viewportStride())));
-            return true;
-        }
-        if (Keys.isJumpTop(event) && count > 0) {
-            stack.replaceTop(moved(state, 0));
-            return true;
-        }
-        if (Keys.isJumpBottom(event) && count > 0) {
-            stack.replaceTop(moved(state, count - 1));
+        int next = CursorPane.select(event, state.selection(), count);
+        if (next != CursorPane.UNHANDLED) {
+            stack.replaceTop(moved(state, next));
             return true;
         }
         return false;
@@ -110,7 +91,7 @@ public final class OffsetIndexScreen {
         Row header = Row.from("#", "Offset", "Size", "First row").style(Theme.accent().bold());
         Block block = Block.builder()
                 .title(" Offset index "
-                        + Plurals.rangeOf(state.selection(), locations.size(), Keys.viewportStride())
+                        + Plurals.rangeOf(window, locations.size())
                         + " ")
                 .borders(Borders.ALL)
                 .borderType(BorderType.ROUNDED)
@@ -138,9 +119,7 @@ public final class OffsetIndexScreen {
         OffsetIndex oi = model.offsetIndex(state.rowGroupIndex(), state.columnIndex());
         int count = oi != null ? oi.pageLocations().size() : 0;
         return new Keys.Hints()
-                .add(count > 1, "[↑↓] move")
-                .add(count > Keys.viewportStride(), "[PgDn/PgUp or Shift+↓↑] page")
-                .add(count > 1, "[g/G] first/last")
+                .add(true, CursorPane.hints(count))
                 .add(true, "[Esc] back")
                 .build();
     }

--- a/cli/src/main/java/dev/hardwood/cli/dive/internal/OverviewScreen.java
+++ b/cli/src/main/java/dev/hardwood/cli/dive/internal/OverviewScreen.java
@@ -50,6 +50,28 @@ public final class OverviewScreen {
 
     static final int MENU_SIZE = MenuItem.values().length;
 
+    /// Rows the facts pane holds before its key/value list: the five facts.
+    /// The heading and the blank above it are decoration, so they do not
+    /// count — an entry's row is this plus its index.
+    private static final int FACTS_HEADER_ROWS = 5;
+
+    /// Rows in the facts pane, which is what the cursor moves over.
+    private static int factsRowCount(ParquetModel model) {
+        return FACTS_HEADER_ROWS + model.facts().keyValueMetadata().size();
+    }
+
+    /// The key/value entry `row` shows, or `-1` for one of the facts above
+    /// the list — a row the cursor rests on but `Enter` cannot act on.
+    private static int kvIndexForRow(int row) {
+        return row < FACTS_HEADER_ROWS ? -1 : row - FACTS_HEADER_ROWS;
+    }
+
+    /// The pane row showing key/value entry `index` — the inverse of
+    /// [#kvIndexForRow(int)], for callers that know which entry they want.
+    public static int kvEntryRow(int index) {
+        return FACTS_HEADER_ROWS + index;
+    }
+
     private OverviewScreen() {
     }
 
@@ -60,73 +82,39 @@ public final class OverviewScreen {
                 stack.replaceTop(withKvModal(state, false));
                 return true;
             }
-            int totalLines = kvModalLineCount(model, state);
-            // Scroll is meaningful only when content overflows the modal
-            // viewport. Use Keys.viewportStride as a proxy for the modal's
-            // own viewport (the modal sizes to the screen body area).
-            // When content fits in full, ↑/↓ are no-ops — match the
-            // general "scroll enabled iff content > viewport" rule.
-            int viewport = Keys.viewportStride();
-            int maxScroll = Math.max(0, totalLines - viewport);
-            if (maxScroll == 0) {
+            int next = ScrollPane.scroll(event, state.kvModalScroll(),
+                    kvModalLineCount(model, state), Keys.viewportStride());
+            if (next == ScrollPane.UNHANDLED) {
                 return false;
             }
-            if (event.isUp() && !event.hasShift()) {
-                if (state.kvModalScroll() == 0) {
-                    return false;
-                }
-                stack.replaceTop(withKvScroll(state, state.kvModalScroll() - 1));
-                return true;
+            if (next != state.kvModalScroll()) {
+                stack.replaceTop(withKvScroll(state, next));
             }
-            if (event.isDown() && !event.hasShift()) {
-                if (state.kvModalScroll() >= maxScroll) {
-                    return false;
-                }
-                stack.replaceTop(withKvScroll(state, state.kvModalScroll() + 1));
-                return true;
-            }
-            if (event.isUp() && event.hasShift()) {
-                stack.replaceTop(withKvScroll(state, Math.max(0, state.kvModalScroll() - 10)));
-                return true;
-            }
-            if (event.isDown() && event.hasShift()) {
-                stack.replaceTop(withKvScroll(state, Math.min(maxScroll, state.kvModalScroll() + 10)));
-                return true;
-            }
-            return false;
+            return true;
         }
         if (event.isFocusNext() || event.isFocusPrevious()) {
             ScreenState.Overview.Pane next = state.focus() == ScreenState.Overview.Pane.FACTS
                     ? ScreenState.Overview.Pane.MENU
                     : ScreenState.Overview.Pane.FACTS;
-            stack.replaceTop(withFocus(state, next));
+            stack.replaceTop(withFocus(state, next, model));
             return true;
         }
         if (state.focus() == ScreenState.Overview.Pane.FACTS) {
-            int kvCount = model.facts().keyValueMetadata().size();
-            if (kvCount == 0) {
-                return false;
-            }
-            if (event.isUp()) {
-                stack.replaceTop(withKvSelection(state, Math.max(0, state.kvSelection() - 1)));
+            int selected = factsDocument(model, state, true)
+                    .select(event, state.kvSelection(), Keys.viewportStride());
+            if (selected != CursorPane.UNHANDLED) {
+                stack.replaceTop(withKvSelection(state, selected, model));
                 return true;
             }
-            if (event.isDown()) {
-                stack.replaceTop(withKvSelection(state, Math.min(kvCount - 1, state.kvSelection() + 1)));
-                return true;
-            }
-            if (event.isConfirm()) {
+            if (event.isConfirm() && kvIndexForRow(state.kvSelection()) >= 0) {
                 stack.replaceTop(withKvModal(state, true));
                 return true;
             }
             return false;
         }
-        if (event.isUp()) {
-            stack.replaceTop(withMenuSelection(state, Math.max(0, state.menuSelection() - 1)));
-            return true;
-        }
-        if (event.isDown()) {
-            stack.replaceTop(withMenuSelection(state, Math.min(MENU_SIZE - 1, state.menuSelection() + 1)));
+        int onMenu = CursorPane.select(event, state.menuSelection(), MENU_SIZE);
+        if (onMenu != CursorPane.UNHANDLED) {
+            stack.replaceTop(withMenuSelection(state, onMenu));
             return true;
         }
         if (event.isConfirm()) {
@@ -134,7 +122,7 @@ public final class OverviewScreen {
             switch (item) {
                 case SCHEMA -> stack.push(ScreenState.Schema.initial());
                 case ROW_GROUPS -> stack.push(new ScreenState.RowGroups(0));
-                case FOOTER -> stack.push(ScreenState.Footer.initial());
+                case FOOTER -> stack.push(FooterScreen.initialState(model));
                 case DATA_PREVIEW -> stack.push(DataPreviewScreen.initialState(model));
             }
             return true;
@@ -142,28 +130,45 @@ public final class OverviewScreen {
         return false;
     }
 
-    private static ScreenState.Overview withFocus(ScreenState.Overview s, ScreenState.Overview.Pane next) {
-        return new ScreenState.Overview(next, s.menuSelection(), s.kvSelection(),
-                s.kvModalOpen(), s.kvModalScroll());
+    /// Switching into the facts pane puts the cursor on the first key/value
+    /// entry rather than the first fact: the entries are what `Enter` acts
+    /// on, and the facts above them are read without being visited.
+    private static ScreenState.Overview withFocus(ScreenState.Overview s,
+                                                  ScreenState.Overview.Pane next,
+                                                  ParquetModel model) {
+        int cursor = s.kvSelection();
+        int top = s.factsTop();
+        if (next == ScreenState.Overview.Pane.FACTS && cursor == 0
+                && !model.facts().keyValueMetadata().isEmpty()) {
+            cursor = FACTS_HEADER_ROWS;
+        }
+        return new ScreenState.Overview(next, s.menuSelection(), cursor,
+                s.kvModalOpen(), s.kvModalScroll(), top);
     }
 
     private static ScreenState.Overview withMenuSelection(ScreenState.Overview s, int sel) {
         return new ScreenState.Overview(s.focus(), sel, s.kvSelection(),
-                s.kvModalOpen(), s.kvModalScroll());
+                s.kvModalOpen(), s.kvModalScroll(), s.factsTop());
     }
 
-    private static ScreenState.Overview withKvSelection(ScreenState.Overview s, int sel) {
-        return new ScreenState.Overview(s.focus(), s.menuSelection(), sel,
-                s.kvModalOpen(), 0);
+    /// Moving the key/value cursor resets the modal scroll — a new entry is
+    /// a new document — and slides the pane's window the least it can to keep
+    /// the cursor on screen.
+    private static ScreenState.Overview withKvSelection(ScreenState.Overview s, int sel,
+                                                       ParquetModel model) {
+        Document facts = factsDocument(model, s, true);
+        return new ScreenState.Overview(s.focus(), s.menuSelection(), sel, s.kvModalOpen(), 0,
+                facts.windowTopAfterMove(s.factsTop(), s.kvSelection(), sel,
+                        Keys.viewportStride()));
     }
 
     private static ScreenState.Overview withKvModal(ScreenState.Overview s, boolean open) {
-        return new ScreenState.Overview(s.focus(), s.menuSelection(), s.kvSelection(), open, 0);
+        return new ScreenState.Overview(s.focus(), s.menuSelection(), s.kvSelection(), open, 0, s.factsTop());
     }
 
     private static ScreenState.Overview withKvScroll(ScreenState.Overview s, int scroll) {
         return new ScreenState.Overview(s.focus(), s.menuSelection(), s.kvSelection(),
-                s.kvModalOpen(), scroll);
+                s.kvModalOpen(), scroll, s.factsTop());
     }
 
     private static int kvModalLineCount(ParquetModel model, ScreenState.Overview state) {
@@ -171,7 +176,7 @@ public final class OverviewScreen {
         if (kv.isEmpty()) {
             return 0;
         }
-        int idx = Math.min(state.kvSelection(), kv.size() - 1);
+        int idx = Math.max(0, Math.min(kvIndexForRow(state.kvSelection()), kv.size() - 1));
         java.util.Map.Entry<String, String> entry = kv.get(idx);
         return KvMetadataFormatter.format(entry.getKey(), entry.getValue()).split("\n", -1).length;
     }
@@ -197,41 +202,64 @@ public final class OverviewScreen {
         boolean factsHasKv = kvCount > 0;
         return new Keys.Hints()
                 .add(factsHasKv, "[Tab] pane")
-                .add(onFacts ? kvCount > 1 : MENU_SIZE > 1, "[↑↓] move")
-                .add(onFacts && factsHasKv, "[Enter] view entry")
+                .add(true, onFacts
+                        ? factsDocument(model, state, true).hints(Keys.viewportStride())
+                        : CursorPane.hints(MENU_SIZE))
+                .add(onFacts && kvIndexForRow(state.kvSelection()) >= 0, "[Enter] view entry")
                 .add(!onFacts, "[Enter] open")
                 .build();
     }
 
-    private static void renderFactsPane(Buffer buffer, Rect area, ParquetModel model, ScreenState.Overview state) {
-        boolean focused = state.focus() == ScreenState.Overview.Pane.FACTS;
-        Block block = paneBlock("File facts", focused);
+    /// The facts pane's content: the facts, then the key/value entries.
+    /// Section headings and the blank above them are decoration — the cursor
+    /// passes over them, since there is nothing there to be at.
+    private static Document factsDocument(ParquetModel model, ScreenState.Overview state,
+                                          boolean focused) {
         ParquetModel.Facts f = model.facts();
-        List<Line> lines = new ArrayList<>();
-        lines.add(factsLine("Format version", String.valueOf(f.formatVersion())));
-        lines.add(factsLine("Created by", f.createdBy() != null ? f.createdBy() : "unknown"));
-        lines.add(factsLine("Uncompressed", Sizes.format(f.uncompressedBytes())));
-        lines.add(factsLine("Compressed", Sizes.format(f.compressedBytes())));
-        lines.add(factsLine("Compression",
-                Sizes.compression(f.compressedBytes(), f.uncompressedBytes(), "—")));
+        int cursorRow = focused ? state.kvSelection() : -1;
         List<Map.Entry<String, String>> kv = f.keyValueMetadata();
+        Document.Builder doc = Document.builder();
+        doc.row(factsLine("Format version", String.valueOf(f.formatVersion()), cursorRow == 0));
+        doc.row(factsLine("Created by", f.createdBy() != null ? f.createdBy() : "unknown",
+                cursorRow == 1));
+        doc.row(factsLine("Uncompressed", Sizes.format(f.uncompressedBytes()), cursorRow == 2));
+        doc.row(factsLine("Compressed", Sizes.format(f.compressedBytes()), cursorRow == 3));
+        doc.row(factsLine("Compression",
+                Sizes.compression(f.compressedBytes(), f.uncompressedBytes(), "—"), cursorRow == 4));
         if (!kv.isEmpty()) {
-            lines.add(Line.empty());
-            lines.add(Line.from(new Span("key/value meta (" + kv.size() + ")", Theme.accent().bold())));
+            doc.blank();
+            doc.decoration(Line.from(new Span("  key/value meta (" + kv.size() + ")",
+                    Theme.accent().bold())));
             for (int i = 0; i < kv.size(); i++) {
                 Map.Entry<String, String> entry = kv.get(i);
-                boolean selected = focused && i == state.kvSelection();
-                String marker = selected ? "▶ " : "  ";
+                boolean selected = FACTS_HEADER_ROWS + i == cursorRow;
+                // The facts above are not actionable, so this is a mixed
+                // pane: every entry is marked, not only the one under the
+                // cursor.
+                String marker = CursorPane.marker(true, selected, true);
                 Style rowStyle = selected ? Theme.selection() : null;
                 Style keyStyle = rowStyle != null ? rowStyle : Theme.primary();
                 Style valueStyle = rowStyle != null ? rowStyle : Style.EMPTY;
-                lines.add(Line.from(
+                doc.row(Line.from(
                         new Span(marker, keyStyle),
                         new Span(padRight(entry.getKey(), 16), keyStyle),
                         new Span(trim(entry.getValue(), 32), valueStyle)));
             }
         }
-        renderParagraph(buffer, area, block, Text.from(lines));
+        return doc.build();
+    }
+
+    private static void renderFactsPane(Buffer buffer, Rect area, ParquetModel model, ScreenState.Overview state) {
+        boolean focused = state.focus() == ScreenState.Overview.Pane.FACTS;
+        Document facts = factsDocument(model, state, focused);
+        int viewport = Math.max(1, area.height() - 2);
+        Keys.observeViewport(viewport);
+        int cursorLine = Math.max(0, facts.lineOfRow(state.kvSelection()));
+        RowWindow window = RowWindow.from(
+                facts.windowTop(state.factsTop(), state.kvSelection(), viewport),
+                cursorLine, facts.lineCount(), viewport);
+        renderParagraph(buffer, area, paneBlock("File facts", focused),
+                Text.from(facts.lines().subList(window.start(), window.end())));
     }
 
     private static void renderKvModal(Buffer buffer, Rect screenArea, ParquetModel model, ScreenState.Overview state) {
@@ -239,7 +267,7 @@ public final class OverviewScreen {
         if (kv.isEmpty()) {
             return;
         }
-        int idx = Math.min(state.kvSelection(), kv.size() - 1);
+        int idx = Math.max(0, Math.min(kvIndexForRow(state.kvSelection()), kv.size() - 1));
         Map.Entry<String, String> entry = kv.get(idx);
         // Grow the modal to fill the available area (leaving a 2-cell margin),
         // not a fixed 30 lines — for ARROW:schema the formatted hex dump can
@@ -255,7 +283,10 @@ public final class OverviewScreen {
         // Reserve 2 rows for borders + 2 rows for the close hint and a blank
         // separator. The remaining inner height is the content viewport.
         int viewport = Math.max(1, height - 4);
-        int maxScroll = Math.max(0, all.length - viewport);
+        // The modal is the only scrollable thing on screen while it is open,
+        // so its inner height is the stride the key handler should use.
+        Keys.observeViewport(viewport);
+        int maxScroll = ScrollPane.maxScroll(all.length, viewport);
         int scroll = Math.max(0, Math.min(state.kvModalScroll(), maxScroll));
         int end = Math.min(all.length, scroll + viewport);
 
@@ -265,9 +296,11 @@ public final class OverviewScreen {
         }
         lines.add(Line.empty());
         String hint = scroll + viewport < all.length
-                ? " ↓ " + (all.length - end) + " more lines · Esc / Enter close · ↑↓ scroll · Shift+↑↓ page"
+                ? " ↓ " + (all.length - end) + " more lines · Esc / Enter close · "
+                        + ScrollPane.hints(all.length, viewport)
                 : (scroll > 0
-                        ? " ↑ " + scroll + " lines above · Esc / Enter close · ↑↓ scroll · Shift+↑↓ page"
+                        ? " ↑ " + scroll + " lines above · Esc / Enter close · "
+                                + ScrollPane.hints(all.length, viewport)
                         : " Press Esc or Enter to close");
         lines.add(Line.from(new Span(hint, Theme.dim())));
         Block block = Block.builder()
@@ -286,7 +319,7 @@ public final class OverviewScreen {
         for (int i = 0; i < items.length; i++) {
             MenuItem item = items[i];
             boolean selected = focused && i == state.menuSelection();
-            String cursor = selected ? "▶ " : "  ";
+            String cursor = CursorPane.marker(true, selected, false);
             MenuHint hint = menuHint(item, model);
             Style labelStyle = selected
                     ? Theme.selection()
@@ -330,10 +363,15 @@ public final class OverviewScreen {
     /// menu rows regardless of count length.
     private static final int AXIS_HINT_WIDTH = 14;
 
-    private static Line factsLine(String key, String value) {
+    /// One fact row. The cursor stops on these as it does on the key/value
+    /// entries below them, but `Enter` does nothing here, so they carry the
+    /// selection colour without a marker.
+    private static Line factsLine(String key, String value, boolean selected) {
+        Style keyStyle = selected ? Theme.selection() : Theme.primary();
         return Line.from(
-                new Span(padRight(key, 16), Theme.primary()),
-                new Span(value, Style.EMPTY));
+                new Span(CursorPane.marker(false, selected, true), keyStyle),
+                new Span(padRight(key, 16), keyStyle),
+                new Span(value, selected ? Theme.selection() : Style.EMPTY));
     }
 
     private static Block paneBlock(String title, boolean focused) {

--- a/cli/src/main/java/dev/hardwood/cli/dive/internal/PagesScreen.java
+++ b/cli/src/main/java/dev/hardwood/cli/dive/internal/PagesScreen.java
@@ -33,12 +33,10 @@ import dev.tamboui.layout.Rect;
 import dev.tamboui.style.Style;
 import dev.tamboui.text.Line;
 import dev.tamboui.text.Span;
-import dev.tamboui.text.Text;
 import dev.tamboui.tui.event.KeyEvent;
 import dev.tamboui.widgets.block.Block;
 import dev.tamboui.widgets.block.BorderType;
 import dev.tamboui.widgets.block.Borders;
-import dev.tamboui.widgets.paragraph.Paragraph;
 import dev.tamboui.widgets.table.Row;
 import dev.tamboui.widgets.table.Table;
 import dev.tamboui.widgets.table.TableState;
@@ -79,32 +77,21 @@ public final class PagesScreen {
                         state.scrollTop()));
                 return true;
             }
-            return false;
-        }
-        if (Keys.isStepUp(event)) {
-            stack.replaceTop(moved(state, Math.max(0, state.selection() - 1), logical));
+            int next = ScrollPane.scroll(event, state.modalScroll(),
+                    modalLineCount(model, state), Keys.viewportStride());
+            if (next == ScrollPane.UNHANDLED) {
+                return false;
+            }
+            if (next != state.modalScroll()) {
+                stack.replaceTop(new ScreenState.Pages(
+                        state.rowGroupIndex(), state.columnIndex(), state.selection(), true, logical,
+                        state.scrollTop(), next));
+            }
             return true;
         }
-        if (Keys.isStepDown(event)) {
-            stack.replaceTop(moved(state, Math.min(headers.size() - 1, state.selection() + 1), logical));
-            return true;
-        }
-        if (Keys.isPageDown(event) && !headers.isEmpty()) {
-            stack.replaceTop(moved(state,
-                    Math.min(headers.size() - 1, state.selection() + Keys.viewportStride()), logical));
-            return true;
-        }
-        if (Keys.isPageUp(event) && !headers.isEmpty()) {
-            stack.replaceTop(moved(state,
-                    Math.max(0, state.selection() - Keys.viewportStride()), logical));
-            return true;
-        }
-        if (Keys.isJumpTop(event) && !headers.isEmpty()) {
-            stack.replaceTop(moved(state, 0, logical));
-            return true;
-        }
-        if (Keys.isJumpBottom(event) && !headers.isEmpty()) {
-            stack.replaceTop(moved(state, headers.size() - 1, logical));
+        int selected = CursorPane.select(event, state.selection(), headers.size());
+        if (selected != CursorPane.UNHANDLED) {
+            stack.replaceTop(moved(state, selected, logical));
             return true;
         }
         if (event.isConfirm() && !headers.isEmpty()) {
@@ -219,7 +206,7 @@ public final class PagesScreen {
         String typeMode = state.logicalTypes() ? "" : " · physical";
         Block block = Block.builder()
                 .title(" Pages "
-                        + Plurals.rangeOf(state.selection(), headers.size(), Keys.viewportStride())
+                        + Plurals.rangeOf(window, headers.size())
                         + titleSuffix + typeMode + " ")
                 .borders(Borders.ALL)
                 .borderType(BorderType.ROUNDED)
@@ -260,7 +247,7 @@ public final class PagesScreen {
         if (state.modalOpen() && !headers.isEmpty()) {
             buffer.setStyle(area, Theme.dim());
             renderHeaderModal(buffer, area, headers.get(state.selection()), state.selection(), col,
-                    state.logicalTypes());
+                    state.logicalTypes(), state.modalScroll());
         }
     }
 
@@ -268,7 +255,7 @@ public final class PagesScreen {
         if (state.modalOpen()) {
             return "";
         }
-        java.util.List<PageHeader> headers = model.pageHeaders(state.rowGroupIndex(), state.columnIndex());
+        List<PageHeader> headers = model.pageHeaders(state.rowGroupIndex(), state.columnIndex());
         int count = headers.size();
         ColumnSchema col = model.schema().getColumn(state.columnIndex());
         // `t` toggles logical-type rendering of inline-stats Min / Max,
@@ -280,9 +267,7 @@ public final class PagesScreen {
                 && headers.get(state.selection()).type() != PageType.DICTIONARY_PAGE;
         boolean hasLogical = col.logicalType() != null && onDataPage;
         return new Keys.Hints()
-                .add(count > 1, "[↑↓] move")
-                .add(count > Keys.viewportStride(), "[PgDn/PgUp or Shift+↓↑] page")
-                .add(count > 1, "[g/G] first/last")
+                .add(true, CursorPane.hints(count))
                 .add(count > 0, "[Enter] view page header")
                 .add(hasLogical, "[t] logical types")
                 .add(true, "[Esc] back")
@@ -339,19 +324,34 @@ public final class PagesScreen {
     }
 
     private static void renderHeaderModal(Buffer buffer, Rect screenArea, PageHeader header,
-                                          int index, ColumnSchema col, boolean logical) {
+                                          int index, ColumnSchema col, boolean logical, int scroll) {
         // Grow the modal to fill the available area so long inline-stats
-        // values aren't clipped at a fixed 60-cell width (the previous cap
-        // hid the bulk of any UTF-8 string min/max past ~50 chars).
-        int width = Math.max(40, screenArea.width() - 4);
-        int height = Math.max(8, screenArea.height() - 2);
-        int x = screenArea.left() + (screenArea.width() - width) / 2;
-        int y = screenArea.top() + (screenArea.height() - height) / 2;
-        Rect area = new Rect(x, y, width, height);
-        // Wipe the area so the underlying table doesn't bleed through cells
-        // that the Paragraph doesn't paint (Paragraph only writes where text is).
-        dev.tamboui.widgets.Clear.INSTANCE.render(area, buffer);
+        // values aren't clipped at a fixed 60-cell width.
+        Rect area = ScrollPane.modalArea(screenArea, Math.max(40, screenArea.width()), screenArea.height());
+        // Dictionary pages have no inline stats — `t` is a no-op even
+        // when the column carries a logical type, so suppress the hint.
+        boolean onDataPage = header.type() != PageType.DICTIONARY_PAGE;
+        boolean hasLogical = col.logicalType() != null && onDataPage;
+        ScrollPane.renderModal(buffer, area, "Page #" + index + " header",
+                headerModalLines(header, col, logical), scroll,
+                "Esc / Enter close" + (hasLogical ? " · t logical types" : ""));
+    }
 
+    /// Line count of the open header modal, so the key handler and the
+    /// renderer agree on how far it can scroll.
+    private static int modalLineCount(ParquetModel model, ScreenState.Pages state) {
+        List<PageHeader> headers = model.pageHeaders(state.rowGroupIndex(), state.columnIndex());
+        if (headers.isEmpty()) {
+            return 0;
+        }
+        ColumnSchema col = model.schema().getColumn(state.columnIndex());
+        int index = Math.min(state.selection(), headers.size() - 1);
+        return headerModalLines(headers.get(index), col, state.logicalTypes()).size();
+    }
+
+    /// The header modal's content. Shared with the key handler, which needs
+    /// the line count to know how far the modal can scroll.
+    private static List<Line> headerModalLines(PageHeader header, ColumnSchema col, boolean logical) {
         List<Line> lines = new ArrayList<>();
         lines.add(kv("Type", header.type().name()));
         lines.add(kv("Compressed size", Sizes.dualFormat(header.compressedPageSize())));
@@ -390,20 +390,7 @@ public final class PagesScreen {
                 lines.add(kv("  Nulls", Fmt.fmt("%,d", inline.nullCount())));
             }
         }
-        lines.add(Line.empty());
-        // Dictionary pages have no inline stats — `t` is a no-op even
-        // when the column carries a logical type, so suppress the hint.
-        boolean onDataPage = header.type() != PageType.DICTIONARY_PAGE;
-        boolean hasLogical = col.logicalType() != null && onDataPage;
-        String hint = " Esc / Enter close" + (hasLogical ? " · t logical types" : "");
-        lines.add(Line.from(new Span(hint, Theme.dim())));
-
-        Block block = Block.builder()
-                .title(" Page #" + index + " header ")
-                .borders(Borders.ALL)
-                .borderType(BorderType.ROUNDED)
-                .build();
-        Paragraph.builder().block(block).text(Text.from(lines)).left().build().render(area, buffer);
+        return lines;
     }
 
     /// Returns the per-page inline statistics (if any), preferring v2 over v1

--- a/cli/src/main/java/dev/hardwood/cli/dive/internal/Plurals.java
+++ b/cli/src/main/java/dev/hardwood/cli/dive/internal/Plurals.java
@@ -23,27 +23,18 @@ public final class Plurals {
         return Fmt.fmt("%,d", count) + " " + (count == 1 ? singular : plural);
     }
 
-    /// Renders an approximate "X-Y of Z" range string for a list-shaped
-    /// screen that paints into a bounded viewport. Mirrors how Data
-    /// preview shows "rows N-M of total" so other list screens can do
-    /// the same. The visible window is bottom-pinned to the cursor:
-    /// `end = max(viewport, selection + 1)`; `start = end - viewport + 1`.
-    /// This matches what tamboui's TableState does on first
-    /// scroll-past-viewport (selection ends up at the bottom row), so
-    /// for the common downward-navigation case the displayed range
-    /// matches what's actually visible.
-    public static String rangeOf(int selection, int total, int viewport) {
+    /// "12-31 of 4,096" for the rows a window actually shows, or "0" when
+    /// there are none. `window` is the same slice the body renders, so the
+    /// title cannot report a range the reader is not looking at.
+    public static String rangeOf(RowWindow window, int total) {
         if (total <= 0) {
             return "0";
         }
-        int v = Math.max(1, viewport);
-        if (total <= v) {
-            return total == 1 ? "1 of 1"
-                    : "1-" + Fmt.fmt("%,d", total) + " of " + Fmt.fmt("%,d", total);
+        int start = window.start() + 1;
+        int end = Math.min(total, window.end());
+        if (start == end) {
+            return Fmt.fmt("%,d of %,d", start, total);
         }
-        int sel = Math.max(0, Math.min(selection, total - 1));
-        int end = Math.min(total, Math.max(v, sel + 1));
-        int start = Math.max(1, end - v + 1);
         return Fmt.fmt("%,d-%,d of %,d", start, end, total);
     }
 }

--- a/cli/src/main/java/dev/hardwood/cli/dive/internal/RowGroupDetailScreen.java
+++ b/cli/src/main/java/dev/hardwood/cli/dive/internal/RowGroupDetailScreen.java
@@ -63,11 +63,12 @@ public final class RowGroupDetailScreen {
                     ? ScreenState.RowGroupDetail.Pane.MENU
                     : ScreenState.RowGroupDetail.Pane.FACTS;
             stack.replaceTop(new ScreenState.RowGroupDetail(
-                    state.rowGroupIndex(), next, state.menuSelection()));
+                    state.rowGroupIndex(), next, state.menuSelection(), state.scrollTop(),
+                    state.factsTop()));
             return true;
         }
         if (state.focus() != ScreenState.RowGroupDetail.Pane.MENU) {
-            return false;
+            return scrollFacts(event, model, stack, state);
         }
         MenuItem[] items = MenuItem.values();
         if (event.isUp()) {
@@ -97,23 +98,67 @@ public final class RowGroupDetailScreen {
         renderMenuPane(buffer, cols.get(1), model, state);
     }
 
-    public static String keybarKeys(ScreenState.RowGroupDetail state) {
+    public static String keybarKeys(ScreenState.RowGroupDetail state, ParquetModel model) {
         boolean onMenu = state.focus() == ScreenState.RowGroupDetail.Pane.MENU;
         return new Keys.Hints()
                 .add(true, "[Tab] pane")
                 .add(onMenu && MenuItem.values().length > 1, "[↑↓] move")
+                .add(!onMenu, factsLines(model, state).hints(Keys.viewportStride()))
                 .add(onMenu, "[Enter] open")
                 .add(true, "[Esc] back")
                 .build();
     }
 
+    /// Moves the facts cursor, which is what the navigation keys mean while
+    /// the pane has focus. Nothing here is actionable, so the cursor carries
+    /// no marker; it is the reader's place in the pane.
+    private static boolean scrollFacts(KeyEvent event, ParquetModel model, NavigationStack stack,
+                                       ScreenState.RowGroupDetail state) {
+        int next = factsLines(model, state).select(event, state.scrollTop(), Keys.viewportStride());
+        if (next == CursorPane.UNHANDLED) {
+            return false;
+        }
+        if (next != state.scrollTop()) {
+            stack.replaceTop(new ScreenState.RowGroupDetail(
+                    state.rowGroupIndex(), state.focus(), state.menuSelection(), next,
+                    factsLines(model, state).windowTopAfterMove(state.factsTop(),
+                            state.scrollTop(), next, Keys.viewportStride())));
+        }
+        return true;
+    }
+
     private static ScreenState.RowGroupDetail state(ScreenState.RowGroupDetail s, int selection) {
-        return new ScreenState.RowGroupDetail(s.rowGroupIndex(), s.focus(), selection);
+        return new ScreenState.RowGroupDetail(s.rowGroupIndex(), s.focus(), selection, s.scrollTop(),
+                s.factsTop());
     }
 
     private static void renderFactsPane(Buffer buffer, Rect area, ParquetModel model,
                                         ScreenState.RowGroupDetail state) {
         boolean focused = state.focus() == ScreenState.RowGroupDetail.Pane.FACTS;
+        Document facts = factsLines(model, state);
+        // The facts pane is the only thing the arrows move on this screen, so
+        // its height is the stride the key handler should use.
+        int viewport = factsViewport(area);
+        Keys.observeViewport(viewport);
+        int cursorLine = Math.max(0, facts.lineOfRow(state.scrollTop()));
+        RowWindow window = RowWindow.from(
+                facts.windowTop(state.factsTop(), state.scrollTop(), viewport),
+                cursorLine, facts.lineCount(), viewport);
+        Block block = paneBlock(" RG #" + state.rowGroupIndex() + " ", focused);
+        Paragraph.builder()
+                .block(block)
+                .text(Text.from(withCursor(
+                        facts.lines().subList(window.start(), window.end()),
+                        cursorLine - window.start(), focused)))
+                .left()
+                .build()
+                .render(area, buffer);
+    }
+
+    /// The facts pane's full content, independent of how much of it fits.
+    /// Shared with the keybar, which needs the line count to decide whether
+    /// the pane scrolls.
+    private static Document factsLines(ParquetModel model, ScreenState.RowGroupDetail state) {
         RowGroup rg = model.rowGroup(state.rowGroupIndex());
         long compressed = 0;
         long uncompressed = 0;
@@ -141,32 +186,53 @@ public final class RowGroupDetailScreen {
                 oiCount++;
             }
         }
-        List<Line> lines = new ArrayList<>();
-        lines.add(fact("Row group index", String.valueOf(state.rowGroupIndex())));
-        lines.add(fact("Rows", Fmt.fmt("%,d", rg.numRows())));
-        lines.add(fact("Column chunks", String.valueOf(chunkCount)));
-        lines.add(fact("Total byte size", Sizes.dualFormat(rg.totalByteSize())));
-        lines.add(Line.empty());
+        Document.Builder lines = Document.builder();
+        lines.row(fact("Row group index", String.valueOf(state.rowGroupIndex())));
+        lines.row(fact("Rows", Fmt.fmt("%,d", rg.numRows())));
+        lines.row(fact("Column chunks", String.valueOf(chunkCount)));
+        lines.row(fact("Total byte size", Sizes.dualFormat(rg.totalByteSize())));
+        lines.blank();
         // "Storage" rather than "Compression": the group holds a `Compression`
         // row of its own now, and it is the same vocabulary the column chunk
         // detail screen groups the same three figures under.
-        lines.add(Line.from(new Span(" Storage ", Theme.accent().bold())));
-        lines.add(fact("  Compressed", Sizes.dualFormat(compressed)));
-        lines.add(fact("  Uncompressed", Sizes.dualFormat(uncompressed)));
-        lines.add(fact("  Compression", Sizes.compression(compressed, uncompressed, "—")));
-        lines.add(Line.empty());
-        lines.add(Line.from(new Span(" Encoding mix ", Theme.accent().bold())));
-        lines.add(fact("  Encodings", mix(encodingCounts)));
-        lines.add(fact("  Codecs", mix(codecCounts)));
-        lines.add(Line.empty());
-        lines.add(Line.from(new Span(" Page indexes ", Theme.accent().bold())));
-        lines.add(fact("  Column indexes", Sizes.dualFormat(ciBytes)
+        lines.decoration(Line.from(new Span(" Storage ", Theme.accent().bold())));
+        lines.row(fact("  Compressed", Sizes.dualFormat(compressed)));
+        lines.row(fact("  Uncompressed", Sizes.dualFormat(uncompressed)));
+        lines.row(fact("  Compression", Sizes.compression(compressed, uncompressed, "—")));
+        lines.blank();
+        lines.decoration(Line.from(new Span(" Encoding mix ", Theme.accent().bold())));
+        lines.row(fact("  Encodings", mix(encodingCounts)));
+        lines.row(fact("  Codecs", mix(codecCounts)));
+        lines.blank();
+        lines.decoration(Line.from(new Span(" Page indexes ", Theme.accent().bold())));
+        lines.row(fact("  Column indexes", Sizes.dualFormat(ciBytes)
                 + "  (" + ciCount + "/" + chunkCount + " chunks)"));
-        lines.add(fact("  Offset indexes", Sizes.dualFormat(oiBytes)
+        lines.row(fact("  Offset indexes", Sizes.dualFormat(oiBytes)
                 + "  (" + oiCount + "/" + chunkCount + " chunks)"));
 
-        Block block = paneBlock(" RG #" + state.rowGroupIndex() + " ", focused);
-        Paragraph.builder().block(block).text(Text.from(lines)).left().build().render(area, buffer);
+        return lines.build();
+    }
+
+
+    /// Repaints the cursor line in the selection colour. Nothing in a facts
+    /// pane is actionable, so the cursor carries no marker — the colour alone
+    /// is the reader's place in the pane.
+    private static List<Line> withCursor(List<Line> window, int offset, boolean focused) {
+        if (!focused || offset < 0 || offset >= window.size()) {
+            return window;
+        }
+        List<Line> painted = new ArrayList<>(window);
+        StringBuilder text = new StringBuilder();
+        for (Span span : window.get(offset).spans()) {
+            text.append(span.content());
+        }
+        painted.set(offset, Line.from(new Span(text.toString(), Theme.selection())));
+        return painted;
+    }
+
+    /// Block borders take a row at the top and bottom of the pane.
+    private static int factsViewport(Rect area) {
+        return Math.max(1, area.height() - 2);
     }
 
     private static void renderMenuPane(Buffer buffer, Rect area, ParquetModel model,
@@ -178,7 +244,7 @@ public final class RowGroupDetailScreen {
         for (int i = 0; i < items.length; i++) {
             MenuItem item = items[i];
             boolean selected = focused && i == state.menuSelection();
-            String cursor = selected ? "▶ " : "  ";
+            String cursor = CursorPane.marker(true, selected, false);
             Style labelStyle = selected
                     ? Theme.selection()
                     : Theme.primary();

--- a/cli/src/main/java/dev/hardwood/cli/dive/internal/RowGroupIndexesScreen.java
+++ b/cli/src/main/java/dev/hardwood/cli/dive/internal/RowGroupIndexesScreen.java
@@ -68,28 +68,9 @@ public final class RowGroupIndexesScreen {
         ScreenState.RowGroupIndexes state = (ScreenState.RowGroupIndexes) stack.top();
         List<Entry> entries = entries(model.rowGroup(state.rowGroupIndex()));
         int count = entries.size();
-        if (Keys.isStepUp(event)) {
-            stack.replaceTop(moved(state, Math.max(0, state.selection() - 1)));
-            return true;
-        }
-        if (Keys.isStepDown(event)) {
-            stack.replaceTop(moved(state, Math.min(count - 1, state.selection() + 1)));
-            return true;
-        }
-        if (Keys.isPageDown(event) && count > 0) {
-            stack.replaceTop(moved(state, Math.min(count - 1, state.selection() + Keys.viewportStride())));
-            return true;
-        }
-        if (Keys.isPageUp(event) && count > 0) {
-            stack.replaceTop(moved(state, Math.max(0, state.selection() - Keys.viewportStride())));
-            return true;
-        }
-        if (Keys.isJumpTop(event) && count > 0) {
-            stack.replaceTop(moved(state, 0));
-            return true;
-        }
-        if (Keys.isJumpBottom(event) && count > 0) {
-            stack.replaceTop(moved(state, count - 1));
+        int next = CursorPane.select(event, state.selection(), count);
+        if (next != CursorPane.UNHANDLED) {
+            stack.replaceTop(moved(state, next));
             return true;
         }
         if (event.isConfirm() && count > 0) {
@@ -141,8 +122,7 @@ public final class RowGroupIndexesScreen {
                 .style(Theme.accent().bold());
         Block block = Block.builder()
                 .title(" RG #" + state.rowGroupIndex() + " index regions "
-                        + Plurals.rangeOf(state.selection(), entries.size(),
-                                Keys.viewportStride()) + " ")
+                        + Plurals.rangeOf(window, entries.size()) + " ")
                 .borders(Borders.ALL)
                 .borderType(BorderType.ROUNDED)
                 .build();
@@ -168,9 +148,7 @@ public final class RowGroupIndexesScreen {
     public static String keybarKeys(ScreenState.RowGroupIndexes state, ParquetModel model) {
         int count = entries(model.rowGroup(state.rowGroupIndex())).size();
         return new Keys.Hints()
-                .add(count > 1, "[↑↓] move")
-                .add(count > Keys.viewportStride(), "[PgDn/PgUp or Shift+↓↑] page")
-                .add(count > 1, "[g/G] first/last")
+                .add(true, CursorPane.hints(count))
                 .add(count > 0, "[Enter] open")
                 .add(true, "[Esc] back")
                 .build();

--- a/cli/src/main/java/dev/hardwood/cli/dive/internal/RowGroupsScreen.java
+++ b/cli/src/main/java/dev/hardwood/cli/dive/internal/RowGroupsScreen.java
@@ -39,28 +39,9 @@ public final class RowGroupsScreen {
     public static boolean handle(KeyEvent event, ParquetModel model, NavigationStack stack) {
         ScreenState.RowGroups state = (ScreenState.RowGroups) stack.top();
         int count = model.rowGroupCount();
-        if (Keys.isStepUp(event)) {
-            stack.replaceTop(moved(state, Math.max(0, state.selection() - 1)));
-            return true;
-        }
-        if (Keys.isStepDown(event)) {
-            stack.replaceTop(moved(state, Math.min(count - 1, state.selection() + 1)));
-            return true;
-        }
-        if (Keys.isPageDown(event) && count > 0) {
-            stack.replaceTop(moved(state, Math.min(count - 1, state.selection() + Keys.viewportStride())));
-            return true;
-        }
-        if (Keys.isPageUp(event) && count > 0) {
-            stack.replaceTop(moved(state, Math.max(0, state.selection() - Keys.viewportStride())));
-            return true;
-        }
-        if (Keys.isJumpTop(event) && count > 0) {
-            stack.replaceTop(moved(state, 0));
-            return true;
-        }
-        if (Keys.isJumpBottom(event) && count > 0) {
-            stack.replaceTop(moved(state, count - 1));
+        int next = CursorPane.select(event, state.selection(), count);
+        if (next != CursorPane.UNHANDLED) {
+            stack.replaceTop(moved(state, next));
             return true;
         }
         if (event.isConfirm() && count > 0) {
@@ -112,8 +93,7 @@ public final class RowGroupsScreen {
         Row header = Row.from("#", "Rows", "Uncompressed", "Compressed", "Compression", "CI", "OI")
                 .style(Theme.accent().bold());
         Block block = Block.builder()
-                .title(" Row groups " + Plurals.rangeOf(state.selection(),
-                        model.rowGroupCount(), Keys.viewportStride()) + " ")
+                .title(" Row groups " + Plurals.rangeOf(window, model.rowGroupCount()) + " ")
                 .borders(Borders.ALL)
                 .borderType(BorderType.ROUNDED)
                 .build();
@@ -140,9 +120,7 @@ public final class RowGroupsScreen {
     public static String keybarKeys(ScreenState.RowGroups state, ParquetModel model) {
         int count = model.rowGroupCount();
         return new Keys.Hints()
-                .add(count > 1, "[↑↓] move")
-                .add(count > Keys.viewportStride(), "[PgDn/PgUp or Shift+↓↑] page")
-                .add(count > 1, "[g/G] first/last")
+                .add(true, CursorPane.hints(count))
                 .add(count > 0, "[Enter] open")
                 .add(true, "[Esc] back")
                 .build();

--- a/cli/src/main/java/dev/hardwood/cli/dive/internal/SchemaScreen.java
+++ b/cli/src/main/java/dev/hardwood/cli/dive/internal/SchemaScreen.java
@@ -71,34 +71,9 @@ public final class SchemaScreen {
         if (rows.isEmpty()) {
             return false;
         }
-        if (Keys.isStepUp(event)) {
-            stack.replaceTop(with(state,
-                    Math.max(0, state.selection() - 1), state.expanded(), state.filter(), false));
-            return true;
-        }
-        if (Keys.isStepDown(event)) {
-            stack.replaceTop(with(state,
-                    Math.min(rows.size() - 1, state.selection() + 1), state.expanded(), state.filter(), false));
-            return true;
-        }
-        if (Keys.isPageDown(event)) {
-            stack.replaceTop(with(state,
-                    Math.min(rows.size() - 1, state.selection() + Keys.viewportStride()),
-                    state.expanded(), state.filter(), false));
-            return true;
-        }
-        if (Keys.isPageUp(event)) {
-            stack.replaceTop(with(state,
-                    Math.max(0, state.selection() - Keys.viewportStride()),
-                    state.expanded(), state.filter(), false));
-            return true;
-        }
-        if (Keys.isJumpTop(event)) {
-            stack.replaceTop(with(state, 0, state.expanded(), state.filter(), false));
-            return true;
-        }
-        if (Keys.isJumpBottom(event)) {
-            stack.replaceTop(with(state, rows.size() - 1, state.expanded(), state.filter(), false));
+        int selected = CursorPane.select(event, state.selection(), rows.size());
+        if (selected != CursorPane.UNHANDLED) {
+            stack.replaceTop(with(state, selected, state.expanded(), state.filter(), false));
             return true;
         }
         // Expand / collapse all — modifier-free e / c. Filter mode (handled
@@ -206,6 +181,11 @@ public final class SchemaScreen {
             maxLogical = Math.max(maxLogical, parts[i].logical().length());
             maxRepetition = Math.max(maxRepetition, parts[i].repetition().length());
         }
+        // Column widths are measured over every row so they do not shift as
+        // the tree scrolls; only the rows on screen become Lines. See
+        // DIVE_LIST_VIEWPORT_VIRTUALIZATION.md.
+        RowWindow window = RowWindow.from(state.scrollTop(), state.selection(),
+                rows.size(), Math.max(1, split.get(1).height() - 3));
         Style headerStyle = Theme.accent().bold();
         lines.add(Line.from(
                 Span.raw("  "),
@@ -213,23 +193,26 @@ public final class SchemaScreen {
                 new Span("  " + padRight("Type", maxType), headerStyle),
                 new Span("  " + padRight("Logical", maxLogical), headerStyle),
                 new Span("  " + padRight("Repetition", maxRepetition), headerStyle)));
-        for (int i = 0; i < rows.size(); i++) {
+        for (int i = window.start(); i < window.end(); i++) {
             Row row = rows.get(i);
             boolean selected = i == state.selection();
-            String cursor = selected ? "▸ " : "  ";
-            Style nameStyle = selected ? Theme.selection() : Style.EMPTY;
+            // Every schema row is actionable — a group expands, a leaf drills
+            // — so the marker rides the cursor. The tree's own ▶/▼ keeps its
+            // own column and its own meaning.
+            String cursor = CursorPane.marker(true, selected, false);
+            Style rowStyle = selected ? Theme.selection() : Style.EMPTY;
             TypeParts p = parts[i];
             String colSuffix = !row.isGroup() ? "[col " + row.columnIndex() + "]" : "";
             if (filtering) {
                 String pad = " ".repeat(maxName - row.path().length());
                 lines.add(Line.from(
-                        Span.raw(cursor),
-                        new Span(row.path(), nameStyle),
+                        new Span(cursor, rowStyle),
+                        new Span(row.path(), rowStyle),
                         Span.raw(pad),
-                        new Span("  " + padRight(p.type(), maxType), Style.EMPTY),
-                        new Span("  " + padRight(p.logical(), maxLogical), Style.EMPTY),
-                        new Span("  " + padRight(p.repetition(), maxRepetition), Style.EMPTY),
-                        new Span("  " + colSuffix, Style.EMPTY)));
+                        new Span("  " + padRight(p.type(), maxType), rowStyle),
+                        new Span("  " + padRight(p.logical(), maxLogical), rowStyle),
+                        new Span("  " + padRight(p.repetition(), maxRepetition), rowStyle),
+                        new Span("  " + colSuffix, rowStyle)));
                 continue;
             }
             String indent = "  ".repeat(row.depth());
@@ -243,19 +226,19 @@ public final class SchemaScreen {
             int rowName = row.depth() * 2 + 2 + row.node().name().length();
             String pad = " ".repeat(maxName - rowName);
             lines.add(Line.from(
-                    Span.raw(cursor),
+                    new Span(cursor, rowStyle),
                     Span.raw(indent),
-                    new Span(marker, Theme.accent()),
-                    new Span(row.node().name(), nameStyle),
+                    new Span(marker, selected ? rowStyle : Theme.accent()),
+                    new Span(row.node().name(), rowStyle),
                     Span.raw(pad),
-                    new Span("  " + padRight(p.type(), maxType), Style.EMPTY),
-                    new Span("  " + padRight(p.logical(), maxLogical), Style.EMPTY),
-                    new Span("  " + padRight(p.repetition(), maxRepetition), Style.EMPTY),
-                    new Span("  " + colSuffix, Style.EMPTY)));
+                    new Span("  " + padRight(p.type(), maxType), rowStyle),
+                    new Span("  " + padRight(p.logical(), maxLogical), rowStyle),
+                    new Span("  " + padRight(p.repetition(), maxRepetition), rowStyle),
+                    new Span("  " + colSuffix, rowStyle)));
         }
         Block block = Block.builder()
                 .title(" Schema "
-                        + Plurals.rangeOf(state.selection(), rows.size(), Keys.viewportStride())
+                        + Plurals.rangeOf(window, rows.size())
                         + (filtering
                                 ? " · "
                                         + Plurals.format(model.columnCount(), "leaf column", "leaf columns")
@@ -276,9 +259,7 @@ public final class SchemaScreen {
         boolean expanded = isGroup && state.expanded().contains(current.path());
         boolean hasGroups = !model.allGroupPaths().isEmpty();
         return new Keys.Hints()
-                .add(count > 1, "[↑↓] move")
-                .add(count > Keys.viewportStride(), "[PgDn/PgUp or Shift+↓↑] page")
-                .add(count > 1, "[g/G] first/last")
+                .add(true, CursorPane.hints(count))
                 .add(current != null, isGroup ? "[→/Enter] expand" : "[Enter] open")
                 .add(expanded, "[←] collapse")
                 .add(hasGroups, "[e/c] all")
@@ -365,10 +346,15 @@ public final class SchemaScreen {
         }
     }
 
+    /// Rebuilds the state, sliding the visible window the least it can to
+    /// keep `selection` on screen. Expanding or filtering changes which rows
+    /// exist, so the offset is recomputed on every transition rather than
+    /// only on cursor movement.
     private static ScreenState.Schema with(ScreenState.Schema state,
                                             int selection, Set<String> expanded,
                                             String filter, boolean searching) {
-        return new ScreenState.Schema(selection, expanded, filter, searching);
+        return new ScreenState.Schema(selection, expanded, filter, searching,
+                RowWindow.adjustTop(state.scrollTop(), selection, Keys.viewportStride()));
     }
 
     /// Decomposed type-info columns (physical type or group tag, optional

--- a/cli/src/main/java/dev/hardwood/cli/dive/internal/ScrollPane.java
+++ b/cli/src/main/java/dev/hardwood/cli/dive/internal/ScrollPane.java
@@ -1,0 +1,168 @@
+/*
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Copyright The original authors
+ *
+ *  Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package dev.hardwood.cli.dive.internal;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import dev.tamboui.buffer.Buffer;
+import dev.tamboui.layout.Rect;
+import dev.tamboui.text.Line;
+import dev.tamboui.text.Span;
+import dev.tamboui.text.Text;
+import dev.tamboui.tui.event.KeyEvent;
+import dev.tamboui.widgets.Clear;
+import dev.tamboui.widgets.block.Block;
+import dev.tamboui.widgets.block.BorderType;
+import dev.tamboui.widgets.block.Borders;
+import dev.tamboui.widgets.paragraph.Paragraph;
+
+/// Navigation for a pane whose content is a document rather than a list of
+/// rows: the facts panes and every modal. There is no cursor, so the three
+/// strides all move the viewport itself — `↑`/`↓` by a line, `PgUp`/`PgDn`
+/// by a viewport, `g`/`G` to the ends.
+///
+/// Screens hold the scroll offset in their [ScreenState] and pass it back
+/// here on every keypress; nothing is retained between calls. The offset is
+/// clamped against the *current* content before it is adjusted, so content
+/// that shrinks underneath a scrolled pane — collapsing a section, say —
+/// cannot leave a stale offset that swallows the next few keypresses.
+public final class ScrollPane {
+
+    /// Returned by [#scroll(KeyEvent,int,int,int)] when the event is not one
+    /// of the navigation keys, so the caller can let it fall through to the
+    /// rest of its handler.
+    public static final int UNHANDLED = -1;
+
+    private ScrollPane() {
+    }
+
+    /// The new scroll offset after `event`, clamped to the content, or
+    /// [#UNHANDLED] if `event` does not scroll. A navigation key that is
+    /// already against its end returns the unchanged offset rather than
+    /// [#UNHANDLED]: it is handled, it simply has nowhere to go.
+    public static int scroll(KeyEvent event, int scroll, int totalLines, int viewport) {
+        int max = maxScroll(totalLines, viewport);
+        int current = Math.max(0, Math.min(scroll, max));
+        if (Keys.isStepUp(event)) {
+            return Math.max(0, current - 1);
+        }
+        if (Keys.isStepDown(event)) {
+            return Math.min(max, current + 1);
+        }
+        if (Keys.isPageUp(event)) {
+            return Math.max(0, current - viewport);
+        }
+        if (Keys.isPageDown(event)) {
+            return Math.min(max, current + viewport);
+        }
+        if (Keys.isJumpTop(event)) {
+            return 0;
+        }
+        if (Keys.isJumpBottom(event)) {
+            return max;
+        }
+        return UNHANDLED;
+    }
+
+    /// The largest offset that still fills the viewport, or zero when the
+    /// content fits.
+    public static int maxScroll(int totalLines, int viewport) {
+        return Math.max(0, totalLines - Math.max(1, viewport));
+    }
+
+    /// True when the content is taller than the viewport, and therefore when
+    /// the navigation keys do anything at all. Keybars gate their scroll
+    /// hints on this.
+    public static boolean overflows(int totalLines, int viewport) {
+        return totalLines > Math.max(1, viewport);
+    }
+
+    /// The slice of `lines` visible at `scroll`, with the offset clamped the
+    /// same way [#scroll(KeyEvent,int,int,int)] clamps it so a stale offset
+    /// renders the last full page instead of an empty pane.
+    public static List<Line> window(List<Line> lines, int scroll, int viewport) {
+        int max = maxScroll(lines.size(), viewport);
+        int start = Math.max(0, Math.min(scroll, max));
+        int end = Math.min(lines.size(), start + Math.max(1, viewport));
+        return lines.subList(start, end);
+    }
+
+    /// A centred modal rect, capped at `maxWidth` by `maxHeight` and inset
+    /// from the screen so the pane behind it stays visible at the edges.
+    public static Rect modalArea(Rect screenArea, int maxWidth, int maxHeight) {
+        int width = Math.min(maxWidth, Math.max(1, screenArea.width() - 4));
+        int height = Math.min(maxHeight, Math.max(1, screenArea.height() - 2));
+        return new Rect(screenArea.left() + (screenArea.width() - width) / 2,
+                screenArea.top() + (screenArea.height() - height) / 2,
+                width, height);
+    }
+
+    /// Content lines a modal of this size can show: its height less the two
+    /// borders, the blank separator and the hint row.
+    public static int modalViewport(Rect area) {
+        return Math.max(1, area.height() - 4);
+    }
+
+    /// Columns a modal of this size can show, less its two borders and the
+    /// one-cell inset every row is rendered with. Callers wrap their content
+    /// to this before handing it over.
+    public static int modalWidth(Rect area) {
+        return Math.max(1, area.width() - 3);
+    }
+
+    /// Renders a scrollable modal: the visible slice of `content`, then a
+    /// hint row stating how much is out of view and which keys move it.
+    ///
+    /// The modal is the only thing the navigation keys can address while it
+    /// is open, so this also records its viewport as the key stride.
+    public static void renderModal(Buffer buffer, Rect area, String title,
+                                   List<Line> content, int scroll, String closeHint) {
+        Clear.INSTANCE.render(area, buffer);
+        int viewport = modalViewport(area);
+        Keys.observeViewport(viewport);
+        Keys.observeModalWidth(modalWidth(area));
+        int max = maxScroll(content.size(), viewport);
+        int start = Math.max(0, Math.min(scroll, max));
+        List<Line> lines = new ArrayList<>(window(content, start, viewport));
+        lines.add(Line.empty());
+        lines.add(Line.from(new Span(hintRow(content.size(), viewport, start, closeHint), Theme.dim())));
+        Paragraph.builder()
+                .block(Block.builder()
+                        .title(" " + title + " ")
+                        .borders(Borders.ALL)
+                        .borderType(BorderType.ROUNDED)
+                        .build())
+                .text(Text.from(lines))
+                .left()
+                .build()
+                .render(area, buffer);
+    }
+
+    private static String hintRow(int totalLines, int viewport, int scroll, String closeHint) {
+        if (!overflows(totalLines, viewport)) {
+            return " " + closeHint;
+        }
+        int below = totalLines - Math.min(totalLines, scroll + viewport);
+        String position = below > 0
+                ? " ↓ " + below + " more lines"
+                : " ↑ " + scroll + " lines above";
+        return position + " · " + closeHint + " · " + hints(totalLines, viewport);
+    }
+
+    /// The keybar fragment for a scrollable pane, empty when the content
+    /// fits. Screens append it to their own hints so the wording of the
+    /// scroll keys is stated in one place.
+    public static String hints(int totalLines, int viewport) {
+        return new Keys.Hints()
+                .add(overflows(totalLines, viewport), "[↑↓] scroll")
+                .add(overflows(totalLines, viewport), "[PgDn/PgUp or Shift+↓↑] page")
+                .add(overflows(totalLines, viewport), "[g/G] top/bottom")
+                .build();
+    }
+}

--- a/cli/src/test/java/dev/hardwood/cli/dive/DiveRenderTest.java
+++ b/cli/src/test/java/dev/hardwood/cli/dive/DiveRenderTest.java
@@ -10,6 +10,7 @@ package dev.hardwood.cli.dive;
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 import java.util.function.Function;
 import java.util.regex.Pattern;
@@ -25,8 +26,13 @@ import org.junit.jupiter.params.provider.MethodSource;
 import dev.hardwood.InputFile;
 import dev.hardwood.cli.dive.internal.ColumnChunkDetailScreen;
 import dev.hardwood.cli.dive.internal.DataPreviewScreen;
+import dev.hardwood.cli.dive.internal.FooterScreen;
 import dev.hardwood.cli.dive.internal.HelpOverlay;
 import dev.hardwood.cli.dive.internal.Keys;
+import dev.hardwood.cli.dive.internal.OverviewScreen;
+import dev.hardwood.cli.dive.internal.PagesScreen;
+import dev.hardwood.cli.dive.internal.RowGroupDetailScreen;
+import dev.hardwood.cli.dive.internal.SchemaScreen;
 import dev.hardwood.cli.internal.Version;
 import dev.hardwood.schema.ColumnSchema;
 import dev.tamboui.buffer.Buffer;
@@ -268,7 +274,7 @@ class DiveRenderTest {
     }
 
     @Test
-    void dataPreviewScalarOnlyRecordIsCursorlessAndScrollsWithPageKeys() {
+    void dataPreviewScalarOnlyRecordStillWalksAndPages() {
         List<String> names = numberedValues("f", 30);
         List<String> values = numberedValues("v", 30);
         ScreenState.DataPreview state = openModal(names, values, values);
@@ -276,37 +282,35 @@ class DiveRenderTest {
         Rect area = new Rect(0, 0, 100, 24);
 
         RenderHarness.RenderedFrame first = RenderHarness.render(area, state, model);
-        assertThat(first.contains("▶f"))
-                .as("nothing in the record can be expanded, so no cursor is drawn")
+        assertThat(first.contains("▶ f"))
+                .as("nothing in the record can be expanded, so no row is marked")
                 .isFalse();
         assertThat(first.contains("Enter expand"))
                 .as("the hint does not offer an expansion that cannot happen")
                 .isFalse();
         assertThat(first.contains("e/c all")).isFalse();
-        assertThat(first.contains("↑↓ field"))
-                .as("there is no expandable field to step to")
-                .isFalse();
-        assertThat(first.contains("PgDn/PgUp scroll"))
-                .as("the body overflows, so paging is what reaches the rest")
+        assertThat(first.contains("↑↓ move"))
+                .as("the cursor walks the body whether or not Enter does anything")
                 .isTrue();
+        assertThat(first.contains("PgDn/PgUp page")).isTrue();
 
-        assertThat(DataPreviewScreen.handle(key(KeyCode.UP), model, stack)).isFalse();
-        assertThat(DataPreviewScreen.handle(key(KeyCode.DOWN), model, stack)).isFalse();
-
-        assertThat(DataPreviewScreen.handle(key(KeyCode.PAGE_DOWN), model, stack)).isTrue();
-        ScreenState.DataPreview scrolled = (ScreenState.DataPreview) stack.top();
-        assertThat(RenderHarness.render(area, scrolled, model).contains("f29"))
-                .as("PgDn reaches the tail of a record no cursor can walk")
+        assertThat(DataPreviewScreen.handle(key(KeyCode.UP), model, stack))
+                .as("already at the top, but the key is still the cursor's")
                 .isTrue();
-        assertThat(DataPreviewScreen.handle(key(KeyCode.PAGE_DOWN), model, stack))
-                .as("already against the bottom")
-                .isFalse();
-        assertThat(DataPreviewScreen.handle(key(KeyCode.PAGE_UP), model, stack)).isTrue();
-        assertThat(((ScreenState.DataPreview) stack.top()).modalScroll()).isZero();
+        assertThat(DataPreviewScreen.handle(key(KeyCode.DOWN), model, stack)).isTrue();
+        assertThat(((ScreenState.DataPreview) stack.top()).modalCursorLine()).isEqualTo(1);
+
+        assertThat(DataPreviewScreen.handle(
+                new KeyEvent(KeyCode.CHAR, KeyModifiers.NONE, 'G'), model, stack)).isTrue();
+        ScreenState.DataPreview bottom = (ScreenState.DataPreview) stack.top();
+        assertThat(bottom.modalCursorLine()).isEqualTo(names.size() - 1);
+        assertThat(RenderHarness.render(area, bottom, model).contains("f29"))
+                .as("the body follows the cursor to the tail")
+                .isTrue();
     }
 
     @Test
-    void dataPreviewOverflowStillStepsBetweenExpandableFieldsOnly() {
+    void dataPreviewCursorStopsOnEveryLineNotOnlyActionableOnes() {
         List<String> names = new ArrayList<>(numberedValues("f", 30));
         List<String> values = new ArrayList<>(numberedValues("v", 30));
         List<String> expanded = new ArrayList<>(values);
@@ -320,24 +324,21 @@ class DiveRenderTest {
         NavigationStack stack = rooted(state);
         Rect area = new Rect(0, 0, 100, 24);
         RenderHarness.RenderedFrame first = RenderHarness.render(area, state, model);
-        assertThat(first.contains("▶items")).isTrue();
 
-        assertThat(DataPreviewScreen.handle(key(KeyCode.DOWN), model, stack)).isTrue();
-        ScreenState.DataPreview atMore = (ScreenState.DataPreview) stack.top();
-        assertThat(atMore.modalCursorLine())
-                .as("↓ skips the 19 scalars between the two expandable fields "
-                        + "even though the body overflows")
-                .isEqualTo(20);
-        RenderHarness.RenderedFrame second = RenderHarness.render(area, atMore, model);
-        assertThat(second.contains("▶more"))
-                .as("the body scrolled far enough to show the newly selected field")
-                .isTrue();
-
-        assertThat(DataPreviewScreen.handle(key(KeyCode.DOWN), model, stack))
-                .as("no expandable field after the last one")
+        // Both expandable fields are marked, so a reader can see where Enter
+        // goes without arrowing onto each row.
+        assertThat(first.contains("▶ items")).isTrue();
+        assertThat(first.contains("▶ f1"))
+                .as("a scalar the row shows in full is not marked")
                 .isFalse();
-        assertThat(DataPreviewScreen.handle(key(KeyCode.UP), model, stack)).isTrue();
-        assertThat(((ScreenState.DataPreview) stack.top()).modalCursorLine()).isZero();
+
+        // ↓ steps one line, onto the scalar immediately below, rather than
+        // skipping the nineteen rows between the two expandable fields.
+        assertThat(DataPreviewScreen.handle(key(KeyCode.DOWN), model, stack)).isTrue();
+        assertThat(((ScreenState.DataPreview) stack.top()).modalCursorLine()).isEqualTo(1);
+        assertThat(DataPreviewScreen.handle(key(KeyCode.ENTER), model, stack))
+                .as("Enter does nothing on a row that is not actionable")
+                .isFalse();
     }
 
     @Test
@@ -348,19 +349,18 @@ class DiveRenderTest {
         names.set(20, "items");
         values.set(20, "[alpha, beta, gamma]");
         expanded.set(20, "[\n  alpha,\n  beta,\n  gamma\n]");
-        ScreenState.DataPreview state = openModal(names, values, expanded);
+        ScreenState.DataPreview state = openModal(names, values, expanded, 20);
         NavigationStack stack = rooted(state);
         Rect area = new Rect(0, 0, 100, 24);
         RenderHarness.render(area, state, model);
 
-        // ↓ lands on `items`, leaving it on the last visible line.
-        assertThat(DataPreviewScreen.handle(key(KeyCode.DOWN), model, stack)).isTrue();
+        // The cursor sits on `items`, the only field Enter can act on.
         assertThat(DataPreviewScreen.handle(key(KeyCode.ENTER), model, stack)).isTrue();
 
         ScreenState.DataPreview opened = (ScreenState.DataPreview) stack.top();
         assertThat(opened.expandedColumns()).containsExactly(20);
         RenderHarness.RenderedFrame rendered = RenderHarness.render(area, opened, model);
-        assertThat(rendered.contains("▶items")).isTrue();
+        assertThat(rendered.contains("▶ items")).isTrue();
         assertThat(rendered.contains("gamma"))
                 .as("expanding scrolls so the revealed lines are on screen, "
                         + "not just the field's key line")
@@ -368,7 +368,7 @@ class DiveRenderTest {
     }
 
     @Test
-    void dataPreviewPageKeysScrollTheBodyWithoutMovingTheCursor() {
+    void dataPreviewPageKeysMoveTheCursorLikeEveryOtherPane() {
         List<String> names = new ArrayList<>(numberedValues("f", 30));
         List<String> values = new ArrayList<>(numberedValues("v", 30));
         List<String> expanded = new ArrayList<>(values);
@@ -381,12 +381,18 @@ class DiveRenderTest {
         RenderHarness.render(area, state, model);
 
         assertThat(DataPreviewScreen.handle(key(KeyCode.PAGE_DOWN), model, stack)).isTrue();
-        ScreenState.DataPreview scrolled = (ScreenState.DataPreview) stack.top();
-        assertThat(scrolled.modalCursorLine())
-                .as("paging reads ahead; it does not drag the selection along")
-                .isZero();
-        assertThat(scrolled.modalScroll()).isPositive();
-        assertThat(RenderHarness.render(area, scrolled, model).contains("f29")).isTrue();
+        ScreenState.DataPreview paged = (ScreenState.DataPreview) stack.top();
+        assertThat(paged.modalCursorLine())
+                .as("PgDn is the coarse ↓, not a second axis")
+                .isPositive();
+        assertThat(paged.modalScroll())
+                .as("the body follows the cursor")
+                .isPositive();
+        assertThat(DataPreviewScreen.handle(
+                new KeyEvent(KeyCode.CHAR, KeyModifiers.NONE, 'G'), model, stack)).isTrue();
+        assertThat(RenderHarness.render(area, (ScreenState) stack.top(), model).contains("f29"))
+                .as("G reaches the tail the cursor now walks")
+                .isTrue();
     }
 
     @Test
@@ -403,7 +409,7 @@ class DiveRenderTest {
         assertThat(DataPreviewScreen.handle(key(KeyCode.DOWN), model, stack)).isTrue();
         ScreenState.DataPreview selectedNote = (ScreenState.DataPreview) stack.top();
         assertThat(selectedNote.modalCursorLine()).isEqualTo(1);
-        assertThat(RenderHarness.render(area, selectedNote, model).contains("▶note"))
+        assertThat(RenderHarness.render(area, selectedNote, model).contains("▶ note"))
                 .as("a truncated single-line value shows an action marker")
                 .isTrue();
 
@@ -414,7 +420,7 @@ class DiveRenderTest {
     }
 
     @Test
-    void dataPreviewFittedSingleExpandableFieldOmitsNavigationHint() {
+    void dataPreviewFittedBodyOffersMovementButNotPaging() {
         ScreenState.DataPreview state = openModal(
                 List.of("items", "id", "status"),
                 List.of("[a, b]", "1", "ready"),
@@ -424,17 +430,13 @@ class DiveRenderTest {
 
         RenderHarness.RenderedFrame rendered = RenderHarness.render(area, state, model);
 
-        assertThat(DataPreviewScreen.handle(key(KeyCode.UP), model, stack))
-                .as("there is no previous actionable field")
-                .isFalse();
         assertThat(DataPreviewScreen.handle(key(KeyCode.DOWN), model, stack))
-                .as("there is no next actionable field")
-                .isFalse();
-        assertThat(rendered.contains("↑↓ field"))
-                .as("the hint omits navigation when neither direction can move")
-                .isFalse();
-        assertThat(rendered.contains("PgDn/PgUp scroll"))
-                .as("the body fits, so there is nothing to scroll to")
+                .as("the cursor moves to the next line, expandable or not")
+                .isTrue();
+        assertThat(((ScreenState.DataPreview) stack.top()).modalCursorLine()).isEqualTo(1);
+        assertThat(rendered.contains("↑↓ move")).isTrue();
+        assertThat(rendered.contains("PgDn/PgUp page"))
+                .as("the body fits, so there is nothing to page to")
                 .isFalse();
         assertThat(rendered.contains("Enter expand"))
                 .as("the selected field remains expandable")
@@ -443,21 +445,21 @@ class DiveRenderTest {
 
     @Test
     void dataPreviewValueFillingTheBudgetExactlyIsNotActionable() {
-        // maxKeyWidth 4 ("note") at width 100 leaves an 85-cell value budget.
-        int budget = 85;
+        // maxKeyWidth 4 ("note") at width 100 leaves an 84-cell value budget.
+        int budget = 84;
         ScreenState.DataPreview fits = openModal(
                 List.of("note"), List.of("x".repeat(budget)), List.of("x".repeat(budget)));
         NavigationStack stack = rooted(fits);
         Rect area = new Rect(0, 0, 100, 24);
 
-        assertThat(RenderHarness.render(area, fits, model).contains("▶note"))
+        assertThat(RenderHarness.render(area, fits, model).contains("▶ note"))
                 .as("a value the collapsed line shows in full is not actionable")
                 .isFalse();
         assertThat(DataPreviewScreen.handle(key(KeyCode.ENTER), model, stack)).isFalse();
 
         ScreenState.DataPreview overflows = openModal(
                 List.of("note"), List.of("x".repeat(budget + 1)), List.of("x".repeat(budget + 1)));
-        assertThat(RenderHarness.render(area, overflows, model).contains("▶note"))
+        assertThat(RenderHarness.render(area, overflows, model).contains("▶ note"))
                 .as("one cell over the budget and expanding reveals something")
                 .isTrue();
     }
@@ -477,7 +479,7 @@ class DiveRenderTest {
         assertThat(rendered.contains("…"))
                 .as("the value fits the budget in cells, so it is not truncated")
                 .isFalse();
-        assertThat(rendered.contains("▶note"))
+        assertThat(rendered.contains("▶ note"))
                 .as("a fully visible value must not be offered as expandable")
                 .isFalse();
         assertThat(DataPreviewScreen.handle(key(KeyCode.ENTER), model, stack)).isFalse();
@@ -502,7 +504,7 @@ class DiveRenderTest {
         assertThat(opened.modalCursorLine())
                 .as("id and name are scalars; the cursor opens on tags")
                 .isEqualTo(2);
-        assertThat(RenderHarness.render(area, opened, model).contains("▶tags")).isTrue();
+        assertThat(RenderHarness.render(area, opened, model).contains("▶ tags")).isTrue();
     }
 
     @Test
@@ -525,7 +527,7 @@ class DiveRenderTest {
         assertThat(opened.modalScroll())
                 .as("the only expandable field sits past the first screenful")
                 .isPositive();
-        assertThat(RenderHarness.render(area, opened, model).contains("▶items"))
+        assertThat(RenderHarness.render(area, opened, model).contains("▶ items"))
                 .as("opening scrolls the field it selected into view")
                 .isTrue();
     }
@@ -549,13 +551,27 @@ class DiveRenderTest {
     }
 
     @Test
+    void helpOverlayReachesItsTailOnAShortTerminal() {
+        // The overlay runs to about thirty lines. On a short terminal it was
+        // capped to the screen and the remainder simply dropped.
+        Rect screenArea = new Rect(0, 0, 120, 16);
+        Buffer buffer = Buffer.empty(screenArea);
+        HelpOverlay.render(buffer, screenArea, 0);
+        assertThat(renderToString(buffer, screenArea)).doesNotContain("Data preview");
+
+        Buffer scrolled = Buffer.empty(screenArea);
+        HelpOverlay.render(scrolled, screenArea, HelpOverlay.lineCount(screenArea));
+        assertThat(renderToString(scrolled, screenArea)).contains("Data preview");
+    }
+
+    @Test
     void helpOverlayWrapsLongDescriptions() {
         // At 80 width, the description budget is 38 chars.
         // The longest description is 52 chars, so it should be forced to wrap.
         Rect screenArea = new Rect(0, 0, 80, 40);
         Buffer buffer = Buffer.empty(screenArea);
 
-        HelpOverlay.render(buffer, screenArea);
+        HelpOverlay.render(buffer, screenArea, 0);
 
         assertThat(renderToString(buffer, screenArea))
                 .contains("enter filter mode (Schema, Column ")
@@ -569,7 +585,7 @@ class DiveRenderTest {
         Rect screenArea = new Rect(0, 0, 120, 40);
         Buffer buffer = Buffer.empty(screenArea);
 
-        HelpOverlay.render(buffer, screenArea);
+        HelpOverlay.render(buffer, screenArea, 0);
 
         assertThat(renderToString(buffer, screenArea)).contains("Version: " + Version.getVersion());
     }
@@ -583,7 +599,7 @@ class DiveRenderTest {
         Rect screenArea = new Rect(0, 0, 50, 40);
         Buffer buffer = Buffer.empty(screenArea);
 
-        HelpOverlay.render(buffer, screenArea);
+        HelpOverlay.render(buffer, screenArea, 0);
 
         // The "Press ? or Esc to close" sentinel is the very last line of the
         // overlay; if it renders, no content above it can have been clipped.
@@ -595,9 +611,17 @@ class DiveRenderTest {
     /// going through the open path.
     private static ScreenState.DataPreview openModal(
             List<String> names, List<String> values, List<String> expandedValues) {
+        return openModal(names, values, expandedValues, 0);
+    }
+
+    /// As above, with the modal's line cursor already on `cursorLine` — for
+    /// tests about what a key does from a given position, rather than about
+    /// where opening puts it.
+    private static ScreenState.DataPreview openModal(
+            List<String> names, List<String> values, List<String> expandedValues, int cursorLine) {
         return new ScreenState.DataPreview(
                 0, 1, names, List.of(values), List.of(expandedValues),
-                0, 0, 0, true, Set.of(), 0);
+                0, 0, 0, true, Set.of(), cursorLine, 0);
     }
 
     /// A Data preview state with the modal closed, for tests that open it
@@ -934,6 +958,326 @@ class DiveRenderTest {
         return ColumnChunkDetailScreen.keybarKeys(new ScreenState.ColumnChunkDetail(
                 0, columnIndexOf(model, dottedName),
                 ScreenState.ColumnChunkDetail.Pane.FACTS, 0, true, false), model);
+    }
+
+    @Test
+    void dataPreviewFillsTheViewportOnTheFrameItIsEnteredOn() {
+        // Entering the screen left the bottom of the viewport blank until the
+        // first keypress: the page was sized from whatever viewport the
+        // previous screen had observed, and only re-loaded on the next event.
+        Keys.resetObservedGeometry();
+        Rect body = new Rect(0, 0, 120, 30);
+        // A page sized for a shorter screen, as arriving from a pane with
+        // less room for rows produces.
+        ScreenState.DataPreview entered = DataPreviewScreen.initialState(model, 5);
+        NavigationStack stack = new NavigationStack(ScreenState.Overview.initial());
+        stack.push(entered);
+
+        DataPreviewScreen.fitToViewport(model, stack, body);
+
+        ScreenState.DataPreview fitted = (ScreenState.DataPreview) stack.top();
+        int viewport = body.height() - 3;
+        assertThat(fitted.rows())
+                .as("the page fills the rows the body can paint")
+                .hasSize(viewport);
+        assertThat(RenderHarness.render(body, fitted, model).contains(String.valueOf(viewport)))
+                .as("the last row of the viewport is painted, not blank")
+                .isTrue();
+    }
+
+    @Test
+    void overviewFactsPaneKeepsTheKeyValueCursorOnScreen() throws Exception {
+        // The facts pane moved a cursor it never scrolled to, so on a short
+        // terminal the selected entry could sit below the fold while the
+        // keybar still offered Enter to open it.
+        Path file = Path.of(getClass().getResource("/cli_info_kv_metadata_test.parquet").getPath());
+        try (ParquetModel m = ParquetModel.open(InputFile.of(file), file.toString())) {
+            Rect area = new Rect(0, 0, 120, 12);
+            NavigationStack stack = new NavigationStack(new ScreenState.Overview(
+                    ScreenState.Overview.Pane.FACTS, 0, 0, false, 0));
+            RenderHarness.render(area, stack.top(), m);
+
+            assertThat(OverviewScreen.handle(
+                    new KeyEvent(KeyCode.CHAR, KeyModifiers.NONE, 'G'), m, stack)).isTrue();
+            ScreenState.Overview bottom = (ScreenState.Overview) stack.top();
+            List<Map.Entry<String, String>> kv = m.facts().keyValueMetadata();
+            assertThat(bottom.kvSelection())
+                    .isEqualTo(OverviewScreen.kvEntryRow(kv.size() - 1));
+            RenderHarness.RenderedFrame frame = RenderHarness.render(area, bottom, m);
+            assertThat(frame.contains(kv.get(kv.size() - 1).getKey())).isTrue();
+        }
+    }
+
+    @Test
+    void dataPreviewModalOffersJumpKeysEvenWhenTheBodyFits() {
+        // g/G move the cursor, so they act whenever there is more than one
+        // line — the hint gated them on the body having to scroll.
+        ScreenState.DataPreview state = openModal(
+                List.of("items", "id", "status"),
+                List.of("[a, b]", "1", "ready"),
+                List.of("[\n  a,\n  b\n]", "1", "ready"));
+        RenderHarness.RenderedFrame rendered =
+                RenderHarness.render(new Rect(0, 0, 100, 24), state, model);
+
+        assertThat(rendered.contains("PgDn/PgUp page"))
+                .as("the body fits, so there is nothing to page to")
+                .isFalse();
+        assertThat(rendered.contains("g/G first/last")).isTrue();
+    }
+
+    @Test
+    void drillIntoCursorWalksPastEntriesTheChunkDoesNotHave() throws Exception {
+        // The cursor was re-snapped to the first enabled entry on every
+        // keypress, so on a chunk with only Pages and Dictionary populated it
+        // moved onto Column index and was dragged straight back.
+        Path file = Path.of(getClass().getResource("/yellow_tripdata_sample.parquet").getPath());
+        try (ParquetModel m = ParquetModel.open(InputFile.of(file), file.toString())) {
+            NavigationStack stack = new NavigationStack(ScreenState.Overview.initial());
+            stack.push(ColumnChunkDetailScreen.initialState(m, 0, 0, true));
+            RenderHarness.render(new Rect(0, 0, 120, 24), stack.top(), m);
+
+            for (int expected = 1; expected <= 3; expected++) {
+                assertThat(ColumnChunkDetailScreen.handle(key(KeyCode.DOWN), m, stack)).isTrue();
+                assertThat(((ScreenState.ColumnChunkDetail) stack.top()).menuSelection())
+                        .isEqualTo(expected);
+            }
+            assertThat(ColumnChunkDetailScreen.handle(key(KeyCode.DOWN), m, stack)).isTrue();
+            assertThat(((ScreenState.ColumnChunkDetail) stack.top()).menuSelection())
+                    .as("the last entry is the last entry")
+                    .isEqualTo(3);
+        }
+    }
+
+    @Test
+    void documentPaneWalksTheCursorToTheEdgeBeforeMovingItsContent() throws Exception {
+        // Recomputing the window from the cursor pinned it to the bottom row,
+        // so every step up dragged the whole pane along instead of walking the
+        // cursor to the top of the window first, as the list screens do.
+        Path file = Path.of(getClass().getResource("/yellow_tripdata_sample.parquet").getPath());
+        try (ParquetModel m = ParquetModel.open(InputFile.of(file), file.toString())) {
+            Keys.resetObservedGeometry();
+            Rect area = new Rect(0, 0, 110, 10);
+            NavigationStack stack = new NavigationStack(ScreenState.Overview.initial());
+            stack.push(new ScreenState.RowGroupDetail(
+                    0, ScreenState.RowGroupDetail.Pane.FACTS, 0));
+            RenderHarness.render(area, stack.top(), m);
+            RowGroupDetailScreen.handle(
+                    new KeyEvent(KeyCode.CHAR, KeyModifiers.NONE, 'G'), m, stack);
+            RenderHarness.render(area, stack.top(), m);
+
+            int settled = ((ScreenState.RowGroupDetail) stack.top()).factsTop();
+            assertThat(settled).isPositive();
+
+            assertThat(RowGroupDetailScreen.handle(key(KeyCode.UP), m, stack)).isTrue();
+            ScreenState.RowGroupDetail moved = (ScreenState.RowGroupDetail) stack.top();
+            assertThat(moved.scrollTop())
+                    .as("the cursor moved")
+                    .isLessThan(((ScreenState.RowGroupDetail) stack.top()).scrollTop() + 1);
+            assertThat(moved.factsTop())
+                    .as("the content did not: the cursor was not yet at the top of the window")
+                    .isEqualTo(settled);
+        }
+    }
+
+    @Test
+    void overviewFactsComeBackWhenTheCursorReturnsToTheTop() throws Exception {
+        // The window only ever slid far enough to reveal the cursor, and this
+        // cursor cannot reach the facts — so once the list had pushed them off
+        // the top, walking back up did not bring them back.
+        Path file = Path.of(getClass().getResource("/cli_info_kv_metadata_test.parquet").getPath());
+        try (ParquetModel m = ParquetModel.open(InputFile.of(file), file.toString())) {
+            Keys.resetObservedGeometry();
+            Rect area = new Rect(0, 0, 110, 12);
+            NavigationStack stack = new NavigationStack(new ScreenState.Overview(
+                    ScreenState.Overview.Pane.FACTS, 0, 0, false, 0));
+            RenderHarness.render(area, stack.top(), m);
+
+            OverviewScreen.handle(new KeyEvent(KeyCode.CHAR, KeyModifiers.NONE, 'G'), m, stack);
+            RenderHarness.render(area, stack.top(), m);
+            OverviewScreen.handle(new KeyEvent(KeyCode.CHAR, KeyModifiers.NONE, 'g'), m, stack);
+
+            assertThat(RenderHarness.render(area, (ScreenState) stack.top(), m)
+                    .contains("Format version"))
+                    .as("the facts are on screen again")
+                    .isTrue();
+        }
+    }
+
+    @Test
+    void footerDoesNotJumpOnTheFirstKeyAfterOpening() {
+        // The entry state was built before this pane had rendered, so its
+        // stored window came from the previous pane's viewport. The frame the
+        // reader saw was drawn from the reconciled value, and the first
+        // keypress used to step the body to catch up.
+        Keys.resetObservedGeometry();
+        Rect area = new Rect(0, 0, 110, 14);
+        NavigationStack stack = new NavigationStack(ScreenState.Overview.initial());
+        stack.push(FooterScreen.initialState(model));
+        RenderHarness.RenderedFrame opened = RenderHarness.render(area, stack.top(), model);
+
+        assertThat(FooterScreen.handle(key(KeyCode.UP), model, stack)).isTrue();
+        RenderHarness.RenderedFrame moved = RenderHarness.render(area, stack.top(), model);
+
+        assertThat(moved.lines().getFirst())
+                .as("the body stayed put; only the cursor moved")
+                .isEqualTo(opened.lines().getFirst());
+    }
+
+    @Test
+    void footerCursorReachesEveryRowOfTheBody() throws Exception {
+        // The cursor stopped only on anchors, and the anchors sit in the
+        // lower half of the body, so the rows above the topmost one could not
+        // be visited at all.
+        Path file = Path.of(getClass().getResource("/yellow_tripdata_sample.parquet").getPath());
+        try (ParquetModel m = ParquetModel.open(InputFile.of(file), file.toString())) {
+            Keys.resetObservedGeometry();
+            Rect area = new Rect(0, 0, 110, 14);
+            NavigationStack stack = new NavigationStack(ScreenState.Overview.initial());
+            stack.push(FooterScreen.initialState(m));
+            RenderHarness.render(area, stack.top(), m);
+            int anchor = ((ScreenState.Footer) stack.top()).cursorRow();
+            assertThat(anchor)
+                    .as("opening lands on an anchor, not on line zero")
+                    .isPositive();
+
+            // One row at a time all the way to the top, visiting every row.
+            for (int expected = anchor - 1; expected >= 0; expected--) {
+                assertThat(FooterScreen.handle(key(KeyCode.UP), m, stack)).isTrue();
+                assertThat(((ScreenState.Footer) stack.top()).cursorRow()).isEqualTo(expected);
+            }
+            assertThat(FooterScreen.handle(key(KeyCode.UP), m, stack))
+                    .as("handled, but there is nowhere above the first line")
+                    .isTrue();
+            assertThat(((ScreenState.Footer) stack.top()).cursorRow()).isZero();
+            assertThat(RenderHarness.render(area, (ScreenState) stack.top(), m)
+                    .contains("Format version"))
+                    .as("the head of the body is on screen")
+                    .isTrue();
+        }
+    }
+
+    @Test
+    void overviewFactsScrollPastTheFixedFactsWhenTheCursorNeedsTheRoom() throws Exception {
+        // The facts above the key/value list were pinned and only the list
+        // was windowed, so on a short pane whatever they pushed past the
+        // bottom could not be reached.
+        Path file = Path.of(getClass().getResource("/cli_info_kv_metadata_test.parquet").getPath());
+        try (ParquetModel m = ParquetModel.open(InputFile.of(file), file.toString())) {
+            Keys.resetObservedGeometry();
+            Rect area = new Rect(0, 0, 110, 12);
+            NavigationStack stack = new NavigationStack(new ScreenState.Overview(
+                    ScreenState.Overview.Pane.FACTS, 0, 0, false, 0));
+            RenderHarness.render(area, stack.top(), m);
+
+            List<Map.Entry<String, String>> kv = m.facts().keyValueMetadata();
+            assertThat(OverviewScreen.handle(
+                    new KeyEvent(KeyCode.CHAR, KeyModifiers.NONE, 'G'), m, stack)).isTrue();
+
+            RenderHarness.RenderedFrame frame =
+                    RenderHarness.render(area, (ScreenState) stack.top(), m);
+            assertThat(frame.contains(kv.get(kv.size() - 1).getKey()))
+                    .as("the last entry is reachable")
+                    .isTrue();
+            assertThat(frame.contains("Format version"))
+                    .as("the facts scrolled out of the way to make room for it")
+                    .isFalse();
+        }
+    }
+
+    @Test
+    void schemaKeepsTheCursorOnScreen() throws Exception {
+        // The schema tree moved its cursor and rendered from row zero, so on
+        // any file with more columns than the viewport the cursor left the
+        // screen — while the title reported a range the body did not show.
+        Path file = Path.of(getClass().getResource("/yellow_tripdata_sample.parquet").getPath());
+        try (ParquetModel m = ParquetModel.open(InputFile.of(file), file.toString())) {
+            Rect area = new Rect(0, 0, 120, 12);
+            NavigationStack stack = new NavigationStack(ScreenState.Overview.initial());
+            stack.push(ScreenState.Schema.initial());
+            RenderHarness.render(area, stack.top(), m);
+
+            assertThat(SchemaScreen.handle(
+                    new KeyEvent(KeyCode.CHAR, KeyModifiers.NONE, 'G'), m, stack)).isTrue();
+            ScreenState.Schema bottom = (ScreenState.Schema) stack.top();
+            assertThat(bottom.scrollTop()).isPositive();
+
+            // G selects the last leaf, so the window must have moved off the
+            // first one and onto the last.
+            RenderHarness.RenderedFrame frame = RenderHarness.render(area, bottom, m);
+            assertThat(frame.contains(m.schema().getColumn(0).name())).isFalse();
+            assertThat(frame.contains(m.schema().getColumn(m.columnCount() - 1).name())).isTrue();
+        }
+    }
+
+    @Test
+    void rowGroupDetailFactsPaneScrollsToItsTail() {
+        // Eighteen lines of facts in a pane that can show eleven: without
+        // scrolling the page-index section is unreachable.
+        Rect area = new Rect(0, 0, 120, 14);
+        ScreenState.RowGroupDetail top = new ScreenState.RowGroupDetail(
+                0, ScreenState.RowGroupDetail.Pane.FACTS, 0);
+        assertThat(RenderHarness.render(area, top, model).contains("Page indexes")).isFalse();
+
+        NavigationStack stack = new NavigationStack(ScreenState.Overview.initial());
+        stack.push(top);
+        assertThat(RowGroupDetailScreen.handle(
+                new KeyEvent(KeyCode.CHAR, KeyModifiers.NONE, 'G'), model, stack)).isTrue();
+        ScreenState.RowGroupDetail bottom = (ScreenState.RowGroupDetail) stack.top();
+        assertThat(bottom.scrollTop()).isPositive();
+        assertThat(RenderHarness.render(area, bottom, model).contains("Page indexes")).isTrue();
+    }
+
+    @Test
+    void keyValueModalPagesWithPageDownAsWellAsShift() throws Exception {
+        // The modal recognised only Shift+↑/↓, so PgDn did nothing there while
+        // it paged on every other scrollable pane.
+        Path file = Path.of(getClass().getResource("/cli_info_kv_metadata_test.parquet").getPath());
+        try (ParquetModel m = ParquetModel.open(InputFile.of(file), file.toString())) {
+            Rect area = new Rect(0, 0, 120, 14);
+            ScreenState.Overview open = new ScreenState.Overview(
+                    ScreenState.Overview.Pane.FACTS, 0,
+                    OverviewScreen.kvEntryRow(kvIndexOf(m, "pandas")), true, 0);
+            RenderHarness.render(area, open, m);
+
+            NavigationStack stack = new NavigationStack(open);
+            assertThat(OverviewScreen.handle(key(KeyCode.PAGE_DOWN), m, stack)).isTrue();
+            assertThat(((ScreenState.Overview) stack.top()).kvModalScroll()).isPositive();
+
+            assertThat(OverviewScreen.handle(
+                    new KeyEvent(KeyCode.CHAR, KeyModifiers.NONE, 'G'), m, stack)).isTrue();
+            int bottom = ((ScreenState.Overview) stack.top()).kvModalScroll();
+            assertThat(bottom).isPositive();
+
+            assertThat(OverviewScreen.handle(
+                    new KeyEvent(KeyCode.CHAR, KeyModifiers.NONE, 'g'), m, stack)).isTrue();
+            assertThat(((ScreenState.Overview) stack.top()).kvModalScroll()).isZero();
+        }
+    }
+
+    @Test
+    void pageHeaderModalScrollsOnAShortTerminal() {
+        // The modal took only Esc/Enter, so on a terminal too short for the
+        // header its tail could not be reached.
+        Rect area = new Rect(0, 0, 120, 14);
+        ScreenState.Pages open = new ScreenState.Pages(0, 0, 0, true, true);
+        RenderHarness.render(area, open, model);
+
+        NavigationStack stack = new NavigationStack(ScreenState.Overview.initial());
+        stack.push(open);
+        assertThat(PagesScreen.handle(key(KeyCode.PAGE_DOWN), model, stack)).isTrue();
+        assertThat(((ScreenState.Pages) stack.top()).modalScroll()).isPositive();
+        // The modal stays open: paging is not a way out of it.
+        assertThat(((ScreenState.Pages) stack.top()).modalOpen()).isTrue();
+    }
+
+    private static int kvIndexOf(ParquetModel model, String key) {
+        List<Map.Entry<String, String>> kv = model.facts().keyValueMetadata();
+        for (int i = 0; i < kv.size(); i++) {
+            if (kv.get(i).getKey().equals(key)) {
+                return i;
+            }
+        }
+        throw new IllegalArgumentException("no such key/value entry: " + key);
     }
 
     private static KeyEvent key(KeyCode code) {

--- a/cli/src/test/java/dev/hardwood/cli/dive/DiveStateTest.java
+++ b/cli/src/test/java/dev/hardwood/cli/dive/DiveStateTest.java
@@ -283,18 +283,25 @@ class DiveStateTest {
     }
 
     @Test
-    void columnChunkDetailDisabledSelectionSnapsToFirstEnabled() {
-        // The fixture chunk has no dictionary, so opening the menu with
-        // DICTIONARY selected should snap to the first enabled item
-        // (PAGES) on the next event rather than firing a no-op drill.
+    void columnChunkDetailEnterDoesNothingOnAnEntryTheChunkDoesNotHave() {
+        // The fixture chunk has no dictionary. The cursor may rest there —
+        // the row carries a fact worth reading — but Enter has nowhere to go,
+        // which the missing ▶ says.
         NavigationStack stack = rooted(new ScreenState.ColumnChunkDetail(
                 0, 0, ScreenState.ColumnChunkDetail.Pane.MENU,
                 ColumnChunkDetailScreen.MenuItem.DICTIONARY.ordinal(), true, false));
 
-        ColumnChunkDetailScreen.handle(key(KeyCode.ENTER), model, stack);
+        assertThat(ColumnChunkDetailScreen.handle(key(KeyCode.ENTER), model, stack)).isFalse();
+        assertThat(stack.top()).isInstanceOf(ScreenState.ColumnChunkDetail.class);
+    }
 
-        // First event snaps to PAGES, then drills.
-        assertThat(stack.top()).isInstanceOf(ScreenState.Pages.class);
+    @Test
+    void columnChunkDetailEntryStateLandsOnTheFirstEntryThatGoesSomewhere() {
+        ScreenState.ColumnChunkDetail entered =
+                ColumnChunkDetailScreen.initialState(model, 0, 0, true);
+
+        assertThat(entered.menuSelection())
+                .isEqualTo(ColumnChunkDetailScreen.MenuItem.PAGES.ordinal());
     }
 
     @Test
@@ -734,15 +741,13 @@ class DiveStateTest {
         ScreenState.DataPreview opened = (ScreenState.DataPreview) stack.top();
         assertThat(opened.modalRow()).isEqualTo(2);
 
-        // ↑/↓ inside the modal move the field cursor — the modalRow stays put
+        // ↑/↓ inside the modal move the line cursor — the modalRow stays put
         // (row stepping is intentionally not available inside the modal; users
-        // close it and pick another row from the table). This fixture is two
-        // scalar columns, so there is no expandable field to step to and the
-        // cursor has nowhere to go.
-        assertThat(DataPreviewScreen.handle(key(KeyCode.DOWN), model, stack)).isFalse();
+        // close it and pick another row from the table).
+        assertThat(DataPreviewScreen.handle(key(KeyCode.DOWN), model, stack)).isTrue();
         ScreenState.DataPreview moved = (ScreenState.DataPreview) stack.top();
         assertThat(moved.modalRow()).isEqualTo(2);
-        assertThat(moved.modalCursorLine()).isZero();
+        assertThat(moved.modalCursorLine()).isEqualTo(1);
 
         // Esc closes the modal.
         DataPreviewScreen.handle(key(KeyCode.ESCAPE), model, stack);
@@ -750,7 +755,7 @@ class DiveStateTest {
     }
 
     @Test
-    void dataPreviewRowModalNavigationSkipsScalarFields() throws Exception {
+    void dataPreviewRowModalCursorStopsOnScalarFieldsToo() throws Exception {
         // First row: scalar id, followed by two non-empty expandable lists.
         Path file = Path.of(getClass().getResource("/list_basic_test.parquet").getPath());
         try (ParquetModel listModel = ParquetModel.open(InputFile.of(file), file.toString())) {
@@ -762,26 +767,22 @@ class DiveStateTest {
             // rather than the one under test.
             RenderHarness.render(new Rect(0, 0, 100, 24), initial, listModel);
 
-            // Opening skips id (line 0) and selects tags (line 1).
+            // Opening still selects the first field Enter can act on, which is
+            // tags (line 1) rather than the scalar id above it.
             DataPreviewScreen.handle(key(KeyCode.ENTER), listModel, stack);
             assertThat(((ScreenState.DataPreview) stack.top()).modalCursorLine()).isEqualTo(1);
 
-            boolean handledAtFirst = DataPreviewScreen.handle(key(KeyCode.UP), listModel, stack);
-            assertThat(handledAtFirst).isFalse();
-            assertThat(((ScreenState.DataPreview) stack.top()).modalCursorLine()).isEqualTo(1);
+            // From there the cursor walks every line, so id is reachable.
+            assertThat(DataPreviewScreen.handle(key(KeyCode.UP), listModel, stack)).isTrue();
+            assertThat(((ScreenState.DataPreview) stack.top()).modalCursorLine()).isZero();
+            assertThat(DataPreviewScreen.handle(key(KeyCode.UP), listModel, stack))
+                    .as("already at the top, but the key is still the cursor's")
+                    .isTrue();
+            assertThat(((ScreenState.DataPreview) stack.top()).modalCursorLine()).isZero();
 
-            boolean handledDown = DataPreviewScreen.handle(key(KeyCode.DOWN), listModel, stack);
-            assertThat(handledDown).isTrue();
-            // The next actionable field is scores (line 2).
+            assertThat(DataPreviewScreen.handle(key(KeyCode.DOWN), listModel, stack)).isTrue();
+            assertThat(DataPreviewScreen.handle(key(KeyCode.DOWN), listModel, stack)).isTrue();
             assertThat(((ScreenState.DataPreview) stack.top()).modalCursorLine()).isEqualTo(2);
-
-            boolean handledAtLast = DataPreviewScreen.handle(key(KeyCode.DOWN), listModel, stack);
-            assertThat(handledAtLast).isFalse();
-            assertThat(((ScreenState.DataPreview) stack.top()).modalCursorLine()).isEqualTo(2);
-
-            boolean handledUp = DataPreviewScreen.handle(key(KeyCode.UP), listModel, stack);
-            assertThat(handledUp).isTrue();
-            assertThat(((ScreenState.DataPreview) stack.top()).modalCursorLine()).isEqualTo(1);
         }
     }
 
@@ -1042,7 +1043,7 @@ class DiveStateTest {
     @Test
     void footerEnterOnColumnAnchorDrillsIntoFileIndexes() {
         // Initial cursor is the Column anchor; Enter drills.
-        NavigationStack stack = rooted(ScreenState.Footer.initial());
+        NavigationStack stack = rooted(FooterScreen.initialState(model));
         FooterScreen.handle(key(KeyCode.ENTER), model, stack);
 
         assertThat(stack.top()).isInstanceOf(ScreenState.FileIndexes.class);
@@ -1064,30 +1065,57 @@ class DiveStateTest {
     }
 
     @Test
-    void footerDownSkipsDisabledDictionaryAnchor() {
-        // The fixture has 0 chunks with dictionary, so ↓ from OFFSET should
-        // not advance to DICTIONARY (it's disabled).
-        NavigationStack stack = rooted(new ScreenState.Footer(
-                ScreenState.Footer.Anchor.OFFSET, 0));
-
+    void footerDownSkipsTheDisabledDictionaryAnchor() {
+        // The fixture has no chunks with a dictionary, so past the offset
+        // anchor the only stop left is the end of the body — ↓ does not pause
+        // on a section the file does not have.
+        NavigationStack stack = rooted(FooterScreen.initialState(model));
         FooterScreen.handle(key(KeyCode.DOWN), model, stack);
+        int offsetAnchor = ((ScreenState.Footer) stack.top()).cursorRow();
 
-        assertThat(((ScreenState.Footer) stack.top()).cursor())
-                .isEqualTo(ScreenState.Footer.Anchor.OFFSET);
+        assertThat(FooterScreen.handle(key(KeyCode.DOWN), model, stack)).isTrue();
+        ScreenState.Footer end = (ScreenState.Footer) stack.top();
+        assertThat(end.cursorRow()).isGreaterThan(offsetAnchor);
+        assertThat(FooterScreen.handle(key(KeyCode.ENTER), model, stack))
+                .as("the end of the body is a stop, not an anchor")
+                .isFalse();
     }
 
     @Test
-    void footerDownTogglesToOffsetAnchorThenEnterDrills() {
-        NavigationStack stack = rooted(ScreenState.Footer.initial());
+    void footerDownJumpsToTheOffsetAnchorThenEnterDrills() {
+        NavigationStack stack = rooted(FooterScreen.initialState(model));
         FooterScreen.handle(key(KeyCode.DOWN), model, stack);
-
-        assertThat(((ScreenState.Footer) stack.top()).cursor())
-                .isEqualTo(ScreenState.Footer.Anchor.OFFSET);
 
         FooterScreen.handle(key(KeyCode.ENTER), model, stack);
         assertThat(stack.top()).isInstanceOf(ScreenState.FileIndexes.class);
         assertThat(((ScreenState.FileIndexes) stack.top()).kind())
                 .isEqualTo(ScreenState.FileIndexes.Kind.OFFSET);
+    }
+
+    @Test
+    void footerPagingMovesTheCursorAndIsNotUndoneByTheNextFrame() {
+        // The body used to re-derive its offset from the anchor on every
+        // render, so anything paged to was discarded on the next repaint and
+        // the top of the body could not be reached at all.
+        NavigationStack stack = rooted(FooterScreen.initialState(model));
+        RenderHarness.render(new Rect(0, 0, 120, 16), stack.top(), model);
+
+        assertThat(FooterScreen.handle(key(KeyCode.PAGE_DOWN), model, stack)).isTrue();
+        ScreenState.Footer paged = (ScreenState.Footer) stack.top();
+        assertThat(paged.cursorRow()).isPositive();
+
+        RenderHarness.render(new Rect(0, 0, 120, 16), paged, model);
+        assertThat(((ScreenState.Footer) stack.top()).cursorRow())
+                .as("rendering does not move the reader back to the anchor")
+                .isEqualTo(paged.cursorRow());
+
+        assertThat(FooterScreen.handle(
+                new KeyEvent(KeyCode.CHAR, KeyModifiers.NONE, 'g'), model, stack)).isTrue();
+        assertThat(((ScreenState.Footer) stack.top()).cursorRow()).isZero();
+        assertThat(RenderHarness.render(new Rect(0, 0, 120, 16), stack.top(), model)
+                .contains("File layout"))
+                .as("g reaches the head of the body")
+                .isTrue();
     }
 
     @Test

--- a/cli/src/test/java/dev/hardwood/cli/dive/RenderHarness.java
+++ b/cli/src/test/java/dev/hardwood/cli/dive/RenderHarness.java
@@ -74,7 +74,7 @@ final class RenderHarness {
             case ScreenState.Overview s -> OverviewScreen.keybarKeys(s, model);
             case ScreenState.Schema s -> SchemaScreen.keybarKeys(s, model);
             case ScreenState.RowGroups s -> RowGroupsScreen.keybarKeys(s, model);
-            case ScreenState.RowGroupDetail s -> RowGroupDetailScreen.keybarKeys(s);
+            case ScreenState.RowGroupDetail s -> RowGroupDetailScreen.keybarKeys(s, model);
             case ScreenState.RowGroupIndexes s -> RowGroupIndexesScreen.keybarKeys(s, model);
             case ScreenState.ColumnChunks s -> ColumnChunksScreen.keybarKeys(s, model);
             case ScreenState.ColumnChunkDetail s -> ColumnChunkDetailScreen.keybarKeys(s, model);

--- a/cli/src/test/java/dev/hardwood/cli/dive/internal/CursorPaneTest.java
+++ b/cli/src/test/java/dev/hardwood/cli/dive/internal/CursorPaneTest.java
@@ -1,0 +1,130 @@
+/*
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Copyright The original authors
+ *
+ *  Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package dev.hardwood.cli.dive.internal;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import dev.tamboui.tui.event.KeyCode;
+import dev.tamboui.tui.event.KeyEvent;
+import dev.tamboui.tui.event.KeyModifiers;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/// The navigation every list pane in dive shares. These pin the rules the
+/// screens are no longer each free to reinterpret.
+class CursorPaneTest {
+
+    private static final int COUNT = 100;
+
+    @BeforeEach
+    @AfterEach
+    void clearObservedViewport() {
+        Keys.resetObservedGeometry();
+    }
+
+    @Test
+    void arrowsStepOneRowAndPageKeysStepAViewport() {
+        assertThat(CursorPane.select(key(KeyCode.DOWN), 50, COUNT)).isEqualTo(51);
+        assertThat(CursorPane.select(key(KeyCode.UP), 50, COUNT)).isEqualTo(49);
+        int stride = Keys.viewportStride();
+        assertThat(CursorPane.select(key(KeyCode.PAGE_DOWN), 50, COUNT)).isEqualTo(50 + stride);
+        assertThat(CursorPane.select(key(KeyCode.PAGE_UP), 50, COUNT)).isEqualTo(50 - stride);
+    }
+
+    @Test
+    void shiftedArrowsArePageKeys() {
+        int stride = Keys.viewportStride();
+        assertThat(CursorPane.select(shift(KeyCode.DOWN), 50, COUNT)).isEqualTo(50 + stride);
+        assertThat(CursorPane.select(shift(KeyCode.UP), 50, COUNT)).isEqualTo(50 - stride);
+    }
+
+    @Test
+    void jumpKeysGoToTheEnds() {
+        assertThat(CursorPane.select(chr('g'), 50, COUNT)).isZero();
+        assertThat(CursorPane.select(chr('G'), 50, COUNT)).isEqualTo(COUNT - 1);
+    }
+
+    @Test
+    void movesAreClampedToTheRowCount() {
+        assertThat(CursorPane.select(key(KeyCode.UP), 0, COUNT)).isZero();
+        assertThat(CursorPane.select(key(KeyCode.DOWN), COUNT - 1, COUNT)).isEqualTo(COUNT - 1);
+        assertThat(CursorPane.select(key(KeyCode.PAGE_UP), 3, COUNT)).isZero();
+        assertThat(CursorPane.select(key(KeyCode.PAGE_DOWN), COUNT - 2, COUNT)).isEqualTo(COUNT - 1);
+    }
+
+    @Test
+    void aStaleSelectionIsClampedBeforeItIsAdjusted() {
+        // The row count can shrink underneath a selection — a filter being
+        // typed, say — without the screen having reset it first.
+        assertThat(CursorPane.select(key(KeyCode.DOWN), 900, COUNT)).isEqualTo(COUNT - 1);
+        assertThat(CursorPane.select(key(KeyCode.UP), 900, COUNT)).isEqualTo(COUNT - 2);
+    }
+
+    @Test
+    void anEmptyListHasNothingToSelect() {
+        assertThat(CursorPane.select(key(KeyCode.DOWN), 0, 0)).isEqualTo(CursorPane.UNHANDLED);
+        assertThat(CursorPane.select(chr('G'), 0, 0)).isEqualTo(CursorPane.UNHANDLED);
+    }
+
+    @Test
+    void keysThatDoNotMoveTheCursorAreLeftToTheCaller() {
+        assertThat(CursorPane.select(key(KeyCode.ENTER), 50, COUNT)).isEqualTo(CursorPane.UNHANDLED);
+        assertThat(CursorPane.select(chr('t'), 50, COUNT)).isEqualTo(CursorPane.UNHANDLED);
+        assertThat(CursorPane.select(key(KeyCode.LEFT), 50, COUNT)).isEqualTo(CursorPane.UNHANDLED);
+    }
+
+    @Test
+    void hintsListOnlyTheKeysWithSomewhereToGo() {
+        assertThat(CursorPane.hints(0)).isEmpty();
+        assertThat(CursorPane.hints(1)).isEmpty();
+        assertThat(CursorPane.hints(2))
+                .contains("[↑↓] move", "[g/G] first/last")
+                .doesNotContain("page");
+        assertThat(CursorPane.hints(Keys.viewportStride() + 1))
+                .contains("[↑↓] move", "[PgDn/PgUp or Shift+↓↑] page", "[g/G] first/last");
+    }
+
+    @Test
+    void theMarkerSaysWhatEnterCanActOnRatherThanWhereTheCursorIs() {
+        // Mixed pane: every actionable row is marked, so a reader can see
+        // which rows go somewhere without arrowing onto each one.
+        assertThat(CursorPane.marker(true, false, true)).isEqualTo(CursorPane.MARKER);
+        assertThat(CursorPane.marker(true, true, true)).isEqualTo(CursorPane.MARKER);
+        assertThat(CursorPane.marker(false, false, true)).isEqualTo(CursorPane.NO_MARKER);
+        // The cursor row is not exempt: a row Enter cannot act on says so
+        // even while selected.
+        assertThat(CursorPane.marker(false, true, true)).isEqualTo(CursorPane.NO_MARKER);
+    }
+
+    @Test
+    void aUniformPaneMarksOnlyTheCursorRow() {
+        // Nothing to distinguish, so a caret against every row would be a
+        // column of identical glyphs.
+        assertThat(CursorPane.marker(true, true, false)).isEqualTo(CursorPane.MARKER);
+        assertThat(CursorPane.marker(true, false, false)).isEqualTo(CursorPane.NO_MARKER);
+    }
+
+    @Test
+    void markedAndUnmarkedRowsAlignWithOneAnother() {
+        assertThat(CursorPane.MARKER).hasSameSizeAs(CursorPane.NO_MARKER);
+    }
+
+    private static KeyEvent key(KeyCode code) {
+        return new KeyEvent(code, KeyModifiers.NONE, '\0');
+    }
+
+    private static KeyEvent shift(KeyCode code) {
+        return new KeyEvent(code, KeyModifiers.SHIFT, '\0');
+    }
+
+    private static KeyEvent chr(char c) {
+        return new KeyEvent(KeyCode.CHAR, KeyModifiers.NONE, c);
+    }
+}

--- a/cli/src/test/java/dev/hardwood/cli/dive/internal/DocumentTest.java
+++ b/cli/src/test/java/dev/hardwood/cli/dive/internal/DocumentTest.java
@@ -1,0 +1,135 @@
+/*
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Copyright The original authors
+ *
+ *  Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package dev.hardwood.cli.dive.internal;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import dev.tamboui.text.Line;
+import dev.tamboui.text.Span;
+import dev.tamboui.tui.event.KeyCode;
+import dev.tamboui.tui.event.KeyEvent;
+import dev.tamboui.tui.event.KeyModifiers;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/// A pane whose rows are not uniform: the cursor moves over the rows, the
+/// window over the lines, and the two are not the same count.
+class DocumentTest {
+
+    /// Three sections of two facts each: a heading and a blank before every
+    /// pair, so six rows across sixteen lines.
+    private static Document sectioned() {
+        Document.Builder b = Document.builder();
+        for (int section = 0; section < 3; section++) {
+            if (section > 0) {
+                b.blank();
+            }
+            b.decoration(Line.from(Span.raw("section " + section)));
+            b.row(Line.from(Span.raw("fact " + section + "a")));
+            b.row(Line.from(Span.raw("fact " + section + "b")));
+        }
+        return b.build();
+    }
+
+    @BeforeEach
+    @AfterEach
+    void clearObservedViewport() {
+        Keys.resetObservedGeometry();
+    }
+
+    @Test
+    void rowsAreTheLinesTheCursorStopsOn() {
+        Document doc = sectioned();
+        assertThat(doc.rowCount()).isEqualTo(6);
+        assertThat(doc.lineCount()).isEqualTo(11);
+        assertThat(doc.lineOfRow(0)).isEqualTo(1);
+        assertThat(doc.rowAtLine(0))
+                .as("a heading is not a row")
+                .isEqualTo(-1);
+        assertThat(doc.rowAtLine(1)).isZero();
+    }
+
+    @Test
+    void steppingMovesOneRowNotOneLine() {
+        Document doc = sectioned();
+        assertThat(doc.select(key(KeyCode.DOWN), 1, 8))
+                .as("over the blank and the heading between the sections")
+                .isEqualTo(2);
+        assertThat(doc.select(key(KeyCode.UP), 2, 8)).isEqualTo(1);
+    }
+
+    @Test
+    void pagingMovesAViewportOfLinesAndLandsOnARow() {
+        Document doc = sectioned();
+        // Row 0 is line 1; four lines on takes us to line 5, whose nearest
+        // row is row 2 at line 5 — not four rows on, which would overshoot
+        // the pane by the headings in between.
+        assertThat(doc.select(key(KeyCode.PAGE_DOWN), 0, 4)).isEqualTo(2);
+        assertThat(doc.select(key(KeyCode.PAGE_UP), 5, 4)).isEqualTo(3);
+    }
+
+    @Test
+    void hintsOfferPagingOnLinesAndSteppingOnRows() {
+        Document doc = sectioned();
+        assertThat(doc.hints(40))
+                .as("everything fits, so there is nothing to page to")
+                .doesNotContain("page");
+        assertThat(doc.hints(40)).contains("[↑↓] move", "[g/G] first/last");
+        assertThat(doc.hints(4))
+                .as("eleven lines do not fit in four, whatever the row count")
+                .contains("[PgDn/PgUp or Shift+↓↑] page");
+        assertThat(Document.builder().row(Line.empty()).build().hints(4))
+                .as("a single row has nowhere to move")
+                .isEmpty();
+    }
+
+    @Test
+    void theWindowSlidesTheLeastItCan() {
+        Document doc = sectioned();
+        // Cursor at the last row with a four-line window: bottom-pinned.
+        int bottom = doc.windowTop(0, 5, 4);
+        assertThat(bottom).isEqualTo(doc.lineOfRow(5) - 3);
+        // Stepping up one row stays inside that window, so it does not move.
+        assertThat(doc.windowTop(bottom, 4, 4)).isEqualTo(bottom);
+    }
+
+    @Test
+    void rowZeroPinsTheWindowToTheFirstLine() {
+        Document doc = sectioned();
+        assertThat(doc.windowTop(5, 0, 4))
+                .as("so a leading heading is not stranded above a cursor that cannot reach it")
+                .isZero();
+    }
+
+    @Test
+    void aMoveReconcilesAStaleWindowBeforeSliding() {
+        Document doc = sectioned();
+        // A state built before this pane rendered carries a window computed
+        // from another pane's viewport. The frame the reader sees was drawn
+        // from the reconciled value, so the move must start there too.
+        int stale = 0;
+        int rendered = doc.windowTop(stale, 5, 4);
+        assertThat(doc.windowTopAfterMove(stale, 5, 4, 4))
+                .isEqualTo(doc.windowTop(rendered, 4, 4))
+                .isEqualTo(rendered);
+    }
+
+    @Test
+    void aDocumentOfPureDecorationHasNoCursor() {
+        Document doc = Document.builder().decoration(Line.empty()).blank().build();
+        assertThat(doc.rowCount()).isZero();
+        assertThat(doc.lineOfRow(0)).isEqualTo(-1);
+        assertThat(doc.select(key(KeyCode.DOWN), 0, 4)).isEqualTo(CursorPane.UNHANDLED);
+    }
+
+    private static KeyEvent key(KeyCode code) {
+        return new KeyEvent(code, KeyModifiers.NONE, '\0');
+    }
+}

--- a/cli/src/test/java/dev/hardwood/cli/dive/internal/PluralsTest.java
+++ b/cli/src/test/java/dev/hardwood/cli/dive/internal/PluralsTest.java
@@ -27,52 +27,38 @@ class PluralsTest {
 
     @Test
     void rangeOfHandlesZeroTotal() {
-        assertThat(Plurals.rangeOf(0, 0, 10)).isEqualTo("0");
+        assertThat(Plurals.rangeOf(RowWindow.from(0, 0, 0, 10), 0)).isEqualTo("0");
     }
 
     @Test
     void rangeOfShowsSingleElementWhenTotalIsOne() {
-        assertThat(Plurals.rangeOf(0, 1, 10)).isEqualTo("1 of 1");
+        assertThat(Plurals.rangeOf(RowWindow.from(0, 0, 1, 10), 1)).isEqualTo("1 of 1");
     }
 
     @Test
     void rangeOfShowsFullRangeWhenTotalFitsViewport() {
-        assertThat(Plurals.rangeOf(2, 5, 10)).isEqualTo("1-5 of 5");
+        assertThat(Plurals.rangeOf(RowWindow.from(0, 2, 5, 10), 5)).isEqualTo("1-5 of 5");
+        assertThat(Plurals.rangeOf(RowWindow.from(0, 0, 10, 10), 10)).isEqualTo("1-10 of 10");
     }
 
     @Test
-    void rangeOfShowsFullRangeWhenTotalEqualsViewport() {
-        assertThat(Plurals.rangeOf(0, 10, 10)).isEqualTo("1-10 of 10");
+    void rangeOfReportsTheWindowTheBodyIsShowing() {
+        // Whatever slice the renderer took, the title says the same one —
+        // scrolled up, scrolled down, or freshly entered.
+        assertThat(Plurals.rangeOf(RowWindow.from(0, 0, 100, 10), 100)).isEqualTo("1-10 of 100");
+        assertThat(Plurals.rangeOf(RowWindow.from(0, 10, 100, 10), 100)).isEqualTo("2-11 of 100");
+        assertThat(Plurals.rangeOf(RowWindow.from(50, 55, 100, 10), 100)).isEqualTo("51-60 of 100");
+        assertThat(Plurals.rangeOf(RowWindow.from(90, 99, 100, 10), 100)).isEqualTo("91-100 of 100");
     }
 
     @Test
-    void rangeOfPinsToTopWhenSelectionWithinFirstViewport() {
-        // selection 0..viewport-1 → window stays 1..viewport
-        assertThat(Plurals.rangeOf(0, 100, 10)).isEqualTo("1-10 of 100");
-        assertThat(Plurals.rangeOf(9, 100, 10)).isEqualTo("1-10 of 100");
-    }
-
-    @Test
-    void rangeOfBottomPinsWhenSelectionPastFirstViewport() {
-        // sel=10 → end=11, start=2 → "2-11 of 100"
-        assertThat(Plurals.rangeOf(10, 100, 10)).isEqualTo("2-11 of 100");
-        assertThat(Plurals.rangeOf(99, 100, 10)).isEqualTo("91-100 of 100");
-    }
-
-    @Test
-    void rangeOfClampsSelectionPastTotal() {
-        assertThat(Plurals.rangeOf(500, 100, 10)).isEqualTo("91-100 of 100");
-    }
-
-    @Test
-    void rangeOfTreatsZeroOrNegativeViewportAsOne() {
-        // viewport=0 collapses to 1: a single-row sliding window
-        assertThat(Plurals.rangeOf(5, 100, 0)).isEqualTo("6-6 of 100");
-        assertThat(Plurals.rangeOf(5, 100, -3)).isEqualTo("6-6 of 100");
+    void rangeOfShowsASingleRowWithoutARange() {
+        assertThat(Plurals.rangeOf(RowWindow.from(5, 5, 100, 1), 100)).isEqualTo("6 of 100");
     }
 
     @Test
     void rangeOfFormatsLargeTotalsWithComma() {
-        assertThat(Plurals.rangeOf(0, 12_400_000, 20)).isEqualTo("1-20 of 12,400,000");
+        assertThat(Plurals.rangeOf(RowWindow.from(0, 0, 12_400_000, 20), 12_400_000))
+                .isEqualTo("1-20 of 12,400,000");
     }
 }

--- a/cli/src/test/java/dev/hardwood/cli/dive/internal/ScrollPaneTest.java
+++ b/cli/src/test/java/dev/hardwood/cli/dive/internal/ScrollPaneTest.java
@@ -1,0 +1,136 @@
+/*
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Copyright The original authors
+ *
+ *  Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package dev.hardwood.cli.dive.internal;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+
+import dev.tamboui.layout.Rect;
+import dev.tamboui.text.Line;
+import dev.tamboui.text.Span;
+import dev.tamboui.tui.event.KeyCode;
+import dev.tamboui.tui.event.KeyEvent;
+import dev.tamboui.tui.event.KeyModifiers;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/// The navigation every document pane in dive shares. These pin the rules
+/// the panes are no longer each free to reinterpret.
+class ScrollPaneTest {
+
+    private static final int VIEWPORT = 10;
+    private static final int LINES = 100;
+
+    @Test
+    void arrowsStepOneLineAndPageKeysStepAViewport() {
+        assertThat(ScrollPane.scroll(key(KeyCode.DOWN), 50, LINES, VIEWPORT)).isEqualTo(51);
+        assertThat(ScrollPane.scroll(key(KeyCode.UP), 50, LINES, VIEWPORT)).isEqualTo(49);
+        assertThat(ScrollPane.scroll(key(KeyCode.PAGE_DOWN), 50, LINES, VIEWPORT)).isEqualTo(60);
+        assertThat(ScrollPane.scroll(key(KeyCode.PAGE_UP), 50, LINES, VIEWPORT)).isEqualTo(40);
+    }
+
+    @Test
+    void shiftedArrowsArePageKeys() {
+        assertThat(ScrollPane.scroll(shift(KeyCode.DOWN), 50, LINES, VIEWPORT)).isEqualTo(60);
+        assertThat(ScrollPane.scroll(shift(KeyCode.UP), 50, LINES, VIEWPORT)).isEqualTo(40);
+    }
+
+    @Test
+    void jumpKeysGoToTheEnds() {
+        assertThat(ScrollPane.scroll(chr('g'), 50, LINES, VIEWPORT)).isZero();
+        assertThat(ScrollPane.scroll(chr('G'), 50, LINES, VIEWPORT)).isEqualTo(LINES - VIEWPORT);
+    }
+
+    @Test
+    void movesAreClampedToTheContent() {
+        assertThat(ScrollPane.scroll(key(KeyCode.PAGE_UP), 3, LINES, VIEWPORT)).isZero();
+        assertThat(ScrollPane.scroll(key(KeyCode.PAGE_DOWN), 95, LINES, VIEWPORT))
+                .isEqualTo(LINES - VIEWPORT);
+    }
+
+    @Test
+    void aStaleOffsetIsClampedBeforeItIsAdjusted() {
+        // Content that shrank underneath a scrolled pane — collapsing a
+        // section, say — must not leave an offset that swallows keypresses.
+        assertThat(ScrollPane.scroll(key(KeyCode.UP), 900, LINES, VIEWPORT))
+                .isEqualTo(LINES - VIEWPORT - 1);
+    }
+
+    @Test
+    void contentThatFitsIsHandledButDoesNotMove() {
+        assertThat(ScrollPane.scroll(key(KeyCode.PAGE_DOWN), 0, 5, VIEWPORT)).isZero();
+        assertThat(ScrollPane.overflows(5, VIEWPORT)).isFalse();
+        assertThat(ScrollPane.maxScroll(5, VIEWPORT)).isZero();
+    }
+
+    @Test
+    void keysThatDoNotScrollAreLeftToTheCaller() {
+        assertThat(ScrollPane.scroll(key(KeyCode.ENTER), 50, LINES, VIEWPORT))
+                .isEqualTo(ScrollPane.UNHANDLED);
+        assertThat(ScrollPane.scroll(chr('t'), 50, LINES, VIEWPORT))
+                .isEqualTo(ScrollPane.UNHANDLED);
+    }
+
+    @Test
+    void theWindowIsTheVisibleSliceAndSurvivesAStaleOffset() {
+        List<Line> lines = lines(LINES);
+        assertThat(ScrollPane.window(lines, 20, VIEWPORT)).isEqualTo(lines.subList(20, 30));
+        assertThat(ScrollPane.window(lines, 900, VIEWPORT)).isEqualTo(lines.subList(90, 100));
+        assertThat(ScrollPane.window(lines(4), 0, VIEWPORT)).hasSize(4);
+    }
+
+    @Test
+    void hintsAreEmptyWhileTheContentFits() {
+        assertThat(ScrollPane.hints(5, VIEWPORT)).isEmpty();
+        assertThat(ScrollPane.hints(LINES, VIEWPORT))
+                .contains("[↑↓] scroll", "[PgDn/PgUp or Shift+↓↑] page", "[g/G] top/bottom");
+    }
+
+    @Test
+    void modalGeometryLeavesRoomForItsChrome() {
+        Rect screen = new Rect(0, 0, 120, 40);
+        Rect modal = ScrollPane.modalArea(screen, 80, 16);
+        assertThat(modal.width()).isEqualTo(80);
+        assertThat(modal.height()).isEqualTo(16);
+        // Borders, blank separator and hint row come off the height; borders
+        // and the row inset come off the width.
+        assertThat(ScrollPane.modalViewport(modal)).isEqualTo(12);
+        assertThat(ScrollPane.modalWidth(modal)).isEqualTo(77);
+    }
+
+    @Test
+    void modalGeometryShrinksToASmallTerminal() {
+        Rect modal = ScrollPane.modalArea(new Rect(0, 0, 30, 10), 80, 16);
+        assertThat(modal.width()).isEqualTo(26);
+        assertThat(modal.height()).isEqualTo(8);
+        assertThat(ScrollPane.modalViewport(modal)).isPositive();
+        assertThat(ScrollPane.modalWidth(modal)).isPositive();
+    }
+
+    private static List<Line> lines(int count) {
+        List<Line> lines = new ArrayList<>(count);
+        for (int i = 0; i < count; i++) {
+            lines.add(Line.from(Span.raw("line " + i)));
+        }
+        return lines;
+    }
+
+    private static KeyEvent key(KeyCode code) {
+        return new KeyEvent(code, KeyModifiers.NONE, '\0');
+    }
+
+    private static KeyEvent shift(KeyCode code) {
+        return new KeyEvent(code, KeyModifiers.SHIFT, '\0');
+    }
+
+    private static KeyEvent chr(char c) {
+        return new KeyEvent(KeyCode.CHAR, KeyModifiers.NONE, c);
+    }
+}


### PR DESCRIPTION
Closes #1008. Closes #963.

Navigation in `dive` was implemented per screen, so the same keypress meant different things depending on where you were, several panes could not be scrolled at all, and `▶` carried three different meanings. Two rules now cover every pane:

- **Keys** — every key moves the cursor, stopping on every row; only how far it goes varies.
- **Markers** — `▶` marks what `Enter` can act on; colour marks where the cursor is.

[_designs/DIVE_NAVIGATION_MODEL.md](https://github.com/hardwood-hq/hardwood/blob/1008-dive-navigation-model/_designs/DIVE_NAVIGATION_MODEL.md) states them, surveys all twenty-one panes against them, and is what a new screen gets reviewed against; CLAUDE.md points at it next to the theme and virtualization rules.

## Why it had drifted

Nine list screens carried the same six key branches — the row groups and column chunks handlers differed by four lines — and ten repeated the same three keybar hints verbatim. Every pane that deviated from the rules was one that hand-rolled its own key handling, and every pane that went through the shared table path conformed. So the rules are now held by shared code rather than restated per screen: `CursorPane` for panes whose content is rows, `Document` for panes whose rows are separated by headings and blanks, and `ScrollPane` for the overlays, which are dismissed rather than navigated.

## Defects this fixes

- **The schema tree and the file facts pane** moved a cursor their renderers never scrolled to. On a file larger than the viewport the cursor walked off screen, while the title reported the range it was in and `Enter` drilled into a row the reader could not see. Schema was also the last list screen building rows for the whole collection rather than the viewport.
- **Five panes had no navigation keys at all** — the row group detail facts pane, the key/value modal, and the page header, dictionary value and min/max modals. The last two exist to show values a table row had to truncate, and did not even wrap them: a value wider than the modal ran off the right edge.
- **The footer** reconciled its cursor against its scroll offset during `render`, so scrolling was discarded on the next repaint and the top of its body could not be reached at all.
- **The record modal and the drill-into menu** skipped the rows `Enter` could not act on, putting content out of reach of the only keys that reach content. The marker says what the skipping was standing in for, and unlike the skipping it costs the reader nothing.
- **Titles reported a range the body was not showing** — `rangeOf` derived its own window from the selection, which only matched for downward navigation.
- **Data preview** was short on the frame it was entered on, because the page was sized from the previous screen's viewport and only reloaded on the first keypress.
- **The help overlay** was capped to the terminal height with its tail silently dropped, including the version line (#963).

## Not in scope

How panes report content that is off screen is still inconsistent — a range in the title on the table screens, an `N more lines` hint row in the overlays, and nothing at all in three panes. Tracked separately as #1009, since the rows-versus-lines distinction this PR introduces has to be settled before that can be unified.

## Testing

`./mvnw verify` is green. New coverage pins the shared mechanisms directly (`CursorPaneTest`, `ScrollPaneTest`, `DocumentTest`) plus regression tests for each defect above. Tests that pinned the previous behaviour — the record modal's skipping, the drill-into snap — are rewritten to state the new rule rather than deleted.