### PR TITLE
#965 Validate fixed-width column schemas before a read starts

### DIFF
--- a/core/src/main/java/dev/hardwood/internal/encoding/PlainDecoder.java
+++ b/core/src/main/java/dev/hardwood/internal/encoding/PlainDecoder.java
@@ -31,7 +31,19 @@ public class PlainDecoder implements ValueDecoder {
     private int currentByte = 0;
     private int bitPosition = 8; // 8 means we need to read a new byte
 
+    /// Creates a decoder over `data`.
+    ///
+    /// @param data the page bytes to decode from
+    /// @param offset the position in `data` to start at
+    /// @param type the physical type of the values to decode
+    /// @param typeLength the value width for `FIXED_LEN_BYTE_ARRAY`, `null` for every
+    ///        other type
+    /// @throws IllegalArgumentException if `type` is `FIXED_LEN_BYTE_ARRAY` and
+    ///         `typeLength` is `null`, which leaves the value boundaries undefined
     public PlainDecoder(byte[] data, int offset, PhysicalType type, Integer typeLength) {
+        if (type == PhysicalType.FIXED_LEN_BYTE_ARRAY && typeLength == null) {
+            throw new IllegalArgumentException("FIXED_LEN_BYTE_ARRAY requires a type length to decode");
+        }
         this.data = data;
         this.pos = offset;
         this.type = type;
@@ -214,12 +226,7 @@ public class PlainDecoder implements ValueDecoder {
     private byte[] readByteArrayValue() throws IOException {
         return switch (type) {
             case BYTE_ARRAY -> readByteArray();
-            case FIXED_LEN_BYTE_ARRAY -> {
-                if (typeLength == null) {
-                    throw new IOException("FIXED_LEN_BYTE_ARRAY requires type_length in schema");
-                }
-                yield readFixedLenByteArray(typeLength);
-            }
+            case FIXED_LEN_BYTE_ARRAY -> readFixedLenByteArray(typeLength);
             case INT96 -> readInt96();
             default -> throw new IOException("readByteArrays not supported for type: " + type);
         };

--- a/core/src/main/java/dev/hardwood/internal/predicate/FilterPredicateResolver.java
+++ b/core/src/main/java/dev/hardwood/internal/predicate/FilterPredicateResolver.java
@@ -13,6 +13,7 @@ import java.time.Instant;
 import java.time.LocalTime;
 import java.util.List;
 
+import dev.hardwood.internal.schema.FixedWidthValidator;
 import dev.hardwood.internal.schema.SchemaPathResolver;
 import dev.hardwood.metadata.ColumnOrder;
 import dev.hardwood.metadata.LogicalType;
@@ -115,10 +116,19 @@ public class FilterPredicateResolver {
                     yield new ResolvedPredicate.LongPredicate(cs.columnIndex(), p.op(),
                             scaled.unscaledValue().longValueExact());
                 }
-                else {
+                else if (physicalType == PhysicalType.FIXED_LEN_BYTE_ARRAY) {
                     yield new ResolvedPredicate.BinaryPredicate(cs.columnIndex(), p.op(),
-                            toFixedLenDecimalBytes(scaled.unscaledValue(), cs.typeLength()),
+                            toFixedLenDecimalBytes(scaled.unscaledValue(),
+                                    FixedWidthValidator.requireWidth(null, cs)),
                             true);
+                }
+                else {
+                    // A BYTE_ARRAY decimal stores the minimal two's complement of each value,
+                    // so padding the literal to a fixed width would compare it against a
+                    // differently sized encoding of the same number.
+                    throw new IllegalArgumentException("Column '" + p.column()
+                            + "' stores its DECIMAL as " + physicalType
+                            + ", which decimal predicates do not support");
                 }
             }
             case IntColumnPredicate p -> {

--- a/core/src/main/java/dev/hardwood/internal/reader/BatchExchange.java
+++ b/core/src/main/java/dev/hardwood/internal/reader/BatchExchange.java
@@ -261,7 +261,9 @@ public class BatchExchange<B> {
     ///   via [BinaryBatchValues#appendAt].
     /// - `FIXED_LEN_BYTE_ARRAY`: bytes buffer is sized exactly to
     ///   `width * capacity` (`width = column.typeLength()`); offsets are
-    ///   filled trivially as `i * width`.
+    ///   filled trivially as `i * width`. The width is present and positive —
+    ///   [RowGroupIterator#initialize] validates it for every column a read
+    ///   touches before the first batch is allocated for it.
     public static Object allocateArray(ColumnSchema column, int capacity) {
         PhysicalType type = column.type();
         return switch (type) {

--- a/core/src/main/java/dev/hardwood/internal/reader/BatchSizing.java
+++ b/core/src/main/java/dev/hardwood/internal/reader/BatchSizing.java
@@ -133,7 +133,9 @@ public final class BatchSizing {
             // interned-String reuse — but the byte-array estimate is intentionally
             // approximate.
             case BYTE_ARRAY -> 16;
-            case FIXED_LEN_BYTE_ARRAY -> col.typeLength() != null ? col.typeLength() : 16;
+            // The width is present and positive: RowGroupIterator#initialize validates every
+            // projected column before a batch size is ever computed for it.
+            case FIXED_LEN_BYTE_ARRAY -> col.typeLength();
         };
     }
 }

--- a/core/src/main/java/dev/hardwood/internal/reader/NestedColumnWorker.java
+++ b/core/src/main/java/dev/hardwood/internal/reader/NestedColumnWorker.java
@@ -762,6 +762,11 @@ public class NestedColumnWorker extends ColumnWorker<NestedBatch> {
         };
     }
 
+    /// Grows a byte-array-shaped value buffer to `newCapacity`.
+    ///
+    /// For `FIXED_LEN_BYTE_ARRAY` the new offsets stay `i * width`, with the width taken
+    /// from the column — present and positive, validated for every touched column by
+    /// [RowGroupIterator#initialize] before this worker was built.
     private BinaryBatchValues growBinaryBatchValues(BinaryBatchValues bbv, int newCapacity) {
         int oldCapacity = bbv.offsets.length - 1;
         if (newCapacity <= oldCapacity) {

--- a/core/src/main/java/dev/hardwood/internal/reader/RowGroupIterator.java
+++ b/core/src/main/java/dev/hardwood/internal/reader/RowGroupIterator.java
@@ -32,6 +32,7 @@ import dev.hardwood.internal.predicate.RowGroupBloomFilterSource;
 import dev.hardwood.internal.predicate.RowGroupFilterEvaluator;
 import dev.hardwood.internal.predicate.dictionary.RowGroupDictionaryFilterSource;
 import dev.hardwood.internal.reader.FileMetadataCache.PreparedFile;
+import dev.hardwood.internal.schema.FixedWidthValidator;
 import dev.hardwood.internal.schema.ProjectedSchema;
 import dev.hardwood.internal.thrift.OffsetIndexReader;
 import dev.hardwood.internal.thrift.ThriftCompactReader;
@@ -332,6 +333,8 @@ public class RowGroupIterator {
         this.touchedColumns = touchedColumns(projected, filter, referenceSchema.getColumnCount());
         this.dropLeavesByColumn = filter != null && metadataFilteringEnabled
                 ? PageDropPredicates.byColumn(filter) : Map.of();
+
+        validateReferenceColumns();
 
         buildWorkList();
 
@@ -1231,6 +1234,26 @@ public class RowGroupIterator {
         event.commit();
 
         return filtered;
+    }
+
+    /// Validates the reference schema's own statement of the columns this read touches,
+    /// before any of them is planned for or decoded.
+    ///
+    /// [#validateSchemaCompatibility] cross-checks every file from the second onwards
+    /// against the reference schema, but the first file *is* the reference schema and so
+    /// is never cross-checked. What it declares therefore has to hold on its own terms:
+    /// a fixed-width column whose width the footer omits cannot be decoded by any of the
+    /// consumers downstream of here, and a read of a single file would otherwise reach
+    /// them with nothing having said so.
+    ///
+    /// @throws SchemaIncompatibleException if a touched column cannot be decoded under
+    ///         the schema the file declares for it
+    private void validateReferenceColumns() {
+        String fileName = inputFiles.get(0).name();
+        for (int originalIndex = touchedColumns.nextSetBit(0); originalIndex >= 0;
+                originalIndex = touchedColumns.nextSetBit(originalIndex + 1)) {
+            FixedWidthValidator.validate(fileName, referenceSchema.getColumn(originalIndex));
+        }
     }
 
     /// The reference leaf ordinals a read with this projection and filter touches.

--- a/core/src/main/java/dev/hardwood/internal/schema/FixedWidthValidator.java
+++ b/core/src/main/java/dev/hardwood/internal/schema/FixedWidthValidator.java
@@ -1,0 +1,68 @@
+/*
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Copyright The original authors
+ *
+ *  Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package dev.hardwood.internal.schema;
+
+import dev.hardwood.internal.ExceptionContext;
+import dev.hardwood.metadata.PhysicalType;
+import dev.hardwood.reader.SchemaIncompatibleException;
+import dev.hardwood.schema.ColumnSchema;
+
+/// Checks that a `FIXED_LEN_BYTE_ARRAY` column carries the width every decode of its
+/// bytes needs.
+///
+/// `type_length` is optional in `parquet.thrift`, so a footer can declare a fixed-width
+/// column without stating how wide its values are. The width sizes the value buffer,
+/// spaces the offsets and advances the decoder's read position, so a column missing it
+/// cannot be decoded at all — and one declaring a non-positive width decodes to
+/// something that is not the column's data.
+///
+/// The check runs over the columns a read touches, before it starts: see
+/// [dev.hardwood.internal.reader.RowGroupIterator#initialize]. Columns that are neither
+/// projected nor filtered on are never checked, so a file remains readable through the
+/// columns that are well-formed, and the metadata tools keep reporting the schema as the
+/// footer states it.
+///
+/// A `type_length` on a column of any other physical type carries its second
+/// `parquet.thrift` meaning — the maximum bit length of a value — and is left alone.
+public final class FixedWidthValidator {
+
+    private FixedWidthValidator() {
+    }
+
+    /// Validates `column` if it is a `FIXED_LEN_BYTE_ARRAY`, and does nothing otherwise.
+    ///
+    /// @param fileName the file the column was read from, for the message; may be `null`
+    /// @param column the column to check
+    /// @throws SchemaIncompatibleException if the column is fixed-width and its declared
+    ///         width is absent or not positive
+    public static void validate(String fileName, ColumnSchema column) {
+        if (column.type() == PhysicalType.FIXED_LEN_BYTE_ARRAY) {
+            requireWidth(fileName, column);
+        }
+    }
+
+    /// Returns the byte width of a `FIXED_LEN_BYTE_ARRAY` column.
+    ///
+    /// @param fileName the file the column was read from, for the message; may be `null`
+    /// @param column the fixed-width column whose width is needed
+    /// @return the column's positive byte width
+    /// @throws SchemaIncompatibleException if the declared width is absent or not positive
+    public static int requireWidth(String fileName, ColumnSchema column) {
+        Integer width = column.typeLength();
+        if (width == null) {
+            throw new SchemaIncompatibleException(ExceptionContext.filePrefix(fileName)
+                    + "Column '" + column.fieldPath() + "' is a FIXED_LEN_BYTE_ARRAY that declares no type length");
+        }
+        if (width <= 0) {
+            throw new SchemaIncompatibleException(ExceptionContext.filePrefix(fileName)
+                    + "Column '" + column.fieldPath() + "' declares a FIXED_LEN_BYTE_ARRAY type length of "
+                    + width + ", which must be positive");
+        }
+        return width;
+    }
+}

--- a/core/src/main/java/dev/hardwood/reader/ParquetFileReader.java
+++ b/core/src/main/java/dev/hardwood/reader/ParquetFileReader.java
@@ -469,6 +469,26 @@ public class ParquetFileReader implements AutoCloseable {
         return reader;
     }
 
+    /// Resolves a user-facing predicate against the reference schema, or returns `null`
+    /// when the read is unfiltered.
+    ///
+    /// Resolution reads the schema of the columns the predicate tests — a `DECIMAL`
+    /// literal, for instance, is converted to the on-disk encoding the column declares —
+    /// so a schema that cannot state that encoding fails here, before the read is
+    /// planned. The file name is added the same way the decode paths add it, so both
+    /// report the same file for the same malformed column.
+    private ResolvedPredicate resolveFilter(FilterPredicate filter) {
+        if (filter == null) {
+            return null;
+        }
+        try {
+            return FilterPredicateResolver.resolve(filter, schema, firstFileMetaData.columnOrders());
+        }
+        catch (SchemaIncompatibleException e) {
+            throw ExceptionContext.addFileContext(inputFiles.get(0).name(), e);
+        }
+    }
+
     private RowReader buildRowReader(ColumnProjection projection, FilterPredicate filter,
                                      long maxRows, List<RowGroup> firstFileRowGroups) {
         return buildRowReader(projection, filter, maxRows, firstFileRowGroups, 0L);
@@ -483,8 +503,7 @@ public class ParquetFileReader implements AutoCloseable {
     private RowReader buildRowReader(ColumnProjection projection, FilterPredicate filter,
                                      long maxRows, List<RowGroup> firstFileRowGroups,
                                      long tailSkip, long physicalSkip) {
-        ResolvedPredicate resolved = filter != null
-                ? FilterPredicateResolver.resolve(filter, schema, firstFileMetaData.columnOrders()) : null;
+        ResolvedPredicate resolved = resolveFilter(filter);
 
         ProjectedSchema projectedSchema = ProjectedSchema.create(schema, projection, true);
 
@@ -586,8 +605,7 @@ public class ParquetFileReader implements AutoCloseable {
             FilterPredicate filter,
             RowGroupPredicate rowGroupFilter,
             int batchSize) {
-        ResolvedPredicate resolved = filter != null
-                ? FilterPredicateResolver.resolve(filter, schema, firstFileMetaData.columnOrders()) : null;
+        ResolvedPredicate resolved = resolveFilter(filter);
         List<RowGroup> rowGroups = filterRowGroups(rowGroupFilter);
 
         if (resolved == null) {

--- a/core/src/main/java/dev/hardwood/reader/SchemaIncompatibleException.java
+++ b/core/src/main/java/dev/hardwood/reader/SchemaIncompatibleException.java
@@ -18,10 +18,16 @@ package dev.hardwood.reader;
 ///
 /// Also thrown, for a read of any size, when a file's footer is internally
 /// inconsistent: the column chunks a row group lists disagree with the schema about
-/// which leaf they hold.
+/// which leaf they hold, or a touched `FIXED_LEN_BYTE_ARRAY` column declares no
+/// `type_length` — which is optional in the format but required to decode the column —
+/// or declares one that is not positive.
 public class SchemaIncompatibleException extends RuntimeException {
 
     public SchemaIncompatibleException(String message) {
         super(message);
+    }
+
+    public SchemaIncompatibleException(String message, Throwable cause) {
+        super(message, cause);
     }
 }

--- a/core/src/test/java/dev/hardwood/reader/FixedWidthSchemaValidationTest.java
+++ b/core/src/test/java/dev/hardwood/reader/FixedWidthSchemaValidationTest.java
@@ -1,0 +1,234 @@
+/*
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Copyright The original authors
+ *
+ *  Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package dev.hardwood.reader;
+
+import java.io.IOException;
+import java.math.BigDecimal;
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import dev.hardwood.InputFile;
+import dev.hardwood.internal.reader.ParquetMetadataReader;
+import dev.hardwood.internal.thrift.FileMetaDataWriter;
+import dev.hardwood.internal.thrift.ThriftCompactWriter;
+import dev.hardwood.internal.writer.ByteBufferOutputFile;
+import dev.hardwood.metadata.FileMetaData;
+import dev.hardwood.metadata.LogicalType;
+import dev.hardwood.metadata.PhysicalType;
+import dev.hardwood.metadata.RepetitionType;
+import dev.hardwood.metadata.SchemaElement;
+import dev.hardwood.schema.ColumnProjection;
+import dev.hardwood.schema.FileSchema;
+import dev.hardwood.writer.ParquetFileWriter;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/// `type_length` is optional in the format, so a footer can declare a
+/// `FIXED_LEN_BYTE_ARRAY` column without saying how wide its values are — and nothing on
+/// the write path can produce one, so these files are built by rewriting the footer of a
+/// well-formed file.
+///
+/// A read that touches such a column fails as the read is planned, naming the column and
+/// the file it came from. A read that does not touch it, and the metadata accessors, are
+/// unaffected: an unreadable column is not an unreadable file.
+class FixedWidthSchemaValidationTest {
+
+    private static final byte[] MAGIC = "PAR1".getBytes(StandardCharsets.US_ASCII);
+
+    @TempDir
+    Path tempDir;
+
+    @Test
+    void aTouchedColumnWithoutAWidthNamesTheColumnAndTheFile() throws Exception {
+        Path file = fileWithDigestWidth(null, "no-width.parquet");
+
+        try (ParquetFileReader reader = ParquetFileReader.open(InputFile.of(file))) {
+            assertThatThrownBy(() -> reader.buildRowReader().projection(ColumnProjection.columns("digest")).build())
+                    .isInstanceOf(SchemaIncompatibleException.class)
+                    .hasMessage("[no-width.parquet] Column 'digest' is a FIXED_LEN_BYTE_ARRAY "
+                            + "that declares no type length");
+        }
+    }
+
+    @Test
+    void aWidthOfZeroIsRejectedRatherThanDecodingToEmptyValues() throws Exception {
+        Path file = fileWithDigestWidth(0, "zero-width.parquet");
+
+        try (ParquetFileReader reader = ParquetFileReader.open(InputFile.of(file))) {
+            assertThatThrownBy(() -> reader.buildRowReader().projection(ColumnProjection.columns("digest")).build())
+                    .isInstanceOf(SchemaIncompatibleException.class)
+                    .hasMessage("[zero-width.parquet] Column 'digest' declares a FIXED_LEN_BYTE_ARRAY "
+                            + "type length of 0, which must be positive");
+        }
+    }
+
+    @Test
+    void aNegativeWidthIsRejectedRatherThanSizingAnArrayFromIt() throws Exception {
+        Path file = fileWithDigestWidth(-4, "negative-width.parquet");
+
+        try (ParquetFileReader reader = ParquetFileReader.open(InputFile.of(file))) {
+            assertThatThrownBy(() -> reader.columnReaders(ColumnProjection.columns("digest")))
+                    .isInstanceOf(SchemaIncompatibleException.class)
+                    .hasMessage("[negative-width.parquet] Column 'digest' declares a FIXED_LEN_BYTE_ARRAY "
+                            + "type length of -4, which must be positive");
+        }
+    }
+
+    @Test
+    void aFilterOnAWidthlessDecimalColumnFailsAsThePredicateResolves() throws Exception {
+        Path file = fileWithPriceWidth(null, "no-decimal-width.parquet");
+
+        try (ParquetFileReader reader = ParquetFileReader.open(InputFile.of(file))) {
+            assertThatThrownBy(() -> reader.buildRowReader()
+                    .projection(ColumnProjection.columns("id"))
+                    .filter(FilterPredicate.gt("price", new BigDecimal("1.00")))
+                    .build())
+                            .isInstanceOf(SchemaIncompatibleException.class)
+                            .hasMessage("[no-decimal-width.parquet] Column 'price' is a FIXED_LEN_BYTE_ARRAY "
+                                    + "that declares no type length");
+        }
+    }
+
+    @Test
+    void aColumnTheReadDoesNotTouchLeavesTheReadAlone() throws Exception {
+        Path file = fileWithDigestWidth(null, "untouched.parquet");
+
+        try (ParquetFileReader reader = ParquetFileReader.open(InputFile.of(file));
+                RowReader rows = reader.buildRowReader()
+                        .projection(ColumnProjection.columns("id")).build()) {
+            List<Integer> ids = new ArrayList<>();
+            while (rows.hasNext()) {
+                rows.next();
+                ids.add(rows.getInt("id"));
+            }
+            assertThat(ids).containsExactly(1, 2, 3);
+        }
+    }
+
+    @Test
+    void theSchemaStaysReportableAsTheFooterStatesIt() throws Exception {
+        Path file = fileWithDigestWidth(null, "reportable.parquet");
+
+        try (ParquetFileReader reader = ParquetFileReader.open(InputFile.of(file))) {
+            FileSchema schema = reader.getFileSchema();
+            assertThat(schema.getColumn("digest").type()).isEqualTo(PhysicalType.FIXED_LEN_BYTE_ARRAY);
+            assertThat(schema.getColumn("digest").typeLength()).isNull();
+        }
+    }
+
+    @Test
+    void aWellFormedWidthStillReads() throws Exception {
+        Path file = writeToTempFile(validFile(), "well-formed.parquet");
+
+        try (ParquetFileReader reader = ParquetFileReader.open(InputFile.of(file));
+                RowReader rows = reader.buildRowReader().projection(ColumnProjection.columns("digest")).build()) {
+            assertThatCode(() -> {
+                while (rows.hasNext()) {
+                    rows.next();
+                    assertThat(rows.getBinary("digest")).hasSize(4);
+                }
+            }).doesNotThrowAnyException();
+        }
+    }
+
+    // ==================== Fixtures ====================
+
+    /// A well-formed three-column file: `id` `INT32`, `digest` `FIXED_LEN_BYTE_ARRAY(4)`,
+    /// and `price` a `FIXED_LEN_BYTE_ARRAY(8)` `DECIMAL` for the predicate path.
+    private static byte[] validFile() throws IOException {
+        FileSchema schema = FileSchema.builder("schema")
+                .addColumn("id", PhysicalType.INT32, RepetitionType.REQUIRED)
+                .addColumn("digest", PhysicalType.FIXED_LEN_BYTE_ARRAY, RepetitionType.REQUIRED, 4)
+                .addColumn("price", PhysicalType.FIXED_LEN_BYTE_ARRAY, RepetitionType.REQUIRED, 8,
+                        new LogicalType.DecimalType(2, 18))
+                .build();
+
+        byte[][] digests = { bytes("aaaa"), bytes("bbbb"), bytes("cccc") };
+        byte[][] prices = { unscaled(100), unscaled(250), unscaled(375) };
+
+        ByteBufferOutputFile out = new ByteBufferOutputFile();
+        try (ParquetFileWriter writer = ParquetFileWriter.create(out, schema)) {
+            writer.columnWriter().writeBatch(batch -> batch
+                    .ints(0, new int[] { 1, 2, 3 })
+                    .fixed(1, digests)
+                    .fixed(2, prices));
+        }
+        return out.toByteArray();
+    }
+
+    private Path fileWithDigestWidth(Integer width, String fileName) throws IOException {
+        return writeToTempFile(withTypeLength(validFile(), "digest", width), fileName);
+    }
+
+    private Path fileWithPriceWidth(Integer width, String fileName) throws IOException {
+        return writeToTempFile(withTypeLength(validFile(), "price", width), fileName);
+    }
+
+    private Path writeToTempFile(byte[] content, String fileName) throws IOException {
+        Path file = tempDir.resolve(fileName);
+        Files.write(file, content);
+        return file;
+    }
+
+    /// Rewrites `file`'s footer with `columnName`'s `type_length` set to `width`, dropping
+    /// the field entirely when `width` is `null`. The data pages are untouched, so what
+    /// changes is only what the file claims about the column.
+    private static byte[] withTypeLength(byte[] file, String columnName, Integer width) throws IOException {
+        FileMetaData metaData = ParquetMetadataReader.readMetadata(InputFile.of(ByteBuffer.wrap(file)));
+
+        List<SchemaElement> patched = new ArrayList<>(metaData.schema().size());
+        for (SchemaElement element : metaData.schema()) {
+            patched.add(element.name().equals(columnName)
+                    ? new SchemaElement(element.name(), element.type(), width, element.repetitionType(),
+                            element.numChildren(), element.convertedType(), element.scale(),
+                            element.precision(), element.fieldId(), element.logicalType())
+                    : element);
+        }
+
+        ThriftCompactWriter footer = new ThriftCompactWriter();
+        FileMetaDataWriter.write(footer, new FileMetaData(metaData.version(), patched, metaData.numRows(),
+                metaData.rowGroups(), metaData.keyValueMetadata(), metaData.createdBy(), metaData.columnOrders()));
+        byte[] footerBytes = footer.toByteArray();
+
+        int dataLength = file.length - MAGIC.length - Integer.BYTES - footerLength(file);
+        ByteBuffer rewritten = ByteBuffer
+                .allocate(dataLength + footerBytes.length + Integer.BYTES + MAGIC.length)
+                .order(ByteOrder.LITTLE_ENDIAN);
+        rewritten.put(file, 0, dataLength);
+        rewritten.put(footerBytes);
+        rewritten.putInt(footerBytes.length);
+        rewritten.put(MAGIC);
+        return rewritten.array();
+    }
+
+    private static int footerLength(byte[] file) {
+        return ByteBuffer.wrap(file, file.length - MAGIC.length - Integer.BYTES, Integer.BYTES)
+                .order(ByteOrder.LITTLE_ENDIAN)
+                .getInt();
+    }
+
+    private static byte[] bytes(String value) {
+        return value.getBytes(StandardCharsets.UTF_8);
+    }
+
+    /// The 8-byte big-endian two's complement of `value`, the `DECIMAL` encoding the
+    /// `price` column declares.
+    private static byte[] unscaled(long value) {
+        return ByteBuffer.allocate(Long.BYTES).order(ByteOrder.BIG_ENDIAN).putLong(value).array();
+    }
+}

--- a/docs/content/reference/query-controls.md
+++ b/docs/content/reference/query-controls.md
@@ -33,7 +33,9 @@ row-group and page skipping.
 The logical-type factories validate the column's logical type at reader creation: `BigDecimal`
 predicates require a `DECIMAL` column and `UUID` predicates require a `UUID` column. Applying them
 to a plain `FIXED_LEN_BYTE_ARRAY` column without the corresponding logical-type annotation throws
-`IllegalArgumentException`. Raw physical-type predicates (`int`, `long`, etc.) remain available for
+`IllegalArgumentException`. A `BigDecimal` predicate reads a `DECIMAL` stored as `INT32`, `INT64`
+or `FIXED_LEN_BYTE_ARRAY`; one stored as `BYTE_ARRAY` is rejected with the same exception.
+Raw physical-type predicates (`int`, `long`, etc.) remain available for
 columns without logical types or for filtering on the underlying physical value directly. Filters
 work with all reader types — `RowReader`, `ColumnReader`, `AvroRowReader`, and across multi-file
 readers.

--- a/parquet-testing-runner/src/test/java/dev/hardwood/testing/IncompatibleLogicalTypeReadTest.java
+++ b/parquet-testing-runner/src/test/java/dev/hardwood/testing/IncompatibleLogicalTypeReadTest.java
@@ -1,0 +1,71 @@
+/*
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Copyright The original authors
+ *
+ *  Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package dev.hardwood.testing;
+
+import java.io.IOException;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+
+import dev.hardwood.InputFile;
+import dev.hardwood.metadata.LogicalType;
+import dev.hardwood.metadata.PhysicalType;
+import dev.hardwood.reader.ParquetFileReader;
+import dev.hardwood.reader.RowReader;
+import dev.hardwood.schema.FileSchema;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/// End-to-end coverage for a logical type its physical type cannot carry, reading the
+/// `int32_with_uuid_logical_type.parquet` fixture from apache/parquet-testing: a `UUID`, which
+/// the format defines over `FIXED_LEN_BYTE_ARRAY(16)`, annotating an `INT32`.
+///
+/// The annotation is not a value: the column's data is ten `INT32`s and reads back as such. So
+/// the file opens, the footer is reported as it stands — annotation included, because dropping it
+/// would misreport what the file says — and the physical values are readable.
+///
+/// [ParquetComparisonTest] skips the fixture: parquet-java rejects the pairing while parsing the
+/// footer ("UUID can only annotate FIXED_LEN_BYTE_ARRAY(16)") and so never opens the file, which
+/// leaves no reference reader to compare against. This test is the coverage that replaces it.
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+class IncompatibleLogicalTypeReadTest {
+
+    private static final String COLUMN = "int32_uuid";
+
+    private final List<Integer> values = new ArrayList<>();
+    private FileSchema schema;
+
+    @BeforeAll
+    void readAllRows() throws IOException {
+        Path file = ParquetTestingRepoCloner.getTestFile("data/int32_with_uuid_logical_type.parquet");
+        try (ParquetFileReader reader = ParquetFileReader.open(InputFile.of(file));
+                RowReader rowReader = reader.rowReader()) {
+
+            schema = reader.getFileSchema();
+            while (rowReader.hasNext()) {
+                rowReader.next();
+                values.add(rowReader.getInt(COLUMN));
+            }
+        }
+    }
+
+    @Test
+    void theSchemaIsReportedAsTheFooterStatesIt() {
+        assertThat(schema.getColumn(COLUMN).type()).isEqualTo(PhysicalType.INT32);
+        assertThat(schema.getColumn(COLUMN).logicalType()).isInstanceOf(LogicalType.UuidType.class);
+    }
+
+    @Test
+    void thePhysicalValuesReadBack() {
+        assertThat(values).containsExactly(0, 1, 2, 3, 4, 5, 6, 7, 8, 9);
+    }
+}

--- a/parquet-testing-runner/src/test/java/dev/hardwood/testing/ParquetTestingRepoTest.java
+++ b/parquet-testing-runner/src/test/java/dev/hardwood/testing/ParquetTestingRepoTest.java
@@ -87,6 +87,7 @@ class ParquetTestingRepoTest {
         files.add("data/incorrect_map_schema.parquet");
         files.add("data/int32_decimal.parquet");
         files.add("data/int32_with_null_pages.parquet");
+        files.add("data/int32_with_uuid_logical_type.parquet");
         files.add("data/int64_decimal.parquet");
         files.add("data/int96_from_spark.parquet");
         files.add("data/large_string_map.brotli.parquet");

--- a/parquet-testing-runner/src/test/java/dev/hardwood/testing/Utils.java
+++ b/parquet-testing-runner/src/test/java/dev/hardwood/testing/Utils.java
@@ -97,6 +97,13 @@ public class Utils {
             // and page index, and rejects the pages themselves until #581 adds ALP support.
             "alp_extended.zstd.parquet", // No parquet-java oracle: ALP encoding
 
+            // The fixture annotates an INT32 with UUID on purpose, to exercise how a reader
+            // handles a logical type its physical type cannot carry. parquet-java rejects the
+            // pairing while parsing the footer ("UUID can only annotate FIXED_LEN_BYTE_ARRAY(16)"),
+            // so it never opens the file and cannot serve as a reference. Hardwood reads the
+            // column as the INT32 it is.
+            "int32_with_uuid_logical_type.parquet", // No parquet-java oracle: invalid annotation
+
             // shredded_variant fixtures are skipped outside this list: spec-invalid
             // ones by isInvalidFixture() (the `-INVALID` suffix), error cases by
             // SHREDDED_VARIANT_ERROR_CASES. Both are folded in by isSkipped().


### PR DESCRIPTION
Fixes #965. Builds on #1064 by @chlgusrbs0, credited as co-author; that PR can be closed in favour of this one.

Bottom of a two-PR stack: #1082 (decimal predicates on `BYTE_ARRAY` columns) sits on top of this branch.

Also fixes #1080 in its own commit — an unrelated break in the comparison gate that makes every branch red. Happy to pull it out if you'd rather it landed separately.

- [x] This change is coming from a human who understands what it does and why, and can discuss it in review

## What changes

`type_length` is optional in a footer, so a `FIXED_LEN_BYTE_ARRAY` column can arrive without the width that separates one value from the next. Nothing said so, and each consumer that reached for it failed its own way: an unboxing `NullPointerException` from the batch allocator, an `IOException` naming neither column nor file from `PlainDecoder`, a silent 16-byte substitution in `BatchSizing`. A width of `0` was worse than an absent one — zero-length buffer, all-zero offsets, empty values and no error at all.

The width is settled before any data is read, so the check belongs in the read plan. `RowGroupIterator#initialize` already resolves which columns a read touches; validating them there covers every consumer at once, before a worker exists, and scoping it to touched columns keeps the reader lenient — a file stays readable through its well-formed columns, and the metadata tools keep reporting the footer as it is.

That placement also closes the gap this fell through: `validateColumn` cross-checks files from the second onwards, because the first file *is* the reference schema, so a single-file read validated nothing.

Consumers now state the invariant instead of re-checking it, and `PlainDecoder` states its contract in its constructor rather than once per value.

Chasing the same unboxing turned up a second one, in `FilterPredicateResolver`: a `BigDecimal` predicate padded its literal to `type_length`, which a `BYTE_ARRAY` column does not have. Here that becomes an `IllegalArgumentException` naming the limitation, so the resolver stops unboxing a `null`. The PR on top of this one makes those predicates work instead.

## Tests

`FixedWidthSchemaValidationTest` rewrites a well-formed file's footer, since no writer can produce those files. Four of its seven cases fail on `main`: missing, zero and negative widths (exact messages, file prefix included) and a filter on a widthless `DECIMAL`. The rest pin the leniency — an untouched column still reads, and the schema still reports as the footer states it.

## Checklist

- [x] `./mvnw clean verify` passes
- [x] Commit messages prefixed with the issue key
- [x] Covered by tests
- [x] `docs/` updated (`reference/query-controls.md`)
