### PR TITLE
#686 Drop the Quarkus references the aesh migration left behind

### DIFF
--- a/.claude/skills/hardwood-address-review/SKILL.md
+++ b/.claude/skills/hardwood-address-review/SKILL.md
@@ -38,7 +38,14 @@ git fetch <https-url> <head-ref>:pr-<N>
 git checkout pr-<N>
 ```
 
-The HTTPS-fetched branch does not track the fork's upstream, which is actually safer here — there is no way to accidentally `git push` back to the contributor's fork. Note this in the hand-back summary so the user knows.
+The HTTPS-fetched branch has no upstream, which is safer for a fork PR — there is no way to accidentally `git push` back to the contributor's fork. The local branch name (`pr-<N>`) also differs from the head ref, so any later push needs an explicit refspec.
+
+Add `isCrossRepository` to that `gh pr view` call, because it decides where a push would go — and most Hardwood PRs are the maintainer's own same-repo branches, not forks:
+
+- `isCrossRepository: false` → `origin` is already `hardwood-hq/hardwood`; the push is `git push origin pr-<N>:<head-ref>`. No remote needs adding.
+- `isCrossRepository: true` → the fork is not a configured remote; see the push-target section of the `hardwood-pr-git` skill.
+
+Never assert a remote is missing without checking `git remote -v` first.
 
 After checkout, confirm you're on the PR branch with `git branch --show-current` so a later git command can't accidentally commit to `main`.
 
@@ -118,7 +125,7 @@ Report:
 - The commit SHA.
 - A 3-bullet summary: decisions picked, findings addressed, anything skipped or contested.
 - If any findings were flagged as wrong-by-reviewer, list them so the user can adjudicate.
-- A reminder: "Not pushed. `git push` from here when you're ready."
+- A reminder that nothing was pushed, giving the exact command from step 3 rather than a generic `git push` — e.g. "Not pushed. `git push origin pr-1054:686-stale-quarkus-references` when you're ready."
 
 ## When NOT to use this skill
 

--- a/NATIVE_BUILD.md
+++ b/NATIVE_BUILD.md
@@ -20,19 +20,17 @@ Build the native binary for the `cli` module and its dependencies:
 
 The resulting binary is at `cli/target/hardwood-cli`. Run it directly (e.g. `cli/target/hardwood-cli --help`); see the [CLI reference](docs/content/reference/cli.md) for command usage.
 
-### Linux binary without a local GraalVM (containerized)
+### Building a Linux binary
 
-To build a Linux binary on a non-Linux host — e.g. for a Docker image on macOS — use Quarkus' containerized native build, which runs GraalVM inside the Mandrel builder container:
+`native-maven-plugin` always targets the host platform, so a Linux ELF binary requires a Linux host with a GraalVM JDK. On macOS the same command produces a Mach-O binary, which a Linux container cannot execute (`exec format error`).
 
-```bash
-./mvnw -Dnative -Dquarkus.native.container-build=true package -pl cli -am
-```
+There is no cross-compilation step in the build. The per-platform binaries published with a release are produced by the `package` job in [.github/workflows/release-cli.yml](.github/workflows/release-cli.yml), which runs the build once per runner OS in a matrix.
 
-This requires Docker to be running. The build always produces a Linux ELF binary; running it directly on macOS fails with `exec format error`.
+To obtain a Linux binary from a non-Linux host, either run the build on a Linux machine (a container with a GraalVM JDK will do — the repository's own dev container ships Temurin, which cannot build native images), or download the Linux dist from a release.
 
 ### Building the Docker image
 
-`cli/build-cli-docker.sh` builds the container image. It produces (or reuses) the full native dist — the Linux binary, completion script, and codec libraries — building it in a container so it targets Linux regardless of the host OS, then builds the image:
+`cli/build-cli-docker.sh` builds the container image. It produces (or reuses) the full native dist — the Linux binary, completion script, and codec libraries — then builds the image from it. Since the dist has to be a Linux one, the script runs on Linux only and refuses to start elsewhere:
 
 ```bash
 cd cli
@@ -59,7 +57,7 @@ Build that module alongside the CLI:
 
 ## How the native build works
 
-The CLI module uses [Quarkus](https://quarkus.io/) with `quarkus-picocli` and GraalVM/Mandrel native image. Several non-obvious pieces are required to make all compression codecs work correctly in a native binary.
+The CLI module uses the [aesh](https://aeshell.github.io/) command framework and GraalVM/Mandrel native image. Several non-obvious pieces are required to make all compression codecs work correctly in a native binary.
 
 ### Compression codec native libraries
 
@@ -67,7 +65,7 @@ All compression codecs (Snappy, ZSTD, LZ4, Brotli) ship their native code as JNI
 
 The solution differs by codec:
 
-- **ZSTD, Snappy, LZ4** — Native libraries are unpacked from their JARs during the Maven `prepare-package` phase (`maven-dependency-plugin`) and bundled in a `lib/` directory alongside the binary. At startup, `NativeImageStartup` fires a Quarkus `StartupEvent` which calls `NativeLibraryLoader` to load each library via `System.load(absolutePath)` before any decompression occurs. For ZSTD, `zstd-jni`'s `Native.assumeLoaded()` is also called to prevent the library's own loader from attempting a duplicate load. Snappy is handled the same way — its loader may have already run at image build time (and failed), so directly calling `System.load()` at runtime bypasses its cached failure state entirely.
+- **ZSTD, Snappy, LZ4** — Native libraries are unpacked from their JARs during the Maven `prepare-package` phase (`maven-dependency-plugin`) and bundled in a `lib/` directory alongside the binary. At startup, `Main.run()` calls `NativeLibraryLoader` to load each library via `System.load(absolutePath)` before dispatching the command, so every library is in place before any decompression occurs. For ZSTD, `zstd-jni`'s `Native.assumeLoaded()` is also called to prevent the library's own loader from attempting a duplicate load. Snappy is handled the same way — its loader may have already run at image build time (and failed), so directly calling `System.load()` at runtime bypasses its cached failure state entirely.
 
 - **Brotli** — `brotli4j`'s loader (`Brotli4jLoader.ensureAvailability()`) is invoked explicitly at decompression time rather than in a static initializer, so it never runs at build time. Its loading strategy — extracting a classpath resource to a temp file and loading that — works in native images provided the resource is embedded in the binary. The `resource-config.json` under `cli/src/main/resources/META-INF/native-image/` instructs GraalVM to embed the brotli native libraries as image resources.
 
@@ -88,6 +86,6 @@ The solution differs by codec:
 
 ## Testing the native binary
 
-Automated coverage of the native binary is provided by the Quarkus integration-test infrastructure; see [_designs/NATIVE_INTEGRATION_TESTS.md](_designs/NATIVE_INTEGRATION_TESTS.md). The ITs run against the compiled native executable during `./mvnw -Pnative -pl cli verify`.
+Automated coverage of the native binary is provided by Failsafe integration tests that spawn the compiled executable as a subprocess; see [_designs/NATIVE_INTEGRATION_TESTS.md](_designs/NATIVE_INTEGRATION_TESTS.md). They run during `./mvnw -Dnative -pl cli verify`.
 
 For ad-hoc manual testing of the native binary against S3, see the [Manual S3 testing](TESTING.md#manual-s3-testing) recipe in [TESTING.md](TESTING.md).

--- a/README.md
+++ b/README.md
@@ -170,7 +170,7 @@ Then build the `cli` module and its dependencies:
 
 The resulting binary is at `cli/target/hardwood-cli`.
 
-See [NATIVE_BUILD.md](NATIVE_BUILD.md) for the full build guide — containerized Linux builds, the Docker image, and how the native build works (codec handling, build arguments).
+See [NATIVE_BUILD.md](NATIVE_BUILD.md) for the full build guide — obtaining a Linux binary, the Docker image, and how the native build works (codec handling, build arguments).
 
 ### Building the Documentation
 

--- a/_designs/INTERACTIVE_DIVE_TUI.md
+++ b/_designs/INTERACTIVE_DIVE_TUI.md
@@ -255,7 +255,7 @@ Dive lives in the existing `cli` module:
 ```
 cli/src/main/java/dev/hardwood/cli/
 ├── command/
-│   └── DiveCommand.java          (picocli entry point on HardwoodCommand)
+│   └── DiveCommand.java          (aesh entry point on HardwoodCommand)
 └── dive/
     ├── DiveApp.java              (TuiRunner wiring; dispatchKey / render)
     ├── NavigationStack.java      (push / pop / replaceTop / clearToRoot)

--- a/_designs/NATIVE_INTEGRATION_TESTS.md
+++ b/_designs/NATIVE_INTEGRATION_TESTS.md
@@ -4,74 +4,63 @@
 
 ## Overview
 
-The CLI native binary is smoke-tested via the Quarkus integration-test infrastructure using
-`@QuarkusMainIntegrationTest`. When the `native` Maven profile is active, these tests run
-the compiled native executable as a subprocess and assert on its exit code and output.
+The CLI native binary is smoke-tested by Failsafe integration tests that spawn the compiled
+executable as a subprocess and assert on its exit code and output. When the `native` Maven
+profile is active (`-Dnative`), these tests run during the `integration-test` phase.
 
 ## Test Layers
 
-### JVM tests (`@QuarkusMainTest`)
+### JVM tests
 
 All `*CommandTest` classes run during the `test` phase against the JVM build of the
 application and provide the primary behavioural coverage for every CLI command. They
 remain the fast feedback loop during development and are unaffected by the native
 integration layer.
 
-### Native smoke tests (`@QuarkusMainIntegrationTest`)
+### Native smoke tests
 
-Two `*SmokeIT` classes run during the `integration-test` phase via the Maven Failsafe
-plugin and exercise the native binary end-to-end:
+Three `*IT` classes run during the `integration-test` phase via the Maven Failsafe plugin
+and exercise the native binary end-to-end:
 
-- `NativeBinarySmokeIT` runs the native binary against a local Parquet file on disk.
+- `NativeBinarySmokeIT` runs the native binary against a local Parquet file on disk, and
+  pins its reported build version against the JVM it was compiled from.
 - `NativeBinaryS3SmokeIT` runs the native binary against a Parquet file served by an
-  S3Mock container.
+  S3 proxy container.
+- `NativeCompressionCodecIT` reads one fixture per supported compression codec, covering
+  `LZ4` and `LZ4_RAW` as separate cases because they use different decompressors.
 
 These tests exist to catch native-image-specific regressions — missing reflection
-registrations, unreachable classpath resources, broken AWS SDK wiring — rather than to
-re-verify per-command behaviour. Per-command assertions live once, in the JVM layer.
+registrations, unreachable classpath resources, broken AWS SDK wiring, codec native
+libraries that fail to load — rather than to re-verify per-command behaviour. Per-command
+assertions live once, in the JVM layer.
 
-The IT class itself runs in the JVM and uses `QuarkusMainLauncher` to spawn the native
-executable as a subprocess. File path arguments are resolved as classpath resources in
-the JVM test process and passed as absolute paths, so they are accessible to the native
-subprocess via the local filesystem.
+## Locating and Configuring the Binary
 
-## Test Resources
+The Failsafe execution in `cli/pom.xml` passes `native.image.path` as a system property,
+pointing at `${project.build.directory}/hardwood-cli`. Each IT reads that property to find
+the executable.
 
-Properties returned by a `QuarkusTestResourceLifecycleManager.start()` are passed by
-Quarkus as `-D` system-property flags on the native binary command line. This is the only
-mechanism for injecting configuration into the native subprocess from the test layer.
+The IT classes themselves run in the JVM and use `ProcessBuilder` to spawn the binary.
+File path arguments are resolved as classpath resources in the JVM test process and passed
+as absolute paths, so they are reachable by the subprocess through the local filesystem.
 
-### `QuietLoggingTestResource`
+Configuration reaches the subprocess as environment variables set on the `ProcessBuilder`.
+`NativeBinaryS3SmokeIT` uses this to pass `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`,
+`AWS_REGION`, `AWS_ENDPOINT_URL`, `AWS_PATH_STYLE`, `AWS_CONFIG_FILE` and
+`AWS_SHARED_CREDENTIALS_FILE`; the AWS SDK embedded in the native image reads them at
+runtime, so no code changes are required in the CLI itself.
 
-The Quarkus integration-test extension unconditionally adds
-`-Dquarkus.log.category."io.quarkus".level=INFO` to the native binary command, which
-overrides the `%prod.quarkus.log.level=ERROR` setting baked into the binary and causes
-startup/shutdown messages to appear in captured stdout. `QuietLoggingTestResource` returns
-`quarkus.log.console.enable=false`, disabling the console log handler at the handler level
-so no log output reaches stdout regardless of category levels.
-
-### `S3MockTestResource`
-
-`S3MockTestResource` launches an S3Mock container, uploads a single test Parquet file
-(`plain_uncompressed.parquet`), and returns a `Map<String, String>` containing
-`quarkus.log.console.enable=false` (for the same reason as above) plus the AWS connection
-properties: `aws.accessKeyId`, `aws.secretAccessKey`, `aws.region`, `aws.endpointUrl`,
-`aws.pathStyle`, `aws.configFile`, and `aws.sharedCredentialsFile`. The AWS SDK embedded
-in the native image reads them at runtime, so no code changes are required in the CLI
-itself.
-
-The JVM S3 tests continue to use `AbstractS3CommandTest`, which configures AWS via
-`System.setProperty()` in a static initializer. That mechanism only works because
-`@QuarkusMainTest` runs the CLI in the same JVM as the test — for the native subprocess,
-configuration has to arrive as `-D` flags on the command line, which is what
-`S3MockTestResource` does.
+The JVM S3 tests instead use `AbstractS3CommandTest`, which configures AWS via
+`System.setProperty()`. That mechanism only works because those tests run the CLI in the
+same JVM as the test — for the native subprocess, configuration has to arrive from the
+outside, which is what the environment variables do.
 
 ## Build Changes
 
-The Maven Failsafe plugin is added to the `cli` module's main `<build>` section with the
-`integration-test` and `verify` goals. Integration tests are skipped by default
-(`skipITs=true`). The `native` profile sets `skipITs=false`, enabling the smoke tests
-only during a native build.
+The Maven Failsafe plugin is configured in the `cli` module's main `<build>` section with
+the `integration-test` and `verify` goals. Integration tests are skipped by default
+(`skipITs=true`). The `native` profile sets `skipITs=false`, enabling the smoke tests only
+during a native build.
 
 ## Running the Native Build Check Locally
 

--- a/cli/build-cli-docker.sh
+++ b/cli/build-cli-docker.sh
@@ -11,8 +11,9 @@ set -e
 
 # Build the CLI Docker image. Produces (or reuses) the native dist — the Linux
 # hardwood binary, the completion script, and the codec native libraries — then
-# builds the image from it. The dist is built in a container so it targets Linux
-# regardless of the host OS, which means the image can be built and used on macOS.
+# builds the image from it. The native build targets the host platform, so this
+# script has to run on Linux; see NATIVE_BUILD.md for how a Linux binary is
+# obtained from another host.
 # Use -f/--force to rebuild the dist even if one already exists.
 #
 # Usage: cd cli && ./build-cli-docker.sh [options] [image-tag]
@@ -60,19 +61,18 @@ dist_ready() {
   is_linux_elf "$BINARY" && [ -f "$COMPLETION" ] && ls "$LIBS_DIR"/*.so >/dev/null 2>&1
 }
 
-# Build the full native dist (binary + codec libraries) targeting Linux, in a
-# container, so the result works regardless of the host OS:
-#   - container-build compiles the native binary inside the Mandrel Linux builder;
+# Build the full native dist (binary + codec libraries) for the image:
 #   - the codec libraries are prebuilt platform binaries shipped inside the
-#     dependency JARs, so force the Linux variants to match the Linux binary on any
-#     host (the os-* Maven profiles otherwise pick the host's, e.g. macOS .dylib);
-#   - native integration tests would exec the Linux binary on the host, so skip them.
+#     dependency JARs, so pin the Linux variants explicitly rather than letting the
+#     os-* Maven profiles pick by host;
+#   - native integration tests are skipped: this build feeds the image, and the
+#     native profile's ITs run in their own CI job.
 build_dist() {
-  echo "Building the native dist (Linux binary + codec libraries) in a container..."
-  echo "This requires Docker to be running and may take several minutes."
+  echo "Building the native dist (Linux binary + codec libraries)..."
+  echo "This may take several minutes."
   echo ""
   cd "$REPO_ROOT"
-  ./mvnw -Dnative -Dquarkus.native.container-build=true package \
+  ./mvnw -Dnative package \
     -pl cli,error-prone-checks -am \
     -DskipTests -DskipITs \
     -Ddist.os=linux -Ddist.lib.extension='*.so' \
@@ -80,6 +80,16 @@ build_dist() {
   cd "$REPO_ROOT/cli"
   echo ""
 }
+
+# Checked up front rather than left to the ELF check below: the native build
+# targets the host, so on a non-Linux host the script would spend several
+# minutes producing a binary the image cannot run before saying so.
+if [ "$(uname -s)" != "Linux" ]; then
+  echo "Error: the image needs a Linux hardwood binary, and the native build targets the"
+  echo "host platform ($(uname -s) detected), so this script has to run on Linux."
+  echo "See NATIVE_BUILD.md, 'Building a Linux binary'."
+  exit 1
+fi
 
 echo "Building Docker image for hardwood CLI: $IMAGE_NAME"
 echo ""

--- a/cli/pom.xml
+++ b/cli/pom.xml
@@ -668,8 +668,8 @@
 
       <!-- Run native integration tests during the integration-test phase.
            Skipped by default; enabled when the native profile sets skipITs=false.
-           native.image.path tells the Quarkus integration-test extension where
-           to find the compiled native binary. -->
+           native.image.path tells the native ITs where to find the compiled
+           binary. -->
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-failsafe-plugin</artifactId>

--- a/cli/src/main/java/dev/hardwood/cli/dive/internal/Theme.java
+++ b/cli/src/main/java/dev/hardwood/cli/dive/internal/Theme.java
@@ -134,12 +134,12 @@ public final class Theme {
     /// released in the last decade that support truecolor.
     ///
     /// Probed on every call rather than cached in a `static final`
-    /// field. In a Quarkus / Mandrel native image the static
-    /// initializer of a reachable class can run at build time,
-    /// which would freeze `System.getenv("COLORTERM")` to whatever
-    /// the build runner saw (typically unset) and disable truecolor
-    /// for every user. Reading on each call sidesteps the class-init
-    /// timing question entirely. See #394.
+    /// field. In a Mandrel native image the static initializer of a
+    /// reachable class can run at build time, which would freeze
+    /// `System.getenv("COLORTERM")` to whatever the build runner saw
+    /// (typically unset) and disable truecolor for every user.
+    /// Reading on each call sidesteps the class-init timing question
+    /// entirely. See #394.
     static boolean supportsTruecolor(String colorterm) {
         return "truecolor".equals(colorterm) || "24bit".equals(colorterm);
     }


### PR DESCRIPTION
Follow-up to #686. The picocli/Quarkus → aesh migration swapped the CLI's framework but not the prose describing it, so the build documentation still explains a stack that is no longer on the classpath. Surfaced while triaging #686 for closure.

### The one that isn't cosmetic

`cli/build-cli-docker.sh` passes `-Dquarkus.native.container-build=true` to produce a Linux binary on a non-Linux host. With Quarkus gone the property is inert, and nothing in the build cross-compiles — so the "build the Docker image on macOS" workflow that both the script header and `NATIVE_BUILD.md` document cannot work.

It fails loudly rather than silently: `is_linux_elf` catches the Mach-O afterwards. But the message is only *"native dist is incomplete"*, which points at the dist rather than at the host OS. The script now names the cause:

```
cli/target/hardwood-cli is not a Linux ELF. The native build targets the host
platform, so the image has to be built on Linux (Darwin detected).
See NATIVE_BUILD.md, 'Building a Linux binary'.
```

`NATIVE_BUILD.md` replaces the containerized-build section with what the build actually does: `native-maven-plugin` targets the host, the per-platform release binaries come from the `build-native` matrix in `release-cli.yml`, and a Linux binary needs a Linux host. (Worth noting the repo's own dev container ships Temurin, so it can't build native images either — called out so nobody reaches for it.)

### Stale prose

- `NATIVE_BUILD.md` — the module "uses Quarkus with `quarkus-picocli`" (now aesh); `NativeImageStartup` firing a Quarkus `StartupEvent` to load the codec libraries, when `Main.run()` calls `NativeLibraryLoader` directly and `NativeImageStartup` no longer exists; the ITs described as Quarkus infrastructure, invoked as `-Pnative` when the profile is property-activated (`-Dnative`).
- `_designs/NATIVE_INTEGRATION_TESTS.md` — the largest gap. It documented `@QuarkusMainTest` / `@QuarkusMainIntegrationTest`, `QuarkusMainLauncher`, and two test-resource classes (`QuietLoggingTestResource`, `S3MockTestResource`) that were deleted with the migration. Rewritten against the current classes: plain Failsafe, `ProcessBuilder`, `native.image.path`, and AWS config arriving as environment variables. Also picks up `NativeCompressionCodecIT` (#804), so the doc lists three IT classes rather than two.
- `_designs/INTERACTIVE_DIVE_TUI.md` and `Theme.java` — one-line references each.
- `cli/pom.xml` — a comment attributing `native.image.path` to "the Quarkus integration-test extension".

No `quarkus` or `picocli` occurrence remains in the repo outside `docs/content/release-notes.md`, where it correctly names the framework the migration moved away from.

### Verification

`bash -n` on the script, `./mvnw validate -pl cli` for the XML comment edit, and `./mvnw compile -pl cli` for the JavaDoc edit. The native path itself is unchanged — no build argument, plugin, or source behaviour is touched, only the `-Dquarkus.*` no-op and prose.
