### PR TITLE
#1048 Sweep nullability in the optional-encoding interop axis

### DIFF
--- a/_designs/WRITER_INTEROP_GATE.md
+++ b/_designs/WRITER_INTEROP_GATE.md
@@ -99,17 +99,22 @@ repetition shape.
 
 Beyond the floor, the matrix varies one axis at a time against a representative base
 rather than taking the full cross product, which would multiply to hundreds of files for
-coverage the axes already give independently. Every axis is swept across all seven
-writable physical types (`BOOLEAN`, `INT32`, `INT64`, `FLOAT`, `DOUBLE`, `BYTE_ARRAY`,
+coverage the axes already give independently. An axis is swept across all seven writable
+physical types (`BOOLEAN`, `INT32`, `INT64`, `FLOAT`, `DOUBLE`, `BYTE_ARRAY`,
 `FIXED_LEN_BYTE_ARRAY`), since the value encoders are per-type and that is where an
-encoding defect lives.
+encoding defect lives — except where the axis is defined over only some of them, as an
+encoding legal for two types is, and there the sweep is restricted to those.
 
 | Axis | Values |
 |------|--------|
 | Repetition | `REQUIRED`; `OPTIONAL` all-present; `OPTIONAL` with interleaved nulls; `OPTIONAL` all-null |
-| Encoding | single-entry dictionary; multi-entry dictionary; dictionary overflowing to mid-chunk `PLAIN`; dictionary disabled |
-| Codec | `UNCOMPRESSED`; `ZSTD` |
+| Encoding | single-entry dictionary; multi-entry dictionary; an all-distinct column the size comparison writes `PLAIN`; dictionary disabled |
+| Optional encoding | `DELTA_BINARY_PACKED`; `DELTA_LENGTH_BYTE_ARRAY`; `DELTA_BYTE_ARRAY`; `BYTE_STREAM_SPLIT` — one case per legal (encoding, physical type) pair, in every repetition shape |
+| Optional encoding × codec | each of those four encodings, on one type it is legal for, against every codec, in every repetition shape |
+| `FIXED_LEN_BYTE_ARRAY` length | 2, 8, 12 and 16 bytes against every encoding legal for the type |
+| Codec | `UNCOMPRESSED`; `GZIP`; `SNAPPY`; `ZSTD`; `LZ4_RAW` |
 | Layout | one page (pinned exactly); several pages; several row groups |
+| Write path | the columnar batch entry point; the row-oriented `RowWriter` |
 
 Two further groups are enumerated rather than swept, because their shapes differ too much
 to parameterize:
@@ -125,8 +130,20 @@ to parameterize:
   merely as `min <= max`: most annotations carry values that sort identically under every
   candidate order, so a consistency check passes for them whichever order the writer used.
 
-Only `UNCOMPRESSED` and `ZSTD` appear on the codec axis because those are the only codecs
-the writer produces today. Stage 19 adds the rest, and extends this axis with them.
+`BROTLI` is the one codec the writer produces that the codec axis omits, because the pinned
+parquet-java resolves a codec by a Hadoop class name that ships in neither parquet-java nor
+Hadoop, but in an unmaintained third-party artifact whose native binaries cover a few
+platforms only — putting it on the classpath would make the gate's result depend on the
+architecture it runs on. It is covered against DuckDB by `WriterDifferentialTest` instead,
+and `WriterInteropTest.parquetJavaHasNoBrotliCodec` pins the reason, so a parquet-java that
+gains the codec fails there rather than leaving the omission standing by inertia.
+
+The repetition axis is not only its own row. The three axes whose defect lives in the value
+encoder — the single-entry dictionary floor, the optional encodings, and those encodings
+crossed with the codecs — are each swept across all four repetition shapes as well, because
+what an encoder is handed differs by shape: a `REQUIRED` column has no definition-level
+stream at all, and an all-null one gives the encoder an empty range and the codec after it a
+page body with no values in it.
 
 ## Writer identification
 

--- a/parquet-testing-runner/src/test/java/dev/hardwood/testing/WriterInteropTest.java
+++ b/parquet-testing-runner/src/test/java/dev/hardwood/testing/WriterInteropTest.java
@@ -91,21 +91,24 @@ class WriterInteropTest {
                         axis.distinct(), FEW_ROWS, axis.config(), axis.plainOnly()));
     }
 
-    /// The optional-encoding axis: one case per legal (encoding, physical type) pair, written
-    /// under a file-wide policy and read back through parquet-java.
+    /// The optional-encoding axis: one case per legal (encoding, physical type) pair, in every
+    /// repetition shape, written under a file-wide policy and read back through parquet-java.
     ///
     /// These are the encodings Hardwood could read but not write before stage 19b, so this axis
     /// is the first time its own output for them is put in front of another implementation. The
     /// pairs come from the same legality table [ColumnEncoding] states, restricted to the types
-    /// this gate writes.
+    /// this gate writes. Nullability is swept the way [#singleEntryDictionary] sweeps it, since a
+    /// `REQUIRED` column takes a different level path and an `OPTIONAL_ALL_NULL` one asks the
+    /// encoder for an empty range.
     static Stream<InteropCase> optionalEncodings() {
         return Stream.of(TypeFixture.values()).flatMap(type -> Stream.of(
                 ColumnEncoding.DELTA_BINARY_PACKED, ColumnEncoding.DELTA_LENGTH_BYTE_ARRAY,
                 ColumnEncoding.DELTA_BYTE_ARRAY, ColumnEncoding.BYTE_STREAM_SPLIT)
                 .filter(encoding -> legal(encoding, type))
-                .map(encoding -> InteropCase.of("encoding " + encoding, type,
-                        Nullability.OPTIONAL_SOME_NULL, 64, FEW_ROWS,
-                        WriterConfig.builder().encoding(encoding).build())));
+                .flatMap(encoding -> Stream.of(Nullability.values())
+                        .map(nullability -> InteropCase.of("encoding " + encoding, type,
+                                nullability, 64, FEW_ROWS,
+                                WriterConfig.builder().encoding(encoding).build()))));
     }
 
     /// The legality table the writer itself applies, rather than a copy of it: a pair dropped

--- a/parquet-testing-runner/src/test/java/dev/hardwood/testing/WriterInteropTest.java
+++ b/parquet-testing-runner/src/test/java/dev/hardwood/testing/WriterInteropTest.java
@@ -126,6 +126,10 @@ class WriterInteropTest {
     /// that makes the point — it changes no page's size on its own, and exists entirely for what
     /// the codec after it can then do — so each encoding is swept over the codecs on one type it
     /// is legal for rather than over all of them.
+    ///
+    /// Nullability is swept as it is in [#optionalEncodings], since the shape of a page body is
+    /// what a codec sees: an `OPTIONAL_ALL_NULL` case hands the codec a body with no values in it
+    /// at all, and a `REQUIRED` one a body the definition levels are absent from.
     static Stream<InteropCase> optionalEncodingCodecs() {
         return Stream.of(
                 new EncodingCodecAxis(ColumnEncoding.DELTA_BINARY_PACKED, TypeFixture.INT64),
@@ -133,12 +137,14 @@ class WriterInteropTest {
                 new EncodingCodecAxis(ColumnEncoding.DELTA_BYTE_ARRAY, TypeFixture.BYTE_ARRAY),
                 new EncodingCodecAxis(ColumnEncoding.BYTE_STREAM_SPLIT, TypeFixture.DOUBLE))
                 .flatMap(axis -> PARQUET_JAVA_CODECS.stream()
-                        .map(codec -> InteropCase.of(axis.encoding() + " under " + codec, axis.type(),
-                                Nullability.OPTIONAL_SOME_NULL, 64, FEW_ROWS,
-                                WriterConfig.builder()
-                                        .encoding(axis.encoding())
-                                        .codec(codec)
-                                        .build())));
+                        .flatMap(codec -> Stream.of(Nullability.values())
+                                .map(nullability -> InteropCase.of(
+                                        axis.encoding() + " under " + codec, axis.type(),
+                                        nullability, 64, FEW_ROWS,
+                                        WriterConfig.builder()
+                                                .encoding(axis.encoding())
+                                                .codec(codec)
+                                                .build()))));
     }
 
     /// The `FIXED_LEN_BYTE_ARRAY` lengths the writer has a reason to see, against every encoding


### PR DESCRIPTION
closes #1048
`WriterInteropTest.optionalEncodings` pinned every case at `OPTIONAL_SOME_NULL` so `DELTA_BINARY_PACKED`, `DELTA_LENGTH_BYTE_ARRAY`, `DELTA_BYTE_ARRAY` and `BYTE_STREAM_SPLIT` never went through the parquet-java gate as REQUIRED, all-present, or all-null columns. The last of those hands an encoder an empty range to encode and `REQUIRED` takes a different level path entirely so the pinned axis was covering only one of the four repetition shapes a legal pair can take. singleEntryDictionary already sweeps Nullability.values() the same way; this widens optionalEncodings to match using the InteropCase machinery that shape already exercises elsewhere.

## Checklist

- [x] Build via `./mvnw clean verify` passes
- [x] The commit message is prefixed with the issue key ("#123 Adding support for...")
- [x] Code changes are covered by tests
- [ ] If this PR adds or changes user-facing behaviour, `docs/` has been updated
