### PR TITLE
#1053 Add predicates to filter JFR events

### DIFF
--- a/core/src/main/java/dev/hardwood/internal/predicate/ResolvedPredicateRenderer.java
+++ b/core/src/main/java/dev/hardwood/internal/predicate/ResolvedPredicateRenderer.java
@@ -1,0 +1,101 @@
+/*
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Copyright The original authors
+ *
+ *  Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package dev.hardwood.internal.predicate;
+
+import java.util.List;
+
+import dev.hardwood.reader.FilterPredicate;
+import dev.hardwood.schema.FileSchema;
+
+/// Renders an execution predicate for diagnostics without exposing its literal values.
+///
+/// Column names and predicate structure are retained so events from separate reads can be
+/// attributed to a query shape. Data-domain values are replaced with `?`; `IN` predicates
+/// additionally retain their arity. Geospatial bounds describe the queried region rather than
+/// values read from the file and are rendered in full.
+public final class ResolvedPredicateRenderer {
+
+    private ResolvedPredicateRenderer() {
+    }
+
+    /// Renders `predicate` using the unambiguous field paths from `schema`.
+    public static String render(ResolvedPredicate predicate, FileSchema schema) {
+        StringBuilder rendered = new StringBuilder();
+        append(rendered, predicate, schema);
+        return rendered.toString();
+    }
+
+    private static void append(StringBuilder rendered, ResolvedPredicate predicate, FileSchema schema) {
+        switch (predicate) {
+            case ResolvedPredicate.IntPredicate p -> appendComparison(rendered, p.op(), column(schema, p.columnIndex()));
+            case ResolvedPredicate.LongPredicate p -> appendComparison(rendered, p.op(), column(schema, p.columnIndex()));
+            case ResolvedPredicate.FloatPredicate p -> appendComparison(rendered, p.op(), column(schema, p.columnIndex()));
+            case ResolvedPredicate.Float16Predicate p -> appendComparison(rendered, p.op(), column(schema, p.columnIndex()));
+            case ResolvedPredicate.DoublePredicate p -> appendComparison(rendered, p.op(), column(schema, p.columnIndex()));
+            case ResolvedPredicate.BooleanPredicate p -> appendComparison(rendered, p.op(), column(schema, p.columnIndex()));
+            case ResolvedPredicate.BinaryPredicate p -> appendComparison(rendered, p.op(), column(schema, p.columnIndex()));
+            case ResolvedPredicate.IntInPredicate p -> appendIn(rendered, column(schema, p.columnIndex()), p.values().length);
+            case ResolvedPredicate.LongInPredicate p -> appendIn(rendered, column(schema, p.columnIndex()), p.values().length);
+            case ResolvedPredicate.BinaryInPredicate p -> appendIn(rendered, column(schema, p.columnIndex()), p.values().length);
+            case ResolvedPredicate.IsNullPredicate p -> appendUnary(rendered, "isNull", column(schema, p.columnIndex()));
+            case ResolvedPredicate.IsNotNullPredicate p -> appendUnary(rendered, "isNotNull", column(schema, p.columnIndex()));
+            case ResolvedPredicate.And p -> appendCompound(rendered, "and", p.children(), schema);
+            case ResolvedPredicate.Or p -> appendCompound(rendered, "or", p.children(), schema);
+            case ResolvedPredicate.GeospatialPredicate p -> appendGeospatial(rendered, p, schema);
+        }
+    }
+
+    private static String column(FileSchema schema, int columnIndex) {
+        return schema.getColumn(columnIndex).fieldPath().toString();
+    }
+
+    private static void appendComparison(StringBuilder rendered, FilterPredicate.Operator operator, String column) {
+        rendered.append(operatorName(operator)).append('(').append(column).append(", ?)");
+    }
+
+    private static String operatorName(FilterPredicate.Operator operator) {
+        return switch (operator) {
+            case EQ -> "eq";
+            case NOT_EQ -> "notEq";
+            case LT -> "lt";
+            case LT_EQ -> "ltEq";
+            case GT -> "gt";
+            case GT_EQ -> "gtEq";
+        };
+    }
+
+    private static void appendIn(StringBuilder rendered, String column, int arity) {
+        rendered.append("in(").append(column).append(", ?×").append(arity).append(')');
+    }
+
+    private static void appendUnary(StringBuilder rendered, String operator, String column) {
+        rendered.append(operator).append('(').append(column).append(')');
+    }
+
+    private static void appendCompound(StringBuilder rendered, String operator,
+                                       List<ResolvedPredicate> children, FileSchema schema) {
+        rendered.append(operator).append('(');
+        for (int i = 0; i < children.size(); i++) {
+            if (i > 0) {
+                rendered.append(", ");
+            }
+            append(rendered, children.get(i), schema);
+        }
+        rendered.append(')');
+    }
+
+    private static void appendGeospatial(StringBuilder rendered, ResolvedPredicate.GeospatialPredicate predicate,
+                                         FileSchema schema) {
+        rendered.append("intersects(")
+                .append(column(schema, predicate.columnIndex())).append(", ")
+                .append(predicate.xmin()).append(", ")
+                .append(predicate.ymin()).append(", ")
+                .append(predicate.xmax()).append(", ")
+                .append(predicate.ymax()).append(')');
+    }
+}

--- a/core/src/main/java/dev/hardwood/internal/predicate/RowGroupPredicateRenderer.java
+++ b/core/src/main/java/dev/hardwood/internal/predicate/RowGroupPredicateRenderer.java
@@ -1,0 +1,48 @@
+/*
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Copyright The original authors
+ *
+ *  Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package dev.hardwood.internal.predicate;
+
+import java.util.List;
+
+import dev.hardwood.reader.RowGroupPredicate;
+
+/// Renders row-group predicates for diagnostics.
+///
+/// Byte offsets are retained because they describe split layout rather than values from the
+/// data domain and are needed to diagnose uneven split assignment.
+public final class RowGroupPredicateRenderer {
+
+    private RowGroupPredicateRenderer() {
+    }
+
+    public static String render(RowGroupPredicate predicate) {
+        StringBuilder rendered = new StringBuilder();
+        append(rendered, predicate);
+        return rendered.toString();
+    }
+
+    private static void append(StringBuilder rendered, RowGroupPredicate predicate) {
+        switch (predicate) {
+            case RowGroupPredicate.ByteRange p -> rendered.append("byteRange(")
+                    .append(p.startInclusive()).append(", ")
+                    .append(p.endExclusive()).append(')');
+            case RowGroupPredicate.And p -> appendAnd(rendered, p.children());
+        }
+    }
+
+    private static void appendAnd(StringBuilder rendered, List<RowGroupPredicate> children) {
+        rendered.append("and(");
+        for (int i = 0; i < children.size(); i++) {
+            if (i > 0) {
+                rendered.append(", ");
+            }
+            append(rendered, children.get(i));
+        }
+        rendered.append(')');
+    }
+}

--- a/core/src/main/java/dev/hardwood/internal/reader/FlatRowReader.java
+++ b/core/src/main/java/dev/hardwood/internal/reader/FlatRowReader.java
@@ -305,7 +305,8 @@ public final class FlatRowReader implements FileAwareRowReader {
         // The tally spans both filtered paths: the drain-side reader feeds it whole
         // batches, the wrapper feeds it single records, and either way the reader
         // marks the file boundaries as it loads batches.
-        RecordFilterTally tally = filter != null ? new RecordFilterTally() : null;
+        RecordFilterTally tally = filter != null
+                ? new RecordFilterTally(rowGroupIterator::renderedFilterPredicate) : null;
         FlatRowReader reader = new FlatRowReader(buffers, workers, schema, projectedSchema,
                 drainSide, wordsLen, mergePlan, readerMatchLimit, tally);
         reader.initialize();

--- a/core/src/main/java/dev/hardwood/internal/reader/NestedRowReader.java
+++ b/core/src/main/java/dev/hardwood/internal/reader/NestedRowReader.java
@@ -158,7 +158,8 @@ public final class NestedRowReader implements FileAwareRowReader {
             worker.start();
         }
 
-        RecordFilterTally tally = filter != null ? new RecordFilterTally() : null;
+        RecordFilterTally tally = filter != null
+                ? new RecordFilterTally(rowGroupIterator::renderedFilterPredicate) : null;
         NestedRowReader reader = new NestedRowReader(buffers, workers, schema, projectedSchema, tally);
         reader.initialize();
         if (filter != null) {

--- a/core/src/main/java/dev/hardwood/internal/reader/RecordFilterTally.java
+++ b/core/src/main/java/dev/hardwood/internal/reader/RecordFilterTally.java
@@ -7,6 +7,9 @@
  */
 package dev.hardwood.internal.reader;
 
+import java.util.Objects;
+import java.util.function.Supplier;
+
 import dev.hardwood.jfr.RecordFilterEvent;
 
 /// Accumulates the outcome of record-level predicate evaluation and emits one
@@ -28,9 +31,14 @@ import dev.hardwood.jfr.RecordFilterEvent;
 /// this revisited.
 public final class RecordFilterTally {
 
+    private final Supplier<String> renderedPredicate;
     private String file;
     private long evaluated;
     private long kept;
+
+    public RecordFilterTally(Supplier<String> renderedPredicate) {
+        this.renderedPredicate = Objects.requireNonNull(renderedPredicate, "renderedPredicate");
+    }
 
     /// Attributes subsequent counts to `fileName`, emitting the counts gathered
     /// for the previous file. Idempotent for repeated calls naming the same file,
@@ -68,11 +76,14 @@ public final class RecordFilterTally {
             return;
         }
         RecordFilterEvent event = new RecordFilterEvent();
-        event.file = file;
-        event.totalRecords = evaluated;
-        event.recordsKept = kept;
-        event.recordsSkipped = evaluated - kept;
-        event.commit();
+        if (event.isEnabled()) {
+            event.file = file;
+            event.predicate = renderedPredicate.get();
+            event.totalRecords = evaluated;
+            event.recordsKept = kept;
+            event.recordsSkipped = evaluated - kept;
+            event.commit();
+        }
         evaluated = 0;
         kept = 0;
     }

--- a/core/src/main/java/dev/hardwood/internal/reader/RowGroupIterator.java
+++ b/core/src/main/java/dev/hardwood/internal/reader/RowGroupIterator.java
@@ -28,6 +28,7 @@ import dev.hardwood.internal.predicate.FilterDecision;
 import dev.hardwood.internal.predicate.PageDropPredicates;
 import dev.hardwood.internal.predicate.PageFilterEvaluator;
 import dev.hardwood.internal.predicate.ResolvedPredicate;
+import dev.hardwood.internal.predicate.ResolvedPredicateRenderer;
 import dev.hardwood.internal.predicate.RowGroupBloomFilterSource;
 import dev.hardwood.internal.predicate.RowGroupFilterEvaluator;
 import dev.hardwood.internal.predicate.dictionary.RowGroupDictionaryFilterSource;
@@ -98,6 +99,7 @@ public class RowGroupIterator {
     private FileSchema referenceSchema;
     private ProjectedSchema projectedSchema;
     private ResolvedPredicate filterPredicate;
+    private volatile String renderedFilterPredicate;
     private boolean filterSatisfiedByStatistics;
     private boolean metadataFilteringEnabled = true;
 
@@ -329,6 +331,7 @@ public class RowGroupIterator {
         this.metadataFilteringEnabled = metadataFilteringEnabled;
         this.projectedSchema = projected;
         this.filterPredicate = filter;
+        this.renderedFilterPredicate = null;
         this.touchedColumns = touchedColumns(projected, filter, referenceSchema.getColumnCount());
         this.dropLeavesByColumn = filter != null && metadataFilteringEnabled
                 ? PageDropPredicates.byColumn(filter) : Map.of();
@@ -365,6 +368,25 @@ public class RowGroupIterator {
     /// Returns the filter predicate, or `null` if none.
     public ResolvedPredicate filterPredicate() {
         return filterPredicate;
+    }
+
+    /// Returns the filter's structural representation with literals elided, rendering it on
+    /// first use and reusing the result for every JFR event emitted by this read.
+    public String renderedFilterPredicate() {
+        if (filterPredicate == null) {
+            return null;
+        }
+        String rendered = renderedFilterPredicate;
+        if (rendered == null) {
+            synchronized (this) {
+                rendered = renderedFilterPredicate;
+                if (rendered == null) {
+                    rendered = ResolvedPredicateRenderer.render(filterPredicate, referenceSchema);
+                    renderedFilterPredicate = rendered;
+                }
+            }
+        }
+        return rendered;
     }
 
     /// Returns shared metadata for the given work item, computing it on first access.
@@ -898,13 +920,17 @@ public class RowGroupIterator {
     /// by push-down and so report nothing. The absence of the event is therefore the
     /// signal that no page was a candidate for skipping, and a `pagesSkipped` of 0
     /// means the filter ran and kept everything.
-    private static void emitPageFilterEvent(String fileName, int rowGroupIndex, String column,
-                                            boolean pageFilterApplied, int totalPages, int pagesKept) {
+    private void emitPageFilterEvent(String fileName, int rowGroupIndex, String column,
+                                     boolean pageFilterApplied, int totalPages, int pagesKept) {
         if (!pageFilterApplied) {
             return;
         }
         PageFilterEvent event = new PageFilterEvent();
+        if (!event.isEnabled()) {
+            return;
+        }
         event.file = fileName;
+        event.predicate = renderedFilterPredicate();
         event.rowGroupIndex = rowGroupIndex;
         event.column = column;
         event.totalPages = totalPages;
@@ -1223,12 +1249,15 @@ public class RowGroupIterator {
         }
 
         RowGroupFilterEvent event = new RowGroupFilterEvent();
-        event.file = inputFile.name();
-        event.totalRowGroups = rowGroups.size();
-        event.rowGroupsKept = filtered.size();
-        event.rowGroupsSkipped = rowGroups.size() - filtered.size();
-        event.rowGroupsFullyMatching = fullyMatching;
-        event.commit();
+        if (event.isEnabled()) {
+            event.file = inputFile.name();
+            event.predicate = renderedFilterPredicate();
+            event.totalRowGroups = rowGroups.size();
+            event.rowGroupsKept = filtered.size();
+            event.rowGroupsSkipped = rowGroups.size() - filtered.size();
+            event.rowGroupsFullyMatching = fullyMatching;
+            event.commit();
+        }
 
         return filtered;
     }

--- a/core/src/main/java/dev/hardwood/jfr/PageFilterEvent.java
+++ b/core/src/main/java/dev/hardwood/jfr/PageFilterEvent.java
@@ -41,6 +41,10 @@ public class PageFilterEvent extends Event {
     @Description("Name of the Parquet file")
     public String file;
 
+    @Label("Predicate")
+    @Description("Predicate structure with literal values elided")
+    public String predicate;
+
     @Label("Row Group Index")
     @Description("Index of the row group within the file")
     public int rowGroupIndex;

--- a/core/src/main/java/dev/hardwood/jfr/RecordFilterEvent.java
+++ b/core/src/main/java/dev/hardwood/jfr/RecordFilterEvent.java
@@ -40,6 +40,10 @@ public class RecordFilterEvent extends Event {
     @Description("Name of the Parquet file whose records were filtered")
     public String file;
 
+    @Label("Predicate")
+    @Description("Predicate structure with literal values elided")
+    public String predicate;
+
     @Label("Total Records")
     @Description("Total number of records evaluated against the predicate")
     public long totalRecords;

--- a/core/src/main/java/dev/hardwood/jfr/RowGroupByteRangeFilterEvent.java
+++ b/core/src/main/java/dev/hardwood/jfr/RowGroupByteRangeFilterEvent.java
@@ -32,6 +32,10 @@ public class RowGroupByteRangeFilterEvent extends Event {
     @Description("Name of the Parquet file")
     public String file;
 
+    @Label("Predicate")
+    @Description("Row-group predicate including byte-range bounds")
+    public String predicate;
+
     @Label("Total Row Groups")
     @Description("Total number of row groups in the file before byte-range selection")
     public int totalRowGroups;

--- a/core/src/main/java/dev/hardwood/jfr/RowGroupFilterEvent.java
+++ b/core/src/main/java/dev/hardwood/jfr/RowGroupFilterEvent.java
@@ -26,6 +26,10 @@ public class RowGroupFilterEvent extends Event {
     @Description("Name of the Parquet file")
     public String file;
 
+    @Label("Predicate")
+    @Description("Predicate structure with literal values elided")
+    public String predicate;
+
     @Label("Total Row Groups")
     @Description("Total number of row groups before predicate push-down")
     public int totalRowGroups;

--- a/core/src/main/java/dev/hardwood/reader/ColumnReaders.java
+++ b/core/src/main/java/dev/hardwood/reader/ColumnReaders.java
@@ -124,7 +124,8 @@ public class ColumnReaders implements AutoCloseable {
         }
 
         SelectionEngine engine = SelectionEngine.create(schema, augProjected, resolved, allReaders, batchSize);
-        FilterCoordinator coordinator = new FilterCoordinator(allReaders, payloadReaders, engine);
+        FilterCoordinator coordinator = new FilterCoordinator(
+                allReaders, payloadReaders, engine, rowGroupIterator::renderedFilterPredicate);
         for (ColumnReader reader : allReaders) {
             reader.setCoordinator(coordinator);
         }

--- a/core/src/main/java/dev/hardwood/reader/FilterCoordinator.java
+++ b/core/src/main/java/dev/hardwood/reader/FilterCoordinator.java
@@ -7,6 +7,8 @@
  */
 package dev.hardwood.reader;
 
+import java.util.function.Supplier;
+
 import dev.hardwood.internal.reader.RecordFilterTally;
 
 /// Drives the filtered column-reader path (#624). It advances every reader of
@@ -29,17 +31,19 @@ final class FilterCoordinator {
     private final SelectionEngine engine;
     /// Per-file record-filter counts for JFR. Every batch this path produces has
     /// passed through the selection, so the counts are complete for the read.
-    private final RecordFilterTally tally = new RecordFilterTally();
+    private final RecordFilterTally tally;
 
     private long generation;
     private boolean hasBatch;
     private int recordCount;
     private boolean closed;
 
-    FilterCoordinator(ColumnReader[] allReaders, ColumnReader[] payloadReaders, SelectionEngine engine) {
+    FilterCoordinator(ColumnReader[] allReaders, ColumnReader[] payloadReaders, SelectionEngine engine,
+                      Supplier<String> renderedPredicate) {
         this.allReaders = allReaders;
         this.payloadReaders = payloadReaders;
         this.engine = engine;
+        this.tally = new RecordFilterTally(renderedPredicate);
     }
 
     long generation() {

--- a/core/src/main/java/dev/hardwood/reader/ParquetFileReader.java
+++ b/core/src/main/java/dev/hardwood/reader/ParquetFileReader.java
@@ -18,6 +18,7 @@ import dev.hardwood.InputFile;
 import dev.hardwood.internal.ExceptionContext;
 import dev.hardwood.internal.predicate.FilterPredicateResolver;
 import dev.hardwood.internal.predicate.ResolvedPredicate;
+import dev.hardwood.internal.predicate.RowGroupPredicateRenderer;
 import dev.hardwood.internal.reader.BatchSizing;
 import dev.hardwood.internal.reader.FileMetadataCache;
 import dev.hardwood.internal.reader.FlatRowReader;
@@ -707,11 +708,14 @@ public class ParquetFileReader implements AutoCloseable {
                 .toList();
 
         RowGroupByteRangeFilterEvent event = new RowGroupByteRangeFilterEvent();
-        event.file = inputFiles.get(0).name();
-        event.totalRowGroups = all.size();
-        event.rowGroupsKept = kept.size();
-        event.rowGroupsSkipped = all.size() - kept.size();
-        event.commit();
+        if (event.isEnabled()) {
+            event.file = inputFiles.get(0).name();
+            event.predicate = RowGroupPredicateRenderer.render(rowGroupFilter);
+            event.totalRowGroups = all.size();
+            event.rowGroupsKept = kept.size();
+            event.rowGroupsSkipped = all.size() - kept.size();
+            event.commit();
+        }
 
         return kept;
     }

--- a/core/src/test/java/dev/hardwood/PageFilterEventTest.java
+++ b/core/src/test/java/dev/hardwood/PageFilterEventTest.java
@@ -62,6 +62,7 @@ class PageFilterEventTest extends AbstractJfrRecorderTest {
 
         for (RecordedEvent event : events) {
             assertThat(event.getString("file")).endsWith("column_index_pushdown.parquet");
+            assertThat(event.getString("predicate")).isEqualTo("lt(id, ?)");
             assertThat(event.getInt("rowGroupIndex")).isZero();
             assertThat(event.getInt("totalPages")).isEqualTo(PAGES_PER_COLUMN);
             assertThat(event.getInt("pagesKept")).isEqualTo(1);

--- a/core/src/test/java/dev/hardwood/RecordFilterEventTest.java
+++ b/core/src/test/java/dev/hardwood/RecordFilterEventTest.java
@@ -63,6 +63,7 @@ class RecordFilterEventTest extends AbstractJfrRecorderTest {
 
         RecordedEvent event = singleEvent();
         assertThat(event.getString("file")).endsWith("filter_pushdown_int.parquet");
+        assertThat(event.getString("predicate")).isEqualTo("gt(id, ?)");
         assertThat(event.getLong("totalRecords"))
                 .as("only the surviving row groups reach the record filter")
                 .isEqualTo(EVALUATED);
@@ -112,6 +113,7 @@ class RecordFilterEventTest extends AbstractJfrRecorderTest {
 
         RecordedEvent event = singleEvent();
         assertThat(event.getString("file")).endsWith("filter_pushdown_nested.parquet");
+        assertThat(event.getString("predicate")).isEqualTo("gt(address.zip, ?)");
         assertThat(event.getLong("totalRecords")).isEqualTo(6);
         assertThat(event.getLong("recordsKept")).isEqualTo(4);
         assertThat(event.getLong("recordsSkipped")).isEqualTo(2);

--- a/core/src/test/java/dev/hardwood/RowGroupFilterEventTest.java
+++ b/core/src/test/java/dev/hardwood/RowGroupFilterEventTest.java
@@ -64,6 +64,7 @@ class RowGroupFilterEventTest extends AbstractJfrRecorderTest {
                 .isEqualTo(3);
         assertThat(pushDown.getFirst().getInt("rowGroupsKept")).isEqualTo(2);
         assertThat(pushDown.getFirst().getInt("rowGroupsSkipped")).isEqualTo(1);
+        assertThat(pushDown.getFirst().getString("predicate")).isEqualTo("gt(id, ?)");
 
         assertThat(events(BYTE_RANGE_EVENT).count())
                 .as("no byte-range event without a RowGroupPredicate")
@@ -116,6 +117,8 @@ class RowGroupFilterEventTest extends AbstractJfrRecorderTest {
         assertThat(events(BYTE_RANGE_EVENT).count())
                 .as("byte-range selection emits exactly one byte-range event")
                 .isEqualTo(1);
+        assertThat(events(BYTE_RANGE_EVENT).findFirst().orElseThrow().getString("predicate"))
+                .isEqualTo("byteRange(0, " + fileLen + ")");
         assertThat(events(PUSH_DOWN_EVENT).count())
                 .as("no push-down event without a FilterPredicate")
                 .isZero();

--- a/core/src/test/java/dev/hardwood/internal/predicate/ResolvedPredicateRendererTest.java
+++ b/core/src/test/java/dev/hardwood/internal/predicate/ResolvedPredicateRendererTest.java
@@ -1,0 +1,99 @@
+/*
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Copyright The original authors
+ *
+ *  Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package dev.hardwood.internal.predicate;
+
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+
+import dev.hardwood.metadata.PhysicalType;
+import dev.hardwood.metadata.RepetitionType;
+import dev.hardwood.reader.FilterPredicate;
+import dev.hardwood.schema.FileSchema;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class ResolvedPredicateRendererTest {
+
+    private static final FileSchema SCHEMA = FileSchema.builder("schema")
+            .addColumn("int_col", PhysicalType.INT32, RepetitionType.REQUIRED)
+            .addColumn("long_col", PhysicalType.INT64, RepetitionType.REQUIRED)
+            .addColumn("float_col", PhysicalType.FLOAT, RepetitionType.REQUIRED)
+            .addColumn("float16_col", PhysicalType.FIXED_LEN_BYTE_ARRAY, RepetitionType.REQUIRED, 2)
+            .addColumn("double_col", PhysicalType.DOUBLE, RepetitionType.REQUIRED)
+            .addColumn("boolean_col", PhysicalType.BOOLEAN, RepetitionType.REQUIRED)
+            .addColumn("binary_col", PhysicalType.BYTE_ARRAY, RepetitionType.REQUIRED)
+            .addColumn("int_in_col", PhysicalType.INT32, RepetitionType.REQUIRED)
+            .addColumn("long_in_col", PhysicalType.INT64, RepetitionType.REQUIRED)
+            .addColumn("binary_in_col", PhysicalType.BYTE_ARRAY, RepetitionType.REQUIRED)
+            .addColumn("nullable_col", PhysicalType.INT32, RepetitionType.OPTIONAL)
+            .addColumn("geo_col", PhysicalType.BYTE_ARRAY, RepetitionType.REQUIRED)
+            .build();
+
+    @Test
+    void elidesEveryLiteralBearingLeaf() {
+        assertThat(render(new ResolvedPredicate.IntPredicate(0, FilterPredicate.Operator.EQ, 123456)))
+                .isEqualTo("eq(int_col, ?)");
+        assertThat(render(new ResolvedPredicate.LongPredicate(1, FilterPredicate.Operator.NOT_EQ, 987654321L)))
+                .isEqualTo("notEq(long_col, ?)");
+        assertThat(render(new ResolvedPredicate.FloatPredicate(2, FilterPredicate.Operator.LT, 12.5F)))
+                .isEqualTo("lt(float_col, ?)");
+        assertThat(render(new ResolvedPredicate.Float16Predicate(3, FilterPredicate.Operator.LT_EQ, 13.5F)))
+                .isEqualTo("ltEq(float16_col, ?)");
+        assertThat(render(new ResolvedPredicate.DoublePredicate(4, FilterPredicate.Operator.GT, 14.5D)))
+                .isEqualTo("gt(double_col, ?)");
+        assertThat(render(new ResolvedPredicate.BooleanPredicate(5, FilterPredicate.Operator.EQ, true)))
+                .isEqualTo("eq(boolean_col, ?)");
+        assertThat(render(new ResolvedPredicate.BinaryPredicate(
+                6, FilterPredicate.Operator.EQ, "secret@example.com".getBytes(StandardCharsets.UTF_8), false)))
+                .isEqualTo("eq(binary_col, ?)");
+        assertThat(render(new ResolvedPredicate.IntInPredicate(7, new int[]{ 123, 456, 789 })))
+                .isEqualTo("in(int_in_col, ?×3)");
+        assertThat(render(new ResolvedPredicate.LongInPredicate(8, new long[]{ 123L, 456L })))
+                .isEqualTo("in(long_in_col, ?×2)");
+        assertThat(render(new ResolvedPredicate.BinaryInPredicate(9, new byte[][]{
+                "first-secret".getBytes(StandardCharsets.UTF_8),
+                "second-secret".getBytes(StandardCharsets.UTF_8) })))
+                .isEqualTo("in(binary_in_col, ?×2)");
+    }
+
+    @Test
+    void rendersNullChecksAndCompoundStructure() {
+        ResolvedPredicate predicate = new ResolvedPredicate.And(List.of(
+                new ResolvedPredicate.IsNullPredicate(10),
+                new ResolvedPredicate.Or(List.of(
+                        new ResolvedPredicate.IsNotNullPredicate(10),
+                        new ResolvedPredicate.IntPredicate(0, FilterPredicate.Operator.GT, 42)))));
+
+        assertThat(render(predicate))
+                .isEqualTo("and(isNull(nullable_col), or(isNotNull(nullable_col), gt(int_col, ?)))");
+    }
+
+    @Test
+    void rendersGeospatialBoundsInFull() {
+        ResolvedPredicate predicate = new ResolvedPredicate.GeospatialPredicate(11, 1.5, 2.5, 3.5, 4.5);
+
+        assertThat(render(predicate)).isEqualTo("intersects(geo_col, 1.5, 2.5, 3.5, 4.5)");
+    }
+
+    @Test
+    void usesTheFullPathForNestedColumns() {
+        FileSchema nested = FileSchema.builder("schema")
+                .struct("address", RepetitionType.OPTIONAL,
+                        address -> address.addColumn("zip", PhysicalType.INT32, RepetitionType.REQUIRED))
+                .build();
+        ResolvedPredicate predicate = new ResolvedPredicate.IntPredicate(0, FilterPredicate.Operator.EQ, 90210);
+
+        assertThat(ResolvedPredicateRenderer.render(predicate, nested)).isEqualTo("eq(address.zip, ?)");
+    }
+
+    private static String render(ResolvedPredicate predicate) {
+        return ResolvedPredicateRenderer.render(predicate, SCHEMA);
+    }
+}

--- a/core/src/test/java/dev/hardwood/internal/predicate/RowGroupPredicateRendererTest.java
+++ b/core/src/test/java/dev/hardwood/internal/predicate/RowGroupPredicateRendererTest.java
@@ -1,0 +1,33 @@
+/*
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Copyright The original authors
+ *
+ *  Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package dev.hardwood.internal.predicate;
+
+import org.junit.jupiter.api.Test;
+
+import dev.hardwood.reader.RowGroupPredicate;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class RowGroupPredicateRendererTest {
+
+    @Test
+    void rendersByteRangeBoundsInFull() {
+        assertThat(RowGroupPredicateRenderer.render(RowGroupPredicate.byteRange(10, 100)))
+                .isEqualTo("byteRange(10, 100)");
+    }
+
+    @Test
+    void rendersCompoundByteRanges() {
+        RowGroupPredicate predicate = RowGroupPredicate.and(
+                RowGroupPredicate.byteRange(10, 100),
+                RowGroupPredicate.byteRange(20, 80));
+
+        assertThat(RowGroupPredicateRenderer.render(predicate))
+                .isEqualTo("and(byteRange(10, 100), byteRange(20, 80))");
+    }
+}

--- a/docs/content/reference/configuration.md
+++ b/docs/content/reference/configuration.md
@@ -94,13 +94,15 @@ Or attach dynamically via `jcmd <pid> JFR.start`.
 | `dev.hardwood.FileMapping` | I/O | Memory-mapping of a file region. Fields: file, offset, size |
 | `dev.hardwood.RowGroupScanned` | Decode | Page boundaries scanned in a column chunk. Fields: file, rowGroupIndex, column, pageCount, scanStrategy (`sequential` or `offset-index`) |
 | `dev.hardwood.PageDecoded` | Decode | Single data page decoded. Fields: column, compressedSize, uncompressedSize |
-| `dev.hardwood.RowGroupFilter` | Filter | Row groups dropped by statistics/bloom predicate pushdown. Fields: file, totalRowGroups, rowGroupsKept, rowGroupsSkipped, rowGroupsFullyMatching |
-| `dev.hardwood.RowGroupByteRangeFilter` | Filter | Row groups selected by a byte-range split predicate (split-aware reading). Fields: file, totalRowGroups, rowGroupsKept, rowGroupsSkipped |
-| `dev.hardwood.PageFilter` | Filter | Pages filtered by Column Index predicate pushdown, one event per column chunk considered. Fields: file, rowGroupIndex, column, totalPages, pagesKept, pagesSkipped |
-| `dev.hardwood.RecordFilter` | Filter | Records filtered by record-level predicate evaluation, one event per file read. Fields: file, totalRecords, recordsKept, recordsSkipped |
+| `dev.hardwood.RowGroupFilter` | Filter | Row groups dropped by statistics/bloom predicate pushdown. Fields: file, predicate, totalRowGroups, rowGroupsKept, rowGroupsSkipped, rowGroupsFullyMatching |
+| `dev.hardwood.RowGroupByteRangeFilter` | Filter | Row groups selected by a byte-range split predicate (split-aware reading). Fields: file, predicate, totalRowGroups, rowGroupsKept, rowGroupsSkipped |
+| `dev.hardwood.PageFilter` | Filter | Pages filtered by Column Index predicate pushdown, one event per column chunk considered. Fields: file, predicate, rowGroupIndex, column, totalPages, pagesKept, pagesSkipped |
+| `dev.hardwood.RecordFilter` | Filter | Records filtered by record-level predicate evaluation, one event per file read. Fields: file, predicate, totalRecords, recordsKept, recordsSkipped |
 | `dev.hardwood.BatchWait` | Pipeline | Consumer blocked waiting for the assembly pipeline; the event's duration is the stall. Fields: column |
 
 Events appear under the **Hardwood** category in JDK Mission Control (JMC) or any JFR analysis tool. Use them to identify:
+
+Filter-event `predicate` values retain column names and predicate structure while replacing data-domain literals with `?`; `IN` predicates report only their arity. Byte-range split bounds and geospatial query bounds are retained in full.
 
 - **I/O bottlenecks** — large `FileMapping` durations
 - **Filter effectiveness** — `RowGroupFilter` shows how many row groups were dropped by statistics/bloom pushdown and `RowGroupByteRangeFilter` how many were excluded by split selection; `PageFilter` shows how many of a column chunk's pages survived the Column Index within a row group that was kept, with no event for a column chunk the Column Index did not narrow — including a chunk that has no Column Index, whose pages are instead dropped from page-header statistics and are not reported; `RecordFilter` shows how many individual records the predicate decided on per file once that pruning is done


### PR DESCRIPTION
## Authorship

- [] This change is coming from a human who understands what it does and why, and can discuss it in review

## Checklist

- [ ] Build via `./mvnw clean verify` passes
- [x] The commit message is prefixed with the issue key ("#123 Adding support for...")
- [x] Code changes are covered by tests
- [x] If this PR adds or changes user-facing behaviour, `docs/` has been updated

## Summary

- add exhaustive renderers for `ResolvedPredicate` and `RowGroupPredicate`
- elide predicate literals while preserving operators, column names, and IN arity
- add predicate information to the four filter-related JFR events
- render predicates lazily after `isEnabled()` and cache the resolved predicate per read
- add renderer and JFR integration tests
- document the new JFR fields

Fixes #1053

## Testing

- Error Prone checks: 10 tests passed
- Hardwood Core: 2771 tests run, 0 failures, 0 errors, 2 skipped
- Core integration tests: 14 passed
- `git diff --check`: passed

The full reactor reached `hardwood-s3`, where tests could not run because Docker was unavailable and the external `aws-c-auth` repository clone timed out. The affected core module completed successfully.

## AI assistance

AI assistance was used during implementation. I reviewed the changes, understand the predicate rendering, caching, and JFR event wiring, and can discuss them during review.