### PR TITLE
#1049 Assert Parquet column orders through interop

### DIFF
--- a/_designs/WRITER_INTEROP_GATE.md
+++ b/_designs/WRITER_INTEROP_GATE.md
@@ -76,10 +76,16 @@ Per file, four things:
    empty-versus-absent repeated values are compared as written.
 3. **The metadata agrees.** parquet-java parses the footer, and the column-chunk
    statistics it exposes — `min`, `max`, `null_count` — match the written data under
-   *its* comparator, which it derives from the annotation and the footer's
-   `column_orders`. Agreement here is the first cross-implementation check on stage 13b:
-   an order the two implementations disagree about produces bounds that would prune a row
-   group holding a matching row.
+   *its* comparator, which it derives from the column's annotation. Agreement here is the
+   first cross-implementation check on stage 13b: an order the two implementations
+   disagree about produces bounds that would prune a row group holding a matching row.
+
+   The `column_orders` those bounds take their meaning from is asserted separately, over
+   the **raw** footer. parquet-java defaults a missing column order to type-defined for
+   every type but `INT96` and `INTERVAL`, so its decoded schema reports
+   `TYPE_DEFINED_ORDER` whether the field reached the wire or not, and every other
+   assertion here would hold on a file that dropped the list — leaving bounds the format
+   calls undefined for a reader that holds it to its word.
 4. **The case covered what it claims to.** The encodings say the case actually produced
    the dictionary, `PLAIN` fallback or plain-only chunk it exists to cover, and the layout
    cases walk parquet-java's page readers to count the data pages they crossed. Without
@@ -198,18 +204,19 @@ classes, split by what they parameterize over rather than by size:
 - `WriterNestedInteropTest` — the enumerated `struct`, `LIST` and `MAP` shapes.
 - `WriterLogicalTypeInteropTest` — the annotation table, pairing each Hardwood
   `LogicalType` with the parquet-java `LogicalTypeAnnotation` it must read back as, plus
-  the two sort orders that differ from their physical type's own (unsigned integers and
-  binary `DECIMAL`).
+  the three sort orders a table of well-behaved values cannot discriminate on its own:
+  unsigned integers, binary `DECIMAL`, and a `STRING` across the signed-byte boundary.
 - `RowWriterLogicalTypeInteropTest` — the same annotation table driven through the
   row-oriented entry point, its expectations taken from Avro's conversions rather than
   from the inverse Hardwood decodes with, so it is an external oracle for
   `PhysicalValueConverter`.
-- `WriterFooterMetadataInteropTest` — the footer's `key_value_metadata` and a
-  caller-supplied `created_by`, read back through parquet-java.
+- `WriterFooterMetadataInteropTest` — the footer fields a value comparison cannot see,
+  read back through parquet-java: `key_value_metadata`, a caller-supplied `created_by`,
+  and the raw `column_orders`, one `TYPE_DEFINED_ORDER` per leaf.
 
-A shared `ParquetJavaReader` helper wraps the Group reader, the footer reader, the page
-walk and the `created_by` check, so the parquet-java surface the gate depends on sits in
-one place. It is separate from `Utils`, which serves the read direction and carries the
+A shared `ParquetJavaReader` helper wraps the Group reader, the footer reader in both its
+decoded and raw-Thrift forms, the page walk and the `created_by` check, so the
+parquet-java surface the gate depends on sits in one place. It is separate from `Utils`, which serves the read direction and carries the
 Avro comparison.
 
 None of the classes touch the `parquet-testing` fixture repository: the gate's inputs are

--- a/parquet-testing-runner/src/test/java/dev/hardwood/testing/ParquetJavaReader.java
+++ b/parquet-testing-runner/src/test/java/dev/hardwood/testing/ParquetJavaReader.java
@@ -105,6 +105,21 @@ final class ParquetJavaReader {
         }
     }
 
+    /// The file's footer as the format's own Thrift structure, parsed by parquet-java. Some
+    /// fields are folded into higher-level defaults by [#readFooter], so tests that need to
+    /// assert the field is really present on the wire use this path.
+    ///
+    /// @param file the file to read
+    /// @return the parsed format footer
+    /// @throws IOException if parquet-java cannot parse the footer
+    static FileMetaData readFormatFooter(Path file) throws IOException {
+        observe(file);
+        try (SeekableInputStream in = HadoopInputFile
+                .fromPath(hadoopPath(file), HadoopConf.DEFAULTS).newStream()) {
+            return readThriftFooter(file, in);
+        }
+    }
+
     /// Asserts that parquet-java can identify the writer that produced the file.
     ///
     /// A `created_by` its [VersionParser] cannot parse leaves parquet-java unable to tell which
@@ -235,18 +250,14 @@ final class ParquetJavaReader {
     /// @return one entry per column chunk in footer order, null where the chunk carries no count
     /// @throws IOException if the footer cannot be read
     static List<Long> readDistinctCounts(Path file) throws IOException {
-        observe(file);
         List<Long> counts = new ArrayList<>();
-        try (SeekableInputStream in = HadoopInputFile
-                .fromPath(hadoopPath(file), HadoopConf.DEFAULTS).newStream()) {
-            FileMetaData metaData = readThriftFooter(file, in);
-            for (RowGroup rowGroup : metaData.getRow_groups()) {
-                for (ColumnChunk chunk : rowGroup.getColumns()) {
-                    Statistics statistics = chunk.getMeta_data().getStatistics();
-                    counts.add(statistics != null && statistics.isSetDistinct_count()
-                            ? statistics.getDistinct_count()
-                            : null);
-                }
+        FileMetaData metaData = readFormatFooter(file);
+        for (RowGroup rowGroup : metaData.getRow_groups()) {
+            for (ColumnChunk chunk : rowGroup.getColumns()) {
+                Statistics statistics = chunk.getMeta_data().getStatistics();
+                counts.add(statistics != null && statistics.isSetDistinct_count()
+                        ? statistics.getDistinct_count()
+                        : null);
             }
         }
         return counts;

--- a/parquet-testing-runner/src/test/java/dev/hardwood/testing/WriterFooterMetadataInteropTest.java
+++ b/parquet-testing-runner/src/test/java/dev/hardwood/testing/WriterFooterMetadataInteropTest.java
@@ -8,15 +8,20 @@
 package dev.hardwood.testing;
 
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Path;
 import java.util.LinkedHashMap;
+import java.util.List;
 import java.util.Map;
 
+import org.apache.parquet.column.ColumnDescriptor;
+import org.apache.parquet.format.ColumnOrder;
 import org.apache.parquet.hadoop.metadata.ParquetMetadata;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
 import dev.hardwood.OutputFile;
+import dev.hardwood.metadata.LogicalType;
 import dev.hardwood.metadata.PhysicalType;
 import dev.hardwood.metadata.RepetitionType;
 import dev.hardwood.schema.FileSchema;
@@ -24,16 +29,51 @@ import dev.hardwood.writer.ParquetFileWriter;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-/// The interop gate over the footer's `key_value_metadata`: what Hardwood stamps on a file is
-/// what an independent implementation reads back out of it.
+/// The interop gate over the footer fields a value comparison cannot see: `key_value_metadata`,
+/// `created_by` and `column_orders`. What Hardwood stamps on a file is what an independent
+/// implementation reads back out of it.
 ///
-/// The field is the one Hardwood's own round trip cannot vouch for on its own. It carries
+/// These are the fields Hardwood's own round trip cannot vouch for. `key_value_metadata` carries
 /// `ARROW:schema`, the pandas descriptor and the table-format stamps, which means the consumer
 /// that has to find them is never Hardwood — a reader that agrees with the writer about a
 /// malformed `list<KeyValue>` would hide the break from both halves of a Hardwood round trip.
+/// `column_orders` is the same blind spot in a different place: it declares the order the bounds
+/// were computed in, which a reader sharing the writer's conventions never has to be told.
 class WriterFooterMetadataInteropTest {
 
     private static final String COLUMN = "v";
+
+    /// `column_orders` gives `min_value` / `max_value` their comparison semantics: the format
+    /// leaves their meaning undefined without it, so a file that lost the list carries bounds a
+    /// reader holding the format to its word has to discard.
+    ///
+    /// The assertion is over the **raw** footer because the decoded view cannot fail.
+    /// `PrimitiveType` defaults a missing column order to type-defined for every type but `INT96`
+    /// and `INTERVAL`, so the schema parquet-java exposes reports `TYPE_DEFINED_ORDER` whether the
+    /// field reached the wire or not. Only `getColumn_orders()` tells the two files apart, by
+    /// coming back null.
+    @Test
+    void parquetJavaReadsColumnOrdersForEveryLeafColumn(@TempDir Path dir) throws IOException {
+        Path file = dir.resolve("column-orders.parquet");
+        try (ParquetFileWriter writer = ParquetFileWriter.create(OutputFile.of(file), columnOrderSchema())) {
+            writer.columnWriter().writeBatch(batch -> batch
+                    .longs("id", new long[]{ 1L, 2L, 3L })
+                    .bytes("person.name", new byte[][]{ utf8("ada"), utf8("alan"), utf8("grace") })
+                    .doubles("person.score", new double[]{ 1.5, 2.5, 3.5 })
+                    .booleans("active", new boolean[]{ true, false, true }));
+        }
+
+        ParquetMetadata footer = ParquetJavaReader.readFooter(file);
+        List<ColumnDescriptor> columns = footer.getFileMetaData().getSchema().getColumns();
+        assertThat(columns).extracting(column -> String.join(".", column.getPath()))
+                .containsExactly("id", "person.name", "person.score", "active");
+
+        List<ColumnOrder> columnOrders = ParquetJavaReader.readFormatFooter(file).getColumn_orders();
+        assertThat(columnOrders).as("raw footer column_orders")
+                .isNotNull()
+                .hasSameSizeAs(columns)
+                .allSatisfy(order -> assertThat(order.isSetTYPE_ORDER()).isTrue());
+    }
 
     @Test
     void parquetJavaReadsTheMetadataHardwoodWrote(@TempDir Path dir) throws IOException {
@@ -103,5 +143,20 @@ class WriterFooterMetadataInteropTest {
         return FileSchema.builder("footer-metadata")
                 .addColumn(COLUMN, PhysicalType.INT32, RepetitionType.REQUIRED)
                 .build();
+    }
+
+    private static FileSchema columnOrderSchema() {
+        return FileSchema.builder("column-orders")
+                .addColumn("id", PhysicalType.INT64, RepetitionType.REQUIRED)
+                .struct("person", RepetitionType.REQUIRED, person -> person
+                        .addColumn("name", PhysicalType.BYTE_ARRAY, RepetitionType.REQUIRED,
+                                new LogicalType.StringType())
+                        .addColumn("score", PhysicalType.DOUBLE, RepetitionType.REQUIRED))
+                .addColumn("active", PhysicalType.BOOLEAN, RepetitionType.REQUIRED)
+                .build();
+    }
+
+    private static byte[] utf8(String value) {
+        return value.getBytes(StandardCharsets.UTF_8);
     }
 }

--- a/parquet-testing-runner/src/test/java/dev/hardwood/testing/WriterLogicalTypeInteropTest.java
+++ b/parquet-testing-runner/src/test/java/dev/hardwood/testing/WriterLogicalTypeInteropTest.java
@@ -231,6 +231,32 @@ class WriterLogicalTypeInteropTest {
         assertThat(statistics.genericGetMax()).as("max").isEqualTo(Binary.fromConstantByteArray(two));
     }
 
+    /// A `STRING` orders by unsigned bytes, so a value whose first byte has the high bit set is
+    /// the column's maximum and not its minimum. A signed comparison — the order the deprecated
+    /// `min` / `max` fields were defined in — reverses both bounds, and a reader pruning on them
+    /// would then skip the row group holding the very value it was asked for.
+    ///
+    /// The bound under test is the one the **writer** computes. parquet-java hands back the bytes
+    /// it finds in `min_value` / `max_value` and takes its sort order from the annotation, so this
+    /// holds whether or not the footer declares `column_orders`; that the field reaches the wire
+    /// at all is asserted in `WriterFooterMetadataInteropTest`.
+    @Test
+    void stringBoundsUseUnsignedOrder(@TempDir Path dir) throws IOException {
+        FileSchema schema = FileSchema.builder("annotated")
+                .addColumn(COLUMN, PhysicalType.BYTE_ARRAY, RepetitionType.REQUIRED,
+                        new LogicalType.StringType())
+                .build();
+
+        byte[] ascii = bytes("a");
+        byte[] highBit = bytes("über");
+        Path file = write(dir, schema, batch -> batch.bytes(COLUMN, new byte[][] { highBit, ascii }));
+
+        Statistics<?> statistics = ParquetJavaReader.readFooter(file).getBlocks().get(0)
+                .getColumns().get(0).getStatistics();
+        assertThat(statistics.genericGetMin()).as("min").isEqualTo(Binary.fromConstantByteArray(ascii));
+        assertThat(statistics.genericGetMax()).as("max").isEqualTo(Binary.fromConstantByteArray(highBit));
+    }
+
     // ==================== Helpers ====================
 
     private Path write(Path dir, Annotated annotated) throws IOException {
@@ -363,8 +389,12 @@ class WriterLogicalTypeInteropTest {
                 annotated.parquetJava(), annotated.binaryValues(), false, annotated.allNull());
     }
 
+    /// Four ASCII values and one whose first byte has the high bit set. Every candidate order
+    /// sorts ASCII identically, so without the last value the bounds of the three annotations
+    /// that share this fixture — `STRING`, `ENUM`, `BSON` — would agree under the unsigned order
+    /// they define and the signed order they must not be read in.
     private static byte[][] utf8() {
-        return new byte[][] { bytes("ada"), bytes("alan"), bytes(""), bytes("grace") };
+        return new byte[][] { bytes("ada"), bytes("alan"), bytes(""), bytes("grace"), bytes("über") };
     }
 
     private static byte[][] wkb() {


### PR DESCRIPTION
## Purpose

Closes #1049.

Hardwood already writes `column_orders`, but there was no independent interop regression proving the raw footer field survives the wire format and is seen as `TYPE_DEFINED_ORDER` by parquet-java.

## Implementation

- add raw Parquet footer reading support to the test helper using parquet-java/parquet-format
- assert raw `column_orders` cardinality for a multi-leaf schema including nested leaves
- assert each raw entry is `TYPE_DEFINED_ORDER`
- additionally assert parquet-java's high-level schema sees `TYPE_DEFINED_ORDER`
- add the complementary STRING statistics regression across the signed/unsigned byte boundary

The STRING bounds test confirms the expected unsigned STRING statistics behaviour, but it is not the independent proof of raw `column_orders` presence. The raw footer assertion provides that proof.

## Testing

- Focused `WriterFooterMetadataInteropTest`: 6 passed, 0 failures/errors/skips
- Adjacent `WriterFooterMetadataInteropTest` + `WriterLogicalTypeInteropTest`: 33 passed, 0 failures/errors/skips
- Relevant reactor:
  - error-prone: 10 passed
  - core: 2683 passed / 1 skipped
  - parquet-testing-runner: 935 passed / 68 skipped
  - write coverage: 5 passed
- Full `./mvnw clean verify`: `BUILD SUCCESS`
- Independent mutation QA: temporarily omitting writer `column_orders` caused the raw regression to fail as intended
- `git diff --check HEAD^ HEAD` passed

### Process-sources note

`./mvnw process-sources` was attempted but currently fails on both this candidate and pristine upstream parent because the `process-sources` lifecycle reaches `hardwood-core` without resolving `dev.hardwood:hardwood-test-support:jar:1.1.0-SNAPSHOT`.

This is classified as `PRE_EXISTING_REPOSITORY_LIFECYCLE_BEHAVIOUR`, not a candidate-caused regression. Full `./mvnw clean verify` succeeds.

## AI assistance

OpenAI Codex assisted with repository analysis, test implementation, validation, and publication preparation. The change was independently QA'd in a separate pass. ChatGPT assisted with planning, review coordination, and publication preparation.

The human contributor reviewed the purpose and evidence and is responsible for the submission and maintainer communication.

## Authorship

Hardwood is built with AI, not by AI. LLM assistance is welcome; submitting raw LLM output without understanding is not.
Neither are unattended agents opening pull requests.
See the [contribution guide](https://github.com/hardwood-hq/hardwood/blob/main/CONTRIBUTING.md) for more details.
Check this box to confirm:

- [x] This change is coming from a human who understands what it does and why, and can discuss it in review

## Checklist
- [x] Build via `./mvnw clean verify` passes
- [x] The commit message is prefixed with the issue key ("#123 Adding support for...")
- [x] Code changes are covered by tests
- [x] If this PR adds or changes user-facing behaviour, `docs/` has been updated
