### PR TITLE
#965 Validate fixed-length byte array width before allocation

### DIFF
--- a/core/src/main/java/dev/hardwood/internal/reader/BatchExchange.java
+++ b/core/src/main/java/dev/hardwood/internal/reader/BatchExchange.java
@@ -282,7 +282,11 @@ public class BatchExchange<B> {
                 yield bbv;
             }
             case FIXED_LEN_BYTE_ARRAY -> {
-                int width = column.typeLength();
+                Integer width = column.typeLength();
+                if (width == null) {
+                    throw new IllegalArgumentException(
+                            "FIXED_LEN_BYTE_ARRAY column " + column.fieldPath() + " has no type length");
+                }
                 byte[] bytes = new byte[Math.multiplyExact(width, capacity)];
                 int[] offsets = new int[capacity + 1];
                 for (int i = 0; i <= capacity; i++) {

--- a/core/src/main/java/dev/hardwood/internal/reader/NestedColumnWorker.java
+++ b/core/src/main/java/dev/hardwood/internal/reader/NestedColumnWorker.java
@@ -769,7 +769,11 @@ public class NestedColumnWorker extends ColumnWorker<NestedBatch> {
         }
         int[] newOffsets = Arrays.copyOf(bbv.offsets, newCapacity + 1);
         if (physicalType == PhysicalType.FIXED_LEN_BYTE_ARRAY) {
-            int width = column.typeLength();
+            Integer width = column.typeLength();
+            if (width == null) {
+                throw new IllegalArgumentException(
+                        "FIXED_LEN_BYTE_ARRAY column " + column.fieldPath() + " has no type length");
+            }
             for (int i = oldCapacity + 1; i <= newCapacity; i++) {
                 newOffsets[i] = Math.multiplyExact(i, width);
             }

--- a/core/src/test/java/dev/hardwood/internal/reader/ColumnWorkerTest.java
+++ b/core/src/test/java/dev/hardwood/internal/reader/ColumnWorkerTest.java
@@ -8,6 +8,7 @@
 package dev.hardwood.internal.reader;
 
 import java.nio.file.Path;
+import java.util.List;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.Executor;
 import java.util.concurrent.TimeUnit;
@@ -19,6 +20,8 @@ import org.junit.jupiter.api.Timeout;
 import dev.hardwood.InputFile;
 import dev.hardwood.internal.schema.ProjectedSchema;
 import dev.hardwood.metadata.PhysicalType;
+import dev.hardwood.metadata.RepetitionType;
+import dev.hardwood.metadata.SchemaElement;
 import dev.hardwood.reader.ParquetFileReader;
 import dev.hardwood.schema.ColumnSchema;
 import dev.hardwood.schema.FileSchema;
@@ -242,6 +245,29 @@ class ColumnWorkerTest {
                     .isInstanceOf(RuntimeException.class)
                     .hasMessageContaining("Simulated pipeline error");
         }
+    }
+
+    /// A FIXED_LEN_BYTE_ARRAY with no type length must fail with a controlled reader error.
+    @Test
+    void allocateArrayRejectsFixedWithoutTypeLength() {
+        SchemaElement root = new SchemaElement("schema", null, null, null,
+                1, null, null, null,
+                null, null);
+        SchemaElement parent = new SchemaElement(
+                "parent", null, null, RepetitionType.REQUIRED,
+                1, null, null, null,
+                null, null);
+        SchemaElement digest = new SchemaElement("digest", PhysicalType.FIXED_LEN_BYTE_ARRAY, null,
+                RepetitionType.REQUIRED, null, null, null, null,
+                null, null);
+
+        FileSchema schema = FileSchema.fromSchemaElements(List.of(root, parent, digest));
+        ColumnSchema column = schema.getColumn("parent.digest");
+
+        assertThat(column.typeLength()).isNull();
+        assertThatThrownBy(() -> BatchExchange.allocateArray(column, 1024))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("FIXED_LEN_BYTE_ARRAY column parent.digest has no type length");
     }
 
     /// Nested pipeline delivers all rows with pre-computed index structures.


### PR DESCRIPTION
Fixes #965

## Authorship

Hardwood is built with AI, not by AI. LLM assistance is welcome; submitting raw LLM output without understanding is not.
Neither are unattended agents opening pull requests.
See the [contribution guide](https://github.com/hardwood-hq/hardwood/blob/main/CONTRIBUTING.md) for more details.
Check this box to confirm:

- [x] This change is coming from a human who understands what it does and why, and can discuss it in review

## Checklist

- [ ] Build via `./mvnw clean verify` passes
- [x] The commit message is prefixed with the issue key ("#123 Adding support for...")
- [x] Code changes are covered by tests
- [ ] If this PR adds or changes user-facing behaviour, `docs/` has been updated
