### PR TITLE
#1055 Lint the shell scripts, and state how concurrent sessions share a checkout

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,6 +4,18 @@ Avoid "not my department" thinking; if, for instance, there are build failures y
 Never add Claude (or any Anthropic identity) as a Co-Authored-By trailer on commit messages. Human co-authors are fine.
 When a CLI tool is missing from the dev container (e.g. `cmp: command not found`), surface it to the user and propose adding the providing package to the `Dockerfile`'s `microdnf install` list — unless there is an obvious one-line alternative (e.g. `command -v` for `which`) or a Python equivalent that is just as terse. Do not silently work around it.
 
+# Multiple Sessions
+
+Several Claude sessions may be running against this repository at once. Git allows one HEAD per working tree, so two sessions sharing a checkout also share HEAD, the index and the files: a `git checkout` in one silently relocates the other, and work gets committed to the wrong branch.
+
+Before any branch work, move into your own worktree. Treat `/workspace` as a reference checkout that stays on `main` — it is where every session lands by default, which is exactly why it must not be where any session commits. Name the worktree directory after its branch, so `git worktree list` reads as a registry of what is in flight.
+
+Stage explicit paths. Never `git add -A` or `git commit -a`: another session's uncommitted files may be sitting in the tree, and a catch-all stage sweeps them into your commit.
+
+Verify before committing, not after. Check that `git rev-parse --abbrev-ref HEAD` is the branch you expect and that `git status` lists only files you touched. A commit on the wrong branch is recoverable through the reflog; one that has been pushed or amended over is not always.
+
+Worktrees live under `.claude/worktrees/`, which `.gitignore` excludes. They must stay inside the repository, because `docker-compose.yaml` bind-mounts the repo root and anything outside it is invisible to an IDE on the host.
+
 # Maven
 
 To run Maven, always run ./mvnw (Maven wrapper).

--- a/Dockerfile
+++ b/Dockerfile
@@ -17,6 +17,7 @@ RUN microdnf install -y --nodocs \
       unzip \
       tar \
       diffutils \
+      ShellCheck \
       binutils \
       gcc \
       glibc-devel \


### PR DESCRIPTION
Closes #1055.

## `ShellCheck` in the dev container

Twelve shell scripts are tracked in this repo with no linter behind them. `bash -n` only proves a script parses — unquoted expansions that word-split, `[ ]` where `[[ ]]` was meant, a `cd` whose failure `set -e` swallows all survive it.

Fedora 43 ships it (`ShellCheck-0:0.11.0-1.fc43.aarch64`), so it is one line in the `microdnf install` list. Verified it installs and runs in the container.

Running it across all 12 tracked scripts turns up two findings, both benign and both left alone here:

- `_demos/demo-script.sh:67` — SC2139, an alias that expands when defined. Intentional for a demo.
- `tools/prune-branches.sh:267` — SC2034, `headref` destructured out of a `read` and never used.

So the scripts are effectively clean today, and this adds a gate rather than a backlog. (`cli/build-cli-docker.sh`, edited in #1054, passes at all severity levels.)

## `CLAUDE.md`: a Multiple Sessions section

Git allows one HEAD per working tree. Two sessions started in `/workspace` therefore share HEAD, the index and the files, and a `git checkout` in one silently relocates the other.

This is written from a failure that already happened in this repo: a commit intended for a fresh branch landed on another session's PR branch instead, and the `git add -A` in that commit swallowed that session's uncommitted work. Both were recovered from the reflog, and only because the misplaced commit happened to make a later `gh pr create` fail loudly. Had it not, the work would have been pushed onto someone else's PR.

What the section states:

- One session, one worktree, including the main checkout — keep `/workspace` on `main` and move into a worktree before branch work. It is where every session lands by default, which is precisely why it must not be where any session commits.
- Name the worktree directory after its branch, so `git worktree list` reads as a registry of what is in flight.
- Stage explicit paths; never `git add -A` or `git commit -a`.
- Check `git rev-parse --abbrev-ref HEAD` and `git status` before committing rather than after.

It also records why worktrees have to stay under `.claude/worktrees/` rather than in a sibling directory: `docker-compose.yaml` bind-mounts the repo root, so anything outside it does not exist for an IDE on the host.

## Note

The `Dockerfile` change only takes effect on the next image rebuild.
