### PR TITLE
#1035 Settle the schema's shape before the destination is opened

### DIFF
--- a/_designs/WRITER_NESTED.md
+++ b/_designs/WRITER_NESTED.md
@@ -41,9 +41,29 @@ Stage 5 settles three things:
 
 Leaf physical type stays `INT32` for the shredding increments; type breadth is stage
 12 and rides unchanged on top of the level machinery. Dictionary encoding (stage 9),
-compression (stage 10), and statistics (stage 11) layer on afterwards. The writer
-emits the canonical 3-level `LIST` and 2-level `MAP` layouts only; the legacy
-backward-compatibility list shapes the reader tolerates on read are not produced.
+compression (stage 10), and statistics (stage 11) layer on afterwards.
+
+`FileSchema.Builder` declares the canonical 3-level `LIST` and 2-level `MAP` layouts
+only. A schema the caller did not build — one read from an existing file through
+`FileSchema.fromSchemaElements` — may carry a legacy shape, and the writer's rule for
+those is that repetition is producible exactly where a `LIST` or `MAP` annotation
+accounts for it: the annotated group is what gives the shredder a repetition layer and
+`ColumnBatch` a path to address its entry offsets under.
+
+An annotation accounts for one repetition, its entry's. So an annotated group is
+`REQUIRED` or `OPTIONAL` and holds exactly one `REPEATED` field, which for a `MAP` is a
+group of `key` and `value`. Both legacy 2-level lists satisfy that and are written:
+`LIST { repeated element }`, whose entry is the element, and
+`LIST { repeated group element { … } }`, whose entry is an element struct. Everything
+else repeated is refused by `ParquetFileWriter.create`:
+
+- a `repeated` leaf or group with no annotated parent, because nothing could supply its
+  entry offsets and shredding it would emit one entry per record — every value its own
+  one-element list;
+- an annotated group that repeats on its own behalf, holds more than its entry, or holds
+  an entry that does not repeat, because the shredder derives one layer from the
+  annotation while the schema declares a different number of repetition levels, and the
+  file's levels and schema then disagree.
 
 ## Path addressing model
 

--- a/_designs/WRITER_ROW_API.md
+++ b/_designs/WRITER_ROW_API.md
@@ -324,9 +324,15 @@ same file invites a double-close that either discards a valid file or writes a s
 `writeRow` after the file writer is closed throws, through the same `ensureOpen` check the
 columnar path uses.
 
-The plan is built when `rowWriter()` is called, so a schema shape the write path cannot produce
-— a nullable struct enclosing a repeated field, a legacy two-level list — is rejected there,
-naming the offending path, rather than when the first batch reaches the shredder.
+Whether a schema can be produced at all is settled by `ParquetFileWriter.create` before either
+view exists, so a nullable struct enclosing a repeated field or a repeated field outside a
+`LIST` or `MAP` group never reaches this layer.
+
+The plan is built when `rowWriter()` is called, and rejects there — naming the offending path —
+the shapes this layer alone cannot *address*: two sibling fields sharing a name, which leaves
+the by-name setters ambiguous, and the legacy 2-level lists, whose entry is the element itself
+where the builders reach a list's values through an element node below the entry. The columnar
+API addresses by index and dotted path and writes those shapes.
 
 ## Reserved surface
 

--- a/core/src/main/java/dev/hardwood/internal/writer/RowPlan.java
+++ b/core/src/main/java/dev/hardwood/internal/writer/RowPlan.java
@@ -217,11 +217,13 @@ public final class RowPlan {
                                      PrecisionLossPolicy policy) {
         return switch (node) {
             case SchemaNode.PrimitiveNode leaf -> {
-                if (leaf.repetitionType() == RepetitionType.REPEATED) {
-                    throw new UnsupportedOperationException("Field " + path
-                            + " is a REPEATED leaf (a legacy two-level list); the writer produces "
-                            + "three-level LIST groups only");
-                }
+                // A REPEATED leaf reaching a struct's field or a three-level list's element is
+                // unproducible and ParquetFileWriter.create has already refused it; the guard
+                // repeats it so a plan built on an unvalidated schema fails the same way rather
+                // than addressing a shape the shredder cannot honour. The one REPEATED leaf that
+                // is producible — a legacy two-level list's entry — is refused by
+                // repeatedChild(...) before reaching here.
+                WriterSchemaShape.requireWritableLeaf(leaf, path, false);
                 yield new RowLeafNode(path, schema.getColumn(leaf.columnIndex()), policy);
             }
             case SchemaNode.GroupNode group -> buildGroup(group, path, schema, nullableAncestor, policy);
@@ -231,11 +233,13 @@ public final class RowPlan {
     private static RowNode buildGroup(SchemaNode.GroupNode group, String path, FileSchema schema,
                                       boolean nullableAncestor, PrecisionLossPolicy policy) {
         boolean optional = group.repetitionType() == RepetitionType.OPTIONAL;
+        // Producibility — a group's own repetition, and an annotated group's entry — is settled
+        // by ParquetFileWriter.create before this plan is built. Asking the same helper again
+        // keeps a plan built on an unvalidated schema from addressing a shape the shredder
+        // cannot honour, and keeps one defect to one wording. A LIST's or MAP's own scaffolding
+        // never reaches here: the branch below navigates through it.
+        WriterSchemaShape.requireWritableGroup(group, path, nullableAncestor, false);
         if (group.isList() || group.isMap()) {
-            if (nullableAncestor) {
-                throw new UnsupportedOperationException("A nullable struct enclosing a repeated field ("
-                        + path + ") is not yet supported by the writer");
-            }
             SchemaNode.GroupNode repeated = repeatedChild(group, path);
             if (group.isMap()) {
                 // A map's entries are a repeated struct of `key` and `value`, populated
@@ -244,25 +248,27 @@ public final class RowPlan {
                         schema, false, false, policy);
                 return new RowMapNode(path, optional, entry);
             }
-            SchemaNode element = onlyChild(repeated, path);
-            String elementPath = childPath(childPath(path, repeated.name()), element.name());
+            String repeatedPath = childPath(path, repeated.name());
+            SchemaNode element = listElement(repeated, repeatedPath);
+            String elementPath = childPath(repeatedPath, element.name());
             return new RowListNode(path, optional, buildNode(element, elementPath, schema, false, policy));
-        }
-        if (group.repetitionType() == RepetitionType.REPEATED) {
-            throw new UnsupportedOperationException("Group " + path
-                    + " is REPEATED but carries no LIST or MAP annotation; the writer cannot produce it");
         }
         // Any other group — a plain struct, or one carrying an annotation the write path does
         // not interpret, such as VARIANT — is written field by field like a struct.
         return buildStruct(group, path, schema, optional, nullableAncestor, policy);
     }
 
+    /// Returns the annotated group's repeated entry group. That the entry exists and is
+    /// `REPEATED` is settled before the plan is built; what is left is the row layer's own
+    /// limit — the builders navigate a list through an element node below the entry, which a
+    /// legacy two-level list, whose entry *is* the element, does not have.
     private static SchemaNode.GroupNode repeatedChild(SchemaNode.GroupNode group, String path) {
         SchemaNode child = onlyChild(group, path);
-        if (!(child instanceof SchemaNode.GroupNode repeated)
-                || repeated.repetitionType() != RepetitionType.REPEATED) {
-            throw new UnsupportedOperationException("Group " + path
-                    + " is annotated LIST or MAP but does not hold a single repeated group");
+        if (!(child instanceof SchemaNode.GroupNode repeated)) {
+            throw new UnsupportedOperationException("Group " + path + " is annotated LIST or MAP and its entry "
+                    + child.name() + " is a leaf (a legacy two-level list); the row API reaches a list's values"
+                    + " through an element node below the entry, so it writes three-level LIST groups only."
+                    + " The columnar API writes this schema");
         }
         return repeated;
     }
@@ -276,7 +282,23 @@ public final class RowPlan {
         return group.children().get(0);
     }
 
+    /// Returns the element node below a three-level list's repeated entry. An entry holding
+    /// several fields is the list's element itself — the legacy two-level list of structs, which
+    /// the columnar API writes and the row builders, which reach a list's values through a
+    /// single element node below the entry, cannot.
+    private static SchemaNode listElement(SchemaNode.GroupNode repeated, String path) {
+        if (repeated.children().size() != 1) {
+            throw new UnsupportedOperationException("Group " + path + " holds " + repeated.children().size()
+                    + " fields and is therefore the list's element itself (a legacy two-level list of structs);"
+                    + " the row API reaches a list's values through a single element node below the entry, so it"
+                    + " writes three-level LIST groups only. The columnar API writes this schema");
+        }
+        return repeated.children().get(0);
+    }
+
+    /// Spells a field's path the way [WriterSchemaShape] does, so a path naming a field in a
+    /// rejection reads the same whichever of the two raised it.
     private static String childPath(String path, String name) {
-        return path.isEmpty() ? name : path + "." + name;
+        return WriterSchemaShape.childPath(path, name);
     }
 }

--- a/core/src/main/java/dev/hardwood/internal/writer/WriterSchemaShape.java
+++ b/core/src/main/java/dev/hardwood/internal/writer/WriterSchemaShape.java
@@ -1,0 +1,171 @@
+/*
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Copyright The original authors
+ *
+ *  Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package dev.hardwood.internal.writer;
+
+import dev.hardwood.metadata.RepetitionType;
+import dev.hardwood.schema.FileSchema;
+import dev.hardwood.schema.SchemaNode;
+
+/// Which schema shapes the writer can turn into bytes.
+///
+/// Producibility is a property of the schema alone, so it is settled once — before the
+/// destination is opened and before either write view exists — rather than by whichever of
+/// the two met the shape first. [RecordShredder] keeps guards of its own, unreachable through
+/// the public API once this has run; [RowPlan]'s remaining guards are reached, and are about
+/// addressing rather than producing — see below.
+///
+/// Three rules live here, and all of them are about repetition.
+///
+/// **A `REPEATED` field is producible only as the entry of a `LIST` or `MAP` group.** The
+/// shredder derives a repetition layer from the annotated group, and [ColumnBatch] addresses
+/// that layer's entry offsets through `list(...)` / `map(...)` under the group's path. A
+/// `REPEATED` field whose parent carries neither annotation has no layer and no verb: nothing
+/// could supply its entry offsets, and shredding it emits one entry per record — every value
+/// its own one-element list. Every spelling of the entry is accepted, the three-level
+/// `LIST { repeated group list { element } }` and both legacy two-level forms,
+/// `LIST { repeated element }` and `LIST { repeated group element { … } }`, because the
+/// annotated group supplies the layer either way.
+///
+/// **An annotated group carries exactly one repetition, in its entry.** A `LIST` or `MAP`
+/// group is itself `REQUIRED` or `OPTIONAL` and holds one `REPEATED` field, which a `MAP`
+/// additionally requires to be a group, since its entry is a key/value pair. The shredder
+/// derives one layer per annotation and the reader derives the repetition levels from the
+/// schema, so an annotation over a different arrangement produces a file whose levels and
+/// schema disagree — a second repetition with no layer behind it, or a layer over a field
+/// that repeats not at all.
+///
+/// **A repeated field must not sit below a nullable struct.** [ColumnBatch] validates a leaf's
+/// nulls against the leaf's own repetition without consulting the ancestor masks that decide
+/// whether a slot is encoded at all, so the two disagree about which slots exist.
+///
+/// Rules about *addressing* a shape rather than producing it belong to [RowPlan] alone, since
+/// the columnar API addresses by index and dotted path and is unharmed by them: two sibling
+/// fields sharing a name, and the legacy two-level entries, which the row builders navigate a
+/// list through an element node to reach.
+public final class WriterSchemaShape {
+
+    private WriterSchemaShape() {
+    }
+
+    /// Rejects a schema the writer cannot produce.
+    ///
+    /// @param schema the schema to write
+    /// @throws UnsupportedOperationException if the schema has a shape the writer cannot produce
+    public static void validate(FileSchema schema) {
+        walk(schema.getRootNode(), "", false, false);
+    }
+
+    /// Walks one group's fields.
+    ///
+    /// `nullableAncestor` is whether an enclosing struct is `OPTIONAL`; a repeated field
+    /// re-bases the record scope, so it clears the flag for the fields below it.
+    /// `parentIsAnnotatedGroup` is whether this group is the `LIST` or `MAP` whose entry the
+    /// fields being walked are, which is the one place repetition is legal.
+    private static void walk(SchemaNode.GroupNode group, String path, boolean nullableAncestor,
+                             boolean parentIsAnnotatedGroup) {
+        for (SchemaNode child : group.children()) {
+            String childPath = childPath(path, child.name());
+            switch (child) {
+                case SchemaNode.PrimitiveNode leaf -> requireWritableLeaf(leaf, childPath, parentIsAnnotatedGroup);
+                case SchemaNode.GroupNode nested -> {
+                    requireWritableGroup(nested, childPath, nullableAncestor, parentIsAnnotatedGroup);
+                    boolean annotated = nested.isList() || nested.isMap();
+                    boolean repeated = annotated || nested.repetitionType() == RepetitionType.REPEATED;
+                    walk(nested, childPath,
+                            !repeated && (nullableAncestor || nested.repetitionType() == RepetitionType.OPTIONAL),
+                            annotated);
+                }
+            }
+        }
+    }
+
+    /// Rejects a leaf the writer cannot produce.
+    ///
+    /// @param leaf the leaf
+    /// @param path the leaf's dotted path
+    /// @param parentIsAnnotatedGroup whether the leaf's parent is a `LIST` or `MAP` group
+    /// @throws UnsupportedOperationException if the leaf is `REPEATED` outside a `LIST` or `MAP`
+    public static void requireWritableLeaf(SchemaNode.PrimitiveNode leaf, String path,
+                                           boolean parentIsAnnotatedGroup) {
+        if (leaf.repetitionType() == RepetitionType.REPEATED && !parentIsAnnotatedGroup) {
+            throw new UnsupportedOperationException("Field " + path + " is a REPEATED leaf outside a LIST or"
+                    + " MAP group; the annotation is what gives a repeated field a layer to be addressed"
+                    + " through, so the writer cannot produce it");
+        }
+    }
+
+    /// Rejects a group the writer cannot produce.
+    ///
+    /// @param group the group
+    /// @param path the group's dotted path
+    /// @param nullableAncestor whether an enclosing struct is `OPTIONAL`
+    /// @param parentIsAnnotatedGroup whether the group's parent is a `LIST` or `MAP` group, which
+    ///        makes this group that annotation's entry scaffolding
+    /// @throws UnsupportedOperationException if the group is `REPEATED` outside a `LIST` or `MAP`,
+    ///         is a `LIST` or `MAP` below a nullable struct, or is a `LIST` or `MAP` whose own
+    ///         repetition or entry the annotation cannot account for
+    public static void requireWritableGroup(SchemaNode.GroupNode group, String path, boolean nullableAncestor,
+                                            boolean parentIsAnnotatedGroup) {
+        if (group.isList() || group.isMap()) {
+            if (nullableAncestor) {
+                throw nullableStructEnclosingRepeated(path);
+            }
+            requireWritableAnnotation(group, path);
+            return;
+        }
+        if (group.repetitionType() == RepetitionType.REPEATED && !parentIsAnnotatedGroup) {
+            throw new UnsupportedOperationException("Group " + path + " is REPEATED but carries no LIST or MAP"
+                    + " annotation, and is not the entry group of one; the writer cannot produce it");
+        }
+    }
+
+    /// Rejects a `LIST` or `MAP` group whose repetition the annotation does not account for: the
+    /// annotated group repeating on its own behalf, or holding anything other than the single
+    /// `REPEATED` entry the shredder derives its one layer from.
+    private static void requireWritableAnnotation(SchemaNode.GroupNode group, String path) {
+        String annotation = group.isMap() ? "MAP" : "LIST";
+        if (group.repetitionType() == RepetitionType.REPEATED) {
+            throw new UnsupportedOperationException("Group " + path + " is annotated " + annotation
+                    + " and is itself REPEATED; the annotation accounts for the repetition of its entry only, so"
+                    + " nothing supplies the group's own entry offsets");
+        }
+        if (group.children().size() != 1) {
+            throw new UnsupportedOperationException("Group " + path + " is annotated " + annotation + " but holds "
+                    + group.children().size() + " fields where the layout requires exactly one, its REPEATED entry");
+        }
+        SchemaNode entry = group.children().get(0);
+        if (entry.repetitionType() != RepetitionType.REPEATED) {
+            throw new UnsupportedOperationException("Group " + path + " is annotated " + annotation + " but its entry "
+                    + entry.name() + " is " + entry.repetitionType() + " rather than REPEATED; the annotation then"
+                    + " carries no repetition and the group's entry offsets have nowhere to go");
+        }
+        if (group.isMap() && !(entry instanceof SchemaNode.GroupNode)) {
+            throw new UnsupportedOperationException("Group " + path + " is annotated MAP but its entry "
+                    + entry.name() + " is a leaf where the layout requires a repeated group of key and value");
+        }
+    }
+
+    /// The rejection of a repeated field below a nullable struct, raised from wherever the pair
+    /// is first seen so that one defect carries one wording.
+    ///
+    /// @param path the repeated field's dotted path
+    /// @return the exception to throw
+    public static UnsupportedOperationException nullableStructEnclosingRepeated(String path) {
+        return new UnsupportedOperationException(
+                "A nullable struct enclosing a repeated field (" + path + ") is not yet supported by the writer");
+    }
+
+    /// Appends a field name to its parent's dotted path.
+    ///
+    /// @param path the parent's path, empty at the root
+    /// @param name the field name
+    /// @return the field's path
+    public static String childPath(String path, String name) {
+        return path.isEmpty() ? name : path + "." + name;
+    }
+}

--- a/core/src/main/java/dev/hardwood/writer/ParquetFileWriter.java
+++ b/core/src/main/java/dev/hardwood/writer/ParquetFileWriter.java
@@ -33,6 +33,7 @@ import dev.hardwood.internal.writer.ColumnSource;
 import dev.hardwood.internal.writer.LogicalTypeValueRange;
 import dev.hardwood.internal.writer.RecordShredder;
 import dev.hardwood.internal.writer.RowGroupBuffer;
+import dev.hardwood.internal.writer.WriterSchemaShape;
 import dev.hardwood.metadata.ColumnOrder;
 import dev.hardwood.metadata.FileMetaData;
 import dev.hardwood.metadata.PhysicalType;
@@ -155,7 +156,7 @@ public final class ParquetFileWriter implements Closeable {
     /// @return an open writer
     /// @throws IOException if the destination cannot be opened
     /// @throws UnsupportedOperationException if the schema has a column of an unsupported
-    ///         physical type
+    ///         physical type, or a shape the writer cannot produce
     public static ParquetFileWriter create(OutputFile out, FileSchema schema) throws IOException {
         return create(out, schema, WriterConfig.defaults());
     }
@@ -168,11 +169,16 @@ public final class ParquetFileWriter implements Closeable {
     /// @return an open writer
     /// @throws IOException if the destination cannot be opened
     /// @throws UnsupportedOperationException if the schema has a column of an unsupported
-    ///         physical type, or the configured codec cannot be written
+    ///         physical type, a shape the writer cannot produce, or the configured codec cannot
+    ///         be written
     /// @throws IllegalArgumentException if an encoding policy names a column the schema does not
     ///         have, or one its physical type cannot carry
     public static ParquetFileWriter create(OutputFile out, FileSchema schema, WriterConfig config)
             throws IOException {
+        // Everything this schema and configuration decide is settled before the output is
+        // touched, so a file the writer cannot honour is never begun: the columns' physical
+        // types, the schema's shape, the encoding policies against the schema's columns, then
+        // the codec and its library.
         for (int c = 0; c < schema.getColumnCount(); c++) {
             ColumnSchema column = schema.getColumn(c);
             if (!isSupportedType(column.type())) {
@@ -181,14 +187,27 @@ public final class ParquetFileWriter implements Closeable {
                                 + column.name() + " is " + column.type());
             }
         }
-        // Everything the configuration says about this schema is settled before the output is
-        // touched, so a file the writer cannot honour is never begun: the encoding policies
-        // against the schema's columns, then the codec and its library.
+        // Settled here rather than by whichever view meets it first, so one unproducible shape
+        // is one rejection, at one moment, with one wording.
+        WriterSchemaShape.validate(schema);
         ColumnEncoding[] encodings = resolveEncodings(schema, config);
         Compressor compressor = new CompressorFactory().getCompressor(config.codec());
         out.create();
-        out.write(ByteBuffer.wrap(MAGIC));
-        return new ParquetFileWriter(out, schema, config, compressor, encodings);
+        try {
+            out.write(ByteBuffer.wrap(MAGIC));
+            return new ParquetFileWriter(out, schema, config, compressor, encodings);
+        }
+        catch (IOException | RuntimeException e) {
+            // The destination is open and holds no valid file. Discard it rather than leaving
+            // the temporary artefact a local OutputFile streams into orphaned at the target.
+            try {
+                out.discard();
+            }
+            catch (IOException suppressed) {
+                e.addSuppressed(suppressed);
+            }
+            throw e;
+        }
     }
 
     /// Resolves each leaf column's encoding policy, rejecting a configuration this schema cannot

--- a/core/src/test/java/dev/hardwood/writer/RowWriterRulesTest.java
+++ b/core/src/test/java/dev/hardwood/writer/RowWriterRulesTest.java
@@ -8,6 +8,7 @@
 package dev.hardwood.writer;
 
 import java.nio.ByteBuffer;
+import java.util.List;
 import java.util.concurrent.atomic.AtomicReference;
 
 import org.junit.jupiter.api.Test;
@@ -17,6 +18,7 @@ import dev.hardwood.internal.writer.ByteBufferOutputFile;
 import dev.hardwood.metadata.LogicalType;
 import dev.hardwood.metadata.PhysicalType;
 import dev.hardwood.metadata.RepetitionType;
+import dev.hardwood.metadata.SchemaElement;
 import dev.hardwood.reader.ParquetFileReader;
 import dev.hardwood.reader.RowReader;
 import dev.hardwood.schema.FileSchema;
@@ -26,6 +28,13 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 /// The rules the row-oriented layer enforces: what a record must cover, which verb fits which
 /// field, how long a builder is valid, and which of the two write APIs a file is bound to.
+///
+/// The schema rules this layer adds are about *addressing* a shape: the by-name setters need
+/// sibling names to be unique, and the builders reach a list's values through an element node
+/// below the entry, which the legacy two-level lists do not have. The columnar API addresses by
+/// index and dotted path and writes both. Whether a shape can be produced at all is settled by
+/// [ParquetFileWriter#create] before either view exists, and is asserted in
+/// `WriterSchemaShapeTest`.
 class RowWriterRulesTest {
 
     private static FileSchema schema() {
@@ -305,30 +314,6 @@ class RowWriterRulesTest {
         }
     }
 
-    /// The same unproducible schema shape must be reported the same way whichever API meets it
-    /// first, so a caller catching it from one is not surprised by the other.
-    @Test
-    void bothWriteApisRejectAnUnproducibleShapeTheSameWay() throws Exception {
-        FileSchema schema = FileSchema.builder("schema")
-                .struct("outer", RepetitionType.OPTIONAL, outer -> outer
-                        .list("inner", RepetitionType.REQUIRED,
-                                element -> element.primitive(PhysicalType.INT32, RepetitionType.REQUIRED)))
-                .build();
-
-        try (ParquetFileWriter writer = ParquetFileWriter.create(new ByteBufferOutputFile(), schema)) {
-            assertThatThrownBy(writer::rowWriter)
-                    .isInstanceOf(UnsupportedOperationException.class)
-                    .hasMessageContaining("nullable struct enclosing a repeated field");
-        }
-        try (ParquetFileWriter writer = ParquetFileWriter.create(new ByteBufferOutputFile(), schema)) {
-            assertThatThrownBy(() -> writer.columnWriter().writeBatch(batch -> batch
-                    .list("outer.inner", new int[] { 0, 1 })
-                    .ints("outer.inner.list.element", new int[] { 1 })))
-                    .isInstanceOf(UnsupportedOperationException.class)
-                    .hasMessageContaining("nullable struct enclosing a repeated field");
-        }
-    }
-
     /// Calls `writeRow` from inside a filler, where the checked `IOException` cannot be
     /// declared.
     private static void uncheckedWriteRow(RowWriter rows) {
@@ -340,21 +325,48 @@ class RowWriterRulesTest {
         }
     }
 
-    /// The write path cannot emit a repeated field below a nullable struct, and the row layer
-    /// says so when the view is opened rather than when the first batch is submitted.
+    /// A legacy two-level list is producible — `create` accepts it and the columnar API writes
+    /// it — but its entry *is* the element, so there is no element node below the entry for the
+    /// builders to navigate to. That divergence is the only one between the two views, so it is
+    /// pinned on both sides of the same schema.
     @Test
-    void nullableStructEnclosingAListIsRejectedUpFront() throws Exception {
-        FileSchema schema = FileSchema.builder("schema")
-                .struct("outer", RepetitionType.OPTIONAL, outer -> outer
-                        .list("inner", RepetitionType.REQUIRED,
-                                element -> element.primitive(PhysicalType.INT32, RepetitionType.REQUIRED)))
-                .build();
+    void aLegacyTwoLevelListIsWritableColumnarAndRejectedByTheRowView() throws Exception {
+        FileSchema schema = FileSchema.fromSchemaElements(List.of(
+                SchemaElement.root("schema", 1),
+                SchemaElement.group("items", RepetitionType.OPTIONAL, 1, new LogicalType.ListType()),
+                SchemaElement.primitive("element", PhysicalType.INT32, RepetitionType.REPEATED)));
 
-        ByteBufferOutputFile out = new ByteBufferOutputFile();
-        try (ParquetFileWriter writer = ParquetFileWriter.create(out, schema)) {
+        try (ParquetFileWriter writer = ParquetFileWriter.create(new ByteBufferOutputFile(), schema)) {
             assertThatThrownBy(writer::rowWriter)
                     .isInstanceOf(UnsupportedOperationException.class)
-                    .hasMessageContaining("outer.inner");
+                    .hasMessageContaining("items")
+                    .hasMessageContaining("legacy two-level list")
+                    .hasMessageContaining("The columnar API writes this schema");
+        }
+        try (ParquetFileWriter writer = ParquetFileWriter.create(new ByteBufferOutputFile(), schema)) {
+            writer.columnWriter().writeBatch(batch -> batch
+                    .list("items", new int[] { 0, 2 })
+                    .ints("items.element", new int[] { 1, 2 }));
+        }
+    }
+
+    /// The same divergence for the other legacy two-level form, where the entry is a group of
+    /// several fields and is therefore itself the element.
+    @Test
+    void aLegacyTwoLevelListOfStructsIsRejectedByTheRowView() throws Exception {
+        FileSchema schema = FileSchema.fromSchemaElements(List.of(
+                SchemaElement.root("schema", 1),
+                SchemaElement.group("items", RepetitionType.OPTIONAL, 1, new LogicalType.ListType()),
+                SchemaElement.group("element", RepetitionType.REPEATED, 2),
+                SchemaElement.primitive("a", PhysicalType.INT32, RepetitionType.REQUIRED),
+                SchemaElement.primitive("b", PhysicalType.INT32, RepetitionType.REQUIRED)));
+
+        try (ParquetFileWriter writer = ParquetFileWriter.create(new ByteBufferOutputFile(), schema)) {
+            assertThatThrownBy(writer::rowWriter)
+                    .isInstanceOf(UnsupportedOperationException.class)
+                    .hasMessageContaining("items.element")
+                    .hasMessageContaining("the list's element itself")
+                    .hasMessageContaining("The columnar API writes this schema");
         }
     }
 

--- a/core/src/test/java/dev/hardwood/writer/WriterBatchContractTest.java
+++ b/core/src/test/java/dev/hardwood/writer/WriterBatchContractTest.java
@@ -34,6 +34,10 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 /// on a `REQUIRED` column or offsets that disagree with the values they index are all
 /// misuse the writer rejects rather than encodes. Rejection has to happen before any bytes
 /// reach the file, and a writer that cannot finish a valid file must leave none behind.
+///
+/// These are rules about a *batch*. Rules about the *schema* — a physical type or a shape the
+/// writer cannot produce — are settled before either view exists and are asserted in
+/// `WriterSchemaShapeTest`.
 class WriterBatchContractTest {
 
     @Test
@@ -93,17 +97,6 @@ class WriterBatchContractTest {
             assertThatThrownBy(() -> writer.columnWriter().writeBatch(batch -> batch.ints(0, new int[] { 1, 2, 3 })))
                     .isInstanceOf(IllegalArgumentException.class);
         }
-    }
-
-    @Test
-    void rejectsUnsupportedType() {
-        // INT96 is deprecated and never produced; the writer rejects it up front rather than
-        // producing a partial file.
-        FileSchema schema = FileSchema.builder("schema")
-                .addColumn("v", PhysicalType.INT96, RepetitionType.REQUIRED)
-                .build();
-        assertThatThrownBy(() -> ParquetFileWriter.create(new ByteBufferOutputFile(), schema))
-                .isInstanceOf(UnsupportedOperationException.class);
     }
 
     @Test
@@ -214,27 +207,6 @@ class WriterBatchContractTest {
                     .ints("props.key_value.key", new int[] { 99, 5 })
                     .ints("props.key_value.value", new int[] { 1, 2 })))
                     .isInstanceOf(IllegalArgumentException.class);
-        }
-    }
-
-    @Test
-    void rejectsNullableStructEnclosingList() throws Exception {
-        // A nullable struct directly enclosing a repeated field is not yet supported and must
-        // be rejected eagerly rather than shredded into an unverified file. It is reported as
-        // an unsupported shape rather than a bad argument, because the batch is well formed and
-        // the schema is what the writer cannot produce — the same type, and the same message,
-        // the row layer raises for it from rowWriter().
-        FileSchema schema = FileSchema.builder("schema")
-                .struct("s", RepetitionType.OPTIONAL, sb -> sb
-                        .list("phones", RepetitionType.OPTIONAL, el -> el.primitive(PhysicalType.INT32, RepetitionType.OPTIONAL)))
-                .build();
-
-        try (ParquetFileWriter writer = ParquetFileWriter.create(new ByteBufferOutputFile(), schema)) {
-            assertThatThrownBy(() -> writer.columnWriter().writeBatch(batch -> batch
-                    .list("s.phones", new int[] { 0, 1 })
-                    .ints("s.phones.list.element", new int[] { 1 })))
-                    .isInstanceOf(UnsupportedOperationException.class)
-                    .hasMessageContaining("nullable struct enclosing a repeated field");
         }
     }
 

--- a/core/src/test/java/dev/hardwood/writer/WriterSchemaShapeTest.java
+++ b/core/src/test/java/dev/hardwood/writer/WriterSchemaShapeTest.java
@@ -1,0 +1,428 @@
+/*
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Copyright The original authors
+ *
+ *  Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package dev.hardwood.writer;
+
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Stream;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import dev.hardwood.InputFile;
+import dev.hardwood.OutputFile;
+import dev.hardwood.internal.writer.ByteBufferOutputFile;
+import dev.hardwood.metadata.LogicalType;
+import dev.hardwood.metadata.PhysicalType;
+import dev.hardwood.metadata.RepetitionType;
+import dev.hardwood.metadata.SchemaElement;
+import dev.hardwood.reader.ColumnReader;
+import dev.hardwood.reader.ParquetFileReader;
+import dev.hardwood.schema.FileSchema;
+
+import static dev.hardwood.writer.WriterTestSupport.oneColumn;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/// The schemas the writer refuses, and the point at which it refuses them.
+///
+/// Whether a schema can be turned into bytes is a property of the schema alone, so it is
+/// settled by [ParquetFileWriter#create] before the destination is opened — ahead of both
+/// views, and therefore identically for both. A shape reaching a view would otherwise be
+/// reported at a different moment and, historically, with a different exception type
+/// depending on which one met it.
+///
+/// The rules here are about *producing* a shape. Rules about *addressing* one — two sibling
+/// fields sharing a name, and the legacy two-level entries a row builder cannot navigate to —
+/// belong to the row layer alone and are asserted in `RowWriterRulesTest`, since the columnar
+/// API addresses by index and path and is unharmed by them.
+///
+/// A schema the writer accepts must produce a file other implementations read, so the shapes
+/// pinned as accepted here are the ones checked against PyArrow.
+class WriterSchemaShapeTest {
+
+    @Test
+    void rejectsUnsupportedPhysicalType() {
+        // INT96 is deprecated and never produced.
+        FileSchema schema = FileSchema.builder("schema")
+                .addColumn("v", PhysicalType.INT96, RepetitionType.REQUIRED)
+                .build();
+
+        assertThatThrownBy(() -> ParquetFileWriter.create(new ByteBufferOutputFile(), schema))
+                .isInstanceOf(UnsupportedOperationException.class)
+                .hasMessageContaining("INT96");
+    }
+
+    /// A `REPEATED` leaf with no annotated parent has no layer, and the columnar API has no
+    /// verb that could supply such a column's entry offsets — so every value would be written
+    /// as its own one-element list, silently changing the record count of anything copied
+    /// through. `FileSchema.Builder` refuses the shape, but `fromSchemaElements` does not, and
+    /// that is the schema a file being copied arrives with.
+    @Test
+    void rejectsRepeatedLeaf() {
+        FileSchema schema = FileSchema.fromSchemaElements(List.of(
+                SchemaElement.root("schema", 1),
+                SchemaElement.primitive("nums", PhysicalType.INT32, RepetitionType.REPEATED)));
+
+        assertThatThrownBy(() -> ParquetFileWriter.create(new ByteBufferOutputFile(), schema))
+                .isInstanceOf(UnsupportedOperationException.class)
+                .hasMessageContaining("nums")
+                .hasMessageContaining("REPEATED leaf");
+    }
+
+    /// The same shape nested inside a struct, so the rejection is known to walk the schema
+    /// rather than to check the top level only.
+    @Test
+    void rejectsRepeatedLeafInsideAStruct() {
+        FileSchema schema = FileSchema.fromSchemaElements(List.of(
+                SchemaElement.root("schema", 1),
+                SchemaElement.group("outer", RepetitionType.REQUIRED, 1),
+                SchemaElement.primitive("nums", PhysicalType.INT32, RepetitionType.REPEATED)));
+
+        assertThatThrownBy(() -> ParquetFileWriter.create(new ByteBufferOutputFile(), schema))
+                .isInstanceOf(UnsupportedOperationException.class)
+                .hasMessageContaining("outer.nums");
+    }
+
+    /// A `REPEATED` group carrying no `LIST` or `MAP` annotation is the two-level shape one
+    /// level up: the reader recognizes it, and the writer has no verb for its offsets.
+    @Test
+    void rejectsRepeatedGroupWithoutListOrMapAnnotation() {
+        FileSchema schema = FileSchema.fromSchemaElements(List.of(
+                SchemaElement.root("schema", 1),
+                SchemaElement.group("g", RepetitionType.REPEATED, 1),
+                SchemaElement.primitive("x", PhysicalType.INT32, RepetitionType.REQUIRED)));
+
+        assertThatThrownBy(() -> ParquetFileWriter.create(new ByteBufferOutputFile(), schema))
+                .isInstanceOf(UnsupportedOperationException.class)
+                .hasMessageContaining("g")
+                .hasMessageContaining("no LIST or MAP annotation");
+    }
+
+    /// The `key_value` group of a `MAP` and the `list` group of a `LIST` are `REPEATED` and
+    /// carry no annotation of their own. They are the scaffolding of an annotated ancestor
+    /// rather than a bare repeated group, and must not be caught by the rule above.
+    @Test
+    void acceptsTheRepeatedScaffoldingOfListsAndMaps() throws Exception {
+        FileSchema schema = FileSchema.builder("schema")
+                .list("items", RepetitionType.OPTIONAL,
+                        element -> element.primitive(PhysicalType.INT32, RepetitionType.REQUIRED))
+                .map("props", RepetitionType.OPTIONAL, PhysicalType.INT32,
+                        value -> value.primitive(PhysicalType.INT32, RepetitionType.OPTIONAL))
+                .build();
+
+        try (ParquetFileWriter writer = ParquetFileWriter.create(new ByteBufferOutputFile(), schema)) {
+            assertThat(writer).isNotNull();
+        }
+    }
+
+    /// A key-only `MAP`, which older writers produce and the reader accepts. The `key_value`
+    /// group holds one field rather than two, which is a shape the writer can shred.
+    @Test
+    void acceptsAKeyOnlyMap() throws Exception {
+        FileSchema schema = FileSchema.fromSchemaElements(List.of(
+                SchemaElement.root("schema", 1),
+                SchemaElement.group("props", RepetitionType.OPTIONAL, 1, new LogicalType.MapType()),
+                SchemaElement.group("key_value", RepetitionType.REPEATED, 1),
+                SchemaElement.primitive("key", PhysicalType.INT32, RepetitionType.REQUIRED)));
+
+        try (ParquetFileWriter writer = ParquetFileWriter.create(new ByteBufferOutputFile(), schema)) {
+            assertThat(writer).isNotNull();
+        }
+    }
+
+    /// The annotation accounts for the repetition of the group's entry, not for the group's
+    /// own: a `REPEATED` `LIST` group declares two repetition levels where the shredder derives
+    /// one layer, and nothing addresses the outer one. PyArrow refuses such a file outright —
+    /// "LIST-annotated groups must not be repeated".
+    @Test
+    void rejectsAnAnnotatedGroupThatIsItselfRepeated() {
+        FileSchema schema = FileSchema.fromSchemaElements(List.of(
+                SchemaElement.root("schema", 1),
+                SchemaElement.group("items", RepetitionType.REPEATED, 1, new LogicalType.ListType()),
+                SchemaElement.group("list", RepetitionType.REPEATED, 1),
+                SchemaElement.primitive("element", PhysicalType.INT32, RepetitionType.OPTIONAL)));
+
+        assertThatThrownBy(() -> ParquetFileWriter.create(new ByteBufferOutputFile(), schema))
+                .isInstanceOf(UnsupportedOperationException.class)
+                .hasMessageContaining("items")
+                .hasMessageContaining("is itself REPEATED");
+    }
+
+    /// The same rule one level in, where the annotated group stands in the entry position of
+    /// another. Being an annotated group's entry excuses a `REPEATED` group from carrying an
+    /// annotation of its own; it does not excuse one that carries an annotation from the rule
+    /// that annotation brings with it.
+    @Test
+    void rejectsAnAnnotatedGroupThatIsItselfRepeatedInsideAList() {
+        FileSchema schema = FileSchema.fromSchemaElements(List.of(
+                SchemaElement.root("schema", 1),
+                SchemaElement.group("items", RepetitionType.OPTIONAL, 1, new LogicalType.ListType()),
+                SchemaElement.group("inner", RepetitionType.REPEATED, 1, new LogicalType.ListType()),
+                SchemaElement.primitive("element", PhysicalType.INT32, RepetitionType.OPTIONAL)));
+
+        assertThatThrownBy(() -> ParquetFileWriter.create(new ByteBufferOutputFile(), schema))
+                .isInstanceOf(UnsupportedOperationException.class)
+                .hasMessageContaining("items.inner")
+                .hasMessageContaining("is itself REPEATED");
+    }
+
+    /// An annotation over an entry that does not repeat carries no repetition at all, so the
+    /// `list(...)` offsets the group's path accepts have nothing to drive. PyArrow refuses the
+    /// file — "Non-repeated nodes in a LIST-annotated group are not supported".
+    @Test
+    void rejectsAnAnnotatedGroupWhoseEntryIsNotRepeated() {
+        FileSchema schema = FileSchema.fromSchemaElements(List.of(
+                SchemaElement.root("schema", 1),
+                SchemaElement.group("items", RepetitionType.OPTIONAL, 1, new LogicalType.ListType()),
+                SchemaElement.primitive("element", PhysicalType.INT32, RepetitionType.OPTIONAL)));
+
+        assertThatThrownBy(() -> ParquetFileWriter.create(new ByteBufferOutputFile(), schema))
+                .isInstanceOf(UnsupportedOperationException.class)
+                .hasMessageContaining("items")
+                .hasMessageContaining("rather than REPEATED");
+    }
+
+    /// A sibling beside the entry would take the annotated group's repetition layer without
+    /// repeating, so its levels and the schema's would disagree.
+    @Test
+    void rejectsAnAnnotatedGroupHoldingMoreThanItsEntry() {
+        FileSchema schema = FileSchema.fromSchemaElements(List.of(
+                SchemaElement.root("schema", 1),
+                SchemaElement.group("items", RepetitionType.OPTIONAL, 2, new LogicalType.ListType()),
+                SchemaElement.primitive("a", PhysicalType.INT32, RepetitionType.OPTIONAL),
+                SchemaElement.primitive("b", PhysicalType.INT32, RepetitionType.OPTIONAL)));
+
+        assertThatThrownBy(() -> ParquetFileWriter.create(new ByteBufferOutputFile(), schema))
+                .isInstanceOf(UnsupportedOperationException.class)
+                .hasMessageContaining("items")
+                .hasMessageContaining("holds 2 fields");
+    }
+
+    /// A `MAP`'s entry is a key/value pair, so a leaf there is not the legacy two-level form a
+    /// `LIST` accepts but a map with nowhere to put a key. PyArrow refuses the file —
+    /// "Key-value node must be a group".
+    @Test
+    void rejectsAMapWhoseEntryIsALeaf() {
+        FileSchema schema = FileSchema.fromSchemaElements(List.of(
+                SchemaElement.root("schema", 1),
+                SchemaElement.group("props", RepetitionType.OPTIONAL, 1, new LogicalType.MapType()),
+                SchemaElement.primitive("key", PhysicalType.INT32, RepetitionType.REPEATED)));
+
+        assertThatThrownBy(() -> ParquetFileWriter.create(new ByteBufferOutputFile(), schema))
+                .isInstanceOf(UnsupportedOperationException.class)
+                .hasMessageContaining("props")
+                .hasMessageContaining("requires a repeated group of key and value");
+    }
+
+    /// The legacy two-level list, whose entry is the element itself. The annotation supplies
+    /// the layer, so the shape is producible and the record count survives a copy — which is
+    /// the whole point of admitting it, since `fromSchemaElements` is how a file being copied
+    /// arrives. Read back through PyArrow this is `[[1, 2], [], [3, 4, 5]]`.
+    @Test
+    void acceptsALegacyTwoLevelListWithALeafEntry() throws Exception {
+        FileSchema schema = FileSchema.fromSchemaElements(List.of(
+                SchemaElement.root("schema", 1),
+                SchemaElement.group("items", RepetitionType.OPTIONAL, 1, new LogicalType.ListType()),
+                SchemaElement.primitive("element", PhysicalType.INT32, RepetitionType.REPEATED)));
+
+        ByteBufferOutputFile out = new ByteBufferOutputFile();
+        try (ParquetFileWriter writer = ParquetFileWriter.create(out, schema)) {
+            writer.columnWriter().writeBatch(batch -> batch
+                    .list("items", new int[] { 0, 2, 2, 5 })
+                    .ints("items.element", new int[] { 1, 2, 3, 4, 5 }));
+        }
+
+        assertThat(listOfInts(out)).containsExactly(List.of(1, 2), List.of(), List.of(3, 4, 5));
+    }
+
+    /// The other legacy two-level form: the entry is a group of several fields and is therefore
+    /// itself the element, a list of structs. It repeats under the annotation exactly as a leaf
+    /// entry does, so the same rule admits it.
+    @Test
+    void acceptsALegacyTwoLevelListOfStructs() throws Exception {
+        FileSchema schema = FileSchema.fromSchemaElements(List.of(
+                SchemaElement.root("schema", 1),
+                SchemaElement.group("items", RepetitionType.OPTIONAL, 1, new LogicalType.ListType()),
+                SchemaElement.group("element", RepetitionType.REPEATED, 2),
+                SchemaElement.primitive("a", PhysicalType.INT32, RepetitionType.REQUIRED),
+                SchemaElement.primitive("b", PhysicalType.INT32, RepetitionType.REQUIRED)));
+
+        ByteBufferOutputFile out = new ByteBufferOutputFile();
+        try (ParquetFileWriter writer = ParquetFileWriter.create(out, schema)) {
+            writer.columnWriter().writeBatch(batch -> batch
+                    .list("items", new int[] { 0, 2, 3 })
+                    .ints("items.element.a", new int[] { 1, 2, 3 })
+                    .ints("items.element.b", new int[] { 10, 20, 30 }));
+        }
+
+        // Both leaves repeat under the one layer the annotation supplies, so they stay aligned.
+        assertThat(listOfInts(out, "items.element.a")).containsExactly(List.of(1, 2), List.of(3));
+        assertThat(listOfInts(out, "items.element.b")).containsExactly(List.of(10, 20), List.of(30));
+    }
+
+    /// The legacy `MAP` form, where only the inner `key_value` group is annotated and the
+    /// reader resolves the outer group to a map. Its `key_value` carries `MAP_KEY_VALUE`, not
+    /// `MAP`, so the entry rules must read it as the entry rather than as an annotation of its
+    /// own. Taken from a real file rather than assembled here, since that is the shape a copy
+    /// arrives with.
+    @Test
+    void acceptsTheLegacyKeyValueMapAnnotation() throws Exception {
+        Path fixture = Path.of("src/test/resources/map_annotation_legacy_key_value_test.parquet");
+
+        try (ParquetFileReader reader = ParquetFileReader.open(InputFile.of(fixture));
+                ParquetFileWriter writer =
+                        ParquetFileWriter.create(new ByteBufferOutputFile(), reader.getFileSchema())) {
+            assertThat(writer).isNotNull();
+        }
+    }
+
+    /// Refused because the writer validates a leaf's nulls against its own repetition without
+    /// consulting the ancestor masks that decide whether a slot is encoded at all (#1026).
+    /// The rejection itself is not new; settling it at `create` is.
+    @Test
+    void rejectsNullableStructEnclosingARepeatedField() {
+        FileSchema schema = FileSchema.builder("schema")
+                .struct("outer", RepetitionType.OPTIONAL, outer -> outer
+                        .list("inner", RepetitionType.REQUIRED,
+                                element -> element.primitive(PhysicalType.INT32, RepetitionType.REQUIRED)))
+                .build();
+
+        assertThatThrownBy(() -> ParquetFileWriter.create(new ByteBufferOutputFile(), schema))
+                .isInstanceOf(UnsupportedOperationException.class)
+                .hasMessageContaining("nullable struct enclosing a repeated field")
+                .hasMessageContaining("outer.inner");
+    }
+
+    /// A repeated field resets the ancestry: a nullable struct *below* a list is the shape
+    /// `WriterNestedRoundTripTest` writes, and must not be swept up by the rule above.
+    @Test
+    void acceptsANullableStructBelowAList() throws Exception {
+        FileSchema schema = FileSchema.builder("schema")
+                .list("items", RepetitionType.REQUIRED, element -> element
+                        .struct(RepetitionType.OPTIONAL,
+                                inner -> inner.addColumn("v", PhysicalType.INT32, RepetitionType.REQUIRED)))
+                .build();
+
+        try (ParquetFileWriter writer = ParquetFileWriter.create(new ByteBufferOutputFile(), schema)) {
+            assertThat(writer).isNotNull();
+        }
+    }
+
+    /// A schema the writer cannot produce must leave the destination as it found it.
+    /// `ChannelOutputFile` streams to a temporary sibling and renames on close, so a refusal
+    /// after the destination was opened orphans that sibling for good — nothing later would
+    /// clean it up.
+    @Test
+    void anUnproducibleSchemaLeavesNothingAtTheDestination(@TempDir Path dir) throws Exception {
+        FileSchema schema = FileSchema.fromSchemaElements(List.of(
+                SchemaElement.root("schema", 1),
+                SchemaElement.primitive("nums", PhysicalType.INT32, RepetitionType.REPEATED)));
+        Path file = dir.resolve("out.parquet");
+
+        assertThatThrownBy(() -> ParquetFileWriter.create(OutputFile.of(file), schema))
+                .isInstanceOf(UnsupportedOperationException.class);
+
+        try (Stream<Path> entries = Files.list(dir)) {
+            assertThat(entries).isEmpty();
+        }
+    }
+
+    /// Everything the schema decides is settled before the destination is opened, so what is
+    /// left between `out.create()` and a usable writer is the magic write and the construction
+    /// itself. Should either fail, the destination is open and holds no file: the failure path
+    /// has to discard it, because `ChannelOutputFile` streams into a temporary sibling and
+    /// renames only on `close()`, and nothing else would ever remove that sibling.
+    @Test
+    void aFailureAfterTheDestinationIsOpenedDiscardsIt(@TempDir Path dir) throws Exception {
+        Path file = dir.resolve("out.parquet");
+        FailingWrite out = new FailingWrite(OutputFile.of(file));
+
+        assertThatThrownBy(() -> ParquetFileWriter.create(out, oneColumn()))
+                .isInstanceOf(IOException.class)
+                .hasMessage("injected write failure");
+
+        assertThat(out.discarded).isTrue();
+        try (Stream<Path> entries = Files.list(dir)) {
+            assertThat(entries).isEmpty();
+        }
+    }
+
+    /// Reads a list column back as one list of values per record, so what the writer emitted
+    /// can be compared against the lists that went in rather than against a level stream.
+    private static List<List<Integer>> listOfInts(ByteBufferOutputFile out) throws IOException {
+        return listOfInts(out, 0);
+    }
+
+    private static List<List<Integer>> listOfInts(ByteBufferOutputFile out, String column) throws IOException {
+        try (ParquetFileReader reader = ParquetFileReader.open(InputFile.of(ByteBuffer.wrap(out.toByteArray())))) {
+            return listOfInts(out, reader.getFileSchema().getColumn(column).columnIndex());
+        }
+    }
+
+    private static List<List<Integer>> listOfInts(ByteBufferOutputFile out, int columnIndex) throws IOException {
+        List<List<Integer>> records = new ArrayList<>();
+        try (ParquetFileReader reader = ParquetFileReader.open(InputFile.of(ByteBuffer.wrap(out.toByteArray())));
+                ColumnReader column = reader.columnReader(columnIndex)) {
+            while (column.nextBatch()) {
+                int[] offsets = column.getLayerOffsets(0);
+                int[] values = column.getInts();
+                for (int r = 0; r < column.getRecordCount(); r++) {
+                    List<Integer> entries = new ArrayList<>();
+                    for (int e = offsets[r]; e < offsets[r + 1]; e++) {
+                        entries.add(values[e]);
+                    }
+                    records.add(entries);
+                }
+            }
+        }
+        return records;
+    }
+
+    /// An `OutputFile` that opens but refuses every write, so the failure lands after the
+    /// destination has been created and the discard is the only thing that can clean it up.
+    private static final class FailingWrite implements OutputFile {
+
+        private final OutputFile delegate;
+        private boolean discarded;
+
+        FailingWrite(OutputFile delegate) {
+            this.delegate = delegate;
+        }
+
+        @Override
+        public void create() throws IOException {
+            delegate.create();
+        }
+
+        @Override
+        public void write(ByteBuffer data) throws IOException {
+            throw new IOException("injected write failure");
+        }
+
+        @Override
+        public long position() {
+            return delegate.position();
+        }
+
+        @Override
+        public void close() throws IOException {
+            delegate.close();
+        }
+
+        @Override
+        public void discard() throws IOException {
+            discarded = true;
+            delegate.discard();
+        }
+    }
+}

--- a/docs/content/how-to/write-column-by-column.md
+++ b/docs/content/how-to/write-column-by-column.md
@@ -154,7 +154,9 @@ Layers compose to any depth: `list("m.list.element", innerOffsets)` describes th
 Offsets are validated: they must start at `0`, be non-decreasing, and end at exactly the number of entries the element column holds.
 
 !!! note "One nested shape is not writable yet"
-    An `OPTIONAL` struct group directly enclosing a repeated field — what Arrow-based writers produce for a nullable struct holding a list — is rejected by both write APIs with an `UnsupportedOperationException` naming the group. Hardwood reads such files; writing them is tracked as [#1026](https://github.com/hardwood-hq/hardwood/issues/1026).
+    An `OPTIONAL` struct group directly enclosing a repeated field — what Arrow-based writers produce for a nullable struct holding a list — is rejected by `ParquetFileWriter.create` with an `UnsupportedOperationException` naming the group. Hardwood reads such files; writing them is tracked as [#1026](https://github.com/hardwood-hq/hardwood/issues/1026).
+
+The `list` and `map` verbs address the entry offsets of a `LIST` or `MAP` group, and a repeated field the annotation does not account for has no offsets to address — so `create` rejects one, listed under [Schema Shapes](../reference/writer.md#schema-shapes). A schema read back from an existing file may carry a legacy two-level list, `LIST { repeated element }` or `LIST { repeated group element { … } }`; both are writable here, addressed through the annotated group's path exactly as the three-level layout is.
 
 ## Batch Size
 

--- a/docs/content/how-to/write-row-by-row.md
+++ b/docs/content/how-to/write-row-by-row.md
@@ -145,7 +145,9 @@ rows.writeRow(row -> row
                 .addList(inner -> inner.addInt(3))));
 ```
 
-One nested shape cannot be written yet: an `OPTIONAL` struct group directly enclosing a repeated field — what Arrow-based writers produce for a nullable struct holding a list. `rowWriter()` rejects such a schema up front, naming the group. Hardwood reads such files; writing them is tracked as [#1026](https://github.com/hardwood-hq/hardwood/issues/1026).
+One nested shape cannot be written yet: an `OPTIONAL` struct group directly enclosing a repeated field — what Arrow-based writers produce for a nullable struct holding a list. `ParquetFileWriter.create` rejects such a schema, naming the group. Hardwood reads such files; writing them is tracked as [#1026](https://github.com/hardwood-hq/hardwood/issues/1026).
+
+Two shapes the columnar API writes are out of reach here: the legacy two-level lists, `LIST { repeated element }` and `LIST { repeated group element { … } }`. The builders reach a list's values through an element node below the entry, and in both of those the entry is the element. `rowWriter()` rejects them, naming the group; [Column by Column](write-column-by-column.md) writes them.
 
 A builder is valid only inside the filler it was handed to. Retaining one and using it after its scope has ended is rejected rather than writing into a later record.
 

--- a/docs/content/reference/error-handling.md
+++ b/docs/content/reference/error-handling.md
@@ -29,7 +29,7 @@ Hardwood throws specific exceptions for common error conditions.
 | Exception | When |
 |-----------|------|
 | `IOException` | The destination cannot be created, written, or finalized. The writer discards its output rather than leaving a truncated file at the target path |
-| `UnsupportedOperationException` | A schema column of an unsupported physical type (`INT96`); a refused compression codec (`LZ4`, `LZO`) or one whose library is not on the classpath; an `OPTIONAL` struct group directly enclosing a repeated field |
+| `UnsupportedOperationException` | A schema column of an unsupported physical type (`INT96`); a refused compression codec (`LZ4`, `LZO`) or one whose library is not on the classpath; a schema shape the writer cannot produce — repetition no `LIST` or `MAP` annotation accounts for, or an `OPTIONAL` struct group enclosing a repeated field |
 | `IllegalArgumentException` | An unknown column name or path, a setter that does not fit the column's type, a column set twice, a batch that leaves a column unset or whose arrays disagree in length, a null mask on a `REQUIRED` column, list offsets that do not describe the elements given, a value outside the range its annotation declares, or a `REQUIRED` field a record leaves unset |
 | `IndexOutOfBoundsException` | A leaf-column index outside `[0, leaf column count)` on a `ColumnBatch` setter, or a field index outside `[0, getFieldCount())` on a `StructBuilder` setter |
 | `IllegalStateException` | Writing after `close()`, using both write APIs on one file, or using a `ColumnBatch` or nested builder after its scope has ended |

--- a/docs/content/reference/writer.md
+++ b/docs/content/reference/writer.md
@@ -232,12 +232,25 @@ hardwood version <version> (build <commit>)
 
 | Exception | When |
 |---|---|
-| `UnsupportedOperationException` | A schema column of an unsupported physical type (`INT96`); a refused codec (`LZ4`, `LZO`) or one whose library is missing; an `OPTIONAL` struct group directly enclosing a repeated field |
+| `UnsupportedOperationException` | A schema column of an unsupported physical type (`INT96`); a refused codec (`LZ4`, `LZO`) or one whose library is missing; a [schema shape](#schema-shapes) the writer cannot produce |
 | `IllegalArgumentException` | A `null` metadata key, metadata map or `created_by`; an unknown column name or path; a setter that does not fit the column's type; a `null` value array, or a `null` value at a present row of a binary column; a column set twice in one batch or record; a batch that leaves a column unset, or whose arrays disagree in length; a null mask on a `REQUIRED` column; a `boolean[]` mask whose length does not match the values; list offsets that do not start at `0`, are not non-decreasing, or disagree with the element count; a value outside the range its annotation declares; a `REQUIRED` field left unset by a record |
 | `IndexOutOfBoundsException` | A leaf-column index outside `[0, leaf column count)` on a `ColumnBatch` setter, or a field index outside `[0, getFieldCount())` on a `StructBuilder` setter |
 | `IllegalStateException` | Writing, or setting key-value metadata or `created_by`, after `close()`; using both write APIs on one file; using a `ColumnBatch` after it has been submitted, or a nested builder after its filler has returned |
 | `IOException` | The destination cannot be created, written, or finalized |
 
-An `OPTIONAL` struct group that encloses a repeated field is the one nested shape the writer cannot produce, although Hardwood reads files containing it; it is tracked as [#1026](https://github.com/hardwood-hq/hardwood/issues/1026).
+### Schema Shapes
+
+Repetition is writable wherever a `LIST` or `MAP` annotation accounts for it. An annotated group is `REQUIRED` or `OPTIONAL` and holds exactly one `REPEATED` entry, which for a `MAP` is a group of `key` and `value`. That admits the canonical three-level `LIST` and two-level `MAP` layouts `FileSchema.builder` declares, and the legacy two-level lists a schema read from an existing file may carry: `LIST { repeated element }`, whose entry is the element, and `LIST { repeated group element { … } }`, whose entry is an element struct.
+
+Every other arrangement of repetition is rejected when the writer is created, since nothing in the schema says where its entries begin and end:
+
+- a `REPEATED` field — leaf or group — whose parent carries neither annotation;
+- a `LIST` or `MAP` group that is itself `REPEATED`;
+- a `LIST` or `MAP` group holding anything other than its single `REPEATED` entry;
+- a `MAP` whose entry is a leaf rather than a group.
+
+An `OPTIONAL` struct group enclosing a repeated field is rejected as well, although Hardwood reads files containing it; it is tracked as [#1026](https://github.com/hardwood-hq/hardwood/issues/1026).
+
+The row API reaches a list's values through an element node below the entry, which the legacy two-level lists do not have, so `rowWriter()` refuses those two shapes and `columnWriter()` writes them. `rowWriter()` also requires sibling field names to be unique, which the `ColumnBatch` indices and dotted paths do not.
 
 A `ParquetFileWriter` that cannot finish a valid file discards its output, leaving nothing at the destination.


### PR DESCRIPTION
Fixes #1035.

`ParquetFileWriter.create` settled each column's physical type and the configured encodings before touching the output, and left the schema's *shape* to whichever write view met it first. Three consequences, in descending order of how badly they behave:

- A `REPEATED` leaf contributes no shredding layer, so a legacy two-level list was shredded as an ordinary flat column: one entry per record, repetition level 0 throughout. `repeated int32 nums` fed five values came back out of PyArrow as `[[1], [2], [3], [4], [5]]` — five one-element lists — with nothing raised. `FileSchema.Builder` refuses the shape, but `fromSchemaElements` does not, and that is the schema a file being copied arrives with.
- A shape the writer genuinely could not produce was caught in the `ParquetFileWriter` constructor, which runs *after* `out.create()` and the `PAR1` magic write. `ChannelOutputFile` streams to a temporary sibling and only renames on `close()`, so the refusal orphaned `<target>.hardwood-tmp` at the destination for good.
- That refusal was an `IllegalStateException` where `create` documents `UnsupportedOperationException`, and the row layer raised `UnsupportedOperationException` for the same defect.

## The rule

Writing the tests first turned up a boundary worth stating plainly: a `REPEATED` leaf **under a `LIST` annotation** — the legacy two-level `LIST { repeated int32 element }` — already writes correctly today, verified through PyArrow (offsets `{0,2,2,5}` read back as `[[1,2], [], [3,4,5]]`). Rejecting every `REPEATED` leaf, which is what `RowPlan` does, would have been a regression on the columnar path.

So the two checks that existed collapse into one narrower rule: **repetition is producible exactly where it hangs off a `LIST` or `MAP` annotation.** The annotated group is what gives the shredder a repetition layer and gives `ColumnBatch` a path to address the entry offsets under; a bare `repeated` leaf or group has neither, which is precisely why it was being shredded one entry per record.

## The change

`WriterSchemaShape` (internal) states that rule and the nullable-struct-over-repeated rule once. `create` calls it beside the physical-type check and ahead of `out.create()`, so producibility is settled before either view exists — one shape, one rejection, one wording. The construction that follows now discards the destination on any failure rather than orphaning the temporary file.

`RowPlan` resolves its two shared rules against the same helper and keeps the stricter ones, which are about *addressing* a shape rather than producing it: sibling names must be unique for the by-name setters, and the row builders navigate a list through its element node. The columnar API addresses by index and dotted path and is unharmed by either. That split is now stated in the class docs on both sides.

This does not change what #1026 asks for — a nullable struct enclosing a repeated field is still refused, just earlier.

## Verification

`WriterSchemaShapeTest` is new: 9 tests, 5 of which fail on `main` and pass here, plus 4 pinning the shapes that must keep working — `LIST`/`MAP` scaffolding, a key-only `MAP`, a nullable struct *below* a list, and the legacy-under-annotation case above.

Four superseded tests were removed from `WriterBatchContractTest` and `RowWriterRulesTest`; they asserted the old, later rejection points.

Full suite, no `-Dquick`: core 2672 · parquet-testing-runner 933 + write-coverage verdict 5 · cli 620 · s3 149 · avro 72 · parquet-java-compat 17 · integration-test 3. All green.

`_designs/WRITER_ROW_API.md` described the old end state (shape rejection at `rowWriter()`); updated, along with `_designs/WRITER_NESTED.md`, whose "the legacy backward-compatibility list shapes the reader tolerates on read are not produced" line was inaccurate given the annotated two-level case.
