### PR TITLE
#1062 Stop presenting independent column readers as row-aligned

### DIFF
--- a/_designs/COLUMN_READER_ARROW_LAYOUT.md
+++ b/_designs/COLUMN_READER_ARROW_LAYOUT.md
@@ -407,10 +407,13 @@ for (int r = 0; r < recordCount; r++) {
 drive them in lockstep on shared layer offsets:
 
 ```java
-try (ColumnReader keys   = reader.columnReader("tags.key_value.key");
-     ColumnReader values = reader.columnReader("tags.key_value.value")) {
+try (ColumnReaders columns = reader.columnReaders(
+        ColumnProjection.columns("tags.key_value.key", "tags.key_value.value"))) {
 
-    while (keys.nextBatch() & values.nextBatch()) {
+    ColumnReader keys   = columns.getColumnReader("tags.key_value.key");
+    ColumnReader values = columns.getColumnReader("tags.key_value.value");
+
+    while (columns.nextBatch()) {
         int[]    entryOffsets  = keys.getLayerOffsets(0);
         Validity mapValidity   = keys.getLayerValidity(0);
         byte[]   keyBytes      = keys.getBinaryValues();

--- a/_designs/MULTI_FILE_COLUMN_READER.md
+++ b/_designs/MULTI_FILE_COLUMN_READER.md
@@ -57,8 +57,8 @@ try (Hardwood hardwood = Hardwood.create();
     ColumnReader col1 = columns.getColumnReader("trip_distance");
     ColumnReader col2 = columns.getColumnReader("fare_amount");
 
-    while (col0.nextBatch() & col1.nextBatch() & col2.nextBatch()) {
-        int count = col0.getRecordCount();
+    while (columns.nextBatch()) {
+        int count = columns.getRecordCount();
         double[] v0 = col0.getDoubles();
         double[] v1 = col1.getDoubles();
         double[] v2 = col2.getDoubles();

--- a/core/src/main/java/dev/hardwood/reader/ColumnReader.java
+++ b/core/src/main/java/dev/hardwood/reader/ColumnReader.java
@@ -151,18 +151,25 @@ public class ColumnReader implements AutoCloseable {
 
     /// Advance to the next batch.
     ///
-    /// **Multi-column alignment.** Every [ColumnReader] over the same file produces
-    /// batches at the same row boundaries — call `nextBatch()` on each in turn and they
-    /// will report identical [#getRecordCount()]s for the matching batch. This holds
-    /// because the per-column drain workers all use the same internal batch capacity and
-    /// every reader observes the same total row count per row group.
+    /// **One reader advances only itself.** Readers built separately — each from its own
+    /// [ParquetFileReader#buildColumnReader(String)] — are independent cursors, and the
+    /// batch a reader hands out is sized for the columns *it* reads. A batch of a
+    /// `BYTE_ARRAY` column therefore covers fewer rows than a batch of an `INT32` one over
+    /// the same file, and a filtered reader is sized for its predicate's columns as well as
+    /// its own. Two such readers reach different rows on their nth batch.
     ///
-    /// Consumers reading multiple columns in lockstep should generally prefer
-    /// [ColumnReaders] (obtained from
-    /// [ParquetFileReader#buildColumnReaders(dev.hardwood.schema.ColumnProjection)]),
-    /// which shares a single [dev.hardwood.internal.reader.RowGroupIterator] across all
-    /// columns and exposes a single coordinated [ColumnReaders#nextBatch()] that drives
-    /// every reader and validates alignment in one call.
+    /// So do not pair them: `while (a.nextBatch() & b.nextBatch())` ends when whichever
+    /// reader has the larger batches runs out first, and the values it took from each on any
+    /// given turn are from different rows. Neither reader reports anything wrong, because
+    /// neither is wrong — each is a complete, correct read of its own column.
+    ///
+    /// To read several columns of the same rows, use [ColumnReaders], from
+    /// [ParquetFileReader#buildColumnReaders(dev.hardwood.schema.ColumnProjection)]. Its
+    /// readers share one [dev.hardwood.internal.reader.RowGroupIterator] and one batch size,
+    /// and [ColumnReaders#nextBatch()] advances them together and checks that their record
+    /// counts agree. Advance them through that method rather than this one: this method moves
+    /// a single reader, so calling it on one member of a [ColumnReaders] leaves the rest
+    /// behind on the batch they already hold.
     ///
     /// @return true if a batch is available, false if exhausted
     public boolean nextBatch() {

--- a/core/src/main/java/dev/hardwood/reader/ColumnReaders.java
+++ b/core/src/main/java/dev/hardwood/reader/ColumnReaders.java
@@ -37,7 +37,7 @@ import dev.hardwood.schema.FileSchema;
 ///
 ///     while (columns.nextBatch()) {
 ///         int count = columns.getRecordCount();
-///         double[] v0 = columns.getColumnReader(0).getDoubles();
+///         double[] v0 = columns.getColumnReader(0).getInts();
 ///         double[] v1 = columns.getColumnReader(1).getDoubles();
 ///         double[] v2 = columns.getColumnReader(2).getDoubles();
 ///         // ...

--- a/core/src/main/java/dev/hardwood/reader/ColumnReaders.java
+++ b/core/src/main/java/dev/hardwood/reader/ColumnReaders.java
@@ -196,9 +196,10 @@ public class ColumnReaders implements AutoCloseable {
     /// happen — the guard exists to detect future regressions in the per-column drain
     /// workers, not to be triggered in production.
     ///
-    /// Single-column consumers, or consumers that need fine-grained control over the
-    /// per-reader cadence, can still call [ColumnReader#nextBatch()] directly on the
-    /// readers returned by [#getColumnReader(int)] / [#getColumnReader(String)].
+    /// This method is how these readers are advanced. [ColumnReader#nextBatch()] on one of
+    /// them moves that reader alone and leaves its siblings on the batch they already hold;
+    /// the counts still match, so the guard above stays silent and every later batch pairs
+    /// values from different rows.
     ///
     /// @return true if a new aligned batch is available across all readers, false if exhausted
     /// @throws IllegalStateException if the readers report mismatched record counts

--- a/core/src/test/java/dev/hardwood/BloomFilterEndToEndTest.java
+++ b/core/src/test/java/dev/hardwood/BloomFilterEndToEndTest.java
@@ -79,11 +79,11 @@ class BloomFilterEndToEndTest {
             try (ColumnReaders cols = reader.buildColumnReaders(projection).filter(PRESENT).build()) {
                 ColumnReader code = cols.getColumnReader("code");
                 ColumnReader id = cols.getColumnReader("id");
-                assertThat(code.nextBatch() & id.nextBatch()).isTrue();
-                assertThat(code.getRecordCount()).isEqualTo(1);
+                assertThat(cols.nextBatch()).isTrue();
+                assertThat(cols.getRecordCount()).isEqualTo(1);
                 assertThat(code.getInts()[0]).isEqualTo(3);
                 assertThat(id.getLongs()[0]).isEqualTo(1L); // code = id*3, so code==3 is id==1
-                assertThat(code.nextBatch() & id.nextBatch()).isFalse();
+                assertThat(cols.nextBatch()).isFalse();
             }
         }
     }

--- a/core/src/test/java/dev/hardwood/ColumnReadersTest.java
+++ b/core/src/test/java/dev/hardwood/ColumnReadersTest.java
@@ -15,6 +15,7 @@ import org.junit.jupiter.api.Test;
 
 import dev.hardwood.reader.ColumnReader;
 import dev.hardwood.reader.ColumnReaders;
+import dev.hardwood.reader.FilterPredicate;
 import dev.hardwood.reader.ParquetFileReader;
 import dev.hardwood.schema.ColumnProjection;
 
@@ -607,5 +608,95 @@ class ColumnReadersTest {
             assertThat(totalRows).isEqualTo(300);
             assertThat(batches).isGreaterThanOrEqualTo(1);
         }
+    }
+
+    // ==================== Multi-column alignment (#1062) ====================
+
+    @Test
+    void testCoordinatedNextBatchKeepsMixedWidthColumnsAligned() throws Exception {
+        // Readers built separately batch at their own row boundaries, so pairing them reads
+        // different rows from each. ColumnReaders carries that guarantee instead, and it has
+        // to hold across batch and row-group boundaries for columns of different physical
+        // widths — INT64 `id`/`value` alongside BYTE_ARRAY `label`.
+        Path filePath = Paths.get("src/test/resources/filter_pushdown_int.parquet");
+
+        try (ParquetFileReader parquet = ParquetFileReader.open(InputFile.of(filePath));
+             ColumnReaders columns = parquet.buildColumnReaders(
+                             ColumnProjection.columns("id", "value", "label"))
+                     .batchSize(7).build()) {
+
+            ColumnReader idReader = columns.getColumnReader("id");
+            ColumnReader valueReader = columns.getColumnReader("value");
+            ColumnReader labelReader = columns.getColumnReader("label");
+
+            int batches = 0;
+            long totalRows = 0;
+            while (columns.nextBatch()) {
+                int count = columns.getRecordCount();
+                assertThat(idReader.getRecordCount()).isEqualTo(count);
+                assertThat(valueReader.getRecordCount()).isEqualTo(count);
+                assertThat(labelReader.getRecordCount()).isEqualTo(count);
+
+                long[] ids = idReader.getLongs();
+                long[] values = valueReader.getLongs();
+                String[] labels = labelReader.getStrings();
+                for (int i = 0; i < count; i++) {
+                    assertThat(values[i]).isEqualTo(ids[i]);
+                    assertThat(labels[i]).isEqualTo(expectedLabel(ids[i]));
+                }
+
+                batches++;
+                totalRows += count;
+            }
+
+            assertThat(batches).isGreaterThan(1);
+            assertThat(totalRows).isEqualTo(300);
+        }
+    }
+
+    @Test
+    void testCoordinatedNextBatchKeepsFilteredColumnsAligned() throws Exception {
+        // #1062 in miniature: a filtered read of several columns must return every matching
+        // row of every column, paired row for row. The batch size is small enough that the
+        // match set spans many batches and a row-group boundary, and the predicate column is
+        // not projected, so it is decoded to evaluate the filter but never exposed.
+        Path filePath = Paths.get("src/test/resources/filter_pushdown_int.parquet");
+
+        try (ParquetFileReader parquet = ParquetFileReader.open(InputFile.of(filePath));
+             ColumnReaders columns = parquet.buildColumnReaders(
+                             ColumnProjection.columns("value", "label"))
+                     .filter(FilterPredicate.gt("id", 120L))
+                     .batchSize(7).build()) {
+
+            ColumnReader valueReader = columns.getColumnReader("value");
+            ColumnReader labelReader = columns.getColumnReader("label");
+
+            int batches = 0;
+            long totalRows = 0;
+            while (columns.nextBatch()) {
+                int count = columns.getRecordCount();
+                assertThat(valueReader.getRecordCount()).isEqualTo(count);
+                assertThat(labelReader.getRecordCount()).isEqualTo(count);
+
+                long[] values = valueReader.getLongs();
+                String[] labels = labelReader.getStrings();
+                for (int i = 0; i < count; i++) {
+                    assertThat(values[i]).isGreaterThan(120L);
+                    assertThat(labels[i]).isEqualTo(expectedLabel(values[i]));
+                }
+
+                batches++;
+                totalRows += count;
+            }
+
+            assertThat(batches).isGreaterThan(1);
+            assertThat(totalRows).isEqualTo(180); // id 121..300
+        }
+    }
+
+    /// `filter_pushdown_int.parquet` labels every row `rg<N>_<id>`, `N` being its 1-based
+    /// hundred, so a label identifies the exact row its neighbours must have come from.
+    private static String expectedLabel(long id) {
+        return "rg" + ((id - 1) / 100 + 1) + "_" + id;
     }
 }

--- a/core/src/test/java/dev/hardwood/DictionaryEndToEndTest.java
+++ b/core/src/test/java/dev/hardwood/DictionaryEndToEndTest.java
@@ -79,7 +79,7 @@ class DictionaryEndToEndTest {
             try (ColumnReaders cols = reader.buildColumnReaders(projection).filter(PRESENT).build()) {
                 ColumnReader category = cols.getColumnReader("category");
                 ColumnReader id = cols.getColumnReader("id");
-                assertThat(category.nextBatch() & id.nextBatch()).isTrue();
+                assertThat(cols.nextBatch()).isTrue();
                 assertThat(category.getStrings()[0]).isEqualTo("cat_5");
                 // category is "cat_" + (id % 10), so the first match is id == 5.
                 assertThat(id.getLongs()[0]).isEqualTo(5L);

--- a/core/src/test/java/dev/hardwood/PredicatePushDownTest.java
+++ b/core/src/test/java/dev/hardwood/PredicatePushDownTest.java
@@ -1085,8 +1085,8 @@ class PredicatePushDownTest {
             ColumnReader valueReader = columns.getColumnReader("value");
 
             int totalRows = 0;
-            while (idReader.nextBatch() & valueReader.nextBatch()) {
-                int count = idReader.getRecordCount();
+            while (columns.nextBatch()) {
+                int count = columns.getRecordCount();
                 long[] ids = idReader.getLongs();
                 long[] values = valueReader.getLongs();
                 for (int i = 0; i < count; i++) {
@@ -1127,8 +1127,8 @@ class PredicatePushDownTest {
             ColumnReader labelReader = columns.getColumnReader("label");
 
             int totalRows = 0;
-            while (valueReader.nextBatch() & labelReader.nextBatch()) {
-                int count = valueReader.getRecordCount();
+            while (columns.nextBatch()) {
+                int count = columns.getRecordCount();
                 long[] values = valueReader.getLongs();
                 String[] labels = labelReader.getStrings();
                 for (int i = 0; i < count; i++) {

--- a/core/src/test/java/dev/hardwood/internal/reader/PageRangeIoTest.java
+++ b/core/src/test/java/dev/hardwood/internal/reader/PageRangeIoTest.java
@@ -114,10 +114,8 @@ class PageRangeIoTest {
                     ? parquet.buildColumnReaders(projection).filter(filter).build()
                     : parquet.columnReaders(projection);
             try (columns) {
-                ColumnReader col0 = columns.getColumnReader("id");
-                ColumnReader col1 = columns.getColumnReader("value");
-                while (col0.nextBatch() & col1.nextBatch()) {
-                    col0.getRecordCount();
+                while (columns.nextBatch()) {
+                    // Drain every batch; the test measures the bytes the read pulled.
                 }
             }
         }

--- a/docs/content/concepts/reader-models.md
+++ b/docs/content/concepts/reader-models.md
@@ -79,6 +79,24 @@ scans. The full mechanics — layer counts per schema shape, the empty-vs-null d
 hot-loop null-check shapes — are documented in
 [Read Column by Column](../how-to/column-reader.md).
 
+## Several columns means one `ColumnReaders`, not several `ColumnReader`s
+
+A `ColumnReader` is a cursor over one column, and each one built separately is sized for itself.
+Batch capacity is a byte budget divided by the widths of the columns that reader projects, so a
+`BYTE_ARRAY` column batches at fewer rows than an `INT32` one over the same file, and a filtered
+reader is sized for its predicate's columns as well as its own. Two readers built independently
+therefore reach different rows on their *n*th batch.
+
+That makes `while (a.nextBatch() & b.nextBatch())` the wrong shape for reading two columns of the
+same rows: the loop stops when whichever reader has the larger batches runs out, and the values it
+took from each on any given turn came from different rows. Neither reader reports a problem,
+because neither has one — each is a complete, correct read of its own column.
+
+`ColumnReaders` is the multi-column read. Its readers share one row-group iterator and one batch
+size, and `ColumnReaders.nextBatch()` advances all of them together and checks that they agree.
+Reach for a bare `ColumnReader` when you want one column, and for `ColumnReaders` the moment you
+want two.
+
 ## They are not exclusive
 
 Nothing forces a single choice per file. A pipeline can open a `ColumnReader` to compute an

--- a/docs/content/how-to/column-reader.md
+++ b/docs/content/how-to/column-reader.md
@@ -56,7 +56,7 @@ A filtered column reader returns **only** the matching rows — exact, with no c
 
 ### Reading Multiple Columns
 
-For reading multiple columns together, use `columnReaders(projection)` which returns a `ColumnReaders` collection. Drive every reader in lockstep with `ColumnReaders.nextBatch()`:
+For reading multiple columns together, use `columnReaders(projection)` which returns a `ColumnReaders` collection. Drive every reader in lockstep with `ColumnReaders.nextBatch()`. Open the columns together rather than building one `ColumnReader` per column: separately built readers batch at different row boundaries, so pairing them by index reads different rows from each (see [RowReader vs. ColumnReader](../concepts/reader-models.md#several-columns-means-one-columnreaders-not-several-columnreaders)).
 
 ```java
 import dev.hardwood.Hardwood;
@@ -100,7 +100,9 @@ try (ColumnReaders columns = parquet.buildColumnReaders(
 
 The batch size caps the number of **records** per batch, never the number of leaf values. A batch boundary always falls between records: a record — and, for a repeated column, all of the leaf values belonging to it — is never split across two batches. A consequence for repeated columns is that `getValueCount()` can exceed the configured batch size, since one record may carry many leaf values; size any per-value buffers off `getValueCount()`, not the batch size.
 
-`ColumnReaders.nextBatch()` advances every underlying reader once and returns `false` when any reader is exhausted — partial advancement isn't possible because all readers consume from a shared `RowGroupIterator`. The aligned record count is exposed via `ColumnReaders.getRecordCount()`. As a defensive guard, mismatched per-reader record counts throw `IllegalStateException`. Single-column consumers, or callers that need fine-grained per-reader cadence, can still call `ColumnReader.nextBatch()` directly on the readers returned by `getColumnReader(...)`.
+`ColumnReaders.nextBatch()` advances every underlying reader once and returns `false` when any reader is exhausted — partial advancement isn't possible because all readers consume from a shared `RowGroupIterator`. The aligned record count is exposed via `ColumnReaders.getRecordCount()`. As a defensive guard, mismatched per-reader record counts throw `IllegalStateException`.
+
+`ColumnReaders.nextBatch()` is how the readers it holds are advanced. `ColumnReader.nextBatch()` moves one reader, so calling it on a reader from `getColumnReader(...)` leaves that reader's siblings on the batch they already hold — the record counts still match, the guard stays silent, and every later batch pairs values from different rows.
 
 ### Retaining and Handing Off Batch Arrays
 
@@ -345,14 +347,17 @@ try (ColumnReader col = reader.columnReader("tags.list.element")) {
 
 Maps report as `REPEATED` (Hardwood does not distinguish map-shape from list-shape on the layer enum — consult `getColumnSchema()` if you need that distinction).
 
-To pair keys with values, open both leaves and drive them in lockstep. The two columns share the same `map.key_value` parent, so their layer offsets agree — entry `i` of one is entry `i` of the other:
+To pair keys with values, open both leaves through `columnReaders(...)` and drive them with `ColumnReaders.nextBatch()`. The two columns share the same `map.key_value` parent, so their layer offsets agree — entry `i` of one is entry `i` of the other. Open them together: a key and a value built as separate `ColumnReader`s batch at different row boundaries.
 
 ```java
-try (ColumnReader keys   = reader.columnReader("tags.key_value.key");
-     ColumnReader values = reader.columnReader("tags.key_value.value")) {
+try (ColumnReaders columns = reader.columnReaders(
+        ColumnProjection.columns("tags.key_value.key", "tags.key_value.value"))) {
 
-    while (keys.nextBatch() & values.nextBatch()) {
-        int recordCount        = keys.getRecordCount();
+    ColumnReader keys   = columns.getColumnReader("tags.key_value.key");
+    ColumnReader values = columns.getColumnReader("tags.key_value.value");
+
+    while (columns.nextBatch()) {
+        int recordCount        = columns.getRecordCount();
         int[]    entryOffsets  = keys.getLayerOffsets(0);
         Validity mapValidity   = keys.getLayerValidity(0);
         byte[]   keyBytes      = keys.getBinaryValues();
@@ -384,7 +389,7 @@ try (ColumnReader keys   = reader.columnReader("tags.key_value.key");
 
 Two orthogonal offset axes show up here, as in `list<string>`: `entryOffsets` walks map entries within a record (across the `getValueCount()` axis), `keyOffsets` walks byte spans within a single key (across the byte axis of `getBinaryValues()`).
 
-If the map sits under an `OPTIONAL` group — e.g. `optional group meta { map<string, int> tags }` — the chain gains a `STRUCT` layer on top. The same key/value lockstep walk applies, with `getLayerValidity(0)` for `meta`, `getLayerValidity(1)` plus `getLayerOffsets(1)` for the map, and `getLeafValidity()` for the value:
+If the map sits under an `OPTIONAL` group — e.g. `optional group meta { map<string, int> tags }` — the chain gains a `STRUCT` layer on top. The same key/value walk applies, with `getLayerValidity(0)` for `meta`, `getLayerValidity(1)` plus `getLayerOffsets(1)` for the map, and `getLeafValidity()` for the value:
 
 ```java
 Validity metaValidity  = values.getLayerValidity(0);   // STRUCT layer for `meta`

--- a/docs/content/how-to/column-reader.md
+++ b/docs/content/how-to/column-reader.md
@@ -56,7 +56,7 @@ A filtered column reader returns **only** the matching rows — exact, with no c
 
 ### Reading Multiple Columns
 
-For reading multiple columns together, use `columnReaders(projection)` which returns a `ColumnReaders` collection. Drive every reader in lockstep with `ColumnReaders.nextBatch()`. Open the columns together rather than building one `ColumnReader` per column: separately built readers batch at different row boundaries, so pairing them by index reads different rows from each (see [RowReader vs. ColumnReader](../concepts/reader-models.md#several-columns-means-one-columnreaders-not-several-columnreaders)).
+For reading multiple columns together, use `columnReaders(projection)` which returns a `ColumnReaders` collection. Drive every reader in lockstep with `ColumnReaders.nextBatch()`. Open the columns together rather than building one `ColumnReader` per column: separately built readers batch at different row boundaries, so pairing their values by position reads different rows from each (see [RowReader vs. ColumnReader](../concepts/reader-models.md#several-columns-means-one-columnreaders-not-several-columnreaders)).
 
 ```java
 import dev.hardwood.Hardwood;

--- a/performance-testing/end-to-end/src/test/java/dev/hardwood/perf/NestedPerformanceTest.java
+++ b/performance-testing/end-to-end/src/test/java/dev/hardwood/perf/NestedPerformanceTest.java
@@ -31,12 +31,14 @@ import dev.hardwood.Hardwood;
 import dev.hardwood.InputFile;
 import dev.hardwood.Validity;
 import dev.hardwood.reader.ColumnReader;
+import dev.hardwood.reader.ColumnReaders;
 import dev.hardwood.reader.LayerKind;
 import dev.hardwood.reader.ParquetFileReader;
 import dev.hardwood.reader.RowReader;
 import dev.hardwood.row.PqList;
 import dev.hardwood.row.PqMap;
 import dev.hardwood.row.PqStruct;
+import dev.hardwood.schema.ColumnProjection;
 import dev.hardwood.schema.SchemaNode;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -639,10 +641,6 @@ class NestedPerformanceTest {
         try (Hardwood hardwood = Hardwood.create();
              ParquetFileReader reader = hardwood.open(InputFile.of(DATA_FILE))) {
 
-            // Resolve column indices from schema
-            int versionColIdx = reader.getFileSchema().getColumn("version").columnIndex();
-            int confidenceColIdx = reader.getFileSchema().getColumn("confidence").columnIndex();
-
             // Find bbox leaf columns by walking the schema tree
             SchemaNode.GroupNode root = reader.getFileSchema().getRootNode();
             SchemaNode.GroupNode bboxNode = (SchemaNode.GroupNode) findChild(root, "bbox");
@@ -660,10 +658,12 @@ class NestedPerformanceTest {
             int namesPrimaryColIdx = ((SchemaNode.PrimitiveNode) findChild(namesNode, "primary")).columnIndex();
 
             // Read flat primitives: version and confidence
-            try (ColumnReader versionCol = reader.columnReader(versionColIdx);
-                 ColumnReader confidenceCol = reader.columnReader(confidenceColIdx)) {
-                while (versionCol.nextBatch() & confidenceCol.nextBatch()) {
-                    int count = versionCol.getRecordCount();
+            try (ColumnReaders columns = reader.columnReaders(
+                    ColumnProjection.columns("version", "confidence"))) {
+                ColumnReader versionCol = columns.getColumnReader("version");
+                ColumnReader confidenceCol = columns.getColumnReader("confidence");
+                while (columns.nextBatch()) {
+                    int count = columns.getRecordCount();
                     int[] versions = versionCol.getInts();
                     double[] confidences = confidenceCol.getDoubles();
                     Validity vValid = versionCol.getLeafValidity();
@@ -690,10 +690,14 @@ class NestedPerformanceTest {
             }
 
             // Read bbox leaf columns
-            try (ColumnReader xminCol = reader.columnReader(bboxXminColIdx);
-                 ColumnReader xmaxCol = reader.columnReader(bboxXmaxColIdx)) {
-                while (xminCol.nextBatch() & xmaxCol.nextBatch()) {
-                    int count = xminCol.getRecordCount();
+            String xminName = columnName(reader, bboxXminColIdx);
+            String xmaxName = columnName(reader, bboxXmaxColIdx);
+            try (ColumnReaders columns = reader.columnReaders(
+                    ColumnProjection.columns(xminName, xmaxName))) {
+                ColumnReader xminCol = columns.getColumnReader(xminName);
+                ColumnReader xmaxCol = columns.getColumnReader(xmaxName);
+                while (columns.nextBatch()) {
+                    int count = columns.getRecordCount();
                     double[] xmins = xminCol.getDoubles();
                     double[] xmaxs = xmaxCol.getDoubles();
                     Validity xminValid = xminCol.getLeafValidity();
@@ -814,6 +818,12 @@ class NestedPerformanceTest {
             }
         }
         throw new IllegalArgumentException("Child not found: " + name + " in " + group.name());
+    }
+
+    /// The path of a leaf found by walking the schema tree, which reaches a node carrying a
+    /// column index where [dev.hardwood.schema.ColumnProjection] addresses columns by path.
+    private static String columnName(ParquetFileReader reader, int columnIndex) {
+        return reader.getFileSchema().getColumn(columnIndex).fieldPath().toString();
     }
 
     private static int findFirstLeafColumnIndex(SchemaNode node) {

--- a/performance-testing/end-to-end/src/test/java/dev/hardwood/perf/PageFilterBenchmarkTest.java
+++ b/performance-testing/end-to-end/src/test/java/dev/hardwood/perf/PageFilterBenchmarkTest.java
@@ -25,8 +25,10 @@ import org.junit.jupiter.api.Test;
 
 import dev.hardwood.InputFile;
 import dev.hardwood.reader.ColumnReader;
+import dev.hardwood.reader.ColumnReaders;
 import dev.hardwood.reader.FilterPredicate;
 import dev.hardwood.reader.ParquetFileReader;
+import dev.hardwood.schema.ColumnProjection;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -131,11 +133,11 @@ class PageFilterBenchmarkTest {
         double sum = 0.0;
 
         try (ParquetFileReader reader = ParquetFileReader.open(InputFile.of(BENCHMARK_FILE));
-             ColumnReader idCol = reader.columnReader("id");
-             ColumnReader valCol = reader.columnReader("value")) {
+             ColumnReaders columns = reader.columnReaders(ColumnProjection.columns("id", "value"))) {
 
-            while (idCol.nextBatch() & valCol.nextBatch()) {
-                int count = idCol.getRecordCount();
+            ColumnReader valCol = columns.getColumnReader("value");
+            while (columns.nextBatch()) {
+                int count = columns.getRecordCount();
                 double[] values = valCol.getDoubles();
                 for (int i = 0; i < count; i++) {
                     sum += values[i];
@@ -156,11 +158,12 @@ class PageFilterBenchmarkTest {
         FilterPredicate filter = FilterPredicate.lt("id", (long) (TOTAL_ROWS / 10));
 
         try (ParquetFileReader reader = ParquetFileReader.open(InputFile.of(BENCHMARK_FILE));
-             ColumnReader idCol = reader.buildColumnReader("id").filter(filter).build();
-             ColumnReader valCol = reader.buildColumnReader("value").filter(filter).build()) {
+             ColumnReaders columns = reader.buildColumnReaders(ColumnProjection.columns("id", "value"))
+                     .filter(filter).build()) {
 
-            while (idCol.nextBatch() & valCol.nextBatch()) {
-                int count = idCol.getRecordCount();
+            ColumnReader valCol = columns.getColumnReader("value");
+            while (columns.nextBatch()) {
+                int count = columns.getRecordCount();
                 double[] values = valCol.getDoubles();
                 for (int i = 0; i < count; i++) {
                     sum += values[i];

--- a/performance-testing/end-to-end/src/test/java/dev/hardwood/perf/PageScanPerformanceTest.java
+++ b/performance-testing/end-to-end/src/test/java/dev/hardwood/perf/PageScanPerformanceTest.java
@@ -26,7 +26,9 @@ import dev.hardwood.Hardwood;
 import dev.hardwood.InputFile;
 import dev.hardwood.Validity;
 import dev.hardwood.reader.ColumnReader;
+import dev.hardwood.reader.ColumnReaders;
 import dev.hardwood.reader.ParquetFileReader;
+import dev.hardwood.schema.ColumnProjection;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.withinPercentage;
@@ -171,12 +173,15 @@ class PageScanPerformanceTest {
 
         try (Hardwood hardwood = Hardwood.create();
              ParquetFileReader reader = hardwood.open(InputFile.of(file));
-             ColumnReader col0 = reader.columnReader("passenger_count");
-             ColumnReader col1 = reader.columnReader("trip_distance");
-             ColumnReader col2 = reader.columnReader("fare_amount")) {
+             ColumnReaders columns = reader.columnReaders(ColumnProjection.columns(
+                     "passenger_count", "trip_distance", "fare_amount"))) {
 
-            while (col0.nextBatch() & col1.nextBatch() & col2.nextBatch()) {
-                int count = col0.getRecordCount();
+            ColumnReader col0 = columns.getColumnReader("passenger_count");
+            ColumnReader col1 = columns.getColumnReader("trip_distance");
+            ColumnReader col2 = columns.getColumnReader("fare_amount");
+
+            while (columns.nextBatch()) {
+                int count = columns.getRecordCount();
                 int[] v0 = col0.getInts();
                 double[] v1 = col1.getDoubles();
                 double[] v2 = col2.getDoubles();


### PR DESCRIPTION
Closes #1062.

`ColumnReader.nextBatch()` promised that every reader over a file batches at the same row boundaries:

> **Multi-column alignment.** Every `ColumnReader` over the same file produces batches at the same row boundaries — call `nextBatch()` on each in turn and they will report identical `getRecordCount()`s for the matching batch. This holds because the per-column drain workers all use the same internal batch capacity and every reader observes the same total row count per row group.

The stated reason is not so. Capacity comes from `BatchSizing.computeOptimalBatchSize(projected, …)`, so it follows the widths of the columns a reader actually reads. Over one file:

```
unfiltered i32 batch1 = 524288
unfiltered i64 batch1 = 524288
unfiltered s   batch1 = 393216      <-- BYTE_ARRAY
```

And a filtered reader is sized for its predicate's columns as well as its own, so `buildColumnReader("id").filter(lt("id", …))` projects one column and `buildColumnReader("value").filter(lt("id", …))` projects two.

## What went wrong when you believed it

Pairing two such readers reads different rows from each and stops when whichever has the larger batches runs out first:

```
lockstep, unfiltered  -> id=20000000 value=20000000
lockstep, filtered    -> id=2000000  value=1572864
```

Nothing is raised, because nothing is wrong with either reader — each is a complete, correct read of its own column, and the loop just stopped asking. 2,000,000 rows matched; one reader returned all of them and the other returned 1,572,864.

## What this changes

Nothing about what a reader does. The promise is withdrawn, and the pattern is no longer modelled anywhere.

- **`nextBatch()`** now says a reader advances only itself, why two readers reach different rows, and that `ColumnReaders` is how to read several columns of the same rows. Calling `nextBatch()` on a reader obtained *from* a `ColumnReaders` stays supported and is called out as such — those are driven as one.
- **The column-reader guide's map key/value walk** paired an independent `BYTE_ARRAY` key reader with an `INT32` value reader — exactly the mismatch above — and now opens both through `columnReaders(...)`. Same for the copy of that example in `_designs/COLUMN_READER_ARROW_LAYOUT.md`.
- **`PageFilterBenchmarkTest`**, which paired two filtered readers, has been failing on `main` with `ArrayIndexOutOfBoundsException: Index 393216 out of bounds for length 393216`. It now uses `ColumnReaders`, passes, and reports the correct 5,000,000 filtered rows.
- **Every other caller** that advanced separate readers together now goes through `ColumnReaders`. Two were genuinely independent and so genuinely unsound (`PageScanPerformanceTest`, `NestedPerformanceTest`); they pass today only because their widths happen to batch alike. The rest already drew their readers from a `ColumnReaders` and only modelled the shape.

`ColumnReadersTest` deliberately keeps it: advancing coordinated siblings individually is behaviour `ColumnReaders` guarantees, and that test is what holds it.

## On not making it fail loudly instead

Two independently built readers hold no reference to each other, so neither can detect the other's boundaries. The alternatives were to size batches from the file rather than the projection — which defeats what `BatchSizing` exists for, bounding memory by what is actually read — or to leave a documented-looking pattern that quietly returns wrong data. `ColumnReaders` already existed for this and was already recommended alongside the promise that made it look optional.