### PR TITLE
#1068 Read dictionary indices of 9 to 32 bits a word at a time

### DIFF
--- a/core/src/main/java/dev/hardwood/internal/encoding/RleBitPackingHybridDecoder.java
+++ b/core/src/main/java/dev/hardwood/internal/encoding/RleBitPackingHybridDecoder.java
@@ -345,6 +345,28 @@ public class RleBitPackingHybridDecoder {
             }
         }
 
+        // Above 8 a group of eight no longer fits one 64-bit word, so it is read a value at a
+        // time instead: the offset inside a byte is at most 7 and the constructor caps the width
+        // at 32, so a value reaches 39 bits and one eight-byte read still covers it whole.
+        // Nothing is carried between values, which is what the bit buffer below cannot do.
+        //
+        // Only while the buffer is empty, because this bypasses it, and only while the reads stay
+        // inside the data: they run past the bytes the group owns, though `pos` advances by just
+        // those, so over-reading would leave the cursor inside the next run's header.
+        else if (width <= 32) {
+            int groupSpan = ((7 * width) >>> 3) + Long.BYTES;
+            while (count >= 8 && bitsInBuffer == 0 && pos + groupSpan <= dataEnd) {
+                for (int i = 0; i < 8; i++) {
+                    int bitOffset = i * width;
+                    long word = dataBuffer.getLong(pos + (bitOffset >>> 3));
+                    output[outPos + i] = (int) ((word >>> (bitOffset & 7)) & mask);
+                }
+                outPos += 8;
+                count -= 8;
+                pos += width;
+            }
+        }
+
         // Handle remaining values
         while (count > 0) {
             while (bitsInBuffer < width && pos < dataEnd) {

--- a/performance-testing/micro-benchmarks/src/main/java/dev/hardwood/benchmarks/BitUnpackBenchmark.java
+++ b/performance-testing/micro-benchmarks/src/main/java/dev/hardwood/benchmarks/BitUnpackBenchmark.java
@@ -1,0 +1,101 @@
+/*
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Copyright The original authors
+ *
+ *  Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package dev.hardwood.benchmarks;
+
+import java.util.Random;
+import java.util.concurrent.TimeUnit;
+
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
+
+import dev.hardwood.internal.encoding.RleBitPackingHybridDecoder;
+import dev.hardwood.internal.encoding.RleBitPackingHybridEncoder;
+
+/// Measures bit-packed index decode throughput across bit widths.
+///
+/// This is the dictionary-index and definition-level path. `decodeBitPacked` has bulk paths for
+/// a bit width of 1 and for widths up to 8; anything wider falls back to a generic bit-buffer
+/// loop. Dictionaries of more than 256 entries need 9 bits or more, so the sweep covers both
+/// sides of that boundary.
+///
+/// Run with:
+/// ```shell
+/// java -jar benchmarks.jar BitUnpackBenchmark
+/// ```
+@BenchmarkMode(Mode.Throughput)
+@OutputTimeUnit(TimeUnit.MILLISECONDS)
+@State(Scope.Benchmark)
+@Fork(value = 2, jvmArgs = { "-Xms512m", "-Xmx512m", "--add-modules", "jdk.incubator.vector" })
+@Warmup(iterations = 3, time = 1)
+@Measurement(iterations = 5, time = 1)
+public class BitUnpackBenchmark {
+
+    /// Values decoded per invocation.
+    @Param({ "4096" })
+    private int size;
+
+    @Param({ "1", "4", "8", "9", "10", "12", "16", "20", "24", "32" })
+    private int bitWidth;
+
+    private byte[] packed;
+    private int[] output;
+
+    @Setup
+    public void setUp() {
+        output = new int[size];
+
+        int[] values = new int[size];
+        Random random = new Random(42);
+        // A width of 32 cannot use nextInt(1 << 32); mask instead so every width is generated
+        // the same way, and so the encoder sees distinct values and emits bit-packed runs.
+        int mask = bitWidth == 32 ? -1 : (1 << bitWidth) - 1;
+        for (int i = 0; i < size; i++) {
+            values[i] = random.nextInt() & mask;
+        }
+
+        RleBitPackingHybridEncoder encoder = new RleBitPackingHybridEncoder(bitWidth);
+        encoder.writeInts(values, 0, size);
+        packed = encoder.toByteArray();
+
+        verify(values);
+    }
+
+    /// Decode once and check the values round-trip, so a decoder that stops early cannot post
+    /// a good score, and confirm the encoder chose bit-packed rather than run-length runs.
+    private void verify(int[] expected) {
+        new RleBitPackingHybridDecoder(packed, bitWidth).readInts(output, 0, size);
+        for (int i = 0; i < size; i++) {
+            if (output[i] != expected[i]) {
+                throw new IllegalStateException("Mismatch at " + i + " for bit width " + bitWidth
+                        + ": expected " + expected[i] + ", got " + output[i]);
+            }
+        }
+
+        int bitPackedBytes = (size * bitWidth + 7) / 8;
+        if (packed.length < bitPackedBytes / 2) {
+            throw new IllegalStateException("Stream collapsed to run-length runs: " + packed.length
+                    + " bytes for " + size + " values of " + bitWidth + " bits");
+        }
+    }
+
+    @Benchmark
+    public int[] decodeBitPacked() {
+        RleBitPackingHybridDecoder decoder = new RleBitPackingHybridDecoder(packed, bitWidth);
+        decoder.readInts(output, 0, size);
+        return output;
+    }
+}

--- a/performance-testing/micro-benchmarks/src/main/java/dev/hardwood/benchmarks/BitUnpackPrimitiveBenchmark.java
+++ b/performance-testing/micro-benchmarks/src/main/java/dev/hardwood/benchmarks/BitUnpackPrimitiveBenchmark.java
@@ -1,0 +1,102 @@
+/*
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Copyright The original authors
+ *
+ *  Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package dev.hardwood.benchmarks;
+
+import java.util.Random;
+import java.util.concurrent.TimeUnit;
+
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
+
+import dev.hardwood.internal.encoding.simd.ScalarOperations;
+import dev.hardwood.internal.encoding.simd.SimdOperations;
+import dev.hardwood.internal.encoding.simd.VectorSupport;
+
+/// Compares the two [SimdOperations] bit-unpack implementations against each other.
+///
+/// `SimdOperations.unpackBitWidthN` is declared for bit widths 2 to 8 and has a scalar
+/// implementation and a Vector-API-module implementation. Wiring the decoder to it is only
+/// worth doing if the second is faster than the first, so this measures exactly that.
+///
+/// Must be run with the Vector API module present, or both benchmarks measure the same
+/// implementation; setup fails loudly if the vector path did not load.
+///
+/// Run with:
+/// ```shell
+/// java -jar benchmarks.jar BitUnpackPrimitiveBenchmark
+/// ```
+@BenchmarkMode(Mode.Throughput)
+@OutputTimeUnit(TimeUnit.MILLISECONDS)
+@State(Scope.Benchmark)
+@Fork(value = 2, jvmArgs = { "-Xms512m", "-Xmx512m", "--add-modules", "jdk.incubator.vector" })
+@Warmup(iterations = 3, time = 1)
+@Measurement(iterations = 5, time = 1)
+public class BitUnpackPrimitiveBenchmark {
+
+    @Param({ "4096" })
+    private int size;
+
+    /// The full range `unpackBitWidthN` declares support for.
+    @Param({ "2", "4", "8" })
+    private int bitWidth;
+
+    private byte[] packed;
+    private int[] output;
+
+    private SimdOperations scalarOps;
+    private SimdOperations vectorOps;
+
+    @Setup
+    public void setUp() {
+        scalarOps = new ScalarOperations();
+        vectorOps = VectorSupport.operations();
+
+        if (!VectorSupport.isAvailable()) {
+            throw new IllegalStateException("Vector API not available (" + VectorSupport.implementationName()
+                    + "); rerun with --add-modules jdk.incubator.vector or this benchmark compares "
+                    + "the scalar implementation with itself");
+        }
+
+        output = new int[size];
+        packed = new byte[size * bitWidth / 8 + 16];
+        new Random(42).nextBytes(packed);
+
+        // Both implementations must agree before either is timed.
+        int[] fromScalar = new int[size];
+        int[] fromVector = new int[size];
+        scalarOps.unpackBitWidthN(packed, 0, fromScalar, 0, size, bitWidth);
+        vectorOps.unpackBitWidthN(packed, 0, fromVector, 0, size, bitWidth);
+        for (int i = 0; i < size; i++) {
+            if (fromScalar[i] != fromVector[i]) {
+                throw new IllegalStateException("Implementations disagree at " + i + " for bit width "
+                        + bitWidth + ": scalar " + fromScalar[i] + ", vector " + fromVector[i]);
+            }
+        }
+    }
+
+    @Benchmark
+    public int[] scalarUnpack() {
+        scalarOps.unpackBitWidthN(packed, 0, output, 0, size, bitWidth);
+        return output;
+    }
+
+    @Benchmark
+    public int[] vectorUnpack() {
+        vectorOps.unpackBitWidthN(packed, 0, output, 0, size, bitWidth);
+        return output;
+    }
+}

--- a/performance-testing/micro-benchmarks/src/main/java/dev/hardwood/benchmarks/DictionaryIndexScanBenchmark.java
+++ b/performance-testing/micro-benchmarks/src/main/java/dev/hardwood/benchmarks/DictionaryIndexScanBenchmark.java
@@ -1,0 +1,144 @@
+/*
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Copyright The original authors
+ *
+ *  Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package dev.hardwood.benchmarks;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Comparator;
+import java.util.Random;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Stream;
+
+import org.apache.avro.Schema;
+import org.apache.avro.generic.GenericData;
+import org.apache.avro.generic.GenericRecord;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.parquet.avro.AvroParquetWriter;
+import org.apache.parquet.hadoop.ParquetWriter;
+import org.apache.parquet.hadoop.metadata.CompressionCodecName;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.TearDown;
+import org.openjdk.jmh.annotations.Warmup;
+import org.openjdk.jmh.infra.Blackhole;
+
+import dev.hardwood.InputFile;
+import dev.hardwood.reader.ColumnReader;
+import dev.hardwood.reader.ParquetFileReader;
+
+/// Scans a dictionary-encoded column at cardinalities that straddle the bit width where the
+/// index decode changes path.
+///
+/// A dictionary index is bit-packed at the width needed for the largest index, so a dictionary
+/// of at most 256 entries decodes at 8 bits or fewer and anything larger does not. `cardinality`
+/// is chosen to sit either side of that: 200 entries needs 8 bits, 10000 needs 14.
+///
+/// Run with:
+/// ```shell
+/// java -jar benchmarks.jar DictionaryIndexScanBenchmark
+/// ```
+@BenchmarkMode(Mode.AverageTime)
+@OutputTimeUnit(TimeUnit.MILLISECONDS)
+@State(Scope.Benchmark)
+@Fork(value = 2, jvmArgs = { "-Xms1g", "-Xmx1g" })
+@Warmup(iterations = 3, time = 1)
+@Measurement(iterations = 5, time = 1)
+public class DictionaryIndexScanBenchmark {
+
+    private static final int ROW_COUNT = 2_000_000;
+
+    private static final String SCHEMA = """
+            {
+              "type": "record",
+              "name": "Row",
+              "fields": [
+                {"name": "label", "type": "string"},
+                {"name": "value", "type": "int"}
+              ]
+            }
+            """;
+
+    /// 200 distinct values pack indices into 8 bits; 10000 needs 14.
+    ///
+    /// The upper value cannot be raised much further: past roughly 50000 entries the writer
+    /// abandons the dictionary and falls back to PLAIN, so the column carries no indices at all
+    /// and measures nothing about index decoding.
+    @Param({ "200", "10000" })
+    private int cardinality;
+
+    private Path directory;
+    private Path file;
+
+    @Setup
+    public void setUp() throws IOException {
+        directory = Files.createTempDirectory("hardwood-dict-scan");
+        file = directory.resolve("dictionary.parquet");
+
+        Schema schema = new Schema.Parser().parse(SCHEMA);
+        Random random = new Random(42);
+
+        try (ParquetWriter<GenericRecord> writer = AvroParquetWriter
+                .<GenericRecord> builder(new org.apache.hadoop.fs.Path(file.toString()))
+                .withSchema(schema)
+                .withConf(new Configuration())
+                .withCompressionCodec(CompressionCodecName.UNCOMPRESSED)
+                .withDictionaryEncoding(true)
+                // One row group, so the whole column shares a dictionary of the full cardinality
+                // rather than several smaller per-group dictionaries at narrower index widths.
+                .withRowGroupSize(1024L * 1024 * 1024)
+                .withDictionaryPageSize(64 * 1024 * 1024)
+                .build()) {
+
+            for (int i = 0; i < ROW_COUNT; i++) {
+                GenericRecord record = new GenericData.Record(schema);
+                int draw = random.nextInt(cardinality);
+                record.put("label", "value-" + draw);
+                // Same cardinality, so both columns carry indices of the same bit width; this
+                // one resolves to a primitive and so is not dominated by String construction.
+                record.put("value", draw * 7);
+                writer.write(record);
+            }
+        }
+    }
+
+    @TearDown
+    public void tearDown() throws IOException {
+        try (Stream<Path> entries = Files.walk(directory)) {
+            entries.sorted(Comparator.reverseOrder()).forEach(path -> path.toFile().delete());
+        }
+    }
+
+    @Benchmark
+    public void scanLabels(Blackhole blackhole) throws IOException {
+        try (ParquetFileReader reader = ParquetFileReader.open(InputFile.of(file));
+                ColumnReader column = reader.columnReader("label")) {
+            while (column.nextBatch()) {
+                blackhole.consume(column.getStrings());
+            }
+        }
+    }
+
+    @Benchmark
+    public void scanValues(Blackhole blackhole) throws IOException {
+        try (ParquetFileReader reader = ParquetFileReader.open(InputFile.of(file));
+                ColumnReader column = reader.columnReader("value")) {
+            while (column.nextBatch()) {
+                blackhole.consume(column.getInts());
+            }
+        }
+    }
+}


### PR DESCRIPTION
Closes #1068.

`RleBitPackingHybridDecoder.decodeBitPacked` has a bulk path for a bit width of 1 and another for widths up to 8. Everything above falls through to a bit buffer refilled **one byte at a time**, so each value waits on a refill covering part of it.

That is not a corner. The RLE bit width follows the dictionary's size — at most 256 entries pack into 8 bits or fewer, anything larger does not — so the byte-at-a-time path is what every dictionary above 256 entries decodes through, on the hot path for every dictionary-encoded column. The constructor caps the width at 32, which makes 9 to 32 the whole of the gap.

## The change

Eight values occupy exactly `width` bytes at every width, so a group of eight can be read from a fixed base with each value taken independently:

```java
int groupSpan = ((7 * width) >>> 3) + Long.BYTES;
while (count >= 8 && bitsInBuffer == 0 && pos + groupSpan <= dataEnd) {
    for (int i = 0; i < 8; i++) {
        int bitOffset = i * width;
        long word = dataBuffer.getLong(pos + (bitOffset >>> 3));
        output[outPos + i] = (int) ((word >>> (bitOffset & 7)) & mask);
    }
    outPos += 8;
    count -= 8;
    pos += width;
}
```

The misalignment inside a byte is at most 7 and the width is at most 32, so a value ends by bit 39 of the word loaded for it — one eight-byte read always covers it whole, with nothing carried between values. Carrying is exactly what the bit buffer does, which is why the loop only runs while the buffer is empty.

The reads run past the bytes the group owns, so the loop is bounded by `groupSpan` rather than by the group's own `width` bytes; `pos` still advances by only those. Reading past the run without the guard would leave the cursor inside the next run's header and everything after it would decode as garbage. Near the end of the data the loop stops and the existing byte-at-a-time tail takes over unchanged.

## Measured

N300 pinned at 1.5 GHz, idle, `taskset -c 2`, JDK 25, 3 forks x (2 warmup + 5 measurement) iterations. ms/op, lower is better. Both jars carry identical benchmark sources — the baseline is `main` plus the three benchmark files — so the only code difference between them is the decoder.

| benchmark | cardinality | main | this PR | |
|---|---|---|---|---|
| `scanValues` | 10000 (14-bit indices) | 53.62 | 33.78 | **1.59x** |
| `scanValues` | 200 (8-bit, control) | 28.40 | 27.98 | 1.02x |
| `scanLabels` | 10000 (14-bit indices) | 156.64 | 141.80 | **1.10x** |
| `scanLabels` | 200 (8-bit, control) | 130.91 | 130.99 | 1.00x |

The 8-bit rows are the control: that path is untouched and does not move. On the 14-bit rows the per-fork spreads do not overlap — 50.64 / 55.99 / 54.22 against 33.67 / 33.12 / 34.55 for `scanValues`.

`scanLabels` gains less because it materialises a `String` per row, which dominates what index decoding costs; `scanValues` reads the same indices into an `int` column and shows the decode change closer to undiluted.

`BitUnpackBenchmark` and `BitUnpackPrimitiveBenchmark` come along as the kernel-level counterparts to this scan-level measurement.

## The three paths stay

Widths 1 and 2–8 keep the reads they had rather than folding into this one, and both merges were measured before being rejected:

- serving 1 through 8 from the width-8 path costs **0.81x** at width 1;
- serving every width a value at a time, as this path does, costs **0.66x** at width 8.

The three are a memory-shape ladder, each rung the widest thing that still holds a group of eight: a byte at width 1, a word at widths up to 8, and above that a word per value. They are three amounts of data per read, not three spellings of one.

What makes the narrow paths worth keeping is register residency rather than the load count. The eight explicit extraction statements let the compiler keep the loaded word in a register and shift it in place; the same word read by a counted loop is reloaded per value — `perfnorm` at width 8 puts that at 23.6 instructions and 9.02 L1 loads per value against 9.3 and 0.76 for the unrolled form.

## What this does not settle

#680 proposes reaching this by wiring `decodeBitPacked` to `SimdOperations.unpackBitWidthN`. That specific move is a no-op, for two reasons visible in the source. The method is declared for widths 2 to 8, which the existing bulk path already covers, so it would not touch 9 to 32 at all. And the java22 `VectorOperations` override of it contains no Vector API code — the same scalar long read and eight shifts as `ScalarOperations`, under a comment wondering whether SIMD would help. Both unpack methods are placeholders; the file does use `IntVector` and `LongVector` elsewhere, in `countNonNulls`, `markNulls` and `applyDictionaryInts`, so this is code that was never written rather than code that was tried. Neither unpack method has a production caller anywhere in the tree.

What that does **not** show is that vectorising the unpack would not pay. An unwritten placeholder says nothing about the ceiling, and SIMD bit-unpacking is well-trodden elsewhere — Arrow's AVX2/AVX-512 unpackers, Lemire's `simdbitpacking`. It may well beat this loop at widths 9 to 32. That is unmeasured, and this PR does not attempt it.

Landing the scalar path first is what makes the question answerable: it becomes the number a vector implementation has to beat. Measured against `main`'s byte-at-a-time buffer instead, vectorisation would collect the 1.59x here for free and the comparison would say nothing about SIMD.

#680 has been reframed to that — implement a real vectorised unpack and measure it per width band against these scalar paths — rather than being left proposing a wiring job that does nothing.
