### PR TITLE
#1038 Emit the JFR events that never fired

### DIFF
--- a/_designs/COLUMN_INDEX_PUSHDOWN.md
+++ b/_designs/COLUMN_INDEX_PUSHDOWN.md
@@ -84,7 +84,7 @@ Added an overloaded constructor accepting an optional `RowRanges matchingRows` p
 In `scanPagesFromIndex()`, after parsing the Offset Index and before slicing pages, a `filterPageLocations()` method filters the page locations:
 - If `matchingRows` is null or `isAll()`, all pages pass through unchanged
 - Otherwise, each page's row range is checked via `overlapsPage()`. The last page uses `Long.MAX_VALUE` as its end sentinel to avoid needing the row group row count.
-- A `PageFilterEvent` is emitted when pages are actually skipped
+- Page selection is reported by a `PageFilterEvent`, emitted from `RowGroupIterator.computeFetchPlans` once the surviving page count for a column chunk is known (see Step 5)
 
 The sequential scan path (`scanPagesSequential`) is unaffected — it has no per-page statistics.
 
@@ -125,7 +125,7 @@ In `scanAllProjectedColumns()`, computes `RowRanges` per row group using the exi
 
 ### New file: `jfr/PageFilterEvent.java`
 
-Emitted once per column per row group when pages are actually skipped (not emitted when all pages pass through). Reports file, rowGroupIndex, column, totalPages, pagesKept, pagesSkipped.
+Emitted from `RowGroupIterator.computeFetchPlans`, once per column chunk whose pages a predicate narrowed — including when the predicate kept every one of them, so that a `pagesSkipped` of 0 stays distinguishable from no page filtering at all. Nothing is emitted when no predicate narrowed the row group's pages: a read with no filter, a column chunk with no Column Index, a row group whose per-page mask gate is closed, or a `tail(N)` whose synthesized row range is the only thing dropping pages. Reports file, rowGroupIndex, column, totalPages, pagesKept, pagesSkipped.
 
 **Files:**
 - `core/src/main/java/dev/hardwood/jfr/PageFilterEvent.java` (new)
@@ -169,9 +169,9 @@ End-to-end benchmark that lazily generates a 50M-row synthetic Parquet file (via
 |------|------|--------|
 | New | `internal/reader/RowRanges.java` | Row range interval set with intersection/union |
 | New | `internal/reader/PageFilterEvaluator.java` | Per-page predicate evaluation → RowRanges |
-| New | `jfr/PageFilterEvent.java` | JFR event for page-level filtering |
+| New | `jfr/PageFilterEvent.java` | JFR event for page-level filtering, emitted from `RowGroupIterator.computeFetchPlans` |
 | Modify | `internal/reader/RowGroupFilterEvaluator.java` | Widened shared comparison and column resolution helpers |
-| Modify | `internal/reader/PageScanner.java` | Accept RowRanges, filter page locations, emit JFR event |
+| Modify | `internal/reader/PageScanner.java` | Accept RowRanges, filter page locations |
 | Modify | `reader/ParquetFileReader.java` | Pass filter to ColumnReader/RowReader |
 | Modify | `reader/SingleFileRowReader.java` | Accept filter, compute RowRanges per row group |
 | Modify | `reader/ColumnReader.java` | Accept filter in factory methods |
@@ -220,7 +220,7 @@ Each call site attempts page-range I/O per column when filtering is active. Fall
 | New | `internal/reader/RowRanges.java` | Row range interval set with intersection/union |
 | New | `internal/reader/PageFilterEvaluator.java` | Per-page predicate evaluation → RowRanges |
 | New | `internal/reader/PageRangeData.java` | Fetched page-range buffers with page/dictionary slicing |
-| New | `jfr/PageFilterEvent.java` | JFR event for page-level filtering |
+| New | `jfr/PageFilterEvent.java` | JFR event for page-level filtering, emitted from `RowGroupIterator.computeFetchPlans` |
 | Modify | `internal/reader/PageRange.java` | Added `forColumn()` factory for page-range computation |
 | Modify | `internal/reader/RowGroupFilterEvaluator.java` | Widened shared comparison and column resolution helpers |
 | Modify | `internal/reader/PageScanner.java` | Accept RowRanges and PageRangeData, bifurcated page slicing |

--- a/_designs/PARSING_PIPELINE_V2.md
+++ b/_designs/PARSING_PIPELINE_V2.md
@@ -91,7 +91,7 @@ Two consumption modes:
 - **Recycling mode** (`BatchExchange.recycling()`): Pre-allocates 3 batch holders (`READY_QUEUE_CAPACITY + 1`) that cycle between drain and consumer. No per-batch allocation. Used by `FlatRowReader` and `NestedRowReader`.
 - **Detaching mode** (`BatchExchange.detaching()`): Allocates a fresh batch via a factory each time the drain needs one. The consumer keeps ownership of each batch permanently. Back-pressure comes from the bounded `readyQueue` only. Used by `ColumnReader` where the caller retains arrays between batches.
 
-**Consumer polling:** `BatchExchange.poll()` encapsulates the consumer-side protocol. A non-blocking poll is attempted first; if the queue is empty, a timed poll loop follows. The `finished` flag is only checked after a timed poll returns null, guaranteeing that any batch published before `finish()` is visible. A JFR `BatchWaitEvent` is emitted when the consumer enters the timed poll loop (deferred past the first 10ms to avoid allocation on the fast path).
+**Consumer polling:** `BatchExchange.poll()` encapsulates the consumer-side protocol. A non-blocking poll is attempted first; if the queue is empty, a timed poll loop follows. The `finished` flag is only checked after a timed poll returns null, guaranteeing that any batch published before `finish()` is visible. A JFR `BatchWaitEvent` spans the timed poll loop, so its duration is the stall the consumer paid. The two returns above the loop keep it off the fast path: a batch already on the ready queue, and a finished and drained exchange, both return before the event exists.
 
 Two batch types:
 

--- a/core/src/main/java/dev/hardwood/internal/reader/BatchExchange.java
+++ b/core/src/main/java/dev/hardwood/internal/reader/BatchExchange.java
@@ -11,6 +11,7 @@ import java.util.concurrent.ArrayBlockingQueue;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Supplier;
 
+import dev.hardwood.jfr.BatchWaitEvent;
 import dev.hardwood.metadata.PhysicalType;
 import dev.hardwood.schema.ColumnSchema;
 
@@ -191,13 +192,24 @@ public class BatchExchange<B> {
         if (finished) {
             return readyQueue.poll();
         }
-        while ((batch = readyQueue.poll(10, TimeUnit.MILLISECONDS)) == null) {
-            if (finished) {
-                return readyQueue.poll();
+        // Past this point the consumer is stalled on the pipeline: the ready
+        // queue is empty and the drain has not finished. The event's duration
+        // is the stall, so it spans every exit from the timed poll loop.
+        BatchWaitEvent event = new BatchWaitEvent();
+        event.begin();
+        try {
+            while ((batch = readyQueue.poll(10, TimeUnit.MILLISECONDS)) == null) {
+                if (finished) {
+                    return readyQueue.poll();
+                }
+                checkError();
             }
-            checkError();
+            return batch;
         }
-        return batch;
+        finally {
+            event.column = columnName;
+            event.commit();
+        }
     }
 
     /// Returns a consumed batch to the free pool so it can be refilled by the drain.

--- a/core/src/main/java/dev/hardwood/internal/reader/FilteredRowReader.java
+++ b/core/src/main/java/dev/hardwood/internal/reader/FilteredRowReader.java
@@ -33,14 +33,18 @@ public final class FilteredRowReader implements FileAwareRowReader {
     /// Cap on matching rows returned (SQL LIMIT over the filtered relation).
     /// [ColumnWorker#UNLIMITED] means no cap.
     private final long maxMatches;
+    /// Counts each evaluation for the JFR record-filter event. The delegate owns
+    /// it: the delegate marks the file boundaries and closes it out.
+    private final RecordFilterTally tally;
 
     private boolean hasMatch;
     private long matchesReturned;
 
-    FilteredRowReader(RowReader delegate, RowMatcher matcher, long maxMatches) {
+    FilteredRowReader(RowReader delegate, RowMatcher matcher, long maxMatches, RecordFilterTally tally) {
         this.delegate = delegate;
         this.matcher = matcher;
         this.maxMatches = maxMatches;
+        this.tally = tally;
     }
 
     @Override
@@ -53,7 +57,9 @@ public final class FilteredRowReader implements FileAwareRowReader {
         }
         while (delegate.hasNext()) {
             delegate.next();
-            if (matcher.test(delegate)) {
+            boolean matched = matcher.test(delegate);
+            tally.record(matched);
+            if (matched) {
                 hasMatch = true;
                 return true;
             }

--- a/core/src/main/java/dev/hardwood/internal/reader/FlatRowReader.java
+++ b/core/src/main/java/dev/hardwood/internal/reader/FlatRowReader.java
@@ -135,10 +135,16 @@ public final class FlatRowReader implements FileAwareRowReader {
     // File name from the current batch — used for exception enrichment
     private String currentFileName;
 
+    /// Per-file record-filter counts for JFR, or `null` when the read has no
+    /// filter and nothing evaluates records.
+    private final RecordFilterTally tally;
+
     public FlatRowReader(BatchExchange<BatchExchange.Batch>[] exchanges, FlatColumnWorker[] columnWorkers,
                          FileSchema fileSchema, ProjectedSchema projectedSchema,
-                         boolean drainSide, int wordsLen, MergePlan mergePlan, long maxMatchedRows) {
+                         boolean drainSide, int wordsLen, MergePlan mergePlan, long maxMatchedRows,
+                         RecordFilterTally tally) {
         this.maxMatchedRows = maxMatchedRows;
+        this.tally = tally;
         this.exchanges = exchanges;
         this.columnWorkers = columnWorkers;
         this.columnCount = exchanges.length;
@@ -296,8 +302,12 @@ public final class FlatRowReader implements FileAwareRowReader {
         // matched rows. On the FilteredRowReader path the wrapper caps; on the
         // no-filter path the worker already capped scanned == matched rows.
         long readerMatchLimit = drainSide ? maxRows : ColumnWorker.UNLIMITED;
+        // The tally spans both filtered paths: the drain-side reader feeds it whole
+        // batches, the wrapper feeds it single records, and either way the reader
+        // marks the file boundaries as it loads batches.
+        RecordFilterTally tally = filter != null ? new RecordFilterTally() : null;
         FlatRowReader reader = new FlatRowReader(buffers, workers, schema, projectedSchema,
-                drainSide, wordsLen, mergePlan, readerMatchLimit);
+                drainSide, wordsLen, mergePlan, readerMatchLimit, tally);
         reader.initialize();
 
         if (drainSide) {
@@ -310,7 +320,7 @@ public final class FlatRowReader implements FileAwareRowReader {
             // a top-level field, and the reader's `getInt(int)` etc. take a
             // projected leaf-column index. Map directly through the projection.
             RowMatcher matcher = RecordFilterCompiler.compile(filter, schema, projectedSchema::toProjectedIndex);
-            return new FilteredRowReader(reader, matcher, maxRows);
+            return new FilteredRowReader(reader, matcher, maxRows, tally);
         }
         return reader;
     }
@@ -853,6 +863,17 @@ public final class FlatRowReader implements FileAwareRowReader {
             // field's default -1.
             runEndExclusive = 0;
         }
+        if (tally != null) {
+            // Ahead of any record of this batch being counted, so the counts land
+            // on the file the batch came from. Batches never straddle files.
+            tally.switchFile(currentFileName);
+            if (drainSide) {
+                // The whole batch was decided on the drain thread — count it here
+                // rather than as rows are yielded, so an early exit does not leave
+                // the batch reported as all-skipped.
+                tally.recordBatch(batchSize, countMatches(combinedWords, batchSize));
+            }
+        }
         return true;
     }
 
@@ -884,6 +905,22 @@ public final class FlatRowReader implements FileAwareRowReader {
         }
         int activeWords = (batchSize + 63) >>> 6;
         mergeEvaluator.eval(mergePlan, combinedWords, activeWords, perColumnMatches);
+    }
+
+    /// Counts the set bits of `words` below `limit`. The words past `limit` hold
+    /// stale bits from an earlier, longer batch (see [#intersectMatches]), so the
+    /// partial tail word is masked rather than counted whole.
+    private static int countMatches(long[] words, int limit) {
+        int fullWords = limit >>> 6;
+        int count = 0;
+        for (int i = 0; i < fullWords; i++) {
+            count += Long.bitCount(words[i]);
+        }
+        int tailBits = limit & 63;
+        if (tailBits != 0) {
+            count += Long.bitCount(words[fullWords] & (~0L >>> (64 - tailBits)));
+        }
+        return count;
     }
 
     /// Collects the projected column indices referenced by `plan`, so
@@ -927,6 +964,9 @@ public final class FlatRowReader implements FileAwareRowReader {
             return;
         }
         closed = true;
+        if (tally != null) {
+            tally.close();
+        }
         if (columnWorkers != null) {
             for (FlatColumnWorker worker : columnWorkers) {
                 worker.close();

--- a/core/src/main/java/dev/hardwood/internal/reader/NestedRowReader.java
+++ b/core/src/main/java/dev/hardwood/internal/reader/NestedRowReader.java
@@ -49,6 +49,9 @@ public final class NestedRowReader implements FileAwareRowReader {
     private final ProjectedSchema projectedSchema;
     private final NestedBatchDataView dataView;
     private final ColumnSchema[] columnSchemas;
+    /// Per-file record-filter counts for JFR, or `null` when the read has no
+    /// filter and nothing evaluates records.
+    private final RecordFilterTally tally;
 
     // Iteration state
     private NestedBatch[] previousBatches;
@@ -61,7 +64,8 @@ public final class NestedRowReader implements FileAwareRowReader {
 
 
     NestedRowReader(BatchExchange<NestedBatch>[] exchanges, NestedColumnWorker[] columnWorkers,
-                    FileSchema fileSchema, ProjectedSchema projectedSchema) {
+                    FileSchema fileSchema, ProjectedSchema projectedSchema, RecordFilterTally tally) {
+        this.tally = tally;
         this.exchanges = exchanges;
         this.columnWorkers = columnWorkers;
         this.columnCount = exchanges.length;
@@ -154,7 +158,8 @@ public final class NestedRowReader implements FileAwareRowReader {
             worker.start();
         }
 
-        NestedRowReader reader = new NestedRowReader(buffers, workers, schema, projectedSchema);
+        RecordFilterTally tally = filter != null ? new RecordFilterTally() : null;
+        NestedRowReader reader = new NestedRowReader(buffers, workers, schema, projectedSchema, tally);
         reader.initialize();
         if (filter != null) {
             // Indexed compile path: for nested schemas, the reader's
@@ -164,7 +169,7 @@ public final class NestedRowReader implements FileAwareRowReader {
             // (or `-1` for nested-leaf columns and unprojected fields).
             int[] topLevelLookup = buildTopLevelFieldIndexLookup(schema, projectedSchema);
             RowMatcher matcher = RecordFilterCompiler.compile(filter, schema, col -> topLevelLookup[col]);
-            return new FilteredRowReader(reader, matcher, maxRows);
+            return new FilteredRowReader(reader, matcher, maxRows, tally);
         }
         return reader;
     }
@@ -277,6 +282,11 @@ public final class NestedRowReader implements FileAwareRowReader {
 
         // Index structures are pre-computed by the drain — just assemble the view
         currentFileName = batches[0].fileName;
+        if (tally != null) {
+            // Ahead of any record of this batch being counted, so the counts land
+            // on the file the batch came from. Batches never straddle files.
+            tally.switchFile(currentFileName);
+        }
         dataView.setBatchData(batches, columnSchemas, currentFileName);
         rowIndex = -1;
         return true;
@@ -354,6 +364,9 @@ public final class NestedRowReader implements FileAwareRowReader {
             return;
         }
         closed = true;
+        if (tally != null) {
+            tally.close();
+        }
         if (columnWorkers != null) {
             for (NestedColumnWorker worker : columnWorkers) {
                 worker.close();

--- a/core/src/main/java/dev/hardwood/internal/reader/RecordFilterTally.java
+++ b/core/src/main/java/dev/hardwood/internal/reader/RecordFilterTally.java
@@ -1,0 +1,79 @@
+/*
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Copyright The original authors
+ *
+ *  Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package dev.hardwood.internal.reader;
+
+import dev.hardwood.jfr.RecordFilterEvent;
+
+/// Accumulates the outcome of record-level predicate evaluation and emits one
+/// [RecordFilterEvent] per file.
+///
+/// A file is the finest granularity the read pipeline maintains below the whole
+/// read: batches are flushed at file boundaries, so a batch — and every record in
+/// it — belongs to exactly one file, while a batch may span row groups. The
+/// readers call [#switchFile] as they advance onto a batch from the next file,
+/// which closes out the counts gathered so far, so no counting has to happen on
+/// the per-record path beyond the two increments themselves.
+///
+/// Counts are closed out on each *change* of file, so a read that lists the same
+/// path twice in a row reports one event covering both passes over it.
+///
+/// Not thread-safe, and does not need to be: every path that feeds it — the
+/// drain-side batch counts, the per-record wrapper, and the column-reader selection
+/// — runs on the consumer thread. Moving any of that onto a drain thread would need
+/// this revisited.
+public final class RecordFilterTally {
+
+    private String file;
+    private long evaluated;
+    private long kept;
+
+    /// Attributes subsequent counts to `fileName`, emitting the counts gathered
+    /// for the previous file. Idempotent for repeated calls naming the same file,
+    /// which is the common case: readers call this on every batch.
+    public void switchFile(String fileName) {
+        if (file != null && !file.equals(fileName)) {
+            emit();
+        }
+        file = fileName;
+    }
+
+    /// Records one record-level predicate evaluation and whether it matched.
+    public void record(boolean matched) {
+        evaluated++;
+        if (matched) {
+            kept++;
+        }
+    }
+
+    /// Records a batch the predicate decided on in one go, as the drain-side and
+    /// column-reader paths do.
+    public void recordBatch(int evaluatedRecords, int matchedRecords) {
+        evaluated += evaluatedRecords;
+        kept += matchedRecords;
+    }
+
+    /// Emits the counts of the file the read ended on. Safe to call more than once
+    /// — the second call has nothing left to report.
+    public void close() {
+        emit();
+    }
+
+    private void emit() {
+        if (evaluated == 0) {
+            return;
+        }
+        RecordFilterEvent event = new RecordFilterEvent();
+        event.file = file;
+        event.totalRecords = evaluated;
+        event.recordsKept = kept;
+        event.recordsSkipped = evaluated - kept;
+        event.commit();
+        evaluated = 0;
+        kept = 0;
+    }
+}

--- a/core/src/main/java/dev/hardwood/internal/reader/RowGroupIterator.java
+++ b/core/src/main/java/dev/hardwood/internal/reader/RowGroupIterator.java
@@ -35,6 +35,7 @@ import dev.hardwood.internal.reader.FileMetadataCache.PreparedFile;
 import dev.hardwood.internal.schema.ProjectedSchema;
 import dev.hardwood.internal.thrift.OffsetIndexReader;
 import dev.hardwood.internal.thrift.ThriftCompactReader;
+import dev.hardwood.jfr.PageFilterEvent;
 import dev.hardwood.jfr.RowGroupFilterEvent;
 import dev.hardwood.metadata.ColumnChunk;
 import dev.hardwood.metadata.FieldPath;
@@ -571,6 +572,14 @@ public class RowGroupIterator {
             matchingRows = RowRanges.ALL;
         }
 
+        // Whether a *predicate* narrowed the pages of this row group, which is what
+        // PageFilterEvent reports. `shared.matchingRows()` is filter-derived, while
+        // the local `matchingRows` also carries the tail-read fast path's synthesized
+        // range — pages that range drops were dropped by `tail(N)`, not by the Column
+        // Index. Both must be narrow: a closed mask gate promotes the local ranges
+        // back to ALL, and then no page is skipped at all.
+        boolean pageFilterApplied = !matchingRows.isAll() && !shared.matchingRows().isAll();
+
         // Convert the iterator-wide maxRows into a per-row-group remainder.
         // `PageLocation.firstRowIndex` and `SequentialFetchPlan.valuesRead`
         // are both row-group-local (reset to 0 each RG), so passing the global
@@ -611,6 +620,13 @@ public class RowGroupIterator {
                 // the records inside the matching ranges.
                 List<NeededPage> neededPages = computeNeededPages(
                         allPages, matchingRows, rowGroup.numRows());
+
+                // Report the page-level filter's effect before `truncateToMaxRows`,
+                // so a `head(N)` cap is not counted as pages the predicate skipped,
+                // and before the empty-plan shortcut below, so the fully-pruned
+                // column — the most effective case — is reported too.
+                emitPageFilterEvent(inputFile.name(), workItem.rowGroupIndex(), columnSchema.name(),
+                        pageFilterApplied, allPages.size(), neededPages.size());
 
                 if (neededPages.isEmpty()) {
                     plans[projCol] = FetchPlan.EMPTY;
@@ -871,6 +887,30 @@ public class RowGroupIterator {
             }
         }
         return needed;
+    }
+
+    /// Emits a [PageFilterEvent] for one column chunk whose pages were narrowed by
+    /// Column Index push-down.
+    ///
+    /// Nothing is emitted unless a predicate actually narrowed this row group's pages:
+    /// a read with no filter, a `tail(N)` whose synthesized range is the only thing
+    /// narrowing the pages, and a row group whose mask gate is closed all skip nothing
+    /// by push-down and so report nothing. The absence of the event is therefore the
+    /// signal that no page was a candidate for skipping, and a `pagesSkipped` of 0
+    /// means the filter ran and kept everything.
+    private static void emitPageFilterEvent(String fileName, int rowGroupIndex, String column,
+                                            boolean pageFilterApplied, int totalPages, int pagesKept) {
+        if (!pageFilterApplied) {
+            return;
+        }
+        PageFilterEvent event = new PageFilterEvent();
+        event.file = fileName;
+        event.rowGroupIndex = rowGroupIndex;
+        event.column = column;
+        event.totalPages = totalPages;
+        event.pagesKept = pagesKept;
+        event.pagesSkipped = totalPages - pagesKept;
+        event.commit();
     }
 
     /// Whether per-page row masks may be applied by the projected plans of

--- a/core/src/main/java/dev/hardwood/jfr/BatchWaitEvent.java
+++ b/core/src/main/java/dev/hardwood/jfr/BatchWaitEvent.java
@@ -18,7 +18,9 @@ import jdk.jfr.StackTrace;
 /// to be assembled by the assembly thread.
 ///
 /// This event indicates that the decode/assembly pipeline cannot keep up
-/// with the consumer, causing the consumer to stall.
+/// with the consumer, causing the consumer to stall. The event's duration is
+/// the length of the stall, and it is recorded on the stalled consumer thread.
+/// A read that never outruns its pipeline emits no event at all.
 @Name("dev.hardwood.BatchWait")
 @Label("Batch Wait")
 @Category({"Hardwood", "Pipeline"})

--- a/core/src/main/java/dev/hardwood/jfr/PageFilterEvent.java
+++ b/core/src/main/java/dev/hardwood/jfr/PageFilterEvent.java
@@ -15,6 +15,21 @@ import jdk.jfr.Name;
 import jdk.jfr.StackTrace;
 
 /// JFR event emitted when pages are filtered by Column Index predicate push-down.
+///
+/// One event per column chunk whose pages the push-down considered, so a row group
+/// read with a filter over two projected columns emits two events. `pagesSkipped`
+/// of 0 means every page survived the predicate.
+///
+/// No event at all means no page was a candidate for push-down in that column chunk:
+/// the read carries no predicate, the column chunk has no Column Index to evaluate,
+/// or the pages were narrowed by something other than a predicate — `tail(N)` skipping
+/// the rows before the tail is not page filtering and is not reported here.
+///
+/// The event covers Column Index push-down only. A column chunk with no Column Index
+/// is read through a sequential plan that drops pages from the statistics in each page
+/// header as it walks them; those drops are real page filtering and none of them are
+/// reported, because that plan has no page total to divide by without first reading
+/// every header it set out to avoid.
 @Name("dev.hardwood.PageFilter")
 @Label("Page Filter")
 @Category({"Hardwood", "Filter"})

--- a/core/src/main/java/dev/hardwood/jfr/RecordFilterEvent.java
+++ b/core/src/main/java/dev/hardwood/jfr/RecordFilterEvent.java
@@ -15,12 +15,30 @@ import jdk.jfr.Name;
 import jdk.jfr.StackTrace;
 
 /// JFR event emitted when records are filtered by record-level predicate evaluation.
+///
+/// One event per file a read touched, committed when the read moves on to the next
+/// file and when the reader is closed — so a reader that is never closed reports
+/// nothing for the file it ended on.
+///
+/// Record-level filtering is what remains after row-group statistics and the Column
+/// Index have narrowed the read, so `totalRecords` counts the records the predicate
+/// actually decided on, not the rows in the file: rows in pruned row groups and pages
+/// never reach it, and a read that stops early — `head(N)`, or a caller that stops
+/// consuming and closes — counts only as far as it got.
+///
+/// The counts are the predicate's selectivity rather than the matcher's workload: a
+/// row group whose statistics prove every one of its rows matches contributes them as
+/// evaluated and kept, though none was tested individually.
 @Name("dev.hardwood.RecordFilter")
 @Label("Record Filter")
 @Category({"Hardwood", "Filter"})
 @Description("Records filtered by record-level predicate evaluation")
 @StackTrace(false)
 public class RecordFilterEvent extends Event {
+
+    @Label("File")
+    @Description("Name of the Parquet file whose records were filtered")
+    public String file;
 
     @Label("Total Records")
     @Description("Total number of records evaluated against the predicate")

--- a/core/src/main/java/dev/hardwood/reader/ColumnReader.java
+++ b/core/src/main/java/dev/hardwood/reader/ColumnReader.java
@@ -688,6 +688,12 @@ public class ColumnReader implements AutoCloseable {
 
     // ==================== Internal ====================
 
+    /// The file the current batch was read from, for the sibling readers of the
+    /// same projection to attribute their per-batch work to.
+    String currentFileName() {
+        return currentFileName;
+    }
+
     private String prefix() {
         return ExceptionContext.filePrefix(currentFileName);
     }

--- a/core/src/main/java/dev/hardwood/reader/FilterCoordinator.java
+++ b/core/src/main/java/dev/hardwood/reader/FilterCoordinator.java
@@ -7,6 +7,8 @@
  */
 package dev.hardwood.reader;
 
+import dev.hardwood.internal.reader.RecordFilterTally;
+
 /// Drives the filtered column-reader path (#624). It advances every reader of
 /// the augmented projection (payload columns plus the predicate columns) in
 /// lockstep, asks the [SelectionEngine] for the matching records of the aligned
@@ -25,6 +27,9 @@ final class FilterCoordinator {
     /// The exposed subset, compacted to the matching records each batch.
     private final ColumnReader[] payloadReaders;
     private final SelectionEngine engine;
+    /// Per-file record-filter counts for JFR. Every batch this path produces has
+    /// passed through the selection, so the counts are complete for the read.
+    private final RecordFilterTally tally = new RecordFilterTally();
 
     private long generation;
     private boolean hasBatch;
@@ -93,6 +98,8 @@ final class FilterCoordinator {
         }
 
         recordCount = matchCount < 0 ? firstCount : matchCount;
+        tally.switchFile(allReaders[0].currentFileName());
+        tally.recordBatch(firstCount, recordCount);
         hasBatch = true;
         generation++;
         return true;
@@ -103,6 +110,7 @@ final class FilterCoordinator {
             return;
         }
         closed = true;
+        tally.close();
         for (ColumnReader reader : allReaders) {
             reader.rawClose();
         }

--- a/core/src/test/java/dev/hardwood/PageFilterEventTest.java
+++ b/core/src/test/java/dev/hardwood/PageFilterEventTest.java
@@ -1,0 +1,169 @@
+/*
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Copyright The original authors
+ *
+ *  Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package dev.hardwood;
+
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+
+import dev.hardwood.jfr.AbstractJfrRecorderTest;
+import dev.hardwood.reader.FilterPredicate;
+import dev.hardwood.reader.ParquetFileReader;
+import dev.hardwood.reader.RowReader;
+import dev.hardwood.schema.ColumnProjection;
+import jdk.jfr.consumer.RecordedEvent;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/// Asserts that Column Index page push-down emits `dev.hardwood.PageFilter`, one event
+/// per column chunk whose pages the push-down considered.
+///
+/// The event exists to answer "how much did page pruning actually skip?", which
+/// `RowGroupScanned` cannot: its `pageCount` is the kept count with no total to divide
+/// by, and its `scanStrategy` reads `offset-index` whether or not a mask was applied.
+/// So the cases pinned here are the ones that distinguish those outcomes — pages
+/// skipped, no page skipped, every page skipped, and no filter at all.
+class PageFilterEventTest extends AbstractJfrRecorderTest {
+
+    /// 1 row group, 10000 rows, sorted `id` [0,9999] and `value` [1000,10999],
+    /// Parquet v2 with a Column Index, 10 pages of 1024 values per column.
+    private static final Path SORTED_FILE = Paths.get("src/test/resources/column_index_pushdown.parquet");
+
+    /// Same geometry, with a `category` column cycling through 10 distinct values,
+    /// so every page holds every category.
+    private static final Path DICT_FILE = Paths.get("src/test/resources/column_index_pushdown_dict.parquet");
+
+    private static final String PAGE_FILTER_EVENT = "dev.hardwood.PageFilter";
+
+    private static final int PAGES_PER_COLUMN = 10;
+
+    @Test
+    void selectiveFilterReportsSkippedPagesPerColumn() throws Exception {
+        // id < 1000 lives entirely in the first of the 10 pages. Both projected
+        // columns are page-aligned on the same row boundaries, so each drops the
+        // same nine pages.
+        long rows = read(SORTED_FILE, ColumnProjection.columns("id", "value"),
+                FilterPredicate.lt("id", 1000L));
+        assertThat(rows).isEqualTo(1000);
+
+        List<RecordedEvent> events = events(PAGE_FILTER_EVENT).toList();
+        assertThat(events)
+                .as("one event per projected column of the single row group")
+                .hasSize(2);
+        assertThat(events).extracting(e -> e.getString("column"))
+                .containsExactlyInAnyOrder("id", "value");
+
+        for (RecordedEvent event : events) {
+            assertThat(event.getString("file")).endsWith("column_index_pushdown.parquet");
+            assertThat(event.getInt("rowGroupIndex")).isZero();
+            assertThat(event.getInt("totalPages")).isEqualTo(PAGES_PER_COLUMN);
+            assertThat(event.getInt("pagesKept")).isEqualTo(1);
+            assertThat(event.getInt("pagesSkipped")).isEqualTo(PAGES_PER_COLUMN - 1);
+        }
+    }
+
+    @Test
+    void filterMatchingEveryPageReportsNothingSkipped() throws Exception {
+        // Every page of `category` holds all ten distinct values, so the predicate
+        // keeps all of them. The event must still fire: "the filter ran and pruned
+        // nothing" is exactly what a skip ratio has to be able to say.
+        long rows = read(DICT_FILE, ColumnProjection.columns("category"),
+                FilterPredicate.eq("category", "cat_3"));
+        assertThat(rows).isEqualTo(1000);
+
+        RecordedEvent event = events(PAGE_FILTER_EVENT).findFirst().orElseThrow();
+        assertThat(event.getString("column")).isEqualTo("category");
+        assertThat(event.getInt("totalPages")).isGreaterThan(1);
+        assertThat(event.getInt("pagesKept")).isEqualTo(event.getInt("totalPages"));
+        assertThat(event.getInt("pagesSkipped")).isZero();
+    }
+
+    @Test
+    void fullyPrunedColumnIsReported() throws Exception {
+        // AND(id < 1000, id >= 9000) survives row-group statistics — the group's
+        // [0,9999] bounds satisfy both leaves — but no page satisfies both, so the
+        // column's fetch plan is empty. That is the most effective pruning there is
+        // and the one case that emits no RowGroupScanned event at all, since no
+        // indexed plan gets built.
+        long rows = read(SORTED_FILE, ColumnProjection.columns("id"),
+                FilterPredicate.and(
+                        FilterPredicate.lt("id", 1000L),
+                        FilterPredicate.gtEq("id", 9000L)));
+        assertThat(rows).isZero();
+
+        RecordedEvent event = events(PAGE_FILTER_EVENT).findFirst().orElseThrow();
+        assertThat(event.getString("column")).isEqualTo("id");
+        assertThat(event.getInt("totalPages")).isEqualTo(PAGES_PER_COLUMN);
+        assertThat(event.getInt("pagesKept")).isZero();
+        assertThat(event.getInt("pagesSkipped")).isEqualTo(PAGES_PER_COLUMN);
+
+        assertThat(events("dev.hardwood.RowGroupScanned").count())
+                .as("no indexed plan is built for a fully pruned column")
+                .isZero();
+    }
+
+    @Test
+    void tailReadWithoutPredicateEmitsNoPageFilterEvent() throws Exception {
+        // A tail read carries no predicate: it synthesizes a row range to skip the
+        // rows before the tail, and the pages that range drops were dropped by
+        // `tail(N)`, not by the Column Index. Reporting them would overstate what
+        // push-down achieved on a read that did none.
+        long rows = 0;
+        try (ParquetFileReader reader = ParquetFileReader.open(InputFile.of(SORTED_FILE));
+             RowReader rowReader = reader.buildRowReader()
+                     .projection(ColumnProjection.columns("id"))
+                     .tail(1000)
+                     .build()) {
+            while (rowReader.hasNext()) {
+                rowReader.next();
+                rows++;
+            }
+        }
+        awaitEvents();
+        assertThat(rows).isEqualTo(1000);
+
+        assertThat(events(PAGE_FILTER_EVENT).count())
+                .as("no predicate ran, so no page was filtered by push-down")
+                .isZero();
+    }
+
+    @Test
+    void unfilteredReadEmitsNoPageFilterEvent() throws Exception {
+        long rows = read(SORTED_FILE, ColumnProjection.columns("id", "value"), null);
+        assertThat(rows).isEqualTo(10000);
+
+        assertThat(events(PAGE_FILTER_EVENT).count())
+                .as("absence of the event means no page was a candidate for skipping")
+                .isZero();
+        assertThat(events("dev.hardwood.RowGroupScanned").count())
+                .as("the read did happen — the sibling event proves the recording caught it")
+                .isGreaterThan(0);
+    }
+
+    /// Reads `file` through a row reader and returns the number of rows produced,
+    /// then stops the recording.
+    private long read(Path file, ColumnProjection projection, FilterPredicate filter) throws Exception {
+        long rows = 0;
+        try (ParquetFileReader reader = ParquetFileReader.open(InputFile.of(file))) {
+            ParquetFileReader.RowReaderBuilder builder = reader.buildRowReader().projection(projection);
+            if (filter != null) {
+                builder = builder.filter(filter);
+            }
+            try (RowReader rowReader = builder.build()) {
+                while (rowReader.hasNext()) {
+                    rowReader.next();
+                    rows++;
+                }
+            }
+        }
+        awaitEvents();
+        return rows;
+    }
+}

--- a/core/src/test/java/dev/hardwood/RecordFilterEventTest.java
+++ b/core/src/test/java/dev/hardwood/RecordFilterEventTest.java
@@ -1,0 +1,234 @@
+/*
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Copyright The original authors
+ *
+ *  Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package dev.hardwood;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import dev.hardwood.jfr.AbstractJfrRecorderTest;
+import dev.hardwood.reader.ColumnReader;
+import dev.hardwood.reader.ColumnReaders;
+import dev.hardwood.reader.FilterPredicate;
+import dev.hardwood.reader.ParquetFileReader;
+import dev.hardwood.reader.RowReader;
+import dev.hardwood.schema.ColumnProjection;
+import jdk.jfr.consumer.RecordedEvent;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/// Asserts that record-level filtering emits `dev.hardwood.RecordFilter`, one event per
+/// file, across all three paths that evaluate a predicate per record: the drain-side
+/// batch matchers, the row-reader wrapper they fall back to, and the column-reader
+/// selection engine.
+///
+/// The fixture is 300 rows in 3 row groups of 100, `id` ascending from 1. With
+/// `id > 150` the first row group never reaches the record filter at all, which is what
+/// makes `totalRecords` (200) differ from the file's row count (300): the event reports
+/// what the predicate decided on after row-group and page pruning, not what the file
+/// holds.
+class RecordFilterEventTest extends AbstractJfrRecorderTest {
+
+    private static final Path FIXTURE = Paths.get("src/test/resources/filter_pushdown_int.parquet");
+
+    private static final String RECORD_FILTER_EVENT = "dev.hardwood.RecordFilter";
+
+    /// `id > 150`: row group 1 (ids 1-100) is dropped by statistics, row group 2
+    /// (101-200) contributes 50 matches, row group 3 (201-300) matches in full.
+    private static final FilterPredicate ID_OVER_150 = FilterPredicate.gt("id", 150L);
+
+    private static final long EVALUATED = 200;
+    private static final long KEPT = 150;
+
+    @Test
+    void drainSideFilterReportsCountsForItsFile() throws Exception {
+        // A flat int comparison compiles to the drain-side batch matchers, where the
+        // row group proven to match in full is never tested record by record. Those
+        // records still count as evaluated and kept: the event reports the filter's
+        // selectivity, not which mechanism decided each record.
+        try (ParquetFileReader reader = ParquetFileReader.open(InputFile.of(FIXTURE));
+             RowReader rows = reader.buildRowReader().filter(ID_OVER_150).build()) {
+            assertThat(countRows(rows)).isEqualTo(KEPT);
+        }
+        awaitEvents();
+
+        RecordedEvent event = singleEvent();
+        assertThat(event.getString("file")).endsWith("filter_pushdown_int.parquet");
+        assertThat(event.getLong("totalRecords"))
+                .as("only the surviving row groups reach the record filter")
+                .isEqualTo(EVALUATED);
+        assertThat(event.getLong("recordsKept")).isEqualTo(KEPT);
+        assertThat(event.getLong("recordsSkipped")).isEqualTo(EVALUATED - KEPT);
+    }
+
+    @Test
+    void rowReaderFallbackReportsCountsForItsFile() throws Exception {
+        // A string predicate has no drain-side matcher, so this read goes through the
+        // per-record wrapper instead — the path where the counts are gathered one
+        // evaluation at a time.
+        try (ParquetFileReader reader = ParquetFileReader.open(InputFile.of(FIXTURE));
+             RowReader rows = reader.buildRowReader()
+                     .filter(FilterPredicate.eq("label", "rg2_150"))
+                     .build()) {
+            assertThat(countRows(rows)).isEqualTo(1);
+        }
+        awaitEvents();
+
+        RecordedEvent event = singleEvent();
+        assertThat(event.getString("file")).endsWith("filter_pushdown_int.parquet");
+        assertThat(event.getLong("recordsKept")).isEqualTo(1);
+        assertThat(event.getLong("recordsSkipped"))
+                .isEqualTo(event.getLong("totalRecords") - 1);
+        assertThat(event.getLong("totalRecords"))
+                .as("the label's own statistics leave one row group, and all 100 of its"
+                        + " records are evaluated one at a time")
+                .isEqualTo(100);
+    }
+
+    @Test
+    void nestedReaderReportsCountsForItsFile() throws Exception {
+        // The nested reader wires the tally separately from the flat one — its own
+        // constructor and its own batch-swap hook — so it needs its own coverage.
+        // 9 rows in 3 row groups of 3: zip > 81000 drops the first group on
+        // statistics, leaves one match in the second and all three in the third.
+        Path nested = Paths.get("src/test/resources/filter_pushdown_nested.parquet");
+        try (ParquetFileReader reader = ParquetFileReader.open(InputFile.of(nested));
+             RowReader rows = reader.buildRowReader()
+                     .projection(ColumnProjection.columns("id", "address"))
+                     .filter(FilterPredicate.gt("address.zip", 81000))
+                     .build()) {
+            assertThat(countRows(rows)).isEqualTo(4);
+        }
+        awaitEvents();
+
+        RecordedEvent event = singleEvent();
+        assertThat(event.getString("file")).endsWith("filter_pushdown_nested.parquet");
+        assertThat(event.getLong("totalRecords")).isEqualTo(6);
+        assertThat(event.getLong("recordsKept")).isEqualTo(4);
+        assertThat(event.getLong("recordsSkipped")).isEqualTo(2);
+    }
+
+    @Test
+    void columnReaderSelectionReportsCountsForItsFile() throws Exception {
+        try (ParquetFileReader reader = ParquetFileReader.open(InputFile.of(FIXTURE));
+             ColumnReaders columns = reader.buildColumnReaders(ColumnProjection.columns("id"))
+                     .filter(ID_OVER_150)
+                     .build()) {
+            ColumnReader id = columns.getColumnReader("id");
+            long rows = 0;
+            while (id.nextBatch()) {
+                rows += id.getRecordCount();
+            }
+            assertThat(rows).isEqualTo(KEPT);
+        }
+        awaitEvents();
+
+        RecordedEvent event = singleEvent();
+        assertThat(event.getString("file")).endsWith("filter_pushdown_int.parquet");
+        assertThat(event.getLong("totalRecords")).isEqualTo(EVALUATED);
+        assertThat(event.getLong("recordsKept")).isEqualTo(KEPT);
+        assertThat(event.getLong("recordsSkipped")).isEqualTo(EVALUATED - KEPT);
+    }
+
+    @Test
+    void multiFileReadReportsOneEventPerFile(@TempDir Path tempDir) throws Exception {
+        Path first = Files.copy(FIXTURE, tempDir.resolve("part-0.parquet"));
+        Path second = Files.copy(FIXTURE, tempDir.resolve("part-1.parquet"));
+
+        try (Hardwood hardwood = Hardwood.create();
+             ParquetFileReader reader = hardwood.openAll(InputFile.ofPaths(List.of(first, second)));
+             RowReader rows = reader.buildRowReader().filter(ID_OVER_150).build()) {
+            assertThat(countRows(rows)).isEqualTo(2 * KEPT);
+        }
+        awaitEvents();
+
+        List<RecordedEvent> events = events(RECORD_FILTER_EVENT).toList();
+        assertThat(events)
+                .as("the counts are attributed per file, not pooled across the read")
+                .hasSize(2);
+        assertThat(events).extracting(e -> Paths.get(e.getString("file")).getFileName().toString())
+                .containsExactly("part-0.parquet", "part-1.parquet");
+        for (RecordedEvent event : events) {
+            assertThat(event.getLong("totalRecords")).isEqualTo(EVALUATED);
+            assertThat(event.getLong("recordsKept")).isEqualTo(KEPT);
+        }
+    }
+
+    @Test
+    void multiFileColumnReaderReportsOneEventPerFile(@TempDir Path tempDir) throws Exception {
+        // The column-reader path is the one place a batch is attributed to a file
+        // through a reader accessor rather than a field on the batch itself, so the
+        // assumption that its batches never straddle a file boundary needs its own
+        // multi-file case — the row-reader one above cannot cover it.
+        Path first = Files.copy(FIXTURE, tempDir.resolve("part-0.parquet"));
+        Path second = Files.copy(FIXTURE, tempDir.resolve("part-1.parquet"));
+
+        try (Hardwood hardwood = Hardwood.create();
+             ParquetFileReader reader = hardwood.openAll(InputFile.ofPaths(List.of(first, second)));
+             ColumnReaders columns = reader.buildColumnReaders(ColumnProjection.columns("id"))
+                     .filter(ID_OVER_150)
+                     .build()) {
+            ColumnReader id = columns.getColumnReader("id");
+            long rows = 0;
+            while (id.nextBatch()) {
+                rows += id.getRecordCount();
+            }
+            assertThat(rows).isEqualTo(2 * KEPT);
+        }
+        awaitEvents();
+
+        List<RecordedEvent> events = events(RECORD_FILTER_EVENT).toList();
+        assertThat(events)
+                .as("the counts are attributed per file, not pooled across the read")
+                .hasSize(2);
+        assertThat(events).extracting(e -> Paths.get(e.getString("file")).getFileName().toString())
+                .containsExactly("part-0.parquet", "part-1.parquet");
+        for (RecordedEvent event : events) {
+            assertThat(event.getLong("totalRecords")).isEqualTo(EVALUATED);
+            assertThat(event.getLong("recordsKept")).isEqualTo(KEPT);
+            assertThat(event.getLong("recordsSkipped")).isEqualTo(EVALUATED - KEPT);
+        }
+    }
+
+    @Test
+    void unfilteredReadEmitsNoRecordFilterEvent() throws Exception {
+        try (ParquetFileReader reader = ParquetFileReader.open(InputFile.of(FIXTURE));
+             RowReader rows = reader.buildRowReader().build()) {
+            assertThat(countRows(rows)).isEqualTo(300);
+        }
+        awaitEvents();
+
+        assertThat(events(RECORD_FILTER_EVENT).count())
+                .as("no predicate, no record-level evaluation to report")
+                .isZero();
+        assertThat(events("dev.hardwood.FileOpened").count())
+                .as("the read did happen — the sibling event proves the recording caught it")
+                .isGreaterThan(0);
+    }
+
+    private RecordedEvent singleEvent() {
+        List<RecordedEvent> events = events(RECORD_FILTER_EVENT).toList();
+        assertThat(events)
+                .as("one event for the single file read")
+                .hasSize(1);
+        return events.getFirst();
+    }
+
+    private static long countRows(RowReader rows) {
+        long count = 0;
+        while (rows.hasNext()) {
+            rows.next();
+            count++;
+        }
+        return count;
+    }
+}

--- a/core/src/test/java/dev/hardwood/internal/reader/BatchWaitEventTest.java
+++ b/core/src/test/java/dev/hardwood/internal/reader/BatchWaitEventTest.java
@@ -1,0 +1,86 @@
+/*
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Copyright The original authors
+ *
+ *  Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package dev.hardwood.internal.reader;
+
+import java.time.Duration;
+
+import org.junit.jupiter.api.Test;
+
+import dev.hardwood.jfr.AbstractJfrRecorderTest;
+import jdk.jfr.consumer.RecordedEvent;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/// Asserts that a consumer stalling on the assembly pipeline emits
+/// `dev.hardwood.BatchWait`, and that a consumer served from a full ready queue
+/// emits nothing.
+///
+/// Driven at the [BatchExchange] level rather than through a file read: whether a
+/// real read outruns its pipeline depends on decode and I/O timing, so publishing
+/// the batch on a known delay is the only way to pin both the presence and the
+/// absence of the event.
+class BatchWaitEventTest extends AbstractJfrRecorderTest {
+
+    private static final String BATCH_WAIT_EVENT = "dev.hardwood.BatchWait";
+
+    private static final long PUBLISH_DELAY_MILLIS = 50;
+
+    @Test
+    void stalledConsumerEmitsBatchWaitEventForItsColumn() throws Exception {
+        BatchExchange<String> exchange = BatchExchange.detaching("price", () -> "batch");
+
+        Thread producer = Thread.ofPlatform().start(() -> {
+            try {
+                Thread.sleep(PUBLISH_DELAY_MILLIS);
+                exchange.publish("batch-1");
+            }
+            catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+            }
+        });
+
+        assertThat(exchange.poll()).isEqualTo("batch-1");
+        producer.join();
+        awaitEvents();
+
+        RecordedEvent event = events(BATCH_WAIT_EVENT).findFirst().orElseThrow();
+        assertThat(event.getString("column")).isEqualTo("price");
+        assertThat(event.getDuration())
+                .as("the event's duration is the stall the consumer paid")
+                .isGreaterThan(Duration.ZERO);
+        assertThat(events(BATCH_WAIT_EVENT).count())
+                .as("one stall, one event")
+                .isEqualTo(1);
+    }
+
+    @Test
+    void consumerServedWithoutWaitingEmitsNoEvent() throws Exception {
+        BatchExchange<String> exchange = BatchExchange.detaching("price", () -> "batch");
+        exchange.publish("batch-1");
+
+        assertThat(exchange.poll()).isEqualTo("batch-1");
+        awaitEvents();
+
+        assertThat(events(BATCH_WAIT_EVENT).count())
+                .as("the non-blocking poll hit, so the consumer never stalled")
+                .isZero();
+    }
+
+    @Test
+    void drainedFinishedExchangeEmitsNoEvent() throws Exception {
+        BatchExchange<String> exchange = BatchExchange.detaching("price", () -> "batch");
+        exchange.finish();
+
+        assertThat(exchange.poll()).isNull();
+        awaitEvents();
+
+        assertThat(events(BATCH_WAIT_EVENT).count())
+                .as("end of stream is not a stall — every column would report one otherwise")
+                .isZero();
+    }
+}

--- a/docs/content/concepts/concurrency-model.md
+++ b/docs/content/concepts/concurrency-model.md
@@ -50,13 +50,10 @@ your loop is processing the current batch (or row), pool threads are already dec
 decoding the pages that feed the next batches, queuing the results. The consumer thread
 generally pulls ready-to-use decoded data instead of blocking on decode.
 
-Two [JFR events](../reference/configuration.md#jfr-java-flight-recorder-events) make the pipeline visible
-when you profile:
-
-- **`BatchWait`** — the consumer blocked waiting for the pipeline. Frequent or long waits mean
-  decode (or I/O) isn't keeping up with consumption.
-- **`PrefetchMiss`** — a needed page wasn't prefetched in time and had to be decoded
-  synchronously on the consumer's path.
+The **`BatchWait`** [JFR event](../reference/configuration.md#jfr-java-flight-recorder-events) makes
+that visible when you profile. It is recorded on the consumer thread each time it blocks waiting for
+the pipeline, and lasts as long as the block. Frequent or long waits mean decode (or I/O) isn't
+keeping up with consumption.
 
 ## Cross-file prefetching
 

--- a/docs/content/reference/configuration.md
+++ b/docs/content/reference/configuration.md
@@ -96,15 +96,14 @@ Or attach dynamically via `jcmd <pid> JFR.start`.
 | `dev.hardwood.PageDecoded` | Decode | Single data page decoded. Fields: column, compressedSize, uncompressedSize |
 | `dev.hardwood.RowGroupFilter` | Filter | Row groups dropped by statistics/bloom predicate pushdown. Fields: file, totalRowGroups, rowGroupsKept, rowGroupsSkipped, rowGroupsFullyMatching |
 | `dev.hardwood.RowGroupByteRangeFilter` | Filter | Row groups selected by a byte-range split predicate (split-aware reading). Fields: file, totalRowGroups, rowGroupsKept, rowGroupsSkipped |
-| `dev.hardwood.PageFilter` | Filter | Pages filtered by Column Index predicate pushdown. Fields: file, rowGroupIndex, column, totalPages, pagesKept, pagesSkipped |
-| `dev.hardwood.RecordFilter` | Filter | Records filtered by record-level predicate evaluation. Fields: totalRecords, recordsKept, recordsSkipped |
-| `dev.hardwood.BatchWait` | Pipeline | Consumer blocked waiting for the assembly pipeline. Fields: column |
-| `dev.hardwood.PrefetchMiss` | Pipeline | Prefetch queue miss requiring synchronous decode. Fields: file, column, newDepth, queueEmpty |
+| `dev.hardwood.PageFilter` | Filter | Pages filtered by Column Index predicate pushdown, one event per column chunk considered. Fields: file, rowGroupIndex, column, totalPages, pagesKept, pagesSkipped |
+| `dev.hardwood.RecordFilter` | Filter | Records filtered by record-level predicate evaluation, one event per file read. Fields: file, totalRecords, recordsKept, recordsSkipped |
+| `dev.hardwood.BatchWait` | Pipeline | Consumer blocked waiting for the assembly pipeline; the event's duration is the stall. Fields: column |
 
 Events appear under the **Hardwood** category in JDK Mission Control (JMC) or any JFR analysis tool. Use them to identify:
 
-- **I/O bottlenecks** — large `FileMapping` durations or frequent `PrefetchMiss` events
-- **Filter effectiveness** — `RowGroupFilter` shows how many row groups were dropped by statistics/bloom pushdown and `RowGroupByteRangeFilter` how many were excluded by split selection; `PageFilter` shows how many pages were skipped within surviving row groups; `RecordFilter` shows how many individual records were filtered out
+- **I/O bottlenecks** — large `FileMapping` durations
+- **Filter effectiveness** — `RowGroupFilter` shows how many row groups were dropped by statistics/bloom pushdown and `RowGroupByteRangeFilter` how many were excluded by split selection; `PageFilter` shows how many of a column chunk's pages survived the Column Index within a row group that was kept, with no event for a column chunk the Column Index did not narrow — including a chunk that has no Column Index, whose pages are instead dropped from page-header statistics and are not reported; `RecordFilter` shows how many individual records the predicate decided on per file once that pruning is done
 - **Decode hotspots** — `PageDecoded` events with large uncompressed sizes or high frequency
 - **Pipeline stalls** — `BatchWait` events indicate the reader is waiting for decoded data
 


### PR DESCRIPTION
Fixes #1038.

`dev.hardwood.jfr` shipped four `jdk.jfr.Event` subclasses that no code path could emit —
`PageFilter`, `RecordFilter`, `BatchWait`, `PrefetchMiss` — while
`docs/content/reference/configuration.md` listed all four as available events with their
field lists, and `concepts/concurrency-model.md` told readers to watch two of them when
profiling. Six sibling events were live. This wires up the three that have live machinery
behind them and takes the fourth out of the docs.

### PageFilter

Emitted from `RowGroupIterator.computeFetchPlans`, which already holds both numbers per
column chunk. Two placement details carry the meaning:

- **before** the `neededPages.isEmpty() → FetchPlan.EMPTY` shortcut, so a fully pruned column
  is reported instead of vanishing along with its indexed plan — that case emits no
  `RowGroupScanned` either, so it was previously invisible in both events;
- **before** `truncateToMaxRows`, so a `head(N)` cap is not counted as pages the predicate
  skipped.

It is gated on `!matchingRows.isAll()`: no event means no page-level filter ran, and
`pagesSkipped == 0` means it ran and kept everything. `RowGroupScanned` cannot make that
distinction — its `pageCount` is the kept count with no total, and its `scanStrategy` reads
`offset-index` whether or not a mask was applied, since a row group whose mask gate is closed
has its ranges promoted back to `ALL` with the strategy string unchanged.

### BatchWait

Emitted around the timed poll loop in `BatchExchange.poll()` — the exact point where the ready
queue is empty and the drain has not finished. The event spans the loop, so its duration is the
stall itself, recorded on the stalled consumer thread. The fast path allocates nothing: an
exchange served immediately, and a drained finished exchange, both return before the event
exists.

### RecordFilter

Emitted **per file**, which needed a new `file` field. The counts had no key at all — no file,
no row group, no column — so the event was only ever readable as one aggregate, and a file is
the finest granularity the read pipeline actually maintains: batches are flushed when the file
changes but deliberately span row groups (`ColumnWorker.drainReadyPages`), and the record filter
runs above that, on a row stream that has left the row-group structure behind.

All three paths that decide records feed one `RecordFilterTally`: the drain-side batch matchers
count a batch at a time from the popcount of the merged mask, the `FilteredRowReader` they fall
back to counts one evaluation at a time, and the column-reader `SelectionEngine` counts the
selection it just computed. The readers mark file boundaries where they already swap batches, so
the per-record path pays two increments and no boundary check.

`totalRecords` is what the predicate decided on, not what the file holds: row groups and pages
pruned earlier never reach it, and a read that stops early counts only as far as it got.

### PrefetchMiss

Left dead and filed separately as #1042 for removal. Unlike the others it cannot simply be wired
up: `newDepth` and the class JavaDoc describe an adaptive prefetch depth that no longer exists
anywhere in the reader. It drops out of the docs here.

### Tests

Emission tests on the existing `AbstractJfrRecorderTest`, asserting recorded events rather than
declarations, and pinning the absences too:

- `PageFilterEventTest` — 10 pages → 1 kept / 9 skipped per column; a predicate matching every
  page → 0 skipped; `AND(id < 1000, id >= 9000)` → 0 kept / 10 skipped, with no `RowGroupScanned`
  at all; unfiltered read → no event.
- `BatchWaitEventTest` — one event with positive duration on a delayed publish; none when the
  consumer is served immediately or the exchange is finished and drained.
- `RecordFilterEventTest` — one test per path, plus a two-file read emitting one event per file
  with counts unpooled, and an unfiltered read emitting none.

`./mvnw verify` is green across all modules.
