### PR TITLE
#1019 Decode DELTA_BINARY_PACKED a miniblock at a time

### DIFF
--- a/core/src/main/java/dev/hardwood/internal/encoding/DeltaBinaryPackedDecoder.java
+++ b/core/src/main/java/dev/hardwood/internal/encoding/DeltaBinaryPackedDecoder.java
@@ -45,11 +45,11 @@ public class DeltaBinaryPackedDecoder implements ValueDecoder {
     private long minDelta;
     private int[] bitWidths;
     private int currentMiniblock;
-    private int valuesInCurrentMiniblock;
 
-    // Bit unpacking buffer
-    private byte[] miniblockData;
-    private int bitPosition;
+    // Pre-allocated miniblock decode buffer (size = valuesPerMiniblock)
+    private long[] miniblockBuffer;
+    private int bufferPos;
+    private int bufferFill;
 
     public DeltaBinaryPackedDecoder(byte[] data, int offset) {
         this.data = data;
@@ -78,9 +78,31 @@ public class DeltaBinaryPackedDecoder implements ValueDecoder {
     /// Read INT64 values directly into a primitive long array.
     @Override
     public void readLongs(long[] output, int[] definitionLevels, int maxDefLevel) throws IOException {
+        if (!headerRead) {
+            readHeader();
+            headerRead = true;
+        }
         if (definitionLevels == null) {
-            for (int i = 0; i < output.length; i++) {
-                output[i] = readLongValue();
+            int out = 0;
+            int len = output.length;
+            while (out < len) {
+                if (valuesRead == 0) {
+                    output[out++] = firstValue;
+                    lastValue = firstValue;
+                    valuesRead = 1;
+                    continue;
+                }
+                if (valuesRead >= totalValueCount) {
+                    throw new IOException("No more values to read");
+                }
+                if (bufferPos >= bufferFill) {
+                    loadNextMiniblockInternal();
+                }
+                int canDrain = Math.min(bufferFill - bufferPos, len - out);
+                System.arraycopy(miniblockBuffer, bufferPos, output, out, canDrain);
+                bufferPos += canDrain;
+                out += canDrain;
+                valuesRead += canDrain;
             }
         }
         else {
@@ -95,9 +117,31 @@ public class DeltaBinaryPackedDecoder implements ValueDecoder {
     /// Read INT32 values directly into a primitive int array.
     @Override
     public void readInts(int[] output, int[] definitionLevels, int maxDefLevel) throws IOException {
+        if (!headerRead) {
+            readHeader();
+            headerRead = true;
+        }
         if (definitionLevels == null) {
-            for (int i = 0; i < output.length; i++) {
-                output[i] = (int) readLongValue();
+            int out = 0;
+            int len = output.length;
+            while (out < len) {
+                if (valuesRead == 0) {
+                    output[out++] = (int) firstValue;
+                    lastValue = firstValue;
+                    valuesRead = 1;
+                    continue;
+                }
+                if (valuesRead >= totalValueCount) {
+                    throw new IOException("No more values to read");
+                }
+                if (bufferPos >= bufferFill) {
+                    loadNextMiniblockInternal();
+                }
+                int canDrain = Math.min(bufferFill - bufferPos, len - out);
+                for (int i = 0; i < canDrain; i++) {
+                    output[out++] = (int) miniblockBuffer[bufferPos++];
+                }
+                valuesRead += canDrain;
             }
         }
         else {
@@ -118,6 +162,7 @@ public class DeltaBinaryPackedDecoder implements ValueDecoder {
 
         if (valuesRead == 0) {
             valuesRead = 1;
+            lastValue = firstValue;
             return firstValue;
         }
 
@@ -125,29 +170,24 @@ public class DeltaBinaryPackedDecoder implements ValueDecoder {
             throw new IOException("No more values to read");
         }
 
-        // Check if we need to start a new block (first value after header doesn't count)
-        int valuesAfterFirst = valuesRead - 1;
-        if (valuesAfterFirst % blockSize == 0) {
+        if (bufferPos >= bufferFill) {
+            loadNextMiniblockInternal();
+        }
+
+        valuesRead++;
+        return miniblockBuffer[bufferPos++];
+    }
+
+    /// Decide whether we need a new block header or just the next miniblock, then load it.
+    private void loadNextMiniblockInternal() throws IOException {
+        int valuesFromBlocks = valuesRead - 1;
+        if (valuesFromBlocks % blockSize == 0) {
             readBlockHeader();
         }
-
-        // Check if we need a new miniblock
-        if (valuesInCurrentMiniblock >= valuesPerMiniblock) {
+        else {
             currentMiniblock++;
-            valuesInCurrentMiniblock = 0;
-            if (currentMiniblock < miniblockCount) {
-                loadMiniblock();
-            }
+            loadMiniblock(currentMiniblock);
         }
-
-        // Unpack delta and reconstruct value
-        long packedDelta = unpackValue(bitWidths[currentMiniblock]);
-        long delta = minDelta + packedDelta;
-        lastValue += delta;
-        valuesInCurrentMiniblock++;
-        valuesRead++;
-
-        return lastValue;
     }
 
     private void readHeader() throws IOException {
@@ -156,73 +196,164 @@ public class DeltaBinaryPackedDecoder implements ValueDecoder {
         totalValueCount = readUleb128();
         firstValue = readZigzagUleb128();
 
+        if (blockSize <= 0) {
+            throw new IOException("Invalid block size: " + blockSize);
+        }
         if (miniblockCount == 0) {
             throw new IOException("Invalid miniblock count: 0");
         }
+        if (blockSize % miniblockCount != 0) {
+            throw new IOException("Block size " + blockSize + " is not divisible by miniblock count " + miniblockCount);
+        }
+
         valuesPerMiniblock = blockSize / miniblockCount;
         bitWidths = new int[miniblockCount];
-
+        miniblockBuffer = new long[valuesPerMiniblock];
+        bufferPos = 0;
+        bufferFill = 0;
         lastValue = firstValue;
     }
 
     private void readBlockHeader() throws IOException {
         minDelta = readZigzagUleb128();
 
-        // Read bit widths for all miniblocks
+        // Read bit widths for all miniblocks in this block
         for (int i = 0; i < miniblockCount; i++) {
             if (pos >= data.length) {
                 throw new IOException("Unexpected EOF reading bitwidths");
             }
-            bitWidths[i] = data[pos++] & 0xFF;
+            int bw = data[pos++] & 0xFF;
+            if (bw > 64) {
+                throw new IOException("Invalid bit width: " + bw);
+            }
+            bitWidths[i] = bw;
         }
 
         currentMiniblock = 0;
-        valuesInCurrentMiniblock = 0;
-        loadMiniblock();
+        loadMiniblock(0);
     }
 
-    private void loadMiniblock() throws IOException {
-        int bitWidth = bitWidths[currentMiniblock];
+    /// Decode one miniblock into miniblockBuffer, applying the prefix sum in-place.
+    ///
+    /// validValues is capped at (totalValueCount - valuesRead) so the caller never reads
+    /// more values than the header declared: the encoder pads the last miniblock with zeros,
+    /// but those zeros are not real values and must not be returned.
+    private void loadMiniblock(int miniblockIdx) throws IOException {
+        int bitWidth = bitWidths[miniblockIdx];
+        // Number of actual values in this miniblock (may be < valuesPerMiniblock for the last one)
+        int validValues = Math.min(valuesPerMiniblock, totalValueCount - valuesRead);
+
         if (bitWidth == 0) {
-            // All values in this miniblock have the same delta (minDelta)
-            miniblockData = new byte[0];
+            // All residuals are zero — no bytes consumed
+            for (int i = 0; i < validValues; i++) {
+                lastValue += minDelta;
+                miniblockBuffer[i] = lastValue;
+            }
         }
         else {
             int bytesNeeded = (valuesPerMiniblock * bitWidth + 7) / 8;
             if (pos + bytesNeeded > data.length) {
                 throw new IOException("Unexpected EOF reading miniblock data: expected " + bytesNeeded
-                        + ", got " + (data.length - pos));
+                        + " bytes, got " + (data.length - pos));
             }
-            miniblockData = new byte[bytesNeeded];
-            System.arraycopy(data, pos, miniblockData, 0, bytesNeeded);
+            unpackAndPrefixSum(bitWidth, validValues);
             pos += bytesNeeded;
         }
-        bitPosition = 0;
+
+        bufferPos = 0;
+        bufferFill = validValues;
     }
 
-    private long unpackValue(int bitWidth) {
-        if (bitWidth == 0) {
-            return 0;
+    /// Unpack raw residuals from data[pos..] and apply the prefix sum into miniblockBuffer.
+    ///
+    /// Three paths based on width:
+    ///   1-8:  8 values occupy exactly bitWidth bytes; one LE multi-byte load per group of 8.
+    ///   9-32: 64-bit accumulator refilled one byte at a time.
+    ///   33-64: bit-at-a-time (handles the case where accumulator would overflow at width 57+).
+    private void unpackAndPrefixSum(int bitWidth, int validValues) {
+        if (bitWidth <= 8 && (valuesPerMiniblock % 8) == 0) {
+            unpackAndPrefixSum1to8(bitWidth, validValues);
         }
-
-        long value = 0;
-        int bitsRemaining = bitWidth;
-
-        while (bitsRemaining > 0) {
-            int byteOffset = bitPosition / 8;
-            int bitOffset = bitPosition % 8;
-            int bitsAvailable = 8 - bitOffset;
-            int bitsToRead = Math.min(bitsAvailable, bitsRemaining);
-
-            int mask = (1 << bitsToRead) - 1;
-            long bits = (miniblockData[byteOffset] >>> bitOffset) & mask;
-            value |= bits << (bitWidth - bitsRemaining);
-
-            bitPosition += bitsToRead;
-            bitsRemaining -= bitsToRead;
+        else if (bitWidth <= 32) {
+            unpackAndPrefixSum9to32(bitWidth, validValues);
         }
+        else {
+            unpackAndPrefixSum33to64(bitWidth, validValues);
+        }
+    }
 
-        return value;
+    /// Width 1-8: every 8 values occupy exactly bitWidth bytes.
+    /// Load those bytes into a 64-bit word (little-endian) and extract 8 values via shift-and-mask.
+    private void unpackAndPrefixSum1to8(int bitWidth, int validValues) {
+        long mask = (1L << bitWidth) - 1;
+        int groups = valuesPerMiniblock / 8;
+        int dataPos = pos;
+        int idx = 0;
+        for (int g = 0; g < groups; g++) {
+            // Load bitWidth bytes as a little-endian long
+            long word = 0;
+            for (int b = 0; b < bitWidth; b++) {
+                word |= (long) (data[dataPos++] & 0xFF) << (b * 8);
+            }
+            // Extract 8 values packed at bitWidth bits each
+            for (int v = 0; v < 8; v++) {
+                long residual = (word >>> (v * bitWidth)) & mask;
+                if (idx < validValues) {
+                    lastValue += minDelta + residual;
+                    miniblockBuffer[idx] = lastValue;
+                }
+                idx++;
+            }
+        }
+    }
+
+    /// Width 9-32: use a 64-bit accumulator refilled one byte at a time.
+    /// Max bits in accumulator is bitWidth-1+8 <= 39, safely within a long.
+    private void unpackAndPrefixSum9to32(int bitWidth, int validValues) {
+        long mask = bitWidth == 32 ? 0xFFFFFFFFL : (1L << bitWidth) - 1;
+        long accumulator = 0;
+        int bits = 0;
+        int dataPos = pos;
+        for (int i = 0; i < valuesPerMiniblock; i++) {
+            while (bits < bitWidth) {
+                accumulator |= (long) (data[dataPos++] & 0xFF) << bits;
+                bits += 8;
+            }
+            long residual = accumulator & mask;
+            accumulator >>>= bitWidth;
+            bits -= bitWidth;
+            if (i < validValues) {
+                lastValue += minDelta + residual;
+                miniblockBuffer[i] = lastValue;
+            }
+        }
+    }
+
+    /// Width 33-64: bit-at-a-time from data[pos..].
+    /// Used instead of the accumulator path because widths 57+ can overfill a 64-bit accumulator.
+    private void unpackAndPrefixSum33to64(int bitWidth, int validValues) {
+        int bitPosition = 0;
+        for (int i = 0; i < valuesPerMiniblock; i++) {
+            long residual = 0;
+            int bitsRemaining = bitWidth;
+            int localBitPos = bitPosition;
+            while (bitsRemaining > 0) {
+                int byteOffset = localBitPos / 8;
+                int bitOffset = localBitPos % 8;
+                int bitsAvailable = 8 - bitOffset;
+                int bitsToRead = Math.min(bitsAvailable, bitsRemaining);
+                // bitsToRead is at most 8, so the mask fits in an int
+                long bits = ((data[pos + byteOffset] & 0xFF) >>> bitOffset) & ((1 << bitsToRead) - 1);
+                residual |= bits << (bitWidth - bitsRemaining);
+                localBitPos += bitsToRead;
+                bitsRemaining -= bitsToRead;
+            }
+            bitPosition += bitWidth;
+            if (i < validValues) {
+                lastValue += minDelta + residual;
+                miniblockBuffer[i] = lastValue;
+            }
+        }
     }
 
     private int readUleb128() throws IOException {

--- a/core/src/main/java/dev/hardwood/internal/encoding/DeltaByteArrayDecoder.java
+++ b/core/src/main/java/dev/hardwood/internal/encoding/DeltaByteArrayDecoder.java
@@ -72,9 +72,7 @@ public class DeltaByteArrayDecoder implements ValueDecoder {
         // Read all prefix lengths using DELTA_BINARY_PACKED
         // Prefix lengths are always encoded as INT32 per the spec
         DeltaBinaryPackedDecoder prefixDecoder = new DeltaBinaryPackedDecoder(data, offset);
-        for (int i = 0; i < numNonNullValues; i++) {
-            prefixLengths[i] = prefixDecoder.readInt();
-        }
+        prefixDecoder.readInts(prefixLengths, null, 0);
 
         // Create the suffix decoder (uses DELTA_LENGTH_BYTE_ARRAY)
         // Continue reading from where the prefix decoder stopped

--- a/core/src/main/java/dev/hardwood/internal/encoding/DeltaLengthByteArrayDecoder.java
+++ b/core/src/main/java/dev/hardwood/internal/encoding/DeltaLengthByteArrayDecoder.java
@@ -54,9 +54,7 @@ public class DeltaLengthByteArrayDecoder implements ValueDecoder {
         // Read all lengths using DELTA_BINARY_PACKED
         // Lengths are always encoded as INT32 per the spec
         DeltaBinaryPackedDecoder lengthDecoder = new DeltaBinaryPackedDecoder(data, pos);
-        for (int i = 0; i < numNonNullValues; i++) {
-            lengths[i] = lengthDecoder.readInt();
-        }
+        lengthDecoder.readInts(lengths, null, 0);
         pos = lengthDecoder.getPos();
     }
 

--- a/core/src/test/java/dev/hardwood/internal/encoding/DeltaBinaryPackedDecoderWidthSweepTest.java
+++ b/core/src/test/java/dev/hardwood/internal/encoding/DeltaBinaryPackedDecoderWidthSweepTest.java
@@ -1,0 +1,112 @@
+/*
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Copyright The original authors
+ *
+ *  Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package dev.hardwood.internal.encoding;
+
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.stream.IntStream;
+
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/// Sweeps every bit width 0–32 for INT32 and 0–64 for INT64 to verify the bulk miniblock
+/// decoder handles all width-specialised paths (0, 1–8, 9–32, 33–64).
+///
+/// Each case encodes 50 values: a full miniblock of 32 plus a partial miniblock of 17, which
+/// exercises the partial-last-miniblock truncation in [DeltaBinaryPackedDecoder].
+///
+/// Value construction forces the encoder to select approximately the target bit width:
+/// - Width 0: constant column — all deltas zero.
+/// - Width 1–31 (INT32) / 1–63 (INT64): most deltas = 1 (minDelta=1), one delta = 1&lt;&lt;w, so
+///   the largest residual is (1&lt;&lt;w)-1 which requires exactly w bits.
+/// - Width 32 (INT32): alternating Integer.MIN_VALUE / Integer.MAX_VALUE — the wrap-around case.
+/// - Width 64 (INT64): alternating Long.MIN_VALUE / Long.MAX_VALUE — the wrap-around case.
+class DeltaBinaryPackedDecoderWidthSweepTest {
+
+    private static final int VALUE_COUNT = 50;
+
+    // ==================== INT32 ====================
+
+    static IntStream int32BitWidths() {
+        return IntStream.rangeClosed(0, 32);
+    }
+
+    @ParameterizedTest(name = "INT32 width {0}")
+    @MethodSource("int32BitWidths")
+    void sweepsInt32BitWidths(int w) throws IOException {
+        int[] values = buildInt32Values(w);
+        byte[] encoded = DeltaBinaryPackedEncoder.encodeInts(values, 0, VALUE_COUNT);
+        int[] decoded = new int[VALUE_COUNT];
+        new DeltaBinaryPackedDecoder(encoded, 0).readInts(decoded, null, 0);
+        assertThat(decoded).as("INT32 width %d", w).containsExactly(values);
+    }
+
+    private static int[] buildInt32Values(int w) {
+        int[] values = new int[VALUE_COUNT];
+        if (w == 0) {
+            // Constant column: all deltas zero
+            Arrays.fill(values, 42);
+        }
+        else if (w == 32) {
+            // Wrap-around case: delta from MAX_VALUE to MIN_VALUE wraps to 1 modulo 2^32
+            for (int i = 0; i < VALUE_COUNT; i++) {
+                values[i] = i % 2 == 0 ? Integer.MIN_VALUE : Integer.MAX_VALUE;
+            }
+        }
+        else {
+            // Most deltas = 1 (minDelta=1), one delta = 1<<w.
+            // Largest residual = (1<<w)-1, which requires exactly w bits.
+            values[0] = 0;
+            for (int i = 1; i < VALUE_COUNT; i++) {
+                values[i] = values[i - 1] + (i == 25 ? (1 << w) : 1);
+            }
+        }
+        return values;
+    }
+
+    // ==================== INT64 ====================
+
+    static IntStream int64BitWidths() {
+        return IntStream.rangeClosed(0, 64);
+    }
+
+    @ParameterizedTest(name = "INT64 width {0}")
+    @MethodSource("int64BitWidths")
+    void sweepsInt64BitWidths(int w) throws IOException {
+        long[] values = buildInt64Values(w);
+        byte[] encoded = DeltaBinaryPackedEncoder.encodeLongs(values, 0, VALUE_COUNT);
+        long[] decoded = new long[VALUE_COUNT];
+        new DeltaBinaryPackedDecoder(encoded, 0).readLongs(decoded, null, 0);
+        assertThat(decoded).as("INT64 width %d", w).containsExactly(values);
+    }
+
+    private static long[] buildInt64Values(int w) {
+        long[] values = new long[VALUE_COUNT];
+        if (w == 0) {
+            // Constant column: all deltas zero
+            Arrays.fill(values, 42L);
+        }
+        else if (w == 64) {
+            // Wrap-around case: delta from Long.MAX_VALUE to Long.MIN_VALUE wraps to 1 modulo 2^64
+            for (int i = 0; i < VALUE_COUNT; i++) {
+                values[i] = i % 2 == 0 ? Long.MIN_VALUE : Long.MAX_VALUE;
+            }
+        }
+        else {
+            // Most deltas = 1 (minDelta=1), one delta = 1L<<w.
+            // Largest residual = (1L<<w)-1, which requires exactly w bits.
+            values[0] = 0L;
+            for (int i = 1; i < VALUE_COUNT; i++) {
+                values[i] = values[i - 1] + (i == 25 ? (1L << w) : 1L);
+            }
+        }
+        return values;
+    }
+}


### PR DESCRIPTION
_Prepared via Claude._

### What changed

`DeltaBinaryPackedDecoder` now decodes a whole miniblock at a time into a
pre-allocated `long[]` buffer, with three width-specialised unpack paths:

- **Width 0**: all residuals are zero; no bytes consumed, the loop writes
  `minDelta` directly.
- **Widths 1–8**: every 8 values occupy exactly `bitWidth` bytes. Those bytes
  are loaded into a 64-bit word (little-endian) and 8 values are extracted via
  shift-and-mask, one multi-byte load per group of 8.
- **Widths 9–32**: a 64-bit accumulator is refilled one byte at a time; max
  bits in the accumulator at any point is `bitWidth − 1 + 8 ≤ 39`, safely
  within a `long`.
- **Widths 33–64**: bit-at-a-time (the previous slow path, retained because
  widths 57+ would overflow a 64-bit accumulator on the 9–32 path).

The per-miniblock `byte[]` allocation is eliminated; `miniblockBuffer` is
allocated once in `readHeader()` and reused for every miniblock.

`readInts` and `readLongs` drain from the buffer in chunks via
`System.arraycopy` / a bulk int-cast loop rather than calling `readLongValue()`
per value.

`DeltaLengthByteArrayDecoder` and `DeltaByteArrayDecoder` are updated to call
`readInts(lengths, null, 0)` / `readInts(prefixLengths, null, 0)` in their
`initialize()` methods, replacing the per-element `readInt()` loop.

Header validation is added: `blockSize` must be positive and divisible by
`miniblockCount`; each bit width is validated as an unsigned byte in `[0, 64]`.

### New test

`DeltaBinaryPackedDecoderWidthSweepTest` is a parameterised JUnit 5 test that
sweeps every bit width 0–32 for INT32 and 0–64 for INT64. Each case encodes 50
values, which gives a full miniblock of 32 plus a partial last miniblock of 17,
exercising the partial-last-miniblock truncation. The width-64 and width-32
cases use alternating `Long.MIN_VALUE`/`Long.MAX_VALUE` and
`Integer.MIN_VALUE`/`Integer.MAX_VALUE` to cover wrap-around. All other cases
construct values so that the largest residual requires exactly `w` bits.

### Benchmark results

From the benchmark suite referenced in issue #1019
(4096 values/op; ops/ms, higher is better):

| deltaBits | Before | After  | Speedup |
|-----------|--------|--------|---------|
| 1         | 83.3   | 300.4  | 3.6×    |
| 5         | 63.2   | 316.3  | 5.0×    |
| 12        | 49.8   | 179.8  | 3.6×    |
| 21        | 27.1   | 143.8  | 5.3×    |

End-to-end column scan (2 M-row synthetic file, ms/op — lower is better):

| Column type                    | Before | After | Speedup |
|-------------------------------|--------|-------|---------|
| INT32, DELTA_BINARY_PACKED     | 5.343  | 2.602 | ~2.1×   |
| INT64, DELTA_BINARY_PACKED     | 4.442  | 2.896 | ~1.5×   |
| BYTE_ARRAY, DELTA_BYTE_ARRAY   | 40.852 | 39.916 | no change |

Gains are largest at narrow bit widths, where the 1–8 path processes 8 values
per `bitWidth`-byte load; the BYTE_ARRAY scan is unchanged because string
copying dominates, not the integer length decode.

### Why this is scalar, and not SIMD

`DeltaBinaryPackedDecoder` has never been on a vectorised path, on any JVM: it
does not reference `SimdOperations`, and `RleBitPackingHybridDecoder` — the only
class in `core/src/main/java` that does — calls it for `countNonNulls` and the
four `applyDictionary*` methods, never for bit unpacking. So this change speeds
up every JVM equally, whether or not `jdk.incubator.vector` resolves; there is
no faster path it is competing with.

`SimdOperations` does declare `unpackBitWidth1` and `unpackBitWidthN`, which
look like the primitives a miniblock body wants, and using them was tried. Two
things rule it out. They have no production caller today, and
`VectorOperations.unpackBitWidthN` is byte-for-byte identical to
`ScalarOperations.unpackBitWidthN` — the same little-endian word load and
unrolled shift-and-mask this patch's 1–8 path uses, with a comment saying scalar
unrolling was judged competitive for eight values. There is no vector code in
either. Their contract is also narrower than the delta path needs: they write
`int[]` and load `bitWidth` bytes into a `long`, so they are correct only up to
width 8, while a miniblock runs to 64.

Routing the delta path through them therefore costs rather than gains, because
it splits one fused pass into an unpack into `int[]` plus a separate prefix-sum
pass. Measured on a 4096-value sweep (ops/ms, higher is better):

| width | fused (this patch) | via `unpackBitWidthN` + prefix sum | real `LongVector` unpack + prefix sum |
|-------|-------|-------|-------|
| 1     | 462.1 | 310.3 | 335.5 |
| 4     | 317.1 | 255.8 | 273.3 |
| 8     | 217.8 | 180.8 |  58.1 |

The fused kernel wins at every width. The underlying reason is that the prefix
sum is serial and cannot be vectorised — isolating the two halves puts the
unpack at 247–581 ops/ms and the prefix sum alone at 509–574, so even a free
unpack would leave the prefix sum as the floor. Any formulation that vectorises
the unpack has to materialise residuals to memory for the serial sum to read
back, and that round-trip costs more than the unpack saves. This is the same
result as the FastLanes experiment below, reached from the other direction: at a
32-value miniblock there is not enough width to pay for breaking the dependency
chain. (Measurements are on 128-bit NEON, where `LongVector` has two lanes;
wider hardware would narrow the last column's gap but not change the floor.)

### FastLanes chain-shortening: implemented, measured, rejected

The FastLanes prefix-sum chain-shortening approach (interleaving 32 independent
sub-sums and merging at the end to break the serial dependency chain) was
implemented and benchmarked on 32-value miniblocks. It is **9–22% slower** at
every bit width at this miniblock size. The overhead of the merge pass exceeds
any out-of-order execution benefit at 32 values. Hardwood's miniblock size is
32; the FastLanes paper targets 1024-value lanes. 

### Notes

The partial-last-miniblock truncation in `loadMiniblock` limits `validValues`
to `totalValueCount − valuesRead`. The Parquet spec requires encoders to pad
the last miniblock with zero-delta values; this bounds the caller to the
declared count rather than the full miniblock size.

Closes #1019


## Authorship

Hardwood is built with AI, not by AI. LLM assistance is welcome; submitting raw LLM output without understanding is not.
Neither are unattended agents opening pull requests.
See the [contribution guide](https://github.com/hardwood-hq/hardwood/blob/main/CONTRIBUTING.md) for more details.
Check this box to confirm:

- [x] This change is coming from a human who understands what it does and why, and can discuss it in review

## Checklist

- [x] Build via `./mvnw clean verify` passes
- [x] The commit message is prefixed with the issue key
- [x] Code changes are covered by tests
- [x] If this PR adds or changes user-facing behaviour, `docs/` has been updated
