### PR TITLE
#342 Surface IOExceptions in DataPreviewScreen as an error overlay

### DIFF
--- a/cli/src/main/java/dev/hardwood/cli/dive/ScreenState.java
+++ b/cli/src/main/java/dev/hardwood/cli/dive/ScreenState.java
@@ -292,7 +292,8 @@ public sealed interface ScreenState {
             boolean logicalTypes,
             java.util.Set<Integer> expandedColumns,
             int modalCursorLine,
-            int modalScroll)
+            int modalScroll,
+            String errorMessage)
             implements ScreenState {
         public DataPreview {
             columnNames = java.util.List.copyOf(columnNames);
@@ -307,7 +308,21 @@ public sealed interface ScreenState {
                            int columnScroll, int selectedRow, int modalRow, boolean logicalTypes,
                            java.util.Set<Integer> expandedColumns, int modalCursorLine) {
             this(firstRow, pageSize, columnNames, rows, expandedRows, columnScroll, selectedRow,
-                    modalRow, logicalTypes, expandedColumns, modalCursorLine, 0);
+                    modalRow, logicalTypes, expandedColumns, modalCursorLine, 0, null);
+        }
+
+        public DataPreview(long firstRow, int pageSize, java.util.List<String> columnNames,
+                           java.util.List<java.util.List<String>> rows,
+                           java.util.List<java.util.List<String>> expandedRows,
+                           int columnScroll, int selectedRow, int modalRow, boolean logicalTypes,
+                           java.util.Set<Integer> expandedColumns, int modalCursorLine,
+                           int modalScroll) {
+            this(firstRow, pageSize, columnNames, rows, expandedRows, columnScroll, selectedRow,
+                    modalRow, logicalTypes, expandedColumns, modalCursorLine, modalScroll, null);
+        }
+
+        public boolean hasError() {
+            return errorMessage != null;
         }
     }
 }

--- a/cli/src/main/java/dev/hardwood/cli/dive/internal/DataPreviewScreen.java
+++ b/cli/src/main/java/dev/hardwood/cli/dive/internal/DataPreviewScreen.java
@@ -74,6 +74,9 @@ public final class DataPreviewScreen {
     public static boolean handle(KeyEvent event, ParquetModel model, dev.hardwood.cli.dive.NavigationStack stack) {
         ScreenState.DataPreview state = (ScreenState.DataPreview) stack.top();
         long total = model.facts().totalRows();
+        if (state.hasError()) {
+            return false;
+        }
         if (state.modalRow() >= 0) {
             return handleModal(event, state, stack, model);
         }
@@ -179,7 +182,7 @@ public final class DataPreviewScreen {
     /// Does nothing while the record modal is open: the modal owns the
     /// screen, and re-loading underneath it would move the row it is showing.
     public static void fitToViewport(ParquetModel model, NavigationStack stack, Rect body) {
-        if (!(stack.top() instanceof ScreenState.DataPreview state) || state.modalRow() >= 0) {
+        if (!(stack.top() instanceof ScreenState.DataPreview state) || state.modalRow() >= 0 || state.hasError()) {
             return;
         }
         int viewport = viewportRows(body);
@@ -200,6 +203,13 @@ public final class DataPreviewScreen {
         Keys.observeDataPreviewArea(area.width(), area.height());
         Keys.observeViewport(viewportRows(area));
         Keys.observeViewportWidth(area.width());
+
+        if (state.hasError()) {
+            buffer.setStyle(area, Theme.dim());
+            renderErrorOverlay(buffer, area, state.errorMessage());
+            return;
+        }
+
         int columnCount = state.columnNames().size();
         ColumnWindow window = columnWindow(state, area.width());
 
@@ -250,6 +260,22 @@ public final class DataPreviewScreen {
             buffer.setStyle(area, Theme.dim());
             renderRecordModal(buffer, area, model, state);
         }
+    }
+
+    private static void renderErrorOverlay(Buffer buffer, Rect screenArea, String message) {
+        int width = Math.min(60, Math.max(1, screenArea.width() - 4));
+        int descBudget = Math.max(1, width - 4);
+
+        List<Line> lines = new ArrayList<>();
+        lines.add(Line.from(new Span(" ERROR : Page could not be read", Theme.error())));
+        lines.add(Line.empty());
+        for (String chunk : Strings.wordWrap(message, descBudget)) {
+            lines.add(Line.from(Span.raw(" " + chunk)));
+        }
+
+        Rect area = ScrollPane.modalArea(screenArea, width, Math.max(10, lines.size() + 8));
+        ScrollPane.renderModal(buffer, area, " Data preview — error ", lines, 0,
+                "[Esc] to go back");
     }
 
     private static void renderRecordModal(Buffer buffer, Rect screenArea, ParquetModel model,
@@ -456,6 +482,9 @@ public final class DataPreviewScreen {
     }
 
     public static String keybarKeys(ScreenState.DataPreview state, ParquetModel model) {
+        if (state.hasError()) {
+            return "[Esc] back";
+        }
         if (state.modalRow() >= 0) {
             return "";
         }
@@ -751,10 +780,20 @@ public final class DataPreviewScreen {
 
     private static ScreenState.DataPreview loadPage(ParquetModel model, long firstRow, int pageSize,
                                                     int columnScroll, boolean logicalTypes) {
-        PreviewWindow.Slice slice = WINDOW.slice(model, firstRow, pageSize, logicalTypes);
-        return new ScreenState.DataPreview(firstRow, pageSize, slice.columnNames(),
-                slice.rows(), slice.expandedRows(), columnScroll, 0, -1,
-                logicalTypes, Set.of(), 0);
+        try {
+            PreviewWindow.Slice slice = WINDOW.slice(model, firstRow, pageSize, logicalTypes);
+            return new ScreenState.DataPreview(firstRow, pageSize, slice.columnNames(),
+                    slice.rows(), slice.expandedRows(), columnScroll, 0, -1,
+                    logicalTypes, Set.of(), 0);
+        } catch (Exception e) {
+            String msg = e.getMessage();
+            if (msg == null || msg.isBlank()) {
+                msg = e.getClass().getSimpleName();
+            }
+            return new ScreenState.DataPreview(firstRow, pageSize, List.of(),
+                    List.of(), List.of(), columnScroll, 0, -1,
+                    logicalTypes, Set.of(), 0, 0, msg);
+        }
     }
 
     /// How to position the cursor within the viewport after a navigation move.

--- a/cli/src/test/java/dev/hardwood/cli/dive/DiveRenderTest.java
+++ b/cli/src/test/java/dev/hardwood/cli/dive/DiveRenderTest.java
@@ -668,6 +668,24 @@ class DiveRenderTest {
                 .contains("               index, Dictionary) ");
     }
 
+    @Test
+    void dataPreviewErrorOverlayWrapsLongMessageWithinModalWidth() {
+        String longMessage = "IOException: Failed to decompress page data in column chunk at offset 1234. "
+                + "The decompressor returned an unexpected length. "
+                + "The file may be truncated or written by an incompatible encoder.";
+        ScreenState.DataPreview state = new ScreenState.DataPreview(
+                0, 5, List.of("id"), List.of(), List.of(),
+                0, 0, -1, true, Set.of(), 0, 0, longMessage);
+
+        RenderHarness.RenderedFrame frame = RenderHarness.render(new Rect(0, 0, 80, 24), state, model);
+
+        assertThat(frame.contains(" Data preview — error")).isTrue();
+        assertThat(frame.contains("[Esc] to go back")).isTrue();
+        for (String line : frame.lines()) {
+            assertThat(line.length()).isLessThanOrEqualTo(80);
+        }
+    }
+
     /// The overlay is where a TUI user reads which build they are on, so the line must carry
     /// the resolved version rather than the label alone.
     @Test

--- a/cli/src/test/java/dev/hardwood/cli/dive/DiveStateTest.java
+++ b/cli/src/test/java/dev/hardwood/cli/dive/DiveStateTest.java
@@ -850,6 +850,29 @@ class DiveStateTest {
     }
 
     @Test
+    void dataPreviewValidLoadHasNoError() {
+        ScreenState.DataPreview state = DataPreviewScreen.initialState(model, 5);
+
+        assertThat(state.hasError()).isFalse();
+        assertThat(state.errorMessage()).isNull();
+        assertThat(state.rows()).isNotEmpty();
+    }
+
+    @Test
+    void dataPreviewIoErrorSurfacesAsOverlayAndBlocksNavigation() {
+        ScreenState.DataPreview errorState = new ScreenState.DataPreview(
+                0, 5, List.of("id"), List.of(), List.of(),
+                0, 0, -1, true, java.util.Set.of(), 0, 0, "Corrupt page: bad checksum");
+        NavigationStack stack = rooted(errorState);
+
+        assertThat(errorState.hasError()).isTrue();
+        assertThat(DataPreviewScreen.handle(key(KeyCode.DOWN), model, stack)).isFalse();
+        assertThat(DataPreviewScreen.handle(key(KeyCode.PAGE_DOWN), model, stack)).isFalse();
+        assertThat(DataPreviewScreen.handle(key(KeyCode.ESCAPE), model, stack)).isFalse();
+        assertThat(stack.top()).isSameAs(errorState);
+    }
+
+    @Test
     void columnChunkDetailDictionaryEnabledWhenChunkHasDictionary() {
         // Walk chunks until we find one with a dictionary; if none, test is vacuous.
         for (int rg = 0; rg < model.rowGroupCount(); rg++) {


### PR DESCRIPTION
#342 Surface IOExceptions in DataPreviewScreen as an error overlay 

## Authorship

Hardwood is built with AI, not by AI. LLM assistance is welcome; submitting raw LLM output without understanding is not.
Neither are unattended agents opening pull requests.
See the [contribution guide](https://github.com/hardwood-hq/hardwood/blob/main/CONTRIBUTING.md) for more details.
Check this box to confirm:

- [x] This change is coming from a human who understands what it does and why, and can discuss it in review

## Checklist

- [x] Build via `./mvnw clean verify` passes
- [x] The commit message is prefixed with the issue key ("#123 Adding support for...")
- [x] Code changes are covered by tests
- [ ] If this PR adds or changes user-facing behaviour, `docs/` has been updated

---
## Note regarding local tests: 
<del>
While running the required `./mvnw clean verify` locally, my build failed with the following error:
IllegalState UUID can only annotate FIXED_LEN_BYTE_ARRAY(16)

I tested a clean checkout of the main branch without any of my changes, and the exact same error occurred, so this appears to be a pre-existing issue upstream.

</del>

---

[io_error_test.webm](https://github.com/user-attachments/assets/ec3a549c-9da5-4c0d-8a8a-661b39feeac0)
