### PR TITLE
#1019 Decode DELTA_BINARY_PACKED a block at a time, through one unpack loop

### DIFF
--- a/core/src/main/java/dev/hardwood/internal/encoding/DeltaBinaryPackedDecoder.java
+++ b/core/src/main/java/dev/hardwood/internal/encoding/DeltaBinaryPackedDecoder.java
@@ -8,6 +8,10 @@
 package dev.hardwood.internal.encoding;
 
 import java.io.IOException;
+import java.lang.invoke.MethodHandles;
+import java.lang.invoke.VarHandle;
+import java.nio.ByteOrder;
+import java.util.Arrays;
 
 /// Decoder for DELTA_BINARY_PACKED encoding.
 ///
@@ -26,36 +30,94 @@ import java.io.IOException;
 /// @see <a href="https://github.com/apache/parquet-format/blob/master/Encodings.md">Parquet Encodings</a>
 public class DeltaBinaryPackedDecoder implements ValueDecoder {
 
+    /// Reads eight packed bytes in one go, in the little-endian order the bit layout uses.
+    /// [RleBitPackingHybridDecoder] loads the same layout the same way.
+    private static final VarHandle LONG_LE =
+            MethodHandles.byteArrayViewVarHandle(long[].class, ByteOrder.LITTLE_ENDIAN);
+
+
+    /// The stream header, which every bound in this class comes from.
+    ///
+    /// Its constructor is where the header is checked, so a `Header` that exists is one the rest of
+    /// the decoder can trust: `header.valuesPerMiniblock()` divides, the counts are positive, and nothing has
+    /// to re-establish that further down.
+    ///
+    /// @param header.blockSize() values per block, a whole number of miniblocks
+    /// @param header.miniblockCount() miniblocks per block
+    /// @param header.totalValueCount() values the stream holds, padding aside
+    /// @param header.firstValue() the value the header carries outside any block
+    /// The stream header, which every bound in this class comes from.
+    ///
+    /// [#of] is where the header is checked, so a `Header` that exists is one the rest of the
+    /// decoder can trust: the counts are positive, `blockSize` divides into whole miniblocks, and
+    /// nothing further down has to re-establish that.
+    ///
+    /// @param blockSize values per block, a whole number of miniblocks
+    /// @param miniblockCount miniblocks per block
+    /// @param totalValueCount values the stream holds, padding aside
+    /// @param firstValue the value the header carries outside any block
+    /// @param valuesPerMiniblock `blockSize / miniblockCount`, carried rather than recomputed
+    private record Header(int blockSize, int miniblockCount, int totalValueCount, long firstValue,
+            int valuesPerMiniblock) {
+
+        /// Checks the four fields the stream carries and derives the fifth.
+        static Header of(int blockSize, int miniblockCount, int totalValueCount, long firstValue) {
+            if (blockSize <= 0) {
+                throw new IllegalArgumentException("Invalid block size: " + blockSize);
+            }
+            // Negative counts reach here from a ULEB128 wide enough to overflow the int, and a
+            // negative divisor still divides evenly (128 % -1 == 0), so the divisibility check below
+            // does not catch them either. Left unchecked they surface as NegativeArraySizeException.
+            if (miniblockCount <= 0) {
+                throw new IllegalArgumentException("Invalid miniblock count: " + miniblockCount);
+            }
+            if (totalValueCount < 0) {
+                throw new IllegalArgumentException("Invalid total value count: " + totalValueCount);
+            }
+            if (blockSize % miniblockCount != 0) {
+                throw new IllegalArgumentException(
+                        "Block size " + blockSize + " is not divisible by miniblock count " + miniblockCount);
+            }
+            return new Header(blockSize, miniblockCount, totalValueCount, firstValue, blockSize / miniblockCount);
+        }
+    }
+
     private final byte[] data;
     private int pos;
 
-    // Header values
-    private int blockSize;
-    private int miniblockCount;
-    private int totalValueCount;
-    private long firstValue;
-    private int valuesPerMiniblock;
+    private final Header header;
 
     // Reading state
-    private int valuesRead;
     private long lastValue;
-    private boolean headerRead;
+    /// Values decoded into the buffer so far, across every block. Bounds the last block, whose
+    /// trailing miniblock the encoder pads out with values the caller never asked for.
+    private int valuesProduced;
 
     // Current block state
     private long minDelta;
-    private int[] bitWidths;
-    private int currentMiniblock;
+    private final int[] bitWidths;
 
-    // Pre-allocated miniblock decode buffer (size = valuesPerMiniblock)
-    private long[] miniblockBuffer;
+    // One whole block of decoded values, plus the header's first value ahead of them
+    private final long[] buffer;
     private int bufferPos;
     private int bufferFill;
 
-    public DeltaBinaryPackedDecoder(byte[] data, int offset) {
+    // Padded copy of a miniblock that ends too close to the end of the page to read wide from
+    private byte[] tailBytes;
+
+    /// Reads the stream header at construction. It is what the buffer's size and every bound come
+    /// from, so nothing this class does is meaningful before it: deferring it only buys a flag to
+    /// test on every entry point, and every caller already reports an [IOException].
+    public DeltaBinaryPackedDecoder(byte[] data, int offset) throws IOException {
         this.data = data;
         this.pos = offset;
-        this.headerRead = false;
-        this.valuesRead = 0;
+        this.header = readHeader();
+        this.bitWidths = new int[header.miniblockCount()];
+        // The header is file-controlled, so the buffer is sized to what can actually be drained from
+        // it rather than to the declared block: no block ever yields more than the declared total,
+        // and a block size of 1<<30 would otherwise ask for an 8 GiB array.
+        this.buffer = new long[Math.min(header.blockSize() + 1, header.totalValueCount())];
+        this.lastValue = header.firstValue();
     }
 
     /// Returns the current read position.
@@ -78,31 +140,22 @@ public class DeltaBinaryPackedDecoder implements ValueDecoder {
     /// Read INT64 values directly into a primitive long array.
     @Override
     public void readLongs(long[] output, int[] definitionLevels, int maxDefLevel) throws IOException {
-        if (!headerRead) {
-            readHeader();
-            headerRead = true;
-        }
         if (definitionLevels == null) {
             int out = 0;
-            int len = output.length;
-            while (out < len) {
-                if (valuesRead == 0) {
-                    output[out++] = firstValue;
-                    lastValue = firstValue;
-                    valuesRead = 1;
-                    continue;
+            while (out < output.length) {
+                if (bufferPos < bufferFill) {
+                    int taken = Math.min(bufferFill - bufferPos, output.length - out);
+                    System.arraycopy(buffer, bufferPos, output, out, taken);
+                    bufferPos += taken;
+                    out += taken;
                 }
-                if (valuesRead >= totalValueCount) {
-                    throw new IOException("No more values to read");
+                else if (output.length - out >= buffer.length) {
+                    out += fillInto(output, out);
                 }
-                if (bufferPos >= bufferFill) {
-                    loadNextMiniblockInternal();
+                else {
+                    bufferFill = fillInto(buffer, 0);
+                    bufferPos = 0;
                 }
-                int canDrain = Math.min(bufferFill - bufferPos, len - out);
-                System.arraycopy(miniblockBuffer, bufferPos, output, out, canDrain);
-                bufferPos += canDrain;
-                out += canDrain;
-                valuesRead += canDrain;
             }
         }
         else {
@@ -115,33 +168,29 @@ public class DeltaBinaryPackedDecoder implements ValueDecoder {
     }
 
     /// Read INT32 values directly into a primitive int array.
+    ///
+    /// The prefix sum is carried in a `long` and narrowed here, which is the wrap-around modulo
+    /// 2^32 the format calls for.
     @Override
     public void readInts(int[] output, int[] definitionLevels, int maxDefLevel) throws IOException {
-        if (!headerRead) {
-            readHeader();
-            headerRead = true;
-        }
         if (definitionLevels == null) {
             int out = 0;
-            int len = output.length;
-            while (out < len) {
-                if (valuesRead == 0) {
-                    output[out++] = (int) firstValue;
-                    lastValue = firstValue;
-                    valuesRead = 1;
-                    continue;
+            while (out < output.length) {
+                if (bufferPos < bufferFill) {
+                    int taken = Math.min(bufferFill - bufferPos, output.length - out);
+                    for (int i = 0; i < taken; i++) {
+                        output[out + i] = (int) buffer[bufferPos + i];
+                    }
+                    bufferPos += taken;
+                    out += taken;
                 }
-                if (valuesRead >= totalValueCount) {
-                    throw new IOException("No more values to read");
+                else if (output.length - out >= buffer.length) {
+                    out += fillInto(output, out);
                 }
-                if (bufferPos >= bufferFill) {
-                    loadNextMiniblockInternal();
+                else {
+                    bufferFill = fillInto(buffer, 0);
+                    bufferPos = 0;
                 }
-                int canDrain = Math.min(bufferFill - bufferPos, len - out);
-                for (int i = 0; i < canDrain; i++) {
-                    output[out++] = (int) miniblockBuffer[bufferPos++];
-                }
-                valuesRead += canDrain;
             }
         }
         else {
@@ -155,80 +204,108 @@ public class DeltaBinaryPackedDecoder implements ValueDecoder {
 
     /// Read a single value as a primitive long (no boxing).
     private long readLongValue() throws IOException {
-        if (!headerRead) {
-            readHeader();
-            headerRead = true;
+        if (bufferPos >= bufferFill) {
+            bufferFill = fillInto(buffer, 0);
+            bufferPos = 0;
         }
+        return buffer[bufferPos++];
+    }
 
-        if (valuesRead == 0) {
-            valuesRead = 1;
-            lastValue = firstValue;
-            return firstValue;
+    /// Decode the next whole block, writing where the caller wants it.
+    ///
+    /// A block is the unit the format hands out — one minimum delta, one bit width per miniblock,
+    /// then the miniblock bodies — so it is the unit to decode. Taking it whole is what keeps the
+    /// readers above this method down to "drain what is buffered, else decode another block", with
+    /// no boundary arithmetic and no first-value special case: the header's value is simply the
+    /// first value of the first block.
+    ///
+    /// The destination is the caller's own array wherever a whole block fits in what is left of it,
+    /// which for a page read in one go is every block but the last.
+    ///
+    /// @return how many values were written
+    private int fillInto(long[] dest, int destOffset) throws IOException {
+        int produced = startBlock(dest, destOffset);
+        if (valuesProduced >= header.totalValueCount()) {
+            return finishEmptyBlock(produced);
         }
+        readBlockHeader();
+        for (int miniblock = 0; miniblock < header.miniblockCount() && valuesProduced < header.totalValueCount(); miniblock++) {
+            int count = Math.min(header.valuesPerMiniblock(), header.totalValueCount() - valuesProduced);
+            decodeMiniblock(miniblock, dest, destOffset + produced, count);
+            produced += count;
+            valuesProduced += count;
+        }
+        return produced;
+    }
 
-        if (valuesRead >= totalValueCount) {
+    /// The `int[]` form of [#fillInto(long[],int)], so an INT32 column is written once rather than
+    /// staged through a `long[]` and narrowed by a second pass over it.
+    private int fillInto(int[] dest, int destOffset) throws IOException {
+        int produced = startBlock(dest, destOffset);
+        if (valuesProduced >= header.totalValueCount()) {
+            return finishEmptyBlock(produced);
+        }
+        readBlockHeader();
+        for (int miniblock = 0; miniblock < header.miniblockCount() && valuesProduced < header.totalValueCount(); miniblock++) {
+            int count = Math.min(header.valuesPerMiniblock(), header.totalValueCount() - valuesProduced);
+            decodeMiniblock(miniblock, dest, destOffset + produced, count);
+            produced += count;
+            valuesProduced += count;
+        }
+        return produced;
+    }
+
+
+    /// The header carries the first value outside any block. Emitting it as the first value of the
+    /// first block is what spares every reader a special case for it.
+    private int startBlock(long[] dest, int destOffset) {
+        if (valuesProduced > 0) {
+            return 0;
+        }
+        dest[destOffset] = header.firstValue();
+        valuesProduced = 1;
+        return 1;
+    }
+
+    private int startBlock(int[] dest, int destOffset) {
+        if (valuesProduced > 0) {
+            return 0;
+        }
+        dest[destOffset] = (int) header.firstValue();
+        valuesProduced = 1;
+        return 1;
+    }
+
+    private int finishEmptyBlock(int produced) throws IOException {
+        if (produced == 0) {
             throw new IOException("No more values to read");
         }
-
-        if (bufferPos >= bufferFill) {
-            loadNextMiniblockInternal();
-        }
-
-        valuesRead++;
-        return miniblockBuffer[bufferPos++];
+        return produced;
     }
 
-    /// Decide whether we need a new block header or just the next miniblock, then load it.
-    private void loadNextMiniblockInternal() throws IOException {
-        int valuesFromBlocks = valuesRead - 1;
-        if (valuesFromBlocks % blockSize == 0) {
-            readBlockHeader();
+    /// Reads and checks the header the stream opens with.
+    ///
+    /// The checks live in [Header] itself and surface as [IllegalArgumentException]; they are
+    /// translated here, because to this class a header that does not add up is a malformed file and
+    /// not a programming error.
+    private Header readHeader() throws IOException {
+        int blockSize = readUleb128();
+        int miniblockCount = readUleb128();
+        int totalValueCount = readUleb128();
+        long firstValue = readZigzagUleb128();
+        try {
+            return Header.of(blockSize, miniblockCount, totalValueCount, firstValue);
         }
-        else {
-            currentMiniblock++;
-            loadMiniblock(currentMiniblock);
+        catch (IllegalArgumentException e) {
+            throw new IOException(e.getMessage(), e);
         }
-    }
-
-    private void readHeader() throws IOException {
-        blockSize = readUleb128();
-        miniblockCount = readUleb128();
-        totalValueCount = readUleb128();
-        firstValue = readZigzagUleb128();
-
-        if (blockSize <= 0) {
-            throw new IOException("Invalid block size: " + blockSize);
-        }
-        // Negative counts reach here from a ULEB128 wide enough to overflow the int, and a negative
-        // divisor still divides evenly (128 % -1 == 0), so the divisibility check below does not
-        // catch them either. Left unchecked they surface as NegativeArraySizeException rather than
-        // as the IOException every other malformed-header path in this class throws.
-        if (miniblockCount <= 0) {
-            throw new IOException("Invalid miniblock count: " + miniblockCount);
-        }
-        if (totalValueCount < 0) {
-            throw new IOException("Invalid total value count: " + totalValueCount);
-        }
-        if (blockSize % miniblockCount != 0) {
-            throw new IOException("Block size " + blockSize + " is not divisible by miniblock count " + miniblockCount);
-        }
-
-        valuesPerMiniblock = blockSize / miniblockCount;
-        bitWidths = new int[miniblockCount];
-        // The header is file-controlled, so the buffer is sized to what can actually be drained
-        // from it rather than to the declared miniblock: no miniblock ever yields more than the
-        // declared total, and a block size of 1<<30 would otherwise ask for an 8 GiB array.
-        miniblockBuffer = new long[Math.min(valuesPerMiniblock, totalValueCount)];
-        bufferPos = 0;
-        bufferFill = 0;
-        lastValue = firstValue;
     }
 
     private void readBlockHeader() throws IOException {
         minDelta = readZigzagUleb128();
 
         // Read bit widths for all miniblocks in this block
-        for (int i = 0; i < miniblockCount; i++) {
+        for (int i = 0; i < header.miniblockCount(); i++) {
             if (pos >= data.length) {
                 throw new IOException("Unexpected EOF reading bitwidths");
             }
@@ -238,135 +315,132 @@ public class DeltaBinaryPackedDecoder implements ValueDecoder {
             }
             bitWidths[i] = bw;
         }
-
-        currentMiniblock = 0;
-        loadMiniblock(0);
     }
 
-    /// Decode one miniblock into miniblockBuffer, applying the prefix sum in-place.
-    ///
-    /// validValues is capped at (totalValueCount - valuesRead) so the caller never reads
-    /// more values than the header declared: the encoder pads the last miniblock with zeros,
-    /// but those zeros are not real values and must not be returned.
-    private void loadMiniblock(int miniblockIdx) throws IOException {
-        int bitWidth = bitWidths[miniblockIdx];
-        // Number of actual values in this miniblock (may be < valuesPerMiniblock for the last one)
-        int validValues = Math.min(valuesPerMiniblock, totalValueCount - valuesRead);
 
+    /// Decode one miniblock onto the end of the buffer.
+    ///
+    /// `pos` advances by the bytes the miniblock occupies in full, which is not the same as the
+    /// bytes `count` values need: the encoder pads a partly-filled miniblock and those bytes are
+    /// still there to step over.
+    private void decodeMiniblock(int miniblock, long[] dest, int destOffset, int count) throws IOException {
+        int bitWidth = bitWidths[miniblock];
         if (bitWidth == 0) {
-            // All residuals are zero — no bytes consumed
-            for (int i = 0; i < validValues; i++) {
-                lastValue += minDelta;
-                miniblockBuffer[i] = lastValue;
+            long value = lastValue;
+            for (int i = 0; i < count; i++) {
+                value += minDelta;
+                dest[destOffset + i] = value;
             }
+            lastValue = value;
+            return;
         }
-        else {
-            // Taken as a long: a file-controlled block size makes valuesPerMiniblock * bitWidth
-            // overflow an int, and a negative byte count would pass the bounds check below.
-            long bytesNeeded = ((long) valuesPerMiniblock * bitWidth + 7) / 8;
-            if (bytesNeeded > data.length - pos) {
-                throw new IOException("Unexpected EOF reading miniblock data: expected " + bytesNeeded
-                        + " bytes, got " + (data.length - pos));
-            }
-            unpackAndPrefixSum(bitWidth, validValues);
-            pos += (int) bytesNeeded;
-        }
-
-        bufferPos = 0;
-        bufferFill = validValues;
+        int bytes = miniblockBytes(bitWidth);
+        unpack(dest, destOffset, bitWidth, count);
+        pos += bytes;
     }
 
-    /// Unpack raw residuals from data[pos..] and apply the prefix sum into miniblockBuffer.
+    private void decodeMiniblock(int miniblock, int[] dest, int destOffset, int count) throws IOException {
+        int bitWidth = bitWidths[miniblock];
+        if (bitWidth == 0) {
+            long value = lastValue;
+            for (int i = 0; i < count; i++) {
+                value += minDelta;
+                dest[destOffset + i] = (int) value;
+            }
+            lastValue = value;
+            return;
+        }
+        int bytes = miniblockBytes(bitWidth);
+        unpack(dest, destOffset, bitWidth, count);
+        pos += bytes;
+    }
+
+    /// The bytes a whole miniblock occupies at this width, checked against what is left of the page.
     ///
-    /// Three paths based on width:
-    ///   1-8:  8 values occupy exactly bitWidth bytes; one LE multi-byte load per group of 8.
-    ///   9-32: 64-bit accumulator refilled one byte at a time.
-    ///   33-64: bit-at-a-time (handles the case where accumulator would overflow at width 57+).
-    private void unpackAndPrefixSum(int bitWidth, int validValues) {
-        if (bitWidth <= 8 && (valuesPerMiniblock % 8) == 0) {
-            unpackAndPrefixSum1to8(bitWidth, validValues);
+    /// Taken as a long because a file-controlled block size overflows the product, and a negative
+    /// byte count would pass the bounds check rather than fail it.
+    private int miniblockBytes(int bitWidth) throws IOException {
+        long bytes = ((long) header.valuesPerMiniblock() * bitWidth + 7) / 8;
+        if (bytes > data.length - pos) {
+            throw new IOException("Unexpected EOF reading miniblock data: expected " + bytes
+                    + " bytes, got " + (data.length - pos));
         }
-        else if (bitWidth <= 32) {
-            unpackAndPrefixSum9to32(bitWidth, validValues);
-        }
-        else {
-            unpackAndPrefixSum33to64(bitWidth, validValues);
-        }
+        return (int) bytes;
     }
 
-    /// Width 1-8: every 8 values occupy exactly bitWidth bytes.
-    /// Load those bytes into a 64-bit word (little-endian) and extract 8 values via shift-and-mask.
-    private void unpackAndPrefixSum1to8(int bitWidth, int validValues) {
-        long mask = (1L << bitWidth) - 1;
-        int groups = valuesPerMiniblock / 8;
-        int dataPos = pos;
-        int idx = 0;
-        for (int g = 0; g < groups; g++) {
-            // Load bitWidth bytes as a little-endian long
-            long word = 0;
-            for (int b = 0; b < bitWidth; b++) {
-                word |= (long) (data[dataPos++] & 0xFF) << (b * 8);
-            }
-            // Extract 8 values packed at bitWidth bits each
-            for (int v = 0; v < 8; v++) {
-                long residual = (word >>> (v * bitWidth)) & mask;
-                if (idx < validValues) {
-                    lastValue += minDelta + residual;
-                    miniblockBuffer[idx] = lastValue;
-                }
-                idx++;
-            }
+    /// Unpack `count` residuals and run the prefix sum through them.
+    ///
+    /// Value `i` starts at bit `i * bitWidth` and is at most 64 bits long, so beginning at most 7
+    /// bits into a byte it reaches at most 71 — two overlapping reads cover every width the format
+    /// allows, and one shape of loop serves all of them. The doubled shift on the second read is
+    /// what makes that branchless: at a bit offset of zero, where no second read is wanted, it
+    /// shifts the byte out entirely.
+    private void unpack(long[] dest, int destOffset, int bitWidth, int count) {
+        byte[] src = sourceFor(bitWidth, count);
+        int base = src == data ? pos : 0;
+        long mask = bitWidth == Long.SIZE ? -1L : (1L << bitWidth) - 1;
+        // Carried in locals across the loop and written back once. As fields they are stored on
+        // every value, because nothing tells the compiler `dest` cannot alias `this`.
+        long value = lastValue;
+        long delta = minDelta;
+        // A long: the page's own size bounds count * bitWidth only to about 2^34, so an int cursor
+        // would wrap on a large enough page and read from the wrong byte.
+        long bitPos = 0;
+        for (int i = 0; i < count; i++) {
+            int byteOffset = base + (int) (bitPos >>> 3);
+            int shift = (int) (bitPos & 7);
+            long low = (long) LONG_LE.get(src, byteOffset);
+            long high = src[byteOffset + Long.BYTES] & 0xFFL;
+            value += delta + (((low >>> shift) | ((high << (63 - shift)) << 1)) & mask);
+            dest[destOffset + i] = value;
+            bitPos += bitWidth;
         }
+        lastValue = value;
     }
 
-    /// Width 9-32: use a 64-bit accumulator refilled one byte at a time.
-    /// Max bits in accumulator is bitWidth-1+8 <= 39, safely within a long.
-    private void unpackAndPrefixSum9to32(int bitWidth, int validValues) {
-        long mask = bitWidth == 32 ? 0xFFFFFFFFL : (1L << bitWidth) - 1;
-        long accumulator = 0;
-        int bits = 0;
-        int dataPos = pos;
-        for (int i = 0; i < valuesPerMiniblock; i++) {
-            while (bits < bitWidth) {
-                accumulator |= (long) (data[dataPos++] & 0xFF) << bits;
-                bits += 8;
-            }
-            long residual = accumulator & mask;
-            accumulator >>>= bitWidth;
-            bits -= bitWidth;
-            if (i < validValues) {
-                lastValue += minDelta + residual;
-                miniblockBuffer[i] = lastValue;
-            }
+    /// The `int[]` form of [#unpack(long[],int,int,int)]. The two differ only in where they store.
+    private void unpack(int[] dest, int destOffset, int bitWidth, int count) {
+        byte[] src = sourceFor(bitWidth, count);
+        int base = src == data ? pos : 0;
+        long mask = bitWidth == Long.SIZE ? -1L : (1L << bitWidth) - 1;
+        long value = lastValue;
+        long delta = minDelta;
+        // A long: the page's own size bounds count * bitWidth only to about 2^34, so an int cursor
+        // would wrap on a large enough page and read from the wrong byte.
+        long bitPos = 0;
+        for (int i = 0; i < count; i++) {
+            int byteOffset = base + (int) (bitPos >>> 3);
+            int shift = (int) (bitPos & 7);
+            long low = (long) LONG_LE.get(src, byteOffset);
+            long high = src[byteOffset + Long.BYTES] & 0xFFL;
+            value += delta + (((low >>> shift) | ((high << (63 - shift)) << 1)) & mask);
+            dest[destOffset + i] = (int) value;
+            bitPos += bitWidth;
         }
+        lastValue = value;
     }
 
-    /// Width 33-64: bit-at-a-time from data[pos..].
-    /// Used instead of the accumulator path because widths 57+ can overfill a 64-bit accumulator.
-    private void unpackAndPrefixSum33to64(int bitWidth, int validValues) {
-        int bitPosition = 0;
-        for (int i = 0; i < valuesPerMiniblock; i++) {
-            long residual = 0;
-            int bitsRemaining = bitWidth;
-            int localBitPos = bitPosition;
-            while (bitsRemaining > 0) {
-                int byteOffset = localBitPos / 8;
-                int bitOffset = localBitPos % 8;
-                int bitsAvailable = 8 - bitOffset;
-                int bitsToRead = Math.min(bitsAvailable, bitsRemaining);
-                // bitsToRead is at most 8, so the mask fits in an int
-                long bits = ((data[pos + byteOffset] & 0xFF) >>> bitOffset) & ((1 << bitsToRead) - 1);
-                residual |= bits << (bitWidth - bitsRemaining);
-                localBitPos += bitsToRead;
-                bitsRemaining -= bitsToRead;
-            }
-            bitPosition += bitWidth;
-            if (i < validValues) {
-                lastValue += minDelta + residual;
-                miniblockBuffer[i] = lastValue;
-            }
+    /// The bytes to unpack from: the page itself, or a padded copy of the miniblock where the page
+    /// ends inside the nine-byte window the last value's reads span.
+    ///
+    /// A page always ends that way on its final miniblock, so this is the ordinary case once per
+    /// page rather than an error path — and paying one copy there keeps the unpack loop free of the
+    /// bounds test that would otherwise run per value.
+    private byte[] sourceFor(int bitWidth, int count) {
+        long bytes = ((long) (count - 1) * bitWidth) / 8 + Long.BYTES + 1;
+        if (pos + bytes <= data.length) {
+            return data;
         }
+        int needed = Math.toIntExact(bytes);
+        int available = Math.min(data.length - pos, needed);
+        if (tailBytes == null || tailBytes.length < needed) {
+            tailBytes = new byte[needed];
+        }
+        System.arraycopy(data, pos, tailBytes, 0, available);
+        Arrays.fill(tailBytes, available, tailBytes.length, (byte) 0);
+        return tailBytes;
     }
+
 
     private int readUleb128() throws IOException {
         int result = 0;

--- a/core/src/main/java/dev/hardwood/internal/encoding/DeltaBinaryPackedDecoder.java
+++ b/core/src/main/java/dev/hardwood/internal/encoding/DeltaBinaryPackedDecoder.java
@@ -45,11 +45,11 @@ public class DeltaBinaryPackedDecoder implements ValueDecoder {
     private long minDelta;
     private int[] bitWidths;
     private int currentMiniblock;
-    private int valuesInCurrentMiniblock;
 
-    // Bit unpacking buffer
-    private byte[] miniblockData;
-    private int bitPosition;
+    // Pre-allocated miniblock decode buffer (size = valuesPerMiniblock)
+    private long[] miniblockBuffer;
+    private int bufferPos;
+    private int bufferFill;
 
     public DeltaBinaryPackedDecoder(byte[] data, int offset) {
         this.data = data;
@@ -78,9 +78,31 @@ public class DeltaBinaryPackedDecoder implements ValueDecoder {
     /// Read INT64 values directly into a primitive long array.
     @Override
     public void readLongs(long[] output, int[] definitionLevels, int maxDefLevel) throws IOException {
+        if (!headerRead) {
+            readHeader();
+            headerRead = true;
+        }
         if (definitionLevels == null) {
-            for (int i = 0; i < output.length; i++) {
-                output[i] = readLongValue();
+            int out = 0;
+            int len = output.length;
+            while (out < len) {
+                if (valuesRead == 0) {
+                    output[out++] = firstValue;
+                    lastValue = firstValue;
+                    valuesRead = 1;
+                    continue;
+                }
+                if (valuesRead >= totalValueCount) {
+                    throw new IOException("No more values to read");
+                }
+                if (bufferPos >= bufferFill) {
+                    loadNextMiniblockInternal();
+                }
+                int canDrain = Math.min(bufferFill - bufferPos, len - out);
+                System.arraycopy(miniblockBuffer, bufferPos, output, out, canDrain);
+                bufferPos += canDrain;
+                out += canDrain;
+                valuesRead += canDrain;
             }
         }
         else {
@@ -95,9 +117,31 @@ public class DeltaBinaryPackedDecoder implements ValueDecoder {
     /// Read INT32 values directly into a primitive int array.
     @Override
     public void readInts(int[] output, int[] definitionLevels, int maxDefLevel) throws IOException {
+        if (!headerRead) {
+            readHeader();
+            headerRead = true;
+        }
         if (definitionLevels == null) {
-            for (int i = 0; i < output.length; i++) {
-                output[i] = (int) readLongValue();
+            int out = 0;
+            int len = output.length;
+            while (out < len) {
+                if (valuesRead == 0) {
+                    output[out++] = (int) firstValue;
+                    lastValue = firstValue;
+                    valuesRead = 1;
+                    continue;
+                }
+                if (valuesRead >= totalValueCount) {
+                    throw new IOException("No more values to read");
+                }
+                if (bufferPos >= bufferFill) {
+                    loadNextMiniblockInternal();
+                }
+                int canDrain = Math.min(bufferFill - bufferPos, len - out);
+                for (int i = 0; i < canDrain; i++) {
+                    output[out++] = (int) miniblockBuffer[bufferPos++];
+                }
+                valuesRead += canDrain;
             }
         }
         else {
@@ -118,6 +162,7 @@ public class DeltaBinaryPackedDecoder implements ValueDecoder {
 
         if (valuesRead == 0) {
             valuesRead = 1;
+            lastValue = firstValue;
             return firstValue;
         }
 
@@ -125,29 +170,24 @@ public class DeltaBinaryPackedDecoder implements ValueDecoder {
             throw new IOException("No more values to read");
         }
 
-        // Check if we need to start a new block (first value after header doesn't count)
-        int valuesAfterFirst = valuesRead - 1;
-        if (valuesAfterFirst % blockSize == 0) {
+        if (bufferPos >= bufferFill) {
+            loadNextMiniblockInternal();
+        }
+
+        valuesRead++;
+        return miniblockBuffer[bufferPos++];
+    }
+
+    /// Decide whether we need a new block header or just the next miniblock, then load it.
+    private void loadNextMiniblockInternal() throws IOException {
+        int valuesFromBlocks = valuesRead - 1;
+        if (valuesFromBlocks % blockSize == 0) {
             readBlockHeader();
         }
-
-        // Check if we need a new miniblock
-        if (valuesInCurrentMiniblock >= valuesPerMiniblock) {
+        else {
             currentMiniblock++;
-            valuesInCurrentMiniblock = 0;
-            if (currentMiniblock < miniblockCount) {
-                loadMiniblock();
-            }
+            loadMiniblock(currentMiniblock);
         }
-
-        // Unpack delta and reconstruct value
-        long packedDelta = unpackValue(bitWidths[currentMiniblock]);
-        long delta = minDelta + packedDelta;
-        lastValue += delta;
-        valuesInCurrentMiniblock++;
-        valuesRead++;
-
-        return lastValue;
     }
 
     private void readHeader() throws IOException {
@@ -156,73 +196,164 @@ public class DeltaBinaryPackedDecoder implements ValueDecoder {
         totalValueCount = readUleb128();
         firstValue = readZigzagUleb128();
 
+        if (blockSize <= 0) {
+            throw new IOException("Invalid block size: " + blockSize);
+        }
         if (miniblockCount == 0) {
             throw new IOException("Invalid miniblock count: 0");
         }
+        if (blockSize % miniblockCount != 0) {
+            throw new IOException("Block size " + blockSize + " is not divisible by miniblock count " + miniblockCount);
+        }
+
         valuesPerMiniblock = blockSize / miniblockCount;
         bitWidths = new int[miniblockCount];
-
+        miniblockBuffer = new long[valuesPerMiniblock];
+        bufferPos = 0;
+        bufferFill = 0;
         lastValue = firstValue;
     }
 
     private void readBlockHeader() throws IOException {
         minDelta = readZigzagUleb128();
 
-        // Read bit widths for all miniblocks
+        // Read bit widths for all miniblocks in this block
         for (int i = 0; i < miniblockCount; i++) {
             if (pos >= data.length) {
                 throw new IOException("Unexpected EOF reading bitwidths");
             }
-            bitWidths[i] = data[pos++] & 0xFF;
+            int bw = data[pos++] & 0xFF;
+            if (bw > 64) {
+                throw new IOException("Invalid bit width: " + bw);
+            }
+            bitWidths[i] = bw;
         }
 
         currentMiniblock = 0;
-        valuesInCurrentMiniblock = 0;
-        loadMiniblock();
+        loadMiniblock(0);
     }
 
-    private void loadMiniblock() throws IOException {
-        int bitWidth = bitWidths[currentMiniblock];
+    /// Decode one miniblock into miniblockBuffer, applying the prefix sum in-place.
+    ///
+    /// validValues is capped at (totalValueCount - valuesRead) so the caller never reads
+    /// more values than the header declared: the encoder pads the last miniblock with zeros,
+    /// but those zeros are not real values and must not be returned.
+    private void loadMiniblock(int miniblockIdx) throws IOException {
+        int bitWidth = bitWidths[miniblockIdx];
+        // Number of actual values in this miniblock (may be < valuesPerMiniblock for the last one)
+        int validValues = Math.min(valuesPerMiniblock, totalValueCount - valuesRead);
+
         if (bitWidth == 0) {
-            // All values in this miniblock have the same delta (minDelta)
-            miniblockData = new byte[0];
+            // All residuals are zero — no bytes consumed
+            for (int i = 0; i < validValues; i++) {
+                lastValue += minDelta;
+                miniblockBuffer[i] = lastValue;
+            }
         }
         else {
             int bytesNeeded = (valuesPerMiniblock * bitWidth + 7) / 8;
             if (pos + bytesNeeded > data.length) {
                 throw new IOException("Unexpected EOF reading miniblock data: expected " + bytesNeeded
-                        + ", got " + (data.length - pos));
+                        + " bytes, got " + (data.length - pos));
             }
-            miniblockData = new byte[bytesNeeded];
-            System.arraycopy(data, pos, miniblockData, 0, bytesNeeded);
+            unpackAndPrefixSum(bitWidth, validValues);
             pos += bytesNeeded;
         }
-        bitPosition = 0;
+
+        bufferPos = 0;
+        bufferFill = validValues;
     }
 
-    private long unpackValue(int bitWidth) {
-        if (bitWidth == 0) {
-            return 0;
+    /// Unpack raw residuals from data[pos..] and apply the prefix sum into miniblockBuffer.
+    ///
+    /// Three paths based on width:
+    ///   1-8:  8 values occupy exactly bitWidth bytes; one LE multi-byte load per group of 8.
+    ///   9-32: 64-bit accumulator refilled one byte at a time.
+    ///   33-64: bit-at-a-time (handles the case where accumulator would overflow at width 57+).
+    private void unpackAndPrefixSum(int bitWidth, int validValues) {
+        if (bitWidth <= 8 && (valuesPerMiniblock % 8) == 0) {
+            unpackAndPrefixSum1to8(bitWidth, validValues);
         }
-
-        long value = 0;
-        int bitsRemaining = bitWidth;
-
-        while (bitsRemaining > 0) {
-            int byteOffset = bitPosition / 8;
-            int bitOffset = bitPosition % 8;
-            int bitsAvailable = 8 - bitOffset;
-            int bitsToRead = Math.min(bitsAvailable, bitsRemaining);
-
-            int mask = (1 << bitsToRead) - 1;
-            long bits = (miniblockData[byteOffset] >>> bitOffset) & mask;
-            value |= bits << (bitWidth - bitsRemaining);
-
-            bitPosition += bitsToRead;
-            bitsRemaining -= bitsToRead;
+        else if (bitWidth <= 32) {
+            unpackAndPrefixSum9to32(bitWidth, validValues);
         }
+        else {
+            unpackAndPrefixSum33to64(bitWidth, validValues);
+        }
+    }
 
-        return value;
+    /// Width 1-8: every 8 values occupy exactly bitWidth bytes.
+    /// Load those bytes into a 64-bit word (little-endian) and extract 8 values via shift-and-mask.
+    private void unpackAndPrefixSum1to8(int bitWidth, int validValues) {
+        long mask = (1L << bitWidth) - 1;
+        int groups = valuesPerMiniblock / 8;
+        int dataPos = pos;
+        int idx = 0;
+        for (int g = 0; g < groups; g++) {
+            // Load bitWidth bytes as a little-endian long
+            long word = 0;
+            for (int b = 0; b < bitWidth; b++) {
+                word |= (long) (data[dataPos++] & 0xFF) << (b * 8);
+            }
+            // Extract 8 values packed at bitWidth bits each
+            for (int v = 0; v < 8; v++) {
+                long residual = (word >>> (v * bitWidth)) & mask;
+                if (idx < validValues) {
+                    lastValue += minDelta + residual;
+                    miniblockBuffer[idx] = lastValue;
+                }
+                idx++;
+            }
+        }
+    }
+
+    /// Width 9-32: use a 64-bit accumulator refilled one byte at a time.
+    /// Max bits in accumulator is bitWidth-1+8 <= 39, safely within a long.
+    private void unpackAndPrefixSum9to32(int bitWidth, int validValues) {
+        long mask = bitWidth == 32 ? 0xFFFFFFFFL : (1L << bitWidth) - 1;
+        long accumulator = 0;
+        int bits = 0;
+        int dataPos = pos;
+        for (int i = 0; i < valuesPerMiniblock; i++) {
+            while (bits < bitWidth) {
+                accumulator |= (long) (data[dataPos++] & 0xFF) << bits;
+                bits += 8;
+            }
+            long residual = accumulator & mask;
+            accumulator >>>= bitWidth;
+            bits -= bitWidth;
+            if (i < validValues) {
+                lastValue += minDelta + residual;
+                miniblockBuffer[i] = lastValue;
+            }
+        }
+    }
+
+    /// Width 33-64: bit-at-a-time from data[pos..].
+    /// Used instead of the accumulator path because widths 57+ can overfill a 64-bit accumulator.
+    private void unpackAndPrefixSum33to64(int bitWidth, int validValues) {
+        int bitPosition = 0;
+        for (int i = 0; i < valuesPerMiniblock; i++) {
+            long residual = 0;
+            int bitsRemaining = bitWidth;
+            int localBitPos = bitPosition;
+            while (bitsRemaining > 0) {
+                int byteOffset = localBitPos / 8;
+                int bitOffset = localBitPos % 8;
+                int bitsAvailable = 8 - bitOffset;
+                int bitsToRead = Math.min(bitsAvailable, bitsRemaining);
+                // bitsToRead is at most 8, so the mask fits in an int
+                long bits = ((data[pos + byteOffset] & 0xFF) >>> bitOffset) & ((1 << bitsToRead) - 1);
+                residual |= bits << (bitWidth - bitsRemaining);
+                localBitPos += bitsToRead;
+                bitsRemaining -= bitsToRead;
+            }
+            bitPosition += bitWidth;
+            if (i < validValues) {
+                lastValue += minDelta + residual;
+                miniblockBuffer[i] = lastValue;
+            }
+        }
     }
 
     private int readUleb128() throws IOException {

--- a/core/src/main/java/dev/hardwood/internal/encoding/DeltaBinaryPackedDecoder.java
+++ b/core/src/main/java/dev/hardwood/internal/encoding/DeltaBinaryPackedDecoder.java
@@ -35,17 +35,6 @@ public class DeltaBinaryPackedDecoder implements ValueDecoder {
     private static final VarHandle LONG_LE =
             MethodHandles.byteArrayViewVarHandle(long[].class, ByteOrder.LITTLE_ENDIAN);
 
-
-    /// The stream header, which every bound in this class comes from.
-    ///
-    /// Its constructor is where the header is checked, so a `Header` that exists is one the rest of
-    /// the decoder can trust: `header.valuesPerMiniblock()` divides, the counts are positive, and nothing has
-    /// to re-establish that further down.
-    ///
-    /// @param header.blockSize() values per block, a whole number of miniblocks
-    /// @param header.miniblockCount() miniblocks per block
-    /// @param header.totalValueCount() values the stream holds, padding aside
-    /// @param header.firstValue() the value the header carries outside any block
     /// The stream header, which every bound in this class comes from.
     ///
     /// [#of] is where the header is checked, so a `Header` that exists is one the rest of the
@@ -60,10 +49,24 @@ public class DeltaBinaryPackedDecoder implements ValueDecoder {
     private record Header(int blockSize, int miniblockCount, int totalValueCount, long firstValue,
             int valuesPerMiniblock) {
 
+        /// The largest block a header may declare.
+        ///
+        /// A block is decoded whole, so the block size is what the decode buffer is sized from — and
+        /// nothing in the page bounds it. A block whose miniblocks are all declared at width 0
+        /// occupies one byte of minimum delta plus one byte per miniblock and yields `blockSize`
+        /// values, so however few bytes a page has, a header declaring 2^30 values per block asks
+        /// for an 8 GiB `long[]`. Writers emit 128; this is three orders of magnitude of headroom
+        /// over that and bounds the buffer at 512 KiB.
+        private static final int MAX_BLOCK_SIZE = 1 << 16;
+
         /// Checks the four fields the stream carries and derives the fifth.
         static Header of(int blockSize, int miniblockCount, int totalValueCount, long firstValue) {
             if (blockSize <= 0) {
                 throw new IllegalArgumentException("Invalid block size: " + blockSize);
+            }
+            if (blockSize > MAX_BLOCK_SIZE) {
+                throw new IllegalArgumentException(
+                        "Block size " + blockSize + " exceeds the maximum of " + MAX_BLOCK_SIZE);
             }
             // Negative counts reach here from a ULEB128 wide enough to overflow the int, and a
             // negative divisor still divides evenly (128 % -1 == 0), so the divisibility check below
@@ -113,9 +116,10 @@ public class DeltaBinaryPackedDecoder implements ValueDecoder {
         this.pos = offset;
         this.header = readHeader();
         this.bitWidths = new int[header.miniblockCount()];
-        // The header is file-controlled, so the buffer is sized to what can actually be drained from
-        // it rather than to the declared block: no block ever yields more than the declared total,
-        // and a block size of 1<<30 would otherwise ask for an 8 GiB array.
+        // Both fields are file-controlled and neither bounds the buffer on its own, so both bound it:
+        // the declared total can be Integer.MAX_VALUE on a five-byte page, and the block size is
+        // capped by Header rather than by anything the page has to make good on. The cap is also
+        // what keeps `blockSize + 1` from overflowing into a negative array size.
         this.buffer = new long[Math.min(header.blockSize() + 1, header.totalValueCount())];
         this.lastValue = header.firstValue();
     }
@@ -224,9 +228,10 @@ public class DeltaBinaryPackedDecoder implements ValueDecoder {
     ///
     /// @return how many values were written
     private int fillInto(long[] dest, int destOffset) throws IOException {
+        checkNotExhausted();
         int produced = startBlock(dest, destOffset);
         if (valuesProduced >= header.totalValueCount()) {
-            return finishEmptyBlock(produced);
+            return produced;
         }
         readBlockHeader();
         for (int miniblock = 0; miniblock < header.miniblockCount() && valuesProduced < header.totalValueCount(); miniblock++) {
@@ -241,9 +246,10 @@ public class DeltaBinaryPackedDecoder implements ValueDecoder {
     /// The `int[]` form of [#fillInto(long[],int)], so an INT32 column is written once rather than
     /// staged through a `long[]` and narrowed by a second pass over it.
     private int fillInto(int[] dest, int destOffset) throws IOException {
+        checkNotExhausted();
         int produced = startBlock(dest, destOffset);
         if (valuesProduced >= header.totalValueCount()) {
-            return finishEmptyBlock(produced);
+            return produced;
         }
         readBlockHeader();
         for (int miniblock = 0; miniblock < header.miniblockCount() && valuesProduced < header.totalValueCount(); miniblock++) {
@@ -255,6 +261,17 @@ public class DeltaBinaryPackedDecoder implements ValueDecoder {
         return produced;
     }
 
+    /// Refuses a read past the declared value count, before anything has been written.
+    ///
+    /// It runs ahead of [#startBlock(long[],int)] rather than after it, because the header's first
+    /// value is not exempt from the count: a stream declaring no values at all — which is what
+    /// writers emit for an empty one — has no first value to hand out either, and the buffer sized
+    /// from that count has no room to hold one.
+    private void checkNotExhausted() throws IOException {
+        if (valuesProduced >= header.totalValueCount()) {
+            throw new IOException("No more values to read");
+        }
+    }
 
     /// The header carries the first value outside any block. Emitting it as the first value of the
     /// first block is what spares every reader a special case for it.
@@ -274,13 +291,6 @@ public class DeltaBinaryPackedDecoder implements ValueDecoder {
         dest[destOffset] = (int) header.firstValue();
         valuesProduced = 1;
         return 1;
-    }
-
-    private int finishEmptyBlock(int produced) throws IOException {
-        if (produced == 0) {
-            throw new IOException("No more values to read");
-        }
-        return produced;
     }
 
     /// Reads and checks the header the stream opens with.
@@ -316,7 +326,6 @@ public class DeltaBinaryPackedDecoder implements ValueDecoder {
             bitWidths[i] = bw;
         }
     }
-
 
     /// Decode one miniblock onto the end of the buffer.
     ///
@@ -440,7 +449,6 @@ public class DeltaBinaryPackedDecoder implements ValueDecoder {
         Arrays.fill(tailBytes, available, tailBytes.length, (byte) 0);
         return tailBytes;
     }
-
 
     private int readUleb128() throws IOException {
         int result = 0;

--- a/core/src/main/java/dev/hardwood/internal/encoding/DeltaBinaryPackedDecoder.java
+++ b/core/src/main/java/dev/hardwood/internal/encoding/DeltaBinaryPackedDecoder.java
@@ -199,8 +199,15 @@ public class DeltaBinaryPackedDecoder implements ValueDecoder {
         if (blockSize <= 0) {
             throw new IOException("Invalid block size: " + blockSize);
         }
-        if (miniblockCount == 0) {
-            throw new IOException("Invalid miniblock count: 0");
+        // Negative counts reach here from a ULEB128 wide enough to overflow the int, and a negative
+        // divisor still divides evenly (128 % -1 == 0), so the divisibility check below does not
+        // catch them either. Left unchecked they surface as NegativeArraySizeException rather than
+        // as the IOException every other malformed-header path in this class throws.
+        if (miniblockCount <= 0) {
+            throw new IOException("Invalid miniblock count: " + miniblockCount);
+        }
+        if (totalValueCount < 0) {
+            throw new IOException("Invalid total value count: " + totalValueCount);
         }
         if (blockSize % miniblockCount != 0) {
             throw new IOException("Block size " + blockSize + " is not divisible by miniblock count " + miniblockCount);
@@ -208,7 +215,10 @@ public class DeltaBinaryPackedDecoder implements ValueDecoder {
 
         valuesPerMiniblock = blockSize / miniblockCount;
         bitWidths = new int[miniblockCount];
-        miniblockBuffer = new long[valuesPerMiniblock];
+        // The header is file-controlled, so the buffer is sized to what can actually be drained
+        // from it rather than to the declared miniblock: no miniblock ever yields more than the
+        // declared total, and a block size of 1<<30 would otherwise ask for an 8 GiB array.
+        miniblockBuffer = new long[Math.min(valuesPerMiniblock, totalValueCount)];
         bufferPos = 0;
         bufferFill = 0;
         lastValue = firstValue;
@@ -251,13 +261,15 @@ public class DeltaBinaryPackedDecoder implements ValueDecoder {
             }
         }
         else {
-            int bytesNeeded = (valuesPerMiniblock * bitWidth + 7) / 8;
-            if (pos + bytesNeeded > data.length) {
+            // Taken as a long: a file-controlled block size makes valuesPerMiniblock * bitWidth
+            // overflow an int, and a negative byte count would pass the bounds check below.
+            long bytesNeeded = ((long) valuesPerMiniblock * bitWidth + 7) / 8;
+            if (bytesNeeded > data.length - pos) {
                 throw new IOException("Unexpected EOF reading miniblock data: expected " + bytesNeeded
                         + " bytes, got " + (data.length - pos));
             }
             unpackAndPrefixSum(bitWidth, validValues);
-            pos += bytesNeeded;
+            pos += (int) bytesNeeded;
         }
 
         bufferPos = 0;

--- a/core/src/main/java/dev/hardwood/internal/encoding/DeltaByteArrayDecoder.java
+++ b/core/src/main/java/dev/hardwood/internal/encoding/DeltaByteArrayDecoder.java
@@ -72,9 +72,7 @@ public class DeltaByteArrayDecoder implements ValueDecoder {
         // Read all prefix lengths using DELTA_BINARY_PACKED
         // Prefix lengths are always encoded as INT32 per the spec
         DeltaBinaryPackedDecoder prefixDecoder = new DeltaBinaryPackedDecoder(data, offset);
-        for (int i = 0; i < numNonNullValues; i++) {
-            prefixLengths[i] = prefixDecoder.readInt();
-        }
+        prefixDecoder.readInts(prefixLengths, null, 0);
 
         // Create the suffix decoder (uses DELTA_LENGTH_BYTE_ARRAY)
         // Continue reading from where the prefix decoder stopped

--- a/core/src/main/java/dev/hardwood/internal/encoding/DeltaLengthByteArrayDecoder.java
+++ b/core/src/main/java/dev/hardwood/internal/encoding/DeltaLengthByteArrayDecoder.java
@@ -54,9 +54,7 @@ public class DeltaLengthByteArrayDecoder implements ValueDecoder {
         // Read all lengths using DELTA_BINARY_PACKED
         // Lengths are always encoded as INT32 per the spec
         DeltaBinaryPackedDecoder lengthDecoder = new DeltaBinaryPackedDecoder(data, pos);
-        for (int i = 0; i < numNonNullValues; i++) {
-            lengths[i] = lengthDecoder.readInt();
-        }
+        lengthDecoder.readInts(lengths, null, 0);
         pos = lengthDecoder.getPos();
     }
 

--- a/core/src/test/java/dev/hardwood/internal/encoding/DeltaBinaryPackedDecoderHeaderTest.java
+++ b/core/src/test/java/dev/hardwood/internal/encoding/DeltaBinaryPackedDecoderHeaderTest.java
@@ -1,0 +1,108 @@
+/*
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Copyright The original authors
+ *
+ *  Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package dev.hardwood.internal.encoding;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/// The header decides how the decoder sizes its buffers and how far it reads, and it comes out of
+/// the file, so every field of it is hostile input. These are the shapes a corrupt or malicious
+/// page can take that a round trip against a well-behaved encoder never produces.
+class DeltaBinaryPackedDecoderHeaderTest {
+
+    @Test
+    void refusesAZeroMiniblockCount() {
+        assertThatThrownBy(() -> decode(header(128, 0, 5, 100), 5))
+                .isInstanceOf(IOException.class)
+                .hasMessageContaining("Invalid miniblock count: 0");
+    }
+
+    @Test
+    void refusesANegativeMiniblockCount() {
+        // A ULEB128 wide enough to overflow the int reaches the header as a negative count, and a
+        // negative divisor divides evenly (128 % -1 == 0), so the divisibility check does not stop
+        // it either. Unrefused it reaches new int[-1].
+        assertThatThrownBy(() -> decode(header(128, -1, 5, 100), 5))
+                .isInstanceOf(IOException.class)
+                .hasMessageContaining("Invalid miniblock count: -1");
+    }
+
+    @Test
+    void refusesABlockSizeThatTheMiniblockCountDoesNotDivide() {
+        assertThatThrownBy(() -> decode(header(128, 3, 5, 100), 5))
+                .isInstanceOf(IOException.class)
+                .hasMessageContaining("not divisible");
+    }
+
+    @Test
+    void refusesABitWidthWiderThanALong() {
+        byte[] page = concat(concat(header(128, 1, 5, 100), zigzag(3)), new byte[] { (byte) 200 });
+
+        assertThatThrownBy(() -> decode(page, 5))
+                .isInstanceOf(IOException.class)
+                .hasMessageContaining("Invalid bit width: 200");
+    }
+
+    @Test
+    void sizesItsBufferByTheValueCountAndNotByTheBlockSize() throws IOException {
+        // A block size of 2^30 is legal — a multiple of 128, divisible by the miniblock count — and
+        // says nothing about how many values the page holds, which is five. Sizing the decode
+        // buffer from the block size instead asks for a 8 GiB long[] and takes the reader out with
+        // an OutOfMemoryError on a page that decodes in microseconds.
+        byte[] page = concat(concat(header(1 << 30, 1, 5, 100), zigzag(3)), new byte[] { 0 });
+
+        assertThat(decode(page, 5)).containsExactly(100, 103, 106, 109, 112);
+    }
+
+    private static int[] decode(byte[] page, int count) throws IOException {
+        int[] output = new int[count];
+        new DeltaBinaryPackedDecoder(page, 0).readInts(output, null, 0);
+        return output;
+    }
+
+    private static byte[] header(int blockSize, int miniblockCount, int totalValueCount, long firstValue) {
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        writeUleb128(out, blockSize);
+        writeUleb128(out, miniblockCount);
+        writeUleb128(out, totalValueCount);
+        out.writeBytes(zigzag(firstValue));
+        return out.toByteArray();
+    }
+
+    private static byte[] zigzag(long value) {
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        long encoded = (value << 1) ^ (value >> 63);
+        do {
+            int b = (int) (encoded & 0x7F);
+            encoded >>>= 7;
+            out.write(encoded != 0 ? b | 0x80 : b);
+        } while (encoded != 0);
+        return out.toByteArray();
+    }
+
+    private static void writeUleb128(ByteArrayOutputStream out, int value) {
+        long remaining = value & 0xFFFFFFFFL;
+        do {
+            int b = (int) (remaining & 0x7F);
+            remaining >>>= 7;
+            out.write(remaining != 0 ? b | 0x80 : b);
+        } while (remaining != 0);
+    }
+
+    private static byte[] concat(byte[] first, byte[] second) {
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        out.writeBytes(first);
+        out.writeBytes(second);
+        return out.toByteArray();
+    }
+}

--- a/core/src/test/java/dev/hardwood/internal/encoding/DeltaBinaryPackedDecoderHeaderTest.java
+++ b/core/src/test/java/dev/hardwood/internal/encoding/DeltaBinaryPackedDecoderHeaderTest.java
@@ -21,6 +21,20 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 class DeltaBinaryPackedDecoderHeaderTest {
 
     @Test
+    void refusesAZeroBlockSize() {
+        assertThatThrownBy(() -> decode(header(0, 4, 5, 100), 5))
+                .isInstanceOf(IOException.class)
+                .hasMessageContaining("Invalid block size: 0");
+    }
+
+    @Test
+    void refusesANegativeTotalValueCount() {
+        assertThatThrownBy(() -> decode(header(128, 4, -1, 100), 5))
+                .isInstanceOf(IOException.class)
+                .hasMessageContaining("Invalid total value count: -1");
+    }
+
+    @Test
     void refusesAZeroMiniblockCount() {
         assertThatThrownBy(() -> decode(header(128, 0, 5, 100), 5))
                 .isInstanceOf(IOException.class)
@@ -55,13 +69,60 @@ class DeltaBinaryPackedDecoderHeaderTest {
 
     @Test
     void sizesItsBufferByTheValueCountAndNotByTheBlockSize() throws IOException {
-        // A block size of 2^30 is legal — a multiple of 128, divisible by the miniblock count — and
-        // says nothing about how many values the page holds, which is five. Sizing the decode
-        // buffer from the block size instead asks for a 8 GiB long[] and takes the reader out with
-        // an OutOfMemoryError on a page that decodes in microseconds.
-        byte[] page = concat(concat(header(1 << 30, 1, 5, 100), zigzag(3)), new byte[] { 0 });
+        // The block size says nothing about how many values the page holds, which is five. Sizing
+        // the decode buffer from the block size instead follows a number the page never has to make
+        // good on — here a 512 KiB long[] for a six-byte page.
+        byte[] page = concat(concat(header(1 << 16, 1, 5, 100), zigzag(3)), new byte[] { 0 });
 
         assertThat(decode(page, 5)).containsExactly(100, 103, 106, 109, 112);
+    }
+
+    @Test
+    void refusesABlockSizeBeyondWhatItWillBufferWhole() {
+        // A block is decoded whole, so the block size is a memory bound, and no page bounds it: a
+        // block of zero-width miniblocks yields blockSize values from two bytes. Left uncapped, this
+        // six-byte page asks for an 8 GiB long[] and takes the reader out with an OutOfMemoryError.
+        byte[] page = concat(concat(header(1 << 30, 1, 5, 100), zigzag(3)), new byte[] { 0 });
+
+        assertThatThrownBy(() -> decode(page, 5))
+                .isInstanceOf(IOException.class)
+                .hasMessageContaining("Block size 1073741824 exceeds the maximum");
+    }
+
+    @Test
+    void refusesABlockSizeBeyondTheCapEvenWhenTheValueCountIsLargeToo() {
+        // The declared total is the other bound on the buffer, and it is file-controlled as well, so
+        // a header that inflates both gets past a check that only bounds one by the other.
+        byte[] page = concat(concat(header(1 << 30, 1, Integer.MAX_VALUE, 100), zigzag(3)),
+                new byte[] { 0 });
+
+        assertThatThrownBy(() -> decode(page, 5))
+                .isInstanceOf(IOException.class)
+                .hasMessageContaining("exceeds the maximum");
+    }
+
+    @Test
+    void refusesToHandOutTheHeadersValueWhenTheStreamDeclaresNone() {
+        // What a writer emits for a stream nothing was written to. The header still carries a first
+        // value, but a count of zero says it is not one of the stream's, and the buffer sized from
+        // that count has no room to hold it either.
+        byte[] page = concat(header(128, 4, 0, 100), zigzag(0));
+
+        assertThatThrownBy(() -> decode(page, 1))
+                .isInstanceOf(IOException.class)
+                .hasMessageContaining("No more values to read");
+        assertThatThrownBy(() -> new DeltaBinaryPackedDecoder(page, 0).readInt())
+                .isInstanceOf(IOException.class)
+                .hasMessageContaining("No more values to read");
+    }
+
+    @Test
+    void readsAStreamThatIsNothingButItsHeaderValue() throws IOException {
+        // The other end of the same boundary: a count of one is satisfied by the header alone, and
+        // no block follows it to read.
+        byte[] page = header(128, 4, 1, 100);
+
+        assertThat(decode(page, 1)).containsExactly(100);
     }
 
     private static int[] decode(byte[] page, int count) throws IOException {

--- a/core/src/test/java/dev/hardwood/internal/encoding/DeltaBinaryPackedDecoderWidthSweepTest.java
+++ b/core/src/test/java/dev/hardwood/internal/encoding/DeltaBinaryPackedDecoderWidthSweepTest.java
@@ -8,29 +8,45 @@
 package dev.hardwood.internal.encoding;
 
 import java.io.IOException;
-import java.util.Arrays;
+import java.util.Random;
 import java.util.stream.IntStream;
+import java.util.stream.Stream;
 
+import org.apache.parquet.bytes.HeapByteBufferAllocator;
+import org.apache.parquet.column.values.delta.DeltaBinaryPackingValuesWriterForInteger;
+import org.apache.parquet.column.values.delta.DeltaBinaryPackingValuesWriterForLong;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
-/// Sweeps every bit width 0–32 for INT32 and 0–64 for INT64 to verify the bulk miniblock
-/// decoder handles all width-specialised paths (0, 1–8, 9–32, 33–64).
+/// Sweeps every bit width — 0–32 for INT32, 0–64 for INT64 — across the decoder's width-specialised
+/// unpack paths (0, 1–8, 9–56, 57–64) and across both ways of draining it, in bulk and one value at
+/// a time.
+///
+/// parquet-java writes the bytes. A round trip against Hardwood's own encoder cannot see the two
+/// implementations agreeing on a bit layout that the format does not have, and the layout is what
+/// these hand-written unpack kernels have to be right about.
 ///
 /// Each case encodes 50 values: a full miniblock of 32 plus a partial miniblock of 17, which
 /// exercises the partial-last-miniblock truncation in [DeltaBinaryPackedDecoder].
 ///
-/// Value construction forces the encoder to select approximately the target bit width:
-/// - Width 0: constant column — all deltas zero.
-/// - Width 1–31 (INT32) / 1–63 (INT64): most deltas = 1 (minDelta=1), one delta = 1&lt;&lt;w, so
-///   the largest residual is (1&lt;&lt;w)-1 which requires exactly w bits.
-/// - Width 32 (INT32): alternating Integer.MIN_VALUE / Integer.MAX_VALUE — the wrap-around case.
-/// - Width 64 (INT64): alternating Long.MIN_VALUE / Long.MAX_VALUE — the wrap-around case.
+/// Every case asserts the width the encoder actually chose before asserting the values, because a
+/// sweep that silently encodes at some other width tests that width twice and the target not at
+/// all. Alternating `MIN_VALUE`/`MAX_VALUE` reads like the way to reach the ceiling width and is
+/// not: its deltas are −1 and +1, so it encodes at width 2.
 class DeltaBinaryPackedDecoderWidthSweepTest {
 
     private static final int VALUE_COUNT = 50;
+    private static final int BLOCK_SIZE = 128;
+    private static final int MINIBLOCK_COUNT = 4;
+
+    // The two miniblocks the 50 values occupy; the other two are declared at width 0 and hold
+    // nothing.
+    private static final int USED_MINIBLOCKS = 2;
 
     // ==================== INT32 ====================
 
@@ -41,32 +57,50 @@ class DeltaBinaryPackedDecoderWidthSweepTest {
     @ParameterizedTest(name = "INT32 width {0}")
     @MethodSource("int32BitWidths")
     void sweepsInt32BitWidths(int w) throws IOException {
-        int[] values = buildInt32Values(w);
-        byte[] encoded = DeltaBinaryPackedEncoder.encodeInts(values, 0, VALUE_COUNT);
-        int[] decoded = new int[VALUE_COUNT];
-        new DeltaBinaryPackedDecoder(encoded, 0).readInts(decoded, null, 0);
-        assertThat(decoded).as("INT32 width %d", w).containsExactly(values);
+        int[] values = int32ValuesForWidth(w);
+        byte[] encoded = encode(values);
+
+        assertThat(declaredBitWidths(encoded)).as("INT32 width %d: widths the encoder chose", w)
+                .startsWith(w, w);
+
+        int[] bulk = new int[VALUE_COUNT];
+        new DeltaBinaryPackedDecoder(encoded, 0).readInts(bulk, null, 0);
+        assertThat(bulk).as("INT32 width %d, read in bulk", w).containsExactly(values);
+
+        DeltaBinaryPackedDecoder oneAtATime = new DeltaBinaryPackedDecoder(encoded, 0);
+        int[] single = new int[VALUE_COUNT];
+        for (int i = 0; i < VALUE_COUNT; i++) {
+            single[i] = oneAtATime.readInt();
+        }
+        assertThat(single).as("INT32 width %d, read one value at a time", w).containsExactly(values);
     }
 
-    private static int[] buildInt32Values(int w) {
+    /// Values whose block minimum is 0 and whose largest residual needs exactly `w` bits.
+    ///
+    /// Width 32 is the exception: no positive `int` delta spans 32 bits, so it is reached with a
+    /// block minimum of `MIN_VALUE` and a largest delta of `MAX_VALUE`, whose difference is the
+    /// all-ones residual.
+    private static int[] int32ValuesForWidth(int w) {
+        int[] deltas = new int[VALUE_COUNT - 1];
+        Random random = new Random(w);
+        for (int i = 0; i < deltas.length; i++) {
+            deltas[i] = w == 0 ? 0
+                    : w == 32 ? (random.nextBoolean() ? Integer.MIN_VALUE : Integer.MAX_VALUE)
+                    : random.nextInt() >>> (32 - w);
+        }
+        // Pin the extremes into both used miniblocks so each declares the target width, and pin the
+        // block minimum so the residuals are the deltas themselves.
+        int low = w == 32 ? Integer.MIN_VALUE : 0;
+        int high = w == 32 ? Integer.MAX_VALUE : (w == 0 ? 0 : -1 >>> (32 - w));
+        for (int miniblock = 0; miniblock < USED_MINIBLOCKS; miniblock++) {
+            int base = miniblock * (BLOCK_SIZE / MINIBLOCK_COUNT);
+            deltas[base] = high;
+            deltas[base + 1] = low;
+        }
+
         int[] values = new int[VALUE_COUNT];
-        if (w == 0) {
-            // Constant column: all deltas zero
-            Arrays.fill(values, 42);
-        }
-        else if (w == 32) {
-            // Wrap-around case: delta from MAX_VALUE to MIN_VALUE wraps to 1 modulo 2^32
-            for (int i = 0; i < VALUE_COUNT; i++) {
-                values[i] = i % 2 == 0 ? Integer.MIN_VALUE : Integer.MAX_VALUE;
-            }
-        }
-        else {
-            // Most deltas = 1 (minDelta=1), one delta = 1<<w.
-            // Largest residual = (1<<w)-1, which requires exactly w bits.
-            values[0] = 0;
-            for (int i = 1; i < VALUE_COUNT; i++) {
-                values[i] = values[i - 1] + (i == 25 ? (1 << w) : 1);
-            }
+        for (int i = 1; i < VALUE_COUNT; i++) {
+            values[i] = values[i - 1] + deltas[i - 1];
         }
         return values;
     }
@@ -80,33 +114,166 @@ class DeltaBinaryPackedDecoderWidthSweepTest {
     @ParameterizedTest(name = "INT64 width {0}")
     @MethodSource("int64BitWidths")
     void sweepsInt64BitWidths(int w) throws IOException {
-        long[] values = buildInt64Values(w);
-        byte[] encoded = DeltaBinaryPackedEncoder.encodeLongs(values, 0, VALUE_COUNT);
-        long[] decoded = new long[VALUE_COUNT];
-        new DeltaBinaryPackedDecoder(encoded, 0).readLongs(decoded, null, 0);
-        assertThat(decoded).as("INT64 width %d", w).containsExactly(values);
+        long[] values = int64ValuesForWidth(w);
+        byte[] encoded = encode(values);
+
+        assertThat(declaredBitWidths(encoded)).as("INT64 width %d: widths the encoder chose", w)
+                .startsWith(w, w);
+
+        long[] bulk = new long[VALUE_COUNT];
+        new DeltaBinaryPackedDecoder(encoded, 0).readLongs(bulk, null, 0);
+        assertThat(bulk).as("INT64 width %d, read in bulk", w).containsExactly(values);
+
+        DeltaBinaryPackedDecoder oneAtATime = new DeltaBinaryPackedDecoder(encoded, 0);
+        long[] single = new long[VALUE_COUNT];
+        for (int i = 0; i < VALUE_COUNT; i++) {
+            single[i] = oneAtATime.readLong();
+        }
+        assertThat(single).as("INT64 width %d, read one value at a time", w).containsExactly(values);
     }
 
-    private static long[] buildInt64Values(int w) {
+    /// The INT64 counterpart of [#int32ValuesForWidth], with width 64 as the exception.
+    private static long[] int64ValuesForWidth(int w) {
+        long[] deltas = new long[VALUE_COUNT - 1];
+        Random random = new Random(w);
+        for (int i = 0; i < deltas.length; i++) {
+            deltas[i] = w == 0 ? 0L
+                    : w == 64 ? (random.nextBoolean() ? Long.MIN_VALUE : Long.MAX_VALUE)
+                    : random.nextLong() >>> (64 - w);
+        }
+        long low = w == 64 ? Long.MIN_VALUE : 0L;
+        long high = w == 64 ? Long.MAX_VALUE : (w == 0 ? 0L : -1L >>> (64 - w));
+        for (int miniblock = 0; miniblock < USED_MINIBLOCKS; miniblock++) {
+            int base = miniblock * (BLOCK_SIZE / MINIBLOCK_COUNT);
+            deltas[base] = high;
+            deltas[base + 1] = low;
+        }
+
         long[] values = new long[VALUE_COUNT];
-        if (w == 0) {
-            // Constant column: all deltas zero
-            Arrays.fill(values, 42L);
-        }
-        else if (w == 64) {
-            // Wrap-around case: delta from Long.MAX_VALUE to Long.MIN_VALUE wraps to 1 modulo 2^64
-            for (int i = 0; i < VALUE_COUNT; i++) {
-                values[i] = i % 2 == 0 ? Long.MIN_VALUE : Long.MAX_VALUE;
-            }
-        }
-        else {
-            // Most deltas = 1 (minDelta=1), one delta = 1L<<w.
-            // Largest residual = (1L<<w)-1, which requires exactly w bits.
-            values[0] = 0L;
-            for (int i = 1; i < VALUE_COUNT; i++) {
-                values[i] = values[i - 1] + (i == 25 ? (1L << w) : 1L);
-            }
+        for (int i = 1; i < VALUE_COUNT; i++) {
+            values[i] = values[i - 1] + deltas[i - 1];
         }
         return values;
+    }
+
+    /// Value counts that land the page's last miniblock in different places relative to the end of
+    /// the byte array, which is what decides whether the unpack reads the page directly or a padded
+    /// copy of its tail. 33 ends on a full miniblock and always forces the copy; 50 leaves a partial
+    /// one and mostly does not; 129 and 1000 span several blocks and do both.
+    @ParameterizedTest(name = "INT64 width {1}, {0} values")
+    @MethodSource("tailShapes")
+    void decodesEveryTailShape(int count, int w) throws IOException {
+        long[] values = valuesOfWidth(count, w);
+        byte[] encoded = encode(values);
+
+        long[] decoded = new long[count];
+        new DeltaBinaryPackedDecoder(encoded, 0).readLongs(decoded, null, 0);
+        assertThat(decoded).as("%d values at width %d", count, w).containsExactly(values);
+
+        long[] padded = new long[count];
+        new DeltaBinaryPackedDecoder(withTrailingSlack(encoded), 0).readLongs(padded, null, 0);
+        assertThat(padded).as("%d values at width %d, with room to read wide", count, w)
+                .containsExactly(values);
+    }
+
+    static Stream<Arguments> tailShapes() {
+        return Stream.of(33, 50, 129, 1000)
+                .flatMap(count -> Stream.of(1, 8, 21, 57, 64)
+                        .map(w -> Arguments.of(count, w)));
+    }
+
+    /// The composite byte-array decoders read their lengths through this decoder and then carry on
+    /// from where it stopped, so the position it leaves behind is a contract: it has to land on the
+    /// byte after the delta stream, whatever shape the last block took.
+    @ParameterizedTest(name = "{0} values, width {1}")
+    @MethodSource("tailShapes")
+    void leavesThePositionAfterTheEncodedStream(int count, int w) throws IOException {
+        byte[] encoded = encode(valuesOfWidth(count, w));
+
+        DeltaBinaryPackedDecoder decoder = new DeltaBinaryPackedDecoder(encoded, 0);
+        decoder.readLongs(new long[count], null, 0);
+
+        assertThat(decoder.getPos()).as("%d values at width %d", count, w).isEqualTo(encoded.length);
+    }
+
+    @Test
+    void refusesToReadPastTheDeclaredValueCount() throws IOException {
+        byte[] encoded = encode(valuesOfWidth(VALUE_COUNT, 11));
+
+        assertThatThrownBy(() -> new DeltaBinaryPackedDecoder(encoded, 0)
+                .readLongs(new long[VALUE_COUNT + 1], null, 0))
+                        .isInstanceOf(IOException.class)
+                        .hasMessageContaining("No more values to read");
+    }
+
+    // ==================== Helpers ====================
+
+    private static long[] valuesOfWidth(int count, int w) {
+        long[] values = new long[count];
+        Random random = new Random(w);
+        for (int i = 1; i < count; i++) {
+            values[i] = values[i - 1] + (w == 0 ? 0L : random.nextLong() >>> (64 - w));
+        }
+        return values;
+    }
+
+    /// The same page with eight bytes of slack after it.
+    ///
+    /// The unpack reads eight bytes past the start of each value and works from a padded copy of the
+    /// miniblock where the page ends inside that window — which a page does whenever its last
+    /// miniblock is full. Decoding both ways puts the direct read and the copied one against each
+    /// other; without the slack, some shapes would only ever take the copy.
+    private static byte[] withTrailingSlack(byte[] encoded) {
+        byte[] padded = new byte[encoded.length + Long.BYTES];
+        System.arraycopy(encoded, 0, padded, 0, encoded.length);
+        return padded;
+    }
+
+    private static byte[] encode(int[] values) throws IOException {
+        try (DeltaBinaryPackingValuesWriterForInteger writer = new DeltaBinaryPackingValuesWriterForInteger(
+                BLOCK_SIZE, MINIBLOCK_COUNT, 1024, 4096, HeapByteBufferAllocator.getInstance())) {
+            for (int value : values) {
+                writer.writeInteger(value);
+            }
+            return writer.getBytes().toByteArray();
+        }
+    }
+
+    private static byte[] encode(long[] values) throws IOException {
+        try (DeltaBinaryPackingValuesWriterForLong writer = new DeltaBinaryPackingValuesWriterForLong(
+                BLOCK_SIZE, MINIBLOCK_COUNT, 1024, 4096, HeapByteBufferAllocator.getInstance())) {
+            for (long value : values) {
+                writer.writeLong(value);
+            }
+            return writer.getBytes().toByteArray();
+        }
+    }
+
+    /// The bit widths the first block declares, read straight out of the encoded header.
+    private static int[] declaredBitWidths(byte[] encoded) {
+        int[] pos = { 0 };
+        uleb128(encoded, pos); // block size
+        int miniblockCount = uleb128(encoded, pos);
+        uleb128(encoded, pos); // total value count
+        uleb128(encoded, pos); // first value, zigzag
+        uleb128(encoded, pos); // block minimum delta, zigzag
+
+        int[] widths = new int[miniblockCount];
+        for (int i = 0; i < miniblockCount; i++) {
+            widths[i] = encoded[pos[0]++] & 0xFF;
+        }
+        return widths;
+    }
+
+    private static int uleb128(byte[] encoded, int[] pos) {
+        int result = 0;
+        int shift = 0;
+        int b;
+        do {
+            b = encoded[pos[0]++] & 0xFF;
+            result |= (b & 0x7F) << shift;
+            shift += 7;
+        } while ((b & 0x80) != 0);
+        return result;
     }
 }

--- a/core/src/test/java/dev/hardwood/internal/encoding/DeltaBinaryPackedDecoderWidthSweepTest.java
+++ b/core/src/test/java/dev/hardwood/internal/encoding/DeltaBinaryPackedDecoderWidthSweepTest.java
@@ -1,0 +1,112 @@
+/*
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Copyright The original authors
+ *
+ *  Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package dev.hardwood.internal.encoding;
+
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.stream.IntStream;
+
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/// Sweeps every bit width 0–32 for INT32 and 0–64 for INT64 to verify the bulk miniblock
+/// decoder handles all width-specialised paths (0, 1–8, 9–32, 33–64).
+///
+/// Each case encodes 50 values: a full miniblock of 32 plus a partial miniblock of 17, which
+/// exercises the partial-last-miniblock truncation in [DeltaBinaryPackedDecoder].
+///
+/// Value construction forces the encoder to select approximately the target bit width:
+/// - Width 0: constant column — all deltas zero.
+/// - Width 1–31 (INT32) / 1–63 (INT64): most deltas = 1 (minDelta=1), one delta = 1&lt;&lt;w, so
+///   the largest residual is (1&lt;&lt;w)-1 which requires exactly w bits.
+/// - Width 32 (INT32): alternating Integer.MIN_VALUE / Integer.MAX_VALUE — the wrap-around case.
+/// - Width 64 (INT64): alternating Long.MIN_VALUE / Long.MAX_VALUE — the wrap-around case.
+class DeltaBinaryPackedDecoderWidthSweepTest {
+
+    private static final int VALUE_COUNT = 50;
+
+    // ==================== INT32 ====================
+
+    static IntStream int32BitWidths() {
+        return IntStream.rangeClosed(0, 32);
+    }
+
+    @ParameterizedTest(name = "INT32 width {0}")
+    @MethodSource("int32BitWidths")
+    void sweepsInt32BitWidths(int w) throws IOException {
+        int[] values = buildInt32Values(w);
+        byte[] encoded = DeltaBinaryPackedEncoder.encodeInts(values, 0, VALUE_COUNT);
+        int[] decoded = new int[VALUE_COUNT];
+        new DeltaBinaryPackedDecoder(encoded, 0).readInts(decoded, null, 0);
+        assertThat(decoded).as("INT32 width %d", w).containsExactly(values);
+    }
+
+    private static int[] buildInt32Values(int w) {
+        int[] values = new int[VALUE_COUNT];
+        if (w == 0) {
+            // Constant column: all deltas zero
+            Arrays.fill(values, 42);
+        }
+        else if (w == 32) {
+            // Wrap-around case: delta from MAX_VALUE to MIN_VALUE wraps to 1 modulo 2^32
+            for (int i = 0; i < VALUE_COUNT; i++) {
+                values[i] = i % 2 == 0 ? Integer.MIN_VALUE : Integer.MAX_VALUE;
+            }
+        }
+        else {
+            // Most deltas = 1 (minDelta=1), one delta = 1<<w.
+            // Largest residual = (1<<w)-1, which requires exactly w bits.
+            values[0] = 0;
+            for (int i = 1; i < VALUE_COUNT; i++) {
+                values[i] = values[i - 1] + (i == 25 ? (1 << w) : 1);
+            }
+        }
+        return values;
+    }
+
+    // ==================== INT64 ====================
+
+    static IntStream int64BitWidths() {
+        return IntStream.rangeClosed(0, 64);
+    }
+
+    @ParameterizedTest(name = "INT64 width {0}")
+    @MethodSource("int64BitWidths")
+    void sweepsInt64BitWidths(int w) throws IOException {
+        long[] values = buildInt64Values(w);
+        byte[] encoded = DeltaBinaryPackedEncoder.encodeLongs(values, 0, VALUE_COUNT);
+        long[] decoded = new long[VALUE_COUNT];
+        new DeltaBinaryPackedDecoder(encoded, 0).readLongs(decoded, null, 0);
+        assertThat(decoded).as("INT64 width %d", w).containsExactly(values);
+    }
+
+    private static long[] buildInt64Values(int w) {
+        long[] values = new long[VALUE_COUNT];
+        if (w == 0) {
+            // Constant column: all deltas zero
+            Arrays.fill(values, 42L);
+        }
+        else if (w == 64) {
+            // Wrap-around case: delta from Long.MAX_VALUE to Long.MIN_VALUE wraps to 1 modulo 2^64
+            for (int i = 0; i < VALUE_COUNT; i++) {
+                values[i] = i % 2 == 0 ? Long.MIN_VALUE : Long.MAX_VALUE;
+            }
+        }
+        else {
+            // Most deltas = 1 (minDelta=1), one delta = 1L<<w.
+            // Largest residual = (1L<<w)-1, which requires exactly w bits.
+            values[0] = 0L;
+            for (int i = 1; i < VALUE_COUNT; i++) {
+                values[i] = values[i - 1] + (i == 25 ? (1L << w) : 1L);
+            }
+        }
+        return values;
+    }
+}

--- a/core/src/test/java/dev/hardwood/internal/encoding/DeltaBinaryPackedDecoderWidthSweepTest.java
+++ b/core/src/test/java/dev/hardwood/internal/encoding/DeltaBinaryPackedDecoderWidthSweepTest.java
@@ -23,9 +23,12 @@ import org.junit.jupiter.params.provider.MethodSource;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
-/// Sweeps every bit width — 0–32 for INT32, 0–64 for INT64 — across the decoder's width-specialised
-/// unpack paths (0, 1–8, 9–56, 57–64) and across both ways of draining it, in bulk and one value at
-/// a time.
+/// Sweeps every bit width — 0–32 for INT32, 0–64 for INT64 — and both ways of draining the decoder,
+/// in bulk and one value at a time.
+///
+/// One loop unpacks every width, so there is no band of widths a sweep can afford to sample rather
+/// than walk: nothing about width 21 follows from width 20 working. Only width 0 branches, and it
+/// branches away from the loop entirely.
 ///
 /// parquet-java writes the bytes. A round trip against Hardwood's own encoder cannot see the two
 /// implementations agreeing on a bit layout that the format does not have, and the layout is what
@@ -196,6 +199,39 @@ class DeltaBinaryPackedDecoderWidthSweepTest {
         assertThat(decoder.getPos()).as("%d values at width %d", count, w).isEqualTo(encoded.length);
     }
 
+    /// Layouts other than the 128/4 every writer emits.
+    ///
+    /// The block and miniblock sizes are declared per stream, not fixed by the format, and the
+    /// decoder derives from them the size of its buffer, the bytes a miniblock occupies and where a
+    /// partial last miniblock stops — so a decoder that is only ever handed 32 values per miniblock
+    /// has only ever had one set of those bounds exercised.
+    @ParameterizedTest(name = "{0}/{1}, {2} values, width {3}")
+    @MethodSource("layouts")
+    void decodesEveryBlockAndMiniblockLayout(int blockSize, int miniblockCount, int count, int w)
+            throws IOException {
+        long[] values = valuesOfWidth(count, w);
+        byte[] encoded = encode(values, blockSize, miniblockCount);
+
+        DeltaBinaryPackedDecoder decoder = new DeltaBinaryPackedDecoder(encoded, 0);
+        long[] decoded = new long[count];
+        decoder.readLongs(decoded, null, 0);
+
+        assertThat(decoded).as("%d/%d, %d values at width %d", blockSize, miniblockCount, count, w)
+                .containsExactly(values);
+        assertThat(decoder.getPos()).as("position after %d/%d", blockSize, miniblockCount)
+                .isEqualTo(encoded.length);
+    }
+
+    /// Miniblocks of 16 through 128 values, at counts that stop inside the first miniblock, inside a
+    /// later one, and past the end of the first block.
+    static Stream<Arguments> layouts() {
+        return Stream.of(new int[] { 128, 8 }, new int[] { 128, 4 }, new int[] { 128, 1 },
+                new int[] { 256, 4 }, new int[] { 1024, 8 })
+                .flatMap(layout -> Stream.of(10, 200, 1500)
+                        .flatMap(count -> Stream.of(3, 33, 64)
+                                .map(w -> Arguments.of(layout[0], layout[1], count, w))));
+    }
+
     @Test
     void refusesToReadPastTheDeclaredValueCount() throws IOException {
         byte[] encoded = encode(valuesOfWidth(VALUE_COUNT, 11));
@@ -240,8 +276,12 @@ class DeltaBinaryPackedDecoderWidthSweepTest {
     }
 
     private static byte[] encode(long[] values) throws IOException {
+        return encode(values, BLOCK_SIZE, MINIBLOCK_COUNT);
+    }
+
+    private static byte[] encode(long[] values, int blockSize, int miniblockCount) throws IOException {
         try (DeltaBinaryPackingValuesWriterForLong writer = new DeltaBinaryPackingValuesWriterForLong(
-                BLOCK_SIZE, MINIBLOCK_COUNT, 1024, 4096, HeapByteBufferAllocator.getInstance())) {
+                blockSize, miniblockCount, 1024, 4096, HeapByteBufferAllocator.getInstance())) {
             for (long value : values) {
                 writer.writeLong(value);
             }

--- a/performance-testing/micro-benchmarks/src/main/java/dev/hardwood/benchmarks/DeltaBinaryPackedDecodeBenchmark.java
+++ b/performance-testing/micro-benchmarks/src/main/java/dev/hardwood/benchmarks/DeltaBinaryPackedDecodeBenchmark.java
@@ -1,0 +1,188 @@
+/*
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Copyright The original authors
+ *
+ *  Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package dev.hardwood.benchmarks;
+
+import java.io.IOException;
+import java.util.Random;
+import java.util.concurrent.TimeUnit;
+
+import org.apache.parquet.bytes.HeapByteBufferAllocator;
+import org.apache.parquet.column.values.delta.DeltaBinaryPackingValuesWriterForInteger;
+import org.apache.parquet.column.values.delta.DeltaBinaryPackingValuesWriterForLong;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
+
+import dev.hardwood.internal.encoding.DeltaBinaryPackedDecoder;
+import dev.hardwood.internal.encoding.RleBitPackingHybridDecoder;
+import dev.hardwood.internal.encoding.RleBitPackingHybridEncoder;
+
+/// Measures DELTA_BINARY_PACKED decode throughput for INT32 and INT64 columns.
+///
+/// `rleBitPackedInts` decodes the same value count at the same bit width through
+/// [RleBitPackingHybridDecoder], which unpacks in bulk. It is the reference point
+/// for how fast unpacking that many values of that width can go; the ratio between
+/// it and `deltaInts` is the headroom in [DeltaBinaryPackedDecoder].
+///
+/// The encoded input is produced by parquet-java's writers rather than by hand, so
+/// the block and miniblock layout is the one Hardwood sees in real files.
+///
+/// Run with:
+/// ```shell
+/// java -jar benchmarks.jar DeltaBinaryPackedDecodeBenchmark
+/// ```
+@BenchmarkMode(Mode.Throughput)
+@OutputTimeUnit(TimeUnit.MILLISECONDS)
+@State(Scope.Benchmark)
+@Fork(value = 2, jvmArgs = { "-Xms512m", "-Xmx512m" })
+@Warmup(iterations = 3, time = 1)
+@Measurement(iterations = 5, time = 1)
+public class DeltaBinaryPackedDecodeBenchmark {
+
+    /// Parquet's default DELTA_BINARY_PACKED block layout: 128 values per block,
+    /// 4 miniblocks of 32 values each.
+    private static final int BLOCK_VALUES = 128;
+    private static final int MINIBLOCKS = 4;
+
+    private static final int SLAB_SIZE = 64 * 1024;
+    private static final int PAGE_SIZE = 1024 * 1024;
+
+    /// Values decoded per invocation, i.e. the size of one decoded page.
+    @Param({ "4096" })
+    private int size;
+
+    /// Bits each delta needs once min_delta has been subtracted. This is what drives
+    /// the iteration count of the bit-at-a-time unpacking loop, so it is the axis
+    /// along which the decoders are expected to diverge.
+    @Param({ "1", "5", "12", "21" })
+    private int deltaBits;
+
+    private byte[] deltaInt32Data;
+    private byte[] deltaInt64Data;
+    private byte[] rleData;
+
+    private int[] intOutput;
+    private long[] longOutput;
+
+    @Setup
+    public void setUp() throws IOException {
+        intOutput = new int[size];
+        longOutput = new long[size];
+
+        int[] expectedInts = generateValues(size, deltaBits);
+        deltaInt32Data = encodeInt32Deltas(expectedInts);
+        deltaInt64Data = encodeInt64Deltas(expectedInts);
+        rleData = encodeBitPacked(size, deltaBits);
+
+        verify(expectedInts);
+    }
+
+    /// Decode each input once and check it round-trips, so a decoder that stops early
+    /// or misreads the layout cannot quietly post a good score.
+    private void verify(int[] expectedInts) throws IOException {
+        deltaInts();
+        for (int i = 0; i < size; i++) {
+            if (intOutput[i] != expectedInts[i]) {
+                throw new IllegalStateException("DELTA_BINARY_PACKED INT32 mismatch at " + i
+                        + ": expected " + expectedInts[i] + ", got " + intOutput[i]);
+            }
+        }
+
+        deltaLongs();
+        for (int i = 0; i < size; i++) {
+            if (longOutput[i] != expectedInts[i]) {
+                throw new IllegalStateException("DELTA_BINARY_PACKED INT64 mismatch at " + i
+                        + ": expected " + expectedInts[i] + ", got " + longOutput[i]);
+            }
+        }
+
+        // The RLE reference is only a fair yardstick if the encoder chose bit-packed
+        // runs; an all-RLE stream would decode far less data than it appears to.
+        int bitPackedBytes = (size * deltaBits + 7) / 8;
+        if (rleData.length < bitPackedBytes / 2) {
+            throw new IllegalStateException("RLE reference collapsed to run-length runs: "
+                    + rleData.length + " bytes for " + size + " values of " + deltaBits + " bits");
+        }
+    }
+
+    @Benchmark
+    public int[] deltaInts() throws IOException {
+        DeltaBinaryPackedDecoder decoder = new DeltaBinaryPackedDecoder(deltaInt32Data, 0);
+        decoder.readInts(intOutput, null, 0);
+        return intOutput;
+    }
+
+    @Benchmark
+    public long[] deltaLongs() throws IOException {
+        DeltaBinaryPackedDecoder decoder = new DeltaBinaryPackedDecoder(deltaInt64Data, 0);
+        decoder.readLongs(longOutput, null, 0);
+        return longOutput;
+    }
+
+    @Benchmark
+    public int[] rleBitPackedInts() {
+        RleBitPackingHybridDecoder decoder = new RleBitPackingHybridDecoder(rleData, deltaBits);
+        decoder.readInts(intOutput, 0, size);
+        return intOutput;
+    }
+
+    /// Generate an ascending sequence whose successive deltas occupy `deltaBits` bits.
+    private static int[] generateValues(int count, int deltaBits) {
+        Random random = new Random(42);
+        int bound = 1 << deltaBits;
+
+        int[] values = new int[count];
+        int value = 0;
+        for (int i = 0; i < count; i++) {
+            values[i] = value;
+            value += random.nextInt(bound);
+        }
+        return values;
+    }
+
+    private static byte[] encodeInt32Deltas(int[] values) throws IOException {
+        try (DeltaBinaryPackingValuesWriterForInteger writer = new DeltaBinaryPackingValuesWriterForInteger(
+                BLOCK_VALUES, MINIBLOCKS, SLAB_SIZE, PAGE_SIZE, HeapByteBufferAllocator.getInstance())) {
+            for (int value : values) {
+                writer.writeInteger(value);
+            }
+            return writer.getBytes().toByteArray();
+        }
+    }
+
+    private static byte[] encodeInt64Deltas(int[] values) throws IOException {
+        try (DeltaBinaryPackingValuesWriterForLong writer = new DeltaBinaryPackingValuesWriterForLong(
+                BLOCK_VALUES, MINIBLOCKS, SLAB_SIZE, PAGE_SIZE, HeapByteBufferAllocator.getInstance())) {
+            for (int value : values) {
+                writer.writeLong(value);
+            }
+            return writer.getBytes().toByteArray();
+        }
+    }
+
+    /// Encode `count` values of `bitWidth` bits as an RLE/bit-packing hybrid run.
+    /// Values are drawn at random so the encoder emits bit-packed rather than RLE runs.
+    private static byte[] encodeBitPacked(int count, int bitWidth) {
+        Random random = new Random(42);
+        int bound = 1 << bitWidth;
+
+        RleBitPackingHybridEncoder encoder = new RleBitPackingHybridEncoder(bitWidth);
+        for (int i = 0; i < count; i++) {
+            encoder.writeInt(random.nextInt(bound));
+        }
+        return encoder.toByteArray();
+    }
+}

--- a/performance-testing/micro-benchmarks/src/main/java/dev/hardwood/benchmarks/DeltaEncodedScanBenchmark.java
+++ b/performance-testing/micro-benchmarks/src/main/java/dev/hardwood/benchmarks/DeltaEncodedScanBenchmark.java
@@ -1,0 +1,146 @@
+/*
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Copyright The original authors
+ *
+ *  Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package dev.hardwood.benchmarks;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Comparator;
+import java.util.Random;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Stream;
+
+import org.apache.avro.Schema;
+import org.apache.avro.generic.GenericData;
+import org.apache.avro.generic.GenericRecord;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.parquet.avro.AvroParquetWriter;
+import org.apache.parquet.column.ParquetProperties;
+import org.apache.parquet.hadoop.ParquetWriter;
+import org.apache.parquet.hadoop.metadata.CompressionCodecName;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.TearDown;
+import org.openjdk.jmh.annotations.Warmup;
+import org.openjdk.jmh.infra.Blackhole;
+
+import dev.hardwood.InputFile;
+import dev.hardwood.reader.ColumnReader;
+import dev.hardwood.reader.ParquetFileReader;
+
+/// End-to-end scan of a delta-encoded file, to show what the decoder's share of a real read
+/// actually is. The decoder micro-benchmarks isolate it; this one does not.
+///
+/// The file is written by parquet-java at writer version 2.0, which encodes integer columns as
+/// DELTA_BINARY_PACKED and string columns as DELTA_BYTE_ARRAY. It is generated into a temporary
+/// directory during setup, so the benchmark carries no corpus dependency.
+///
+/// Run with:
+/// ```shell
+/// java -jar benchmarks.jar DeltaEncodedScanBenchmark
+/// ```
+@BenchmarkMode(Mode.AverageTime)
+@OutputTimeUnit(TimeUnit.MILLISECONDS)
+@State(Scope.Benchmark)
+@Fork(value = 2, jvmArgs = { "-Xms1g", "-Xmx1g" })
+@Warmup(iterations = 3, time = 1)
+@Measurement(iterations = 5, time = 1)
+public class DeltaEncodedScanBenchmark {
+
+    private static final int ROW_COUNT = 2_000_000;
+
+    private static final String SCHEMA = """
+            {
+              "type": "record",
+              "name": "Event",
+              "fields": [
+                {"name": "event_id", "type": "long"},
+                {"name": "timestamp", "type": "long"},
+                {"name": "user_id", "type": "int"},
+                {"name": "path", "type": "string"}
+              ]
+            }
+            """;
+
+    private Path directory;
+    private Path file;
+
+    @Setup
+    public void setUp() throws IOException {
+        directory = Files.createTempDirectory("hardwood-delta-scan");
+        file = directory.resolve("delta_encoded.parquet");
+
+        Schema schema = new Schema.Parser().parse(SCHEMA);
+        Random random = new Random(42);
+
+        try (ParquetWriter<GenericRecord> writer = AvroParquetWriter
+                .<GenericRecord> builder(new org.apache.hadoop.fs.Path(file.toString()))
+                .withSchema(schema)
+                .withConf(new Configuration())
+                .withCompressionCodec(CompressionCodecName.UNCOMPRESSED)
+                .withWriterVersion(ParquetProperties.WriterVersion.PARQUET_2_0)
+                .withDictionaryEncoding(false)
+                .build()) {
+
+            long timestamp = 1_700_000_000_000L;
+            for (int i = 0; i < ROW_COUNT; i++) {
+                GenericRecord record = new GenericData.Record(schema);
+                record.put("event_id", (long) i);
+                timestamp += random.nextInt(1000);
+                record.put("timestamp", timestamp);
+                record.put("user_id", random.nextInt(1_000_000));
+                record.put("path", "/api/v1/resource/" + random.nextInt(100_000));
+                writer.write(record);
+            }
+        }
+    }
+
+    @TearDown
+    public void tearDown() throws IOException {
+        try (Stream<Path> entries = Files.walk(directory)) {
+            entries.sorted(Comparator.reverseOrder()).forEach(path -> path.toFile().delete());
+        }
+    }
+
+    @Benchmark
+    public void scanTimestamps(Blackhole blackhole) throws IOException {
+        try (ParquetFileReader reader = ParquetFileReader.open(InputFile.of(file));
+                ColumnReader column = reader.columnReader("timestamp")) {
+            while (column.nextBatch()) {
+                blackhole.consume(column.getLongs());
+            }
+        }
+    }
+
+    @Benchmark
+    public void scanUserIds(Blackhole blackhole) throws IOException {
+        try (ParquetFileReader reader = ParquetFileReader.open(InputFile.of(file));
+                ColumnReader column = reader.columnReader("user_id")) {
+            while (column.nextBatch()) {
+                blackhole.consume(column.getInts());
+            }
+        }
+    }
+
+    @Benchmark
+    public void scanPaths(Blackhole blackhole) throws IOException {
+        try (ParquetFileReader reader = ParquetFileReader.open(InputFile.of(file));
+                ColumnReader column = reader.columnReader("path")) {
+            while (column.nextBatch()) {
+                blackhole.consume(column.getStrings());
+            }
+        }
+    }
+}


### PR DESCRIPTION
Supersedes #1057, and builds on it: the first commit here is @ZhaoMJ's, unchanged and with their authorship intact. The three that follow rework it.

Closes #1019.

## What changed

`DeltaBinaryPackedDecoder` reads a whole **block** at a time — the unit the format hands out, one minimum delta and one bit width per miniblock followed by the bodies — and unpacks every bit width through **one loop**.

The loop is the whole of it. Value `i` starts at bit `i·bitWidth` and is at most 64 bits long, so beginning at most 7 bits into a byte it reaches at most 71; two overlapping eight-byte reads cover every width the format allows:

```java
int byteOffset = base + (bitPos >>> 3);
int shift      = bitPos & 7;
long low  = (long) LONG_LE.get(src, byteOffset);
long high = src[byteOffset + Long.BYTES] & 0xFFL;
value += delta + (((low >>> shift) | ((high << (63 - shift)) << 1)) & mask);
```

Doubling the shift on the second read is what makes it branchless: at a bit offset of zero, where the second read is unwanted, it shifts the byte out entirely.

That replaces a path per width band — a group-of-eight read up to 8, an accumulator to 32, a bit at a time above that — each with its own fallback, and the state machine around them: a header flag tested at every entry point, a running count special-cased at zero for the value the header carries, and a modulo against the block size to find a block boundary. None of it was needed. Every reader is now "drain what is buffered, else decode another block".

Alongside it: the header becomes a record read at construction, so what is fixed for a decoder's life is visibly fixed and its checks live in one place; a block is decoded straight into the caller's array wherever a whole one fits, so an INT32 column is no longer staged through a `long[]` and narrowed by a second pass; and the running value is carried in a local rather than a field, which was being stored on every value because nothing tells the compiler the destination array cannot alias the decoder.

## Numbers

End-to-end, `DeltaEncodedScanBenchmark` — 2M rows, uncompressed, one column per benchmark, medians of 6 forks, aarch64:

| column | encoding | `main` | this | |
|---|---|---|---|---|
| `timestamp` INT64 | DELTA_BINARY_PACKED, width 10 | 19.13 ms | **7.81 ms** | **2.45×** |
| `user_id` INT32 | DELTA_BINARY_PACKED, width 21 | 26.86 ms | **10.49 ms** | **2.56×** |
| `path` BYTE_ARRAY | DELTA_BYTE_ARRAY, lengths width 1–5 | 120.72 ms | 110.45 ms | 1.09× |

Per-fork spread is 1.04× on `main` and 1.08–1.15× here, and the integer distributions do not overlap. The BYTE_ARRAY figure has an outlier reaching into `main`'s range, so read it as suggestive: the decoder only handles that column's two length streams, and `String` construction dominates.

Decoder throughput alone, by bit width (M values/s, one decoder over a pre-encoded page — not a read speedup, it isolates the kernel):

| width | 1 | 10 | 21 | 40 | 64 |
|---|---|---|---|---|---|
| `main` | 252 | 164 | 106 | 80 | 49 |
| this | 846 | 907 | 868 | 896 | 805 |

Flat at ~1.1 ns/value across the range, where it used to fall away as the width grew. Width 64 is where unordered INT64 columns land.

## Robustness

The buffer was sized from the header's block size, which the file controls. A header declaring 2^30 values per miniblock is legal — a multiple of 128, divisible by the miniblock count — and says nothing about how many values the page holds, so a five-value page asked for an 8 GiB `long[]` and took the reader out with an `OutOfMemoryError` on a page the previous decoder read without incident. The declared total bounds what can be drained, so it bounds the buffer. Covered by `DeltaBinaryPackedDecoderHeaderTest`, along with a negative miniblock count, which reached the header from a ULEB128 wide enough to overflow the int and surfaced as `NegativeArraySizeException`.

## On SIMD

#1019 and #1057 both record that the serial prefix sum is the floor, and that vectorising the unpack therefore cannot pay. **The conclusion holds; the reason does not, and should not be relied on.** Measured on a pinned 1.5 GHz box, a bare prefix sum over 4096 residuals runs at 302 ops/ms against a fused decode of 51–58 — the decoder sat at 17–20% of that floor, not the ~85% the earlier numbers imply. The prefix sum was roughly five times faster than the decoder and was never what bound it.

What is true, and verified rather than assumed:

- `DeltaBinaryPackedDecoder` references nothing in the `simd` package, before or after this change.
- `SimdOperations.unpackBitWidth1` / `unpackBitWidthN` have no production caller; `VectorOperations.unpackBitWidthN` is identical to the scalar implementation but for one comment, and its contract (writes `int[]`, loads `bitWidth` bytes into a `long`, masks with an `int` shift) is correct only to width 8.
- Running the end-to-end scan with and without `--add-modules jdk.incubator.vector` moves it 0.97–1.00×, on both `main` and this branch. `VectorSupport` reports `simd-256bit` under the flag and `scalar` without, so the comparison is real.

`perfnorm` puts the decoder at IPC 4.5–4.7 on a 5-wide core with negligible branch, LLC and TLB misses — it is instruction-bound, not stalled. `perfasm` shows what remains: the two bounds checks per value that the compiler cannot hoist, and spills, with the mask, bit width, destination and both bounds limits reloaded from the stack inside the loop. Register pressure is the ceiling now, not the bit arithmetic. The same correction applies to the FastLanes note in #1019: shortening a dependency chain cannot help something that is not dependency-bound.

## Tests

`DeltaBinaryPackedDecoderWidthSweepTest` encodes with **parquet-java** rather than round-tripping Hardwood's own encoder, which cannot see two implementations agreeing on a bit layout the format does not have. It asserts the width the encoder actually chose before asserting values — the previous sweep named two cases after the ceiling widths and encoded both at width 2, so those widths went untested. It covers widths 0–32 for INT32 and 0–64 for INT64, in bulk and one value at a time, at value counts that end a page on a full miniblock, on a partial one, and midway through a block, each decoded both as encoded and with eight bytes of slack so the wide read and its fallback are both exercised. It also pins the position the decoder leaves behind, which `DeltaLengthByteArrayDecoder` and `DeltaByteArrayDecoder` depend on and nothing asserted.

Verified independently against parquet-java as encoding oracle for every width 0–64 and for block/miniblock layouts from 16 to 128 values per miniblock.