### PR TITLE
#1047 Discard output on close when a write has failed

### DIFF
--- a/core/src/main/java/dev/hardwood/writer/ColumnWriter.java
+++ b/core/src/main/java/dev/hardwood/writer/ColumnWriter.java
@@ -46,13 +46,18 @@ public final class ColumnWriter {
     /// populated (columns addressed by index or name), then submits it. There is no
     /// separate build or submit step to forget.
     ///
+    /// A failure anywhere in the batch — validation or I/O — marks the writer as failed.
+    /// Under the default [WriteFailurePolicy#DISCARD], a failed writer refuses subsequent writes
+    /// and discards the output on [ParquetFileWriter#close()] rather than publishing a
+    /// truncated file.
+    ///
     /// @param filler populates the batch's columns; must cover every column exactly once
     /// @throws IOException if the write fails
     /// @throws IllegalArgumentException if the batch does not cover every column, or its
     ///         per-layer inputs do not agree on a record count
     /// @throws UnsupportedOperationException if the schema has a shape the writer cannot
     ///         produce
-    /// @throws IllegalStateException if the writer is closed
+    /// @throws IllegalStateException if the writer is closed, or a previous write has failed
     public void writeBatch(Consumer<ColumnBatch> filler) throws IOException {
         writer.ensureOpen();
         writer.writeStagedBatch(filler);

--- a/core/src/main/java/dev/hardwood/writer/ParquetFileWriter.java
+++ b/core/src/main/java/dev/hardwood/writer/ParquetFileWriter.java
@@ -60,7 +60,11 @@ import dev.hardwood.schema.FileSchema;
 /// body is compressed with the configured codec (`ZSTD` by default). All of these are
 /// configurable through [WriterConfig]. The row groups and footer are finalized on [#close()].
 ///
-/// The file is produced front to back and is valid only after `close()` returns.
+/// The file is produced front to back and is valid only after `close()` returns. A writer that
+/// has thrown from a write operation is marked as failed and, under the default
+/// [WriteFailurePolicy#DISCARD], refuses to publish: `close()` discards the output silently, and
+/// `try-with-resources` is safe by default. [WriteFailurePolicy#COMMIT_PREFIX] opts into publishing
+/// whatever was flushed before the failure.
 public final class ParquetFileWriter implements Closeable {
 
     private static final byte[] MAGIC = "PAR1".getBytes(StandardCharsets.UTF_8);
@@ -95,9 +99,11 @@ public final class ParquetFileWriter implements Closeable {
     private final Map<String, String> keyValueMetadata = new LinkedHashMap<>();
     private String createdBy = DEFAULT_CREATED_BY;
 
+    private final WriteFailurePolicy writeFailurePolicy;
     private final RowGroupBuffer current;
     private long numRows;
     private boolean closed;
+    private boolean failed;
 
     /// Which of the two write APIs this file is being written through. A file is written
     /// through one or the other: rows and batches would otherwise interleave two independent
@@ -117,6 +123,7 @@ public final class ParquetFileWriter implements Closeable {
         this.shredder = new RecordShredder(schema);
         this.compressor = compressor;
         this.ranges = LogicalTypeValueRange.forSchema(schema);
+        this.writeFailurePolicy = config.writeFailurePolicy();
         // One buffer serves every row group: flushing it resets it in place, so the writer's
         // largest allocation is made once per file rather than once per row group.
         this.current = new RowGroupBuffer(schema, config.pageTargetBytes(),
@@ -367,42 +374,53 @@ public final class ParquetFileWriter implements Closeable {
 
     /// Writes one batch without latching the write mode, so both views can submit through it:
     /// [ColumnWriter] the batch its caller filled, [RowWriter] the batches it stages.
+    ///
+    /// A failure anywhere in the batch — validation or I/O — marks the writer as failed.
+    /// Under the default [WriteFailurePolicy#DISCARD], a failed writer refuses subsequent writes
+    /// and discards the output on [#close()] rather than publishing a truncated file.
     void writeStagedBatch(Consumer<ColumnBatch> filler) throws IOException {
-        ColumnBatch batch = new ColumnBatch(schema, ranges);
-        filler.accept(batch);
-        ColumnSource[] sources = batch.completedSources();
-        shredder.bind(sources, batch.validities(), batch.structValidities(),
-                batch.listValidities(), batch.listOffsets());
-        batch.markConsumed();
-        int rows = shredder.recordCount();
-        int pos = 0;
-        // Carried across iterations: what the row group holds after a slice is also the room the
-        // next slice is sized against, so it is read once per slice rather than once for each.
-        long retained = current.retainedBytes();
-        while (pos < rows) {
-            // A slice at a time. What a range actually costs is only known once it has been
-            // appended — a value interned against a live dictionary retains an index where it
-            // repeats and an index plus the value where it does not, which needs the hash — so
-            // the writer sizes a slice by what it *could* cost and then reads what the row group
-            // turned out to hold. Sizing it by the bound is what keeps a batch whose records
-            // widen part way through from carrying a row group far past its target, which no
-            // measurement of the records already appended could anticipate.
-            int slice = Math.min(Math.min(rows - pos, SLICE_RECORDS),
-                    rowGroupTargetRows - current.rowCount());
-            slice = current.sliceThatFits(shredder, sources, pos, slice,
-                    config.rowGroupBufferTargetBytes() - retained);
-            current.appendRecords(shredder, sources, pos, slice);
-            pos += slice;
-            retained = current.retainedBytes();
-            if (retained > peakRetainedBytes) {
-                peakRetainedBytes = retained;
-            }
-            // Either target closes the group, whichever is reached first.
-            if (retained >= config.rowGroupBufferTargetBytes()
-                    || current.rowCount() >= rowGroupTargetRows) {
-                flushRowGroup();
+        ensureNotFailed();
+        try {
+            ColumnBatch batch = new ColumnBatch(schema, ranges);
+            filler.accept(batch);
+            ColumnSource[] sources = batch.completedSources();
+            shredder.bind(sources, batch.validities(), batch.structValidities(),
+                    batch.listValidities(), batch.listOffsets());
+            batch.markConsumed();
+            int rows = shredder.recordCount();
+            int pos = 0;
+            // Carried across iterations: what the row group holds after a slice is also the room the
+            // next slice is sized against, so it is read once per slice rather than once for each.
+            long retained = current.retainedBytes();
+            while (pos < rows) {
+                // A slice at a time. What a range actually costs is only known once it has been
+                // appended — a value interned against a live dictionary retains an index where it
+                // repeats and an index plus the value where it does not, which needs the hash — so
+                // the writer sizes a slice by what it *could* cost and then reads what the row group
+                // turned out to hold. Sizing it by the bound is what keeps a batch whose records
+                // widen part way through from carrying a row group far past its target, which no
+                // measurement of the records already appended could anticipate.
+                int slice = Math.min(Math.min(rows - pos, SLICE_RECORDS),
+                        rowGroupTargetRows - current.rowCount());
+                slice = current.sliceThatFits(shredder, sources, pos, slice,
+                        config.rowGroupBufferTargetBytes() - retained);
+                current.appendRecords(shredder, sources, pos, slice);
+                pos += slice;
                 retained = current.retainedBytes();
+                if (retained > peakRetainedBytes) {
+                    peakRetainedBytes = retained;
+                }
+                // Either target closes the group, whichever is reached first.
+                if (retained >= config.rowGroupBufferTargetBytes()
+                        || current.rowCount() >= rowGroupTargetRows) {
+                    flushRowGroup();
+                    retained = current.retainedBytes();
+                }
             }
+        }
+        catch (IOException | RuntimeException e) {
+            failed = true;
+            throw e;
         }
     }
 
@@ -415,12 +433,35 @@ public final class ParquetFileWriter implements Closeable {
     /// a column's slice is one bulk copy rather than a call per value.
     private static final int SLICE_RECORDS = 4096;
 
+    /// Closes this writer, finalizing the file or discarding it.
+    ///
+    /// Under the default [WriteFailurePolicy#DISCARD], a writer that has been marked as failed — by
+    /// a previous exception from [ColumnWriter#writeBatch] or from a [RowWriter] flush —
+    /// discards its output silently: `close()` calls [OutputFile#discard()] and returns
+    /// without throwing, so `try-with-resources` propagates only the original exception.
+    ///
+    /// Under [WriteFailurePolicy#COMMIT_PREFIX], a failed writer proceeds normally, writing a valid
+    /// footer over whatever rows were flushed before the failure.
+    ///
+    /// A failure during `close()` itself — the footer cannot be serialized or written —
+    /// always discards, regardless of the policy.
     @Override
     public void close() throws IOException {
         if (closed) {
             return;
         }
         closed = true;
+        if (failed && writeFailurePolicy == WriteFailurePolicy.DISCARD) {
+            // A write has failed and the policy says: leave nothing behind.
+            // Discard silently so try-with-resources propagates only the original exception.
+            try {
+                out.discard();
+            }
+            catch (IOException ignored) {
+                // Best-effort cleanup; the caller already has the write failure.
+            }
+            return;
+        }
         try {
             if (rowWriter != null) {
                 rowWriter.flushPending();
@@ -499,6 +540,16 @@ public final class ParquetFileWriter implements Closeable {
     void ensureOpen() {
         if (closed) {
             throw new IllegalStateException("Writer is closed");
+        }
+    }
+
+    /// Rejects a write after a previous write has failed. Separate from [#ensureOpen()] so
+    /// that metadata setters — [#keyValueMetadata], [#createdBy] — remain usable after a
+    /// failure; only further writes are blocked.
+    private void ensureNotFailed() {
+        if (failed) {
+            throw new IllegalStateException(
+                    "Writer has failed; it cannot accept more data and will discard on close");
         }
     }
 }

--- a/core/src/main/java/dev/hardwood/writer/WriteFailurePolicy.java
+++ b/core/src/main/java/dev/hardwood/writer/WriteFailurePolicy.java
@@ -1,0 +1,43 @@
+/*
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Copyright The original authors
+ *
+ *  Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package dev.hardwood.writer;
+
+/// What [ParquetFileWriter#close()] does when a write has failed.
+///
+/// A writer that throws from [ColumnWriter#writeBatch] or from the flush a
+/// [RowWriter#writeRow] triggers is marked as failed. This policy decides what
+/// `close()` — and therefore `try-with-resources` — does with the output that
+/// was produced before the failure.
+///
+/// The default is [#DISCARD]: a failure leaves nothing behind, and
+/// `try-with-resources` is safe without any extra handling. [#COMMIT_PREFIX]
+/// opts into the pre-1.1 behaviour, publishing whatever rows were flushed
+/// before the failure as a valid, readable, but truncated file.
+public enum WriteFailurePolicy {
+
+    /// Discard the output when a write has failed.
+    ///
+    /// `close()` calls [dev.hardwood.OutputFile#discard()] and returns silently,
+    /// leaving no file at the destination. This is the default, matching the
+    /// documented contract: "a failure leaves nothing behind."
+    ///
+    /// A caller who catches the write failure and wants the successfully-written
+    /// prefix should use [#COMMIT_PREFIX] instead.
+    DISCARD,
+
+    /// Commit whatever was successfully written before the failure.
+    ///
+    /// `close()` writes a valid footer over the rows that were flushed before
+    /// the failure, publishing a well-formed but truncated file. The caller
+    /// takes responsibility for the semantic correctness of the prefix.
+    ///
+    /// This is an opt-in: by default, a failure discards. It exists for
+    /// callers who produce data in a streaming pipeline and can use whatever
+    /// arrived before the break.
+    COMMIT_PREFIX
+}

--- a/core/src/main/java/dev/hardwood/writer/WriterConfig.java
+++ b/core/src/main/java/dev/hardwood/writer/WriterConfig.java
@@ -76,6 +76,10 @@ public final class WriterConfig {
     /// than silently dropping the digits that do not fit.
     public static final PrecisionLossPolicy DEFAULT_PRECISION_LOSS_POLICY = PrecisionLossPolicy.REJECT;
 
+    /// Default write-failure policy: discard the output when a write has failed, so `try-with-resources`
+    /// is safe by default and a failure leaves nothing behind.
+    public static final WriteFailurePolicy DEFAULT_WRITE_FAILURE_POLICY = WriteFailurePolicy.DISCARD;
+
     /// Default encoding policy: [ColumnEncoding#AUTO], leaving each column chunk's encoding to
     /// the size comparison the writer makes once the row group is buffered.
     public static final ColumnEncoding DEFAULT_ENCODING = ColumnEncoding.AUTO;
@@ -88,6 +92,7 @@ public final class WriterConfig {
     private final int statisticsTruncationLength;
     private final CompressionCodec codec;
     private final PrecisionLossPolicy precisionLossPolicy;
+    private final WriteFailurePolicy writeFailurePolicy;
 
     private WriterConfig(Builder builder) {
         this.pageTargetBytes = builder.pageTargetBytes;
@@ -98,6 +103,7 @@ public final class WriterConfig {
         this.statisticsTruncationLength = builder.statisticsTruncationLength;
         this.codec = builder.codec;
         this.precisionLossPolicy = builder.precisionLossPolicy;
+        this.writeFailurePolicy = builder.writeFailurePolicy;
     }
 
     /// The default configuration.
@@ -162,6 +168,12 @@ public final class WriterConfig {
         return precisionLossPolicy;
     }
 
+    /// What [ParquetFileWriter#close()] does when a write has failed: discard the output
+    /// (the default) or commit the successfully-written prefix.
+    public WriteFailurePolicy writeFailurePolicy() {
+        return writeFailurePolicy;
+    }
+
     /// `ZSTD` when its library is loadable, otherwise `UNCOMPRESSED`. The class is only probed
     /// for presence, not initialized, so picking the default never triggers the native load.
     private static CompressionCodec defaultCodec() {
@@ -181,6 +193,7 @@ public final class WriterConfig {
         private int statisticsTruncationLength = DEFAULT_STATISTICS_TRUNCATION_LENGTH;
         private CompressionCodec codec = DEFAULT_CODEC;
         private PrecisionLossPolicy precisionLossPolicy = DEFAULT_PRECISION_LOSS_POLICY;
+        private WriteFailurePolicy writeFailurePolicy = DEFAULT_WRITE_FAILURE_POLICY;
 
         private Builder() {
         }
@@ -310,6 +323,21 @@ public final class WriterConfig {
                 throw new IllegalArgumentException("precisionLossPolicy must not be null");
             }
             this.precisionLossPolicy = precisionLossPolicy;
+            return this;
+        }
+
+        /// Sets what [ParquetFileWriter#close()] does when a write has failed; must be non‑null.
+        /// Defaults to [WriteFailurePolicy#DISCARD].
+        ///
+        /// Under [WriteFailurePolicy#DISCARD], a writer that has thrown once refuses to publish:
+        /// `close()` discards the output silently, and `try‑with‑resources` is safe by default.
+        /// Under [WriteFailurePolicy#COMMIT_PREFIX], `close()` writes a valid footer over the rows
+        /// that were flushed before the failure.
+        public Builder writeFailurePolicy(WriteFailurePolicy policy) {
+            if (policy == null) {
+                throw new IllegalArgumentException("writeFailurePolicy must not be null");
+            }
+            this.writeFailurePolicy = policy;
             return this;
         }
 

--- a/core/src/test/java/dev/hardwood/writer/WriterBatchContractTest.java
+++ b/core/src/test/java/dev/hardwood/writer/WriterBatchContractTest.java
@@ -77,6 +77,10 @@ class WriterBatchContractTest {
             assertThatThrownBy(() -> writer.columnWriter().writeBatch(batch -> batch.ints(1, new int[] { 1 })))
                     .isInstanceOf(IndexOutOfBoundsException.class)
                     .hasMessageContaining("[0, 1)");
+        }
+        // Separate writer: a failed writeBatch poisons the writer, so the negative-index
+        // check needs its own.
+        try (ParquetFileWriter writer = ParquetFileWriter.create(new ByteBufferOutputFile(), oneColumn())) {
             assertThatThrownBy(() -> writer.columnWriter().writeBatch(batch -> batch.ints(-1, new int[] { 1 })))
                     .isInstanceOf(IndexOutOfBoundsException.class);
         }

--- a/core/src/test/java/dev/hardwood/writer/WriterFailurePolicyTest.java
+++ b/core/src/test/java/dev/hardwood/writer/WriterFailurePolicyTest.java
@@ -1,0 +1,250 @@
+/*
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Copyright The original authors
+ *
+ *  Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package dev.hardwood.writer;
+
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import dev.hardwood.InputFile;
+import dev.hardwood.OutputFile;
+import dev.hardwood.internal.writer.ByteBufferOutputFile;
+import dev.hardwood.reader.ParquetFileReader;
+
+import static dev.hardwood.writer.WriterTestSupport.oneColumn;
+import static dev.hardwood.writer.WriterTestSupport.readInts;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/// Tests the failure-poisoning and discard-on-close behaviour introduced to uphold the
+/// documented contract: "a failure leaves nothing behind."
+///
+/// A writer that has thrown from [ColumnWriter#writeBatch] is marked as failed. Under the
+/// default [WriteFailurePolicy#DISCARD], `close()` discards rather than publishing the truncated
+/// prefix; under [WriteFailurePolicy#COMMIT_PREFIX], the prefix is published as a valid file.
+class WriterFailurePolicyTest {
+
+    @Test
+    void failedBatchDiscardsOnClose(@TempDir Path dir) throws Exception {
+        Path file = dir.resolve("out.parquet");
+
+        try (ParquetFileWriter writer = ParquetFileWriter.create(OutputFile.of(file), oneColumn())) {
+            writer.columnWriter().writeBatch(batch -> batch.ints(0, new int[] { 1, 2, 3 }));
+            try {
+                // Second batch is invalid: the same column named twice.
+                writer.columnWriter().writeBatch(
+                        batch -> batch.ints(0, new int[] { 4, 5 }).ints(0, new int[] { 6 }));
+            }
+            catch (IllegalArgumentException expected) {
+                // Caller notices the failure and stops writing.
+            }
+        }
+        // Default policy is DISCARD: no file at the target, no temp file.
+        assertThat(Files.exists(file)).isFalse();
+        assertThat(Files.exists(file.resolveSibling(file.getFileName() + ".hardwood-tmp"))).isFalse();
+    }
+
+    @Test
+    void failedBatchWithCommitPrefixPublishesGoodRows(@TempDir Path dir) throws Exception {
+        Path file = dir.resolve("out.parquet");
+        WriterConfig config = WriterConfig.builder()
+                .writeFailurePolicy(WriteFailurePolicy.COMMIT_PREFIX)
+                .build();
+
+        try (ParquetFileWriter writer = ParquetFileWriter.create(OutputFile.of(file), oneColumn(), config)) {
+            writer.columnWriter().writeBatch(batch -> batch.ints(0, new int[] { 1, 2, 3 }));
+            try {
+                writer.columnWriter().writeBatch(
+                        batch -> batch.ints(0, new int[] { 4, 5 }).ints(0, new int[] { 6 }));
+            }
+            catch (IllegalArgumentException expected) {
+                // Caller notices and stops.
+            }
+        }
+        // COMMIT_PREFIX: the file is published with the first batch's rows.
+        assertThat(Files.exists(file)).isTrue();
+        try (ParquetFileReader reader = ParquetFileReader.open(InputFile.of(file))) {
+            assertThat(reader.getFileMetaData().numRows()).isEqualTo(3);
+            assertThat(readInts(reader, 0)).containsExactly(1, 2, 3);
+        }
+    }
+
+    @Test
+    void writerRejectsWriteAfterFailure() throws Exception {
+        ParquetFileWriter writer = ParquetFileWriter.create(new ByteBufferOutputFile(), oneColumn());
+        ColumnWriter columns = writer.columnWriter();
+
+        // Good batch.
+        columns.writeBatch(batch -> batch.ints(0, new int[] { 1, 2, 3 }));
+
+        // Bad batch: duplicate column.
+        assertThatThrownBy(() -> columns.writeBatch(
+                batch -> batch.ints(0, new int[] { 4, 5 }).ints(0, new int[] { 6 })))
+                .isInstanceOf(IllegalArgumentException.class);
+
+        // The writer is now poisoned: the next writeBatch must be rejected.
+        assertThatThrownBy(() -> columns.writeBatch(batch -> batch.ints(0, new int[] { 7 })))
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessageContaining("failed");
+
+        writer.close();
+    }
+
+    @Test
+    void metadataStillSettableAfterFailure() throws Exception {
+        ParquetFileWriter writer = ParquetFileWriter.create(new ByteBufferOutputFile(), oneColumn());
+        ColumnWriter columns = writer.columnWriter();
+        columns.writeBatch(batch -> batch.ints(0, new int[] { 1 }));
+
+        // Poison the writer.
+        assertThatThrownBy(() -> columns.writeBatch(
+                batch -> batch.ints(0, new int[] { 2 }).ints(0, new int[] { 3 })))
+                .isInstanceOf(IllegalArgumentException.class);
+
+        // Metadata setters remain usable: no exception.
+        writer.keyValueMetadata("key", "value");
+        writer.createdBy("test version 1.0 (build abc)");
+
+        writer.close();
+    }
+
+    @Test
+    void rowWriterRecoveryDoesNotPoison(@TempDir Path dir) throws Exception {
+        Path file = dir.resolve("out.parquet");
+
+        try (ParquetFileWriter writer = ParquetFileWriter.create(OutputFile.of(file), oneColumn())) {
+            RowWriter rows = writer.rowWriter();
+
+            // Good record.
+            rows.writeRow(row -> row.setInt("id", 1));
+
+            // Bad record: unknown field name. This fails in plan.writeRecord(),
+            // before writeStagedBatch(), so it should NOT poison the writer.
+            assertThatThrownBy(() -> rows.writeRow(row -> row.setInt("nope", 2)))
+                    .isInstanceOf(IllegalArgumentException.class);
+
+            // Another good record: should succeed because the writer is NOT poisoned.
+            rows.writeRow(row -> row.setInt("id", 3));
+        }
+        // The file should be published with the two good records.
+        assertThat(Files.exists(file)).isTrue();
+        try (ParquetFileReader reader = ParquetFileReader.open(InputFile.of(file))) {
+            assertThat(reader.getFileMetaData().numRows()).isEqualTo(2);
+            assertThat(readInts(reader, 0)).containsExactly(1, 3);
+        }
+    }
+
+    @Test
+    void ioFailureDuringFlushPoisons(@TempDir Path dir) throws Exception {
+        Path file = dir.resolve("out.parquet");
+
+        // An OutputFile that fails on the third write call. Call 1 is the leading magic
+        // (4 bytes). Calls 2+ are row-group page data. Failing on call 3 simulates an
+        // I/O failure mid-flush.
+        FailOnNthWrite failingOut = new FailOnNthWrite(OutputFile.of(file), 3);
+
+        // A very small row-group target so that writeBatch triggers a flushRowGroup()
+        // inside writeStagedBatch(), which will hit the failing write.
+        WriterConfig config = WriterConfig.builder()
+                .rowGroupTargetRows(1)
+                .build();
+
+        ParquetFileWriter writer = ParquetFileWriter.create(failingOut, oneColumn(), config);
+        ColumnWriter columns = writer.columnWriter();
+
+        // This writeBatch writes multiple rows, and with rowGroupTargetRows=1 each row
+        // triggers a flushRowGroup() inside the loop, hitting the FailOnNthWrite.
+        assertThatThrownBy(() -> columns.writeBatch(batch -> batch.ints(0, new int[] { 1, 2, 3 })))
+                .isInstanceOf(IOException.class);
+
+        // Writer is now poisoned.
+        assertThatThrownBy(() -> columns.writeBatch(batch -> batch.ints(0, new int[] { 4 })))
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessageContaining("failed");
+
+        writer.close();
+        // DISCARD policy: no file at the target.
+        assertThat(Files.exists(file)).isFalse();
+    }
+
+    @Test
+    void doubleCloseAfterFailureIsSilent() throws Exception {
+        ParquetFileWriter writer = ParquetFileWriter.create(new ByteBufferOutputFile(), oneColumn());
+
+        // Poison the writer.
+        assertThatThrownBy(() -> writer.columnWriter().writeBatch(
+                batch -> batch.ints(0, new int[] { 1, 2 }).ints(0, new int[] { 3 })))
+                .isInstanceOf(IllegalArgumentException.class);
+
+        // First close: discards silently.
+        writer.close();
+        // Second close: idempotent, no exception.
+        writer.close();
+    }
+
+    @Test
+    void unpoisonedWriterPublishesNormally(@TempDir Path dir) throws Exception {
+        // Sanity check: a writer that never fails still publishes under the default policy.
+        Path file = dir.resolve("out.parquet");
+
+        try (ParquetFileWriter writer = ParquetFileWriter.create(OutputFile.of(file), oneColumn())) {
+            writer.columnWriter().writeBatch(batch -> batch.ints(0, new int[] { 1, 2, 3 }));
+        }
+        assertThat(Files.exists(file)).isTrue();
+        try (ParquetFileReader reader = ParquetFileReader.open(InputFile.of(file))) {
+            assertThat(reader.getFileMetaData().numRows()).isEqualTo(3);
+            assertThat(readInts(reader, 0)).containsExactly(1, 2, 3);
+        }
+    }
+
+    /// An [OutputFile] that throws on the Nth `write()` call, simulating an I/O failure
+    /// during a row group flush.
+    private static final class FailOnNthWrite implements OutputFile {
+
+        private final OutputFile delegate;
+        private final int failOnCall;
+        private int writeCount;
+
+        FailOnNthWrite(OutputFile delegate, int failOnCall) {
+            this.delegate = delegate;
+            this.failOnCall = failOnCall;
+        }
+
+        @Override
+        public void create() throws IOException {
+            delegate.create();
+        }
+
+        @Override
+        public void write(ByteBuffer data) throws IOException {
+            if (++writeCount == failOnCall) {
+                throw new IOException("injected write failure on call " + failOnCall);
+            }
+            delegate.write(data);
+        }
+
+        @Override
+        public long position() {
+            return delegate.position();
+        }
+
+        @Override
+        public void close() throws IOException {
+            delegate.close();
+        }
+
+        @Override
+        public void discard() throws IOException {
+            delegate.discard();
+        }
+    }
+}

--- a/docs/content/concepts/write-model.md
+++ b/docs/content/concepts/write-model.md
@@ -28,7 +28,7 @@ The `FileMetaData` footer carries the schema and every page and column-chunk off
 Three things follow for a caller:
 
 - **A file is valid only after `close()` returns.** Before that, the destination holds pages without a footer, and no reader can open it. A writer abandoned mid-way leaves nothing readable.
-- **A failure leaves nothing behind.** When the writer cannot finish, it discards what it has written. The local backend writes to a temporary sibling path and renames atomically on close, so a reader never observes a half-written file at the target path.
+- **A failure leaves nothing behind.** When the writer cannot finish — whether `create()`, a `writeBatch`, a `writeRow` flush, or `close()` itself fails — it discards what it has written. A writer that has thrown once refuses to publish; `close()` discards rather than committing a truncated prefix, and `try-with-resources` is safe by default. The local backend writes to a temporary sibling path and renames atomically on close, so a reader never observes a half-written file at the target path. A caller who wants the successfully-written prefix after a failure can configure `WriteFailurePolicy.COMMIT_PREFIX`, which makes `close()` finalize whatever rows were flushed before the failure rather than discarding them.
 - **The destination is a sequential sink.** `OutputFile` is `create` / `write` / `position` / `close` — no seeking, no size known ahead of time. That is what lets the same interface serve a file channel today and a multipart object upload later.
 
 ## What bounds memory

--- a/docs/content/reference/writer.md
+++ b/docs/content/reference/writer.md
@@ -63,10 +63,11 @@ WriterConfig config = WriterConfig.builder()
 | `encoding(String, ColumnEncoding)` | — | Encoding policy for one leaf column, overriding the file-wide default. |
 | `statisticsTruncationLength(int)` | `64` | Longest `BYTE_ARRAY` `min` / `max` statistics bound. A longer bound is truncated and flagged inexact. Must be positive. |
 | `precisionLossPolicy(PrecisionLossPolicy)` | `REJECT` | What the row-oriented layer does with a value carrying more precision than its column can hold. |
+| `writeFailurePolicy(WriteFailurePolicy)` | `DISCARD` | What `close()` does when a write has failed: discard the output (leave nothing behind) or commit the successfully-written prefix as a valid file. |
 
 A row group is cut at whichever of the two row-group targets is reached first.
 
-Each option has a getter that reads the configured value back — `pageTargetBytes()`, `rowGroupTargetRows()`, `rowGroupBufferTargetBytes()`, `codec()`, `statisticsTruncationLength()`, `precisionLossPolicy()`, and, for the two encoding setters, `defaultEncoding()` and `columnEncodings()`. Every setter rejects `null`, and the numeric bounds above are checked when the option is set.
+Each option has a getter that reads the configured value back — `pageTargetBytes()`, `rowGroupTargetRows()`, `rowGroupBufferTargetBytes()`, `codec()`, `statisticsTruncationLength()`, `precisionLossPolicy()`, `writeFailurePolicy()`, and, for the two encoding setters, `defaultEncoding()` and `columnEncodings()`. Every setter rejects `null`, and the numeric bounds above are checked when the option is set.
 
 The footer's key-value metadata and its `created_by` identifier are set on the `ParquetFileWriter` itself; see [File Metadata](#file-metadata).
 
@@ -238,7 +239,7 @@ hardwood version <version> (build <commit>)
 | `UnsupportedOperationException` | A schema column of an unsupported physical type (`INT96`); a refused codec (`LZ4`, `LZO`) or one whose library is missing; a [schema shape](#schema-shapes) the writer cannot produce |
 | `IllegalArgumentException` | A `null` metadata key, metadata map or `created_by`; an unknown column name or path; a setter that does not fit the column's type; a `null` value array, or a `null` value at a present row of a binary column; a column set twice in one batch or record; a batch that leaves a column unset, or whose arrays disagree in length; a null mask on a `REQUIRED` column; a `boolean[]` mask whose length does not match the values; list offsets that do not start at `0`, are not non-decreasing, or disagree with the element count; a value outside the range its annotation declares; a `REQUIRED` field left unset by a record |
 | `IndexOutOfBoundsException` | A leaf-column index outside `[0, leaf column count)` on a `ColumnBatch` setter, or a field index outside `[0, getFieldCount())` on a `StructBuilder` setter |
-| `IllegalStateException` | Writing, or setting key-value metadata or `created_by`, after `close()`; using both write APIs on one file; using a `ColumnBatch` after it has been submitted, or a nested builder after its filler has returned |
+| `IllegalStateException` | Writing, or setting key-value metadata or `created_by`, after `close()`; writing after a previous write has failed (under the default `WriteFailurePolicy.DISCARD`); using both write APIs on one file; using a `ColumnBatch` after it has been submitted, or a nested builder after its filler has returned |
 | `IOException` | The destination cannot be created, written, or finalized |
 
 ### Schema Shapes
@@ -254,4 +255,4 @@ Every other arrangement of repetition is rejected when the writer is created, si
 
 The row API reaches a list's values through an element node below the entry, which the legacy two-level lists do not have, so `rowWriter()` refuses those two shapes and `columnWriter()` writes them. `rowWriter()` also requires sibling field names to be unique, which the `ColumnBatch` indices and dotted paths do not.
 
-A `ParquetFileWriter` that cannot finish a valid file discards its output, leaving nothing at the destination.
+A `ParquetFileWriter` that cannot finish a valid file discards its output, leaving nothing at the destination. Under `WriteFailurePolicy.COMMIT_PREFIX`, a writer that has failed publishes whatever rows were flushed before the failure instead.


### PR DESCRIPTION
Going with the first option, ParquetFileWriter now tracks a failed flag. Under the default WriteFailurePolicy.DISCARD, close() calls OutputFile.discard() instead of finishing the file, so a try-with-resources block never silently publishes a truncated prefix. WriteFailurePolicy.COMMIT_PREFIX opts back into the old behaviour for callers that want whatever arrived before the break.

A failed writer also rejects further writeBatch calls with IllegalStateException, making the poisoned state visible immediately rather than at close time.

### Decisions:
1. After the writer is poisoned, if the caller attempts another writeBatch call, Reject it with IllegalStateException — the writer's internal state may be corrupted, so allowing more data would compound the problem and could produce a silently wrong file.
2. for RowWriter.writeRow(), only the columnar I/O path can poison the writer; a pure validation failure in the row-planning layer cannot, check test WriterFailurePolicyTest.rowWriterRecoveryDoesNotPoison().
3. Metadata setters remain usable: no exception after the writer is failed also the file will discard eventually. should keep this behavior or block them too for consistency?

Closes #1047
 
## Authorship

Hardwood is built with AI, not by AI. LLM assistance is welcome; submitting raw LLM output without understanding is not.
Neither are unattended agents opening pull requests.
See the [contribution guide](https://github.com/hardwood-hq/hardwood/blob/main/CONTRIBUTING.md) for more details.
Check this box to confirm:

- [x] This change is coming from a human who understands what it does and why, and can discuss it in review

## Checklist

- [x] Build via `./mvnw clean verify` passes
- [x] The commit message is prefixed with the issue key ("#123 Adding support for...")
- [x] Code changes are covered by tests
- [x] If this PR adds or changes user-facing behaviour, `docs/` has been updated
