### PR TITLE
#1082 Compare DECIMAL predicates by value on BYTE_ARRAY columns

### DIFF
--- a/core/src/main/java/dev/hardwood/internal/predicate/BinaryComparator.java
+++ b/core/src/main/java/dev/hardwood/internal/predicate/BinaryComparator.java
@@ -9,10 +9,11 @@ package dev.hardwood.internal.predicate;
 
 import java.util.Arrays;
 
-/// Byte array comparison utilities for filter predicate evaluation.
+/// Byte array comparison in the two orders a binary column sorts in: unsigned lexicographic
+/// (for BYTE_ARRAY) and signed two's complement (for DECIMAL columns of either byte-array type).
 ///
-/// Provides unsigned lexicographic comparison (for BYTE_ARRAY) and signed
-/// two's complement comparison (for FIXED_LEN_BYTE_ARRAY decimals).
+/// Both the reader's predicate evaluation and the writer's statistics collection compare through
+/// here, so a chunk's bounds and a predicate over them cannot come to disagree.
 public final class BinaryComparator {
 
     private BinaryComparator() {
@@ -26,24 +27,44 @@ public final class BinaryComparator {
         return Arrays.compareUnsigned(a, b);
     }
 
-    /// Compare two same-length byte arrays as big-endian two's complement signed values.
-    /// Used for `FIXED_LEN_BYTE_ARRAY` decimals where the high bit is the sign bit.
+    /// Compare two byte arrays as big-endian two's complement signed values, the order a
+    /// `DECIMAL`'s unscaled value sorts in.
+    ///
+    /// The two may differ in length. A `FIXED_LEN_BYTE_ARRAY` decimal pads every value to the
+    /// column width, so its values always match; a `BYTE_ARRAY` decimal stores each value in the
+    /// fewest bytes that hold it, so `127` is one byte and `128` is two. Length is not magnitude
+    /// under that encoding — a byte-wise comparison would rank `0x7F` above `0x00 0x80` — so the
+    /// shorter value is sign-extended to the longer before the bytes are compared.
+    ///
+    /// An empty array is the value zero.
     ///
     /// @return negative if a < b, zero if equal, positive if a > b
     public static int compareSigned(byte[] a, byte[] b) {
-        if (a.length != b.length) {
-            throw new IllegalArgumentException(
-                    "Signed binary comparison requires same-length arrays: " + a.length + " vs " + b.length);
+        boolean aNegative = a.length > 0 && a[0] < 0;
+        boolean bNegative = b.length > 0 && b[0] < 0;
+        if (aNegative != bNegative) {
+            return aNegative ? -1 : 1;
         }
-        if (a.length == 0) {
-            return 0;
+        if (a.length == b.length) {
+            if (a.length == 0) {
+                return 0;
+            }
+            // Same sign and same width: the leading bytes carry the same weight, so the whole
+            // string compares unsigned.
+            return Arrays.compareUnsigned(a, b);
         }
-        // First byte: compare as signed to handle the sign bit
-        int cmp = a[0] - b[0];
-        if (cmp != 0) {
-            return cmp;
+        int length = Math.max(a.length, b.length);
+        int aPad = aNegative ? 0xFF : 0x00;
+        int bPad = bNegative ? 0xFF : 0x00;
+        int aOffset = length - a.length;
+        int bOffset = length - b.length;
+        for (int i = 0; i < length; i++) {
+            int aByte = i < aOffset ? aPad : a[i - aOffset] & 0xFF;
+            int bByte = i < bOffset ? bPad : b[i - bOffset] & 0xFF;
+            if (aByte != bByte) {
+                return aByte - bByte;
+            }
         }
-        // Remaining bytes: compare as unsigned
-        return Arrays.compareUnsigned(a, 1, a.length, b, 1, a.length);
+        return 0;
     }
 }

--- a/core/src/main/java/dev/hardwood/internal/predicate/FilterPredicateResolver.java
+++ b/core/src/main/java/dev/hardwood/internal/predicate/FilterPredicateResolver.java
@@ -13,6 +13,7 @@ import java.time.Instant;
 import java.time.LocalTime;
 import java.util.List;
 
+import dev.hardwood.internal.predicate.ResolvedPredicate.BinaryPredicate.Comparison;
 import dev.hardwood.internal.schema.FixedWidthValidator;
 import dev.hardwood.internal.schema.SchemaPathResolver;
 import dev.hardwood.metadata.ColumnOrder;
@@ -117,18 +118,22 @@ public class FilterPredicateResolver {
                             scaled.unscaledValue().longValueExact());
                 }
                 else if (physicalType == PhysicalType.FIXED_LEN_BYTE_ARRAY) {
+                    // Every value is padded to the column width, so the literal is too and the
+                    // encoding of a given number is the only one the column can hold.
                     yield new ResolvedPredicate.BinaryPredicate(cs.columnIndex(), p.op(),
                             toFixedLenDecimalBytes(scaled.unscaledValue(),
                                     FixedWidthValidator.requireWidth(null, cs)),
-                            true);
+                            Comparison.FIXED_DECIMAL);
                 }
                 else {
-                    // A BYTE_ARRAY decimal stores the minimal two's complement of each value,
-                    // so padding the literal to a fixed width would compare it against a
-                    // differently sized encoding of the same number.
-                    throw new IllegalArgumentException("Column '" + p.column()
-                            + "' stores its DECIMAL as " + physicalType
-                            + ", which decimal predicates do not support");
+                    validateType(p.column(), PhysicalType.BYTE_ARRAY, cs);
+                    // A BYTE_ARRAY decimal should store each value in the fewest bytes that hold
+                    // it — `should`, not `must`, so a writer may pad and two byte strings of
+                    // different lengths may be the same number. The literal takes the minimal
+                    // form, which is what a conforming writer produces, and VARIABLE_DECIMAL
+                    // keeps equality from ever riding on that encoding.
+                    yield new ResolvedPredicate.BinaryPredicate(cs.columnIndex(), p.op(),
+                            scaled.unscaledValue().toByteArray(), Comparison.VARIABLE_DECIMAL);
                 }
             }
             case IntColumnPredicate p -> {
@@ -172,21 +177,24 @@ public class FilterPredicateResolver {
                 ColumnSchema cs = resolveColumn(p.column(), schema);
                 rejectRepeated(p.column(), cs);
                 validateType(p.column(), PhysicalType.BYTE_ARRAY, cs);
-                yield new ResolvedPredicate.BinaryPredicate(cs.columnIndex(), p.op(), p.value(), false);
+                yield new ResolvedPredicate.BinaryPredicate(cs.columnIndex(), p.op(), p.value(),
+                        Comparison.BYTE_STRING);
             }
             case FilterPredicate.SignedBinaryColumnPredicate p -> {
                 ColumnSchema cs = resolveColumn(p.column(), schema);
                 rejectRepeated(p.column(), cs);
                 validateType(p.column(), PhysicalType.FIXED_LEN_BYTE_ARRAY, cs);
                 validateLogicalType(p.column(), LogicalType.DecimalType.class, cs);
-                yield new ResolvedPredicate.BinaryPredicate(cs.columnIndex(), p.op(), p.value(), true);
+                yield new ResolvedPredicate.BinaryPredicate(cs.columnIndex(), p.op(), p.value(),
+                        Comparison.FIXED_DECIMAL);
             }
             case FilterPredicate.UUIDColumnPredicate p -> {
                 ColumnSchema cs = resolveColumn(p.column(), schema);
                 rejectRepeated(p.column(), cs);
                 validateType(p.column(), PhysicalType.FIXED_LEN_BYTE_ARRAY, cs);
                 validateLogicalType(p.column(), LogicalType.UuidType.class, cs);
-                yield new ResolvedPredicate.BinaryPredicate(cs.columnIndex(), p.op(), p.value(), false);
+                yield new ResolvedPredicate.BinaryPredicate(cs.columnIndex(), p.op(), p.value(),
+                        Comparison.BYTE_STRING);
             }
             case IntInPredicate p -> {
                 ColumnSchema cs = resolveColumn(p.column(), schema);

--- a/core/src/main/java/dev/hardwood/internal/predicate/ResolvedPredicate.java
+++ b/core/src/main/java/dev/hardwood/internal/predicate/ResolvedPredicate.java
@@ -57,9 +57,95 @@ public sealed interface ResolvedPredicate {
     }
     record BooleanPredicate(int columnIndex, FilterPredicate.Operator op, boolean value) implements ResolvedPredicate {}
 
-    /// Binary predicate with optional signed comparison for FIXED_LEN_BYTE_ARRAY decimals.
+    /// A comparison against a byte string.
+    ///
+    /// The [Comparison] fixes both the order the bytes compare in and whether a number has a
+    /// single encoding in the column. The two are not independent — only a variable-length
+    /// `DECIMAL` compares signed while admitting more than one encoding of the same value — so
+    /// they are carried as one three-valued choice rather than as two flags.
     record BinaryPredicate(int columnIndex, FilterPredicate.Operator op, byte[] value,
-            boolean signed) implements ResolvedPredicate {}
+            Comparison comparison) implements ResolvedPredicate {
+
+        /// The order a binary column's values compare in, and whether a value has one encoding
+        /// in it.
+        public enum Comparison {
+
+            /// Unsigned lexicographic — the type-defined order of a byte string compared as
+            /// itself. A value is exactly the bytes it was written as.
+            BYTE_STRING(false, true),
+
+            /// Big-endian two's complement over a `FIXED_LEN_BYTE_ARRAY` `DECIMAL`, whose every
+            /// value is padded to the column width, so a number has one encoding in it.
+            ///
+            /// `DECIMAL(scale = 2)` over `FIXED_LEN_BYTE_ARRAY(4)`:
+            ///
+            /// ```text
+            ///  1.27  ->  00 00 00 7F
+            ///  1.28  ->  00 00 00 80
+            /// -1.00  ->  FF FF FF 9C
+            /// ```
+            ///
+            /// Equal widths, so the sign decides first and the rest compares unsigned. One
+            /// encoding per number, so a bloom-filter or dictionary probe for the literal's
+            /// bytes answers for the value.
+            FIXED_DECIMAL(true, true),
+
+            /// Big-endian two's complement over a `BYTE_ARRAY` `DECIMAL`. The format asks such a
+            /// column for the fewest bytes that hold each value but does not require them, so a
+            /// writer may pad and the same number may appear under more than one encoding.
+            ///
+            /// `DECIMAL(scale = 2)`, each value in the fewest bytes that hold it:
+            ///
+            /// ```text
+            ///  1.27  ->     7F
+            ///  1.28  ->  00 80     the leading 00 keeps 128 positive
+            /// -1.00  ->     9C
+            /// -2.56  ->  FF 00
+            /// ```
+            ///
+            /// Length does not track magnitude: byte-wise, `7F` outranks `00 80` and `9C` falls
+            /// below `FF 00`, both backwards. The shorter value is sign-extended to the longer
+            /// before the bytes compare — `7F` against `00 80` is `00 7F` against `00 80`.
+            ///
+            /// And `00 00 00 7F` is a legal spelling of the same `1.27`, so equality cannot be
+            /// decided by hashing or matching the literal's own bytes: the probe would miss a
+            /// value the column holds.
+            VARIABLE_DECIMAL(true, false);
+
+            private final boolean signed;
+            private final boolean byteExact;
+
+            Comparison(boolean signed, boolean byteExact) {
+                this.signed = signed;
+                this.byteExact = byteExact;
+            }
+
+            /// Whether the bytes compare as a big-endian two's complement value — the order a
+            /// `DECIMAL`'s unscaled value sorts in — rather than unsigned lexicographically.
+            public boolean signed() {
+                return signed;
+            }
+
+            /// Whether the column can hold a given value only as exactly one byte string.
+            /// Equality shortcuts that test bytes rather than order (bloom filters, dictionary
+            /// membership) are sound only when it holds; without it a padded value hashes to a
+            /// miss and its rows would be dropped.
+            public boolean byteExact() {
+                return byteExact;
+            }
+        }
+
+        /// Whether the predicate's bytes compare signed. See [Comparison#signed()].
+        public boolean signed() {
+            return comparison.signed();
+        }
+
+        /// Whether the column encodes a value as exactly these bytes. See
+        /// [Comparison#byteExact()].
+        public boolean byteExact() {
+            return comparison.byteExact();
+        }
+    }
 
     record IntInPredicate(int columnIndex, int[] values) implements ResolvedPredicate {}
     record LongInPredicate(int columnIndex, long[] values) implements ResolvedPredicate {}
@@ -176,7 +262,7 @@ public sealed interface ResolvedPredicate {
                     p.ieee754TotalOrder());
             case BooleanPredicate p -> new BooleanPredicate(mapped(p.columnIndex(), columnMapping), p.op(), p.value());
             case BinaryPredicate p -> new BinaryPredicate(mapped(p.columnIndex(), columnMapping), p.op(), p.value(),
-                    p.signed());
+                    p.comparison());
             case IntInPredicate p -> new IntInPredicate(mapped(p.columnIndex(), columnMapping), p.values());
             case LongInPredicate p -> new LongInPredicate(mapped(p.columnIndex(), columnMapping), p.values());
             case BinaryInPredicate p -> new BinaryInPredicate(mapped(p.columnIndex(), columnMapping), p.values());
@@ -221,7 +307,8 @@ public sealed interface ResolvedPredicate {
             case DoublePredicate p -> new DoublePredicate(p.columnIndex(), p.op().invert(), p.value(),
                     p.ieee754TotalOrder());
             case BooleanPredicate p -> new BooleanPredicate(p.columnIndex(), p.op().invert(), p.value());
-            case BinaryPredicate p -> new BinaryPredicate(p.columnIndex(), p.op().invert(), p.value(), p.signed());
+            case BinaryPredicate p -> new BinaryPredicate(p.columnIndex(), p.op().invert(), p.value(),
+                    p.comparison());
             case IsNullPredicate p -> new IsNotNullPredicate(p.columnIndex());
             case IsNotNullPredicate p -> new IsNullPredicate(p.columnIndex());
             case And a -> new Or(a.children().stream()
@@ -245,7 +332,8 @@ public sealed interface ResolvedPredicate {
             case BinaryInPredicate p -> {
                 List<ResolvedPredicate> notEqs = new ArrayList<>(p.values().length);
                 for (byte[] value : p.values()) {
-                    notEqs.add(new BinaryPredicate(p.columnIndex(), FilterPredicate.Operator.NOT_EQ, value, false));
+                    notEqs.add(new BinaryPredicate(p.columnIndex(), FilterPredicate.Operator.NOT_EQ, value,
+                            BinaryPredicate.Comparison.BYTE_STRING));
                 }
                 yield new And(notEqs);
             }

--- a/core/src/main/java/dev/hardwood/internal/predicate/RowGroupFilterEvaluator.java
+++ b/core/src/main/java/dev/hardwood/internal/predicate/RowGroupFilterEvaluator.java
@@ -149,8 +149,13 @@ public class RowGroupFilterEvaluator {
                     statisticsDecision(p, p.columnIndex(), rowGroup);
             case ResolvedPredicate.BinaryPredicate p -> {
                 FilterDecision decision = statisticsDecision(p, p.columnIndex(), rowGroup);
+                // Bloom filters and dictionary membership answer "are these exact bytes here?",
+                // which stands in for "is this value here?" only where the value has one
+                // encoding — see BinaryPredicate#byteExact. Statistics compare in the column's
+                // order and stay available either way.
                 if (decision != FilterDecision.CANNOT_MATCH
                         && p.op() == FilterPredicate.Operator.EQ
+                        && p.byteExact()
                         && (BloomFilterSupport.valueAbsent(bloomFilters, p.columnIndex(), p.value())
                                 || DictionaryFilterSupport.valueAbsent(dictionaries, p.columnIndex(), p.value()))) {
                     yield FilterDecision.CANNOT_MATCH;

--- a/core/src/main/java/dev/hardwood/internal/writer/BinaryStatisticsCollector.java
+++ b/core/src/main/java/dev/hardwood/internal/writer/BinaryStatisticsCollector.java
@@ -9,13 +9,14 @@ package dev.hardwood.internal.writer;
 
 import java.util.Arrays;
 
+import dev.hardwood.internal.predicate.BinaryComparator;
 import dev.hardwood.metadata.Statistics;
 
 /// Accumulates a binary column chunk's `min` / `max` / `null_count` in one of the two orders a
 /// byte string is compared in: unsigned lexicographic — the type-defined order for an
-/// unannotated `BYTE_ARRAY` / `FIXED_LEN_BYTE_ARRAY` and for the string-like annotations,
-/// matching the reader's `BinaryComparator` — or signed big-endian two's complement, the order
-/// of a `DECIMAL`'s represented value.
+/// unannotated `BYTE_ARRAY` / `FIXED_LEN_BYTE_ARRAY` and for the string-like annotations — or
+/// signed big-endian two's complement, the order of a `DECIMAL`'s represented value. Both are
+/// the orders `BinaryComparator` compares in, which the signed arm calls directly.
 ///
 /// Bounds are **truncated** to at most `truncationLength` bytes so a chunk of long values does
 /// not bloat the footer. A truncated `min` keeps the value's first *N* bytes — a prefix is `<=`
@@ -67,32 +68,7 @@ final class BinaryStatisticsCollector implements BinaryStatistics {
     private int compare(byte[] left, byte[] right) {
         return order == Order.LEXICOGRAPHIC
                 ? Arrays.compareUnsigned(left, right)
-                : compareSignedBigEndian(left, right);
-    }
-
-    /// Compares two big-endian two's complement integers that may differ in length, as a
-    /// `DECIMAL`'s unscaled values do. A negative value is below every non-negative one; within
-    /// a sign, the shorter value is sign-extended to the longer and the bytes compare unsigned.
-    /// An empty array is the value zero.
-    private static int compareSignedBigEndian(byte[] left, byte[] right) {
-        boolean leftNegative = left.length > 0 && left[0] < 0;
-        boolean rightNegative = right.length > 0 && right[0] < 0;
-        if (leftNegative != rightNegative) {
-            return leftNegative ? -1 : 1;
-        }
-        int length = Math.max(left.length, right.length);
-        int leftPad = leftNegative ? 0xFF : 0x00;
-        int rightPad = rightNegative ? 0xFF : 0x00;
-        int leftOffset = length - left.length;
-        int rightOffset = length - right.length;
-        for (int i = 0; i < length; i++) {
-            int leftByte = i < leftOffset ? leftPad : left[i - leftOffset] & 0xFF;
-            int rightByte = i < rightOffset ? rightPad : right[i - rightOffset] & 0xFF;
-            if (leftByte != rightByte) {
-                return leftByte - rightByte;
-            }
-        }
-        return 0;
+                : BinaryComparator.compareSigned(left, right);
     }
 
     @Override

--- a/core/src/test/java/dev/hardwood/internal/predicate/BatchFilterCompilerTest.java
+++ b/core/src/test/java/dev/hardwood/internal/predicate/BatchFilterCompilerTest.java
@@ -13,6 +13,7 @@ import java.util.function.IntUnaryOperator;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
+import dev.hardwood.internal.predicate.ResolvedPredicate.BinaryPredicate.Comparison;
 import dev.hardwood.internal.predicate.matcher.longs.LongInBatchMatcher;
 import dev.hardwood.internal.predicate.matcher.nulls.IsNullBatchMatcher;
 import dev.hardwood.metadata.PhysicalType;
@@ -150,7 +151,7 @@ class BatchFilterCompilerTest {
             ResolvedPredicate predicate = new ResolvedPredicate.And(List.of(
                     new ResolvedPredicate.LongPredicate(0, Operator.GT, 5L),
                     new ResolvedPredicate.BinaryPredicate(1, Operator.EQ,
-                            new byte[]{'h', 'i'}, false)));
+                            new byte[]{'h', 'i'}, Comparison.BYTE_STRING)));
             assertNull(BatchFilterCompiler.tryCompile(predicate, schema, IntUnaryOperator.identity()));
         }
 
@@ -158,7 +159,7 @@ class BatchFilterCompilerTest {
         void binaryLeaf_returnsNull() {
             FileSchema schema = schema(leaf("name", PhysicalType.BYTE_ARRAY));
             ResolvedPredicate predicate = new ResolvedPredicate.BinaryPredicate(0, Operator.EQ,
-                    new byte[]{'h', 'i'}, false);
+                    new byte[]{'h', 'i'}, Comparison.BYTE_STRING);
             assertNull(BatchFilterCompiler.tryCompile(predicate, schema, IntUnaryOperator.identity()));
         }
 

--- a/core/src/test/java/dev/hardwood/internal/predicate/BinaryDecimalFilterTest.java
+++ b/core/src/test/java/dev/hardwood/internal/predicate/BinaryDecimalFilterTest.java
@@ -1,0 +1,273 @@
+/*
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Copyright The original authors
+ *
+ *  Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package dev.hardwood.internal.predicate;
+
+import java.math.BigDecimal;
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
+import java.util.ArrayList;
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+
+import dev.hardwood.InputFile;
+import dev.hardwood.internal.bloomfilter.BloomFilter;
+import dev.hardwood.internal.bloomfilter.BloomFilterHeader;
+import dev.hardwood.internal.predicate.ResolvedPredicate.BinaryPredicate.Comparison;
+import dev.hardwood.internal.writer.ByteBufferOutputFile;
+import dev.hardwood.metadata.LogicalType;
+import dev.hardwood.metadata.PhysicalType;
+import dev.hardwood.metadata.RepetitionType;
+import dev.hardwood.metadata.RowGroup;
+import dev.hardwood.reader.FilterPredicate;
+import dev.hardwood.reader.ParquetFileReader;
+import dev.hardwood.reader.RowReader;
+import dev.hardwood.schema.FileSchema;
+import dev.hardwood.writer.ParquetFileWriter;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/// A `DECIMAL` stored as `BYTE_ARRAY` holds each unscaled value in the fewest bytes that hold
+/// it, so two values of the same column differ in length and length does not track magnitude:
+/// `127` is `0x7F` and `128` is `0x00 0x80`. Predicates over such a column compare the
+/// represented value, not the byte string.
+class BinaryDecimalFilterTest {
+
+    private static final int PADDED_ROWS = 512;
+
+    /// One split-block bloom filter block, the smallest a bitset can be.
+    private static final int BLOOM_FILTER_BYTES = 32;
+
+    /// Unscaled values at the boundaries where the encoding length changes, and across zero.
+    private static final BigDecimal[] VALUES = {
+            new BigDecimal("0.00"), // 0    -> {} / 0x00
+            new BigDecimal("1.27"), // 127  -> 0x7F
+            new BigDecimal("1.28"), // 128  -> 0x00 0x80  (longer, but greater)
+            new BigDecimal("3.00"), // 300  -> 0x01 0x2C
+            new BigDecimal("-1.00"), // -100 -> 0x9C
+            new BigDecimal("-2.56") // -256 -> 0xFF 0x00  (longer, but smaller)
+    };
+
+    @Test
+    void greaterThanOrdersByValueRatherThanByBytes() throws Exception {
+        assertThat(filtered(FilterPredicate.gt("amount", new BigDecimal("1.27"))))
+                .containsExactly(new BigDecimal("1.28"), new BigDecimal("3.00"));
+    }
+
+    @Test
+    void lessThanSpansTheSignBoundary() throws Exception {
+        assertThat(filtered(FilterPredicate.lt("amount", new BigDecimal("0.00"))))
+                .containsExactly(new BigDecimal("-1.00"), new BigDecimal("-2.56"));
+    }
+
+    @Test
+    void aLongerEncodingIsNotAutomaticallyGreater() throws Exception {
+        assertThat(filtered(FilterPredicate.ltEq("amount", new BigDecimal("-1.00"))))
+                .containsExactly(new BigDecimal("-1.00"), new BigDecimal("-2.56"));
+    }
+
+    @Test
+    void equalityFindsTheValue() throws Exception {
+        assertThat(filtered(FilterPredicate.eq("amount", new BigDecimal("1.28"))))
+                .containsExactly(new BigDecimal("1.28"));
+    }
+
+    /// The format says a `BYTE_ARRAY` decimal *should* use the fewest bytes, not that it must, so
+    /// a writer may pad. A padded value is the same number and must still be found.
+    @Test
+    void aPaddedEncodingIsStillTheSameValue() throws Exception {
+        byte[] file = writeRawBinaryDecimals(paddedRows());
+        try (ParquetFileReader reader = ParquetFileReader.open(InputFile.of(ByteBuffer.wrap(file)));
+                RowReader rows = reader.buildRowReader()
+                        .filter(FilterPredicate.eq("amount", new BigDecimal("1.27")))
+                        .build()) {
+            assertThat(collect(rows)).hasSize(PADDED_ROWS / 2)
+                    .allMatch(value -> value.compareTo(new BigDecimal("1.27")) == 0);
+        }
+    }
+
+    /// Equality on such a column must not be decided by testing the literal's own bytes:
+    /// bloom filters hash them and dictionary membership compares them, and a padded value in
+    /// the file would come back absent while the value is present. The predicate carries that
+    /// as `byteExact = false`, and [RowGroupFilterEvaluator] skips both shortcuts for it —
+    /// statistics, which compare in the column's order, carry the pruning instead.
+    @Test
+    void equalityIsNotMarkedByteExact() {
+        FileSchema schema = schema();
+        ResolvedPredicate resolved = FilterPredicateResolver.resolve(
+                FilterPredicate.eq("amount", new BigDecimal("1.27")), schema);
+
+        assertThat(resolved).isInstanceOfSatisfying(ResolvedPredicate.BinaryPredicate.class, p -> {
+            assertThat(p.signed()).isTrue();
+            assertThat(p.byteExact()).isFalse();
+            // 127 in the fewest bytes that hold it, the form the format asks a writer for.
+            assertThat(p.value()).containsExactly(0x7F);
+        });
+    }
+
+    /// A `FIXED_LEN_BYTE_ARRAY` decimal pads every value to the column width, so the encoding of
+    /// a given number is the only one the column can hold and the shortcuts stay available.
+    @Test
+    void aFixedWidthDecimalStaysByteExact() {
+        FileSchema fixed = FileSchema.builder("schema")
+                .addColumn("amount", PhysicalType.FIXED_LEN_BYTE_ARRAY, RepetitionType.REQUIRED, 8,
+                        new LogicalType.DecimalType(2, 18))
+                .build();
+        ResolvedPredicate resolved = FilterPredicateResolver.resolve(
+                FilterPredicate.eq("amount", new BigDecimal("1.27")), fixed);
+
+        assertThat(resolved).isInstanceOfSatisfying(ResolvedPredicate.BinaryPredicate.class,
+                p -> assertThat(p.byteExact()).isTrue());
+    }
+
+    @Test
+    void notEqualExcludesOnlyTheValue() throws Exception {
+        assertThat(filtered(FilterPredicate.notEq("amount", new BigDecimal("1.28"))))
+                .containsExactly(new BigDecimal("0.00"), new BigDecimal("1.27"),
+                        new BigDecimal("3.00"), new BigDecimal("-1.00"), new BigDecimal("-2.56"));
+    }
+
+    /// A null is not a value, so it satisfies no comparison — including the negated one, which a
+    /// column of the same values without nulls would otherwise answer identically.
+    @Test
+    void aNullMatchesNoValuePredicate() throws Exception {
+        assertThat(filteredWithNulls(FilterPredicate.gtEq("amount", new BigDecimal("-2.56"))))
+                .containsExactly(new BigDecimal("1.27"), new BigDecimal("3.00"));
+        assertThat(filteredWithNulls(FilterPredicate.notEq("amount", new BigDecimal("1.27"))))
+                .containsExactly(new BigDecimal("3.00"));
+        assertThat(filteredWithNulls(FilterPredicate.isNull("amount")))
+                .containsOnlyNulls().hasSize(2);
+    }
+
+    /// Ordering a padded encoding against the resolver's minimal literal: `127` written in four
+    /// bytes must not out-rank `127` itself, and the two-byte `300` must still beat it.
+    @Test
+    void aPaddedEncodingOrdersByValueToo() throws Exception {
+        byte[] file = writeRawBinaryDecimals(paddedRows());
+        try (ParquetFileReader reader = ParquetFileReader.open(InputFile.of(ByteBuffer.wrap(file)));
+                RowReader rows = reader.buildRowReader()
+                        .filter(FilterPredicate.gt("amount", new BigDecimal("1.27")))
+                        .build()) {
+            assertThat(collect(rows)).hasSize(PADDED_ROWS / 2)
+                    .allMatch(value -> value.compareTo(new BigDecimal("3.00")) == 0);
+        }
+    }
+
+    /// The bloom-filter and dictionary shortcuts answer "are these exact bytes present?", which
+    /// stands in for "is this value present?" only where the value has one encoding. A filter
+    /// that proves every probe absent must therefore drop the row group under
+    /// [Comparison#FIXED_DECIMAL] and leave it standing under [Comparison#VARIABLE_DECIMAL],
+    /// where a padded copy of the same number would have missed.
+    @Test
+    void onlyAByteExactEqualityConsultsTheBloomFilter() throws Exception {
+        byte[] file = write(VALUES);
+        try (ParquetFileReader reader = ParquetFileReader.open(InputFile.of(ByteBuffer.wrap(file)))) {
+            RowGroup rowGroup = reader.getFileMetaData().rowGroups().getFirst();
+            // 127 sits inside [-256, 300], so statistics alone keep the row group either way.
+            byte[] literal = { 0x7F };
+
+            assertThat(decideWithEmptyBloomFilter(rowGroup, literal, Comparison.VARIABLE_DECIMAL))
+                    .isEqualTo(FilterDecision.MIGHT_MATCH);
+            assertThat(decideWithEmptyBloomFilter(rowGroup, literal, Comparison.FIXED_DECIMAL))
+                    .isEqualTo(FilterDecision.CANNOT_MATCH);
+        }
+    }
+
+    // ==================== Fixtures ====================
+
+    private static FileSchema schema() {
+        return FileSchema.builder("schema")
+                .addColumn("amount", PhysicalType.BYTE_ARRAY, RepetitionType.REQUIRED,
+                        new LogicalType.DecimalType(2, 18))
+                .build();
+    }
+
+    private static FileSchema nullableSchema() {
+        return FileSchema.builder("schema")
+                .addColumn("amount", PhysicalType.BYTE_ARRAY, RepetitionType.OPTIONAL,
+                        new LogicalType.DecimalType(2, 18))
+                .build();
+    }
+
+    private static byte[] write(BigDecimal[] values) throws Exception {
+        ByteBufferOutputFile out = new ByteBufferOutputFile();
+        try (ParquetFileWriter writer = ParquetFileWriter.create(out, schema())) {
+            for (BigDecimal value : values) {
+                writer.rowWriter().writeRow(row -> row.setDecimal("amount", value));
+            }
+        }
+        return out.toByteArray();
+    }
+
+    private static List<BigDecimal> filtered(FilterPredicate predicate) throws Exception {
+        return filtered(write(VALUES), predicate);
+    }
+
+    /// `1.27`, a null, `3.00`, a null — so a predicate that would take every value still has to
+    /// leave the two nulls behind.
+    private static List<BigDecimal> filteredWithNulls(FilterPredicate predicate) throws Exception {
+        ByteBufferOutputFile out = new ByteBufferOutputFile();
+        try (ParquetFileWriter writer = ParquetFileWriter.create(out, nullableSchema())) {
+            writer.rowWriter().writeRow(row -> row.setDecimal("amount", new BigDecimal("1.27")));
+            writer.rowWriter().writeRow(row -> row.setNull("amount"));
+            writer.rowWriter().writeRow(row -> row.setDecimal("amount", new BigDecimal("3.00")));
+            writer.rowWriter().writeRow(row -> row.setNull("amount"));
+        }
+        return filtered(out.toByteArray(), predicate);
+    }
+
+    private static List<BigDecimal> filtered(byte[] file, FilterPredicate predicate) throws Exception {
+        try (ParquetFileReader reader = ParquetFileReader.open(InputFile.of(ByteBuffer.wrap(file)));
+                RowReader rows = reader.buildRowReader().filter(predicate).build()) {
+            return collect(rows);
+        }
+    }
+
+    /// The row-group decision for an `EQ` against a bloom filter whose bitset is all zeroes, so
+    /// every probe misses and the filter proves any value absent.
+    private static FilterDecision decideWithEmptyBloomFilter(RowGroup rowGroup, byte[] literal,
+            Comparison comparison) {
+        ResolvedPredicate predicate = new ResolvedPredicate.BinaryPredicate(0,
+                FilterPredicate.Operator.EQ, literal, comparison);
+        BloomFilterSource empty = columnIndex -> new BloomFilter(
+                new BloomFilterHeader(BLOOM_FILTER_BYTES, BloomFilterHeader.Algorithm.BLOCK,
+                        BloomFilterHeader.Hash.XXHASH, BloomFilterHeader.Compression.UNCOMPRESSED),
+                ByteBuffer.allocate(BLOOM_FILTER_BYTES).order(ByteOrder.LITTLE_ENDIAN).asReadOnlyBuffer());
+        return RowGroupFilterEvaluator.decideRowGroup(predicate, rowGroup, empty, null);
+    }
+
+    /// Rows alternating a padded `127` with a minimally encoded `300`.
+    private static byte[][] paddedRows() {
+        byte[][] rows = new byte[PADDED_ROWS][];
+        for (int i = 0; i < rows.length; i++) {
+            rows[i] = i % 2 == 0
+                    ? new byte[] { 0x00, 0x00, 0x00, 0x7F } // 127, in four bytes rather than one
+                    : new byte[] { 0x01, 0x2C }; // 300, minimally encoded
+        }
+        return rows;
+    }
+
+    /// Writes the given unscaled encodings verbatim, bypassing the decimal conversion, so the
+    /// column can hold a value in a longer form than the minimal one.
+    private static byte[] writeRawBinaryDecimals(byte[][] unscaled) throws Exception {
+        ByteBufferOutputFile out = new ByteBufferOutputFile();
+        try (ParquetFileWriter writer = ParquetFileWriter.create(out, schema())) {
+            writer.columnWriter().writeBatch(batch -> batch.bytes(0, unscaled));
+        }
+        return out.toByteArray();
+    }
+
+    private static List<BigDecimal> collect(RowReader rows) {
+        List<BigDecimal> matched = new ArrayList<>();
+        while (rows.hasNext()) {
+            rows.next();
+            matched.add(rows.getDecimal("amount"));
+        }
+        return matched;
+    }
+}

--- a/core/src/test/java/dev/hardwood/internal/predicate/FilterDecisionTest.java
+++ b/core/src/test/java/dev/hardwood/internal/predicate/FilterDecisionTest.java
@@ -14,6 +14,7 @@ import java.util.Random;
 
 import org.junit.jupiter.api.Test;
 
+import dev.hardwood.internal.predicate.ResolvedPredicate.BinaryPredicate.Comparison;
 import dev.hardwood.reader.FilterPredicate;
 
 import static dev.hardwood.internal.predicate.FilterDecision.ALWAYS_MATCHES;
@@ -239,7 +240,7 @@ class FilterDecisionTest {
     private static FilterDecision decideBinary(FilterPredicate.Operator op, String value,
             String min, String max) {
         ResolvedPredicate leaf = new ResolvedPredicate.BinaryPredicate(
-                0, op, value.getBytes(StandardCharsets.UTF_8), false);
+                0, op, value.getBytes(StandardCharsets.UTF_8), Comparison.BYTE_STRING);
         return StatisticsFilterSupport.decideLeaf(leaf, stats(
                 min.getBytes(StandardCharsets.UTF_8), max.getBytes(StandardCharsets.UTF_8), 0L));
     }

--- a/core/src/test/java/dev/hardwood/internal/predicate/RecordFilterCompilerTest.java
+++ b/core/src/test/java/dev/hardwood/internal/predicate/RecordFilterCompilerTest.java
@@ -22,6 +22,7 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 
+import dev.hardwood.internal.predicate.ResolvedPredicate.BinaryPredicate.Comparison;
 import dev.hardwood.metadata.PhysicalType;
 import dev.hardwood.metadata.RepetitionType;
 import dev.hardwood.metadata.SchemaElement;
@@ -200,7 +201,8 @@ class RecordFilterCompilerTest {
     @Test
     void testBinaryEq() {
         FileSchema schema = binarySchema("col");
-        ResolvedPredicate eq = new ResolvedPredicate.BinaryPredicate(0, Operator.EQ, bytes("banana"), false);
+        ResolvedPredicate eq = new ResolvedPredicate.BinaryPredicate(0, Operator.EQ, bytes("banana"),
+                Comparison.BYTE_STRING);
         assertTrue(matchesRow(eq, binaryStub("col", bytes("banana"), false), schema));
         assertFalse(matchesRow(eq, binaryStub("col", bytes("apple"), false), schema));
     }
@@ -208,7 +210,8 @@ class RecordFilterCompilerTest {
     @Test
     void testBinaryLt() {
         FileSchema schema = binarySchema("col");
-        ResolvedPredicate lt = new ResolvedPredicate.BinaryPredicate(0, Operator.LT, bytes("banana"), false);
+        ResolvedPredicate lt = new ResolvedPredicate.BinaryPredicate(0, Operator.LT, bytes("banana"),
+                Comparison.BYTE_STRING);
         assertTrue(matchesRow(lt, binaryStub("col", bytes("apple"), false), schema));
         assertFalse(matchesRow(lt, binaryStub("col", bytes("cherry"), false), schema));
     }

--- a/docs/content/how-to/query-controls.md
+++ b/docs/content/how-to/query-controls.md
@@ -149,8 +149,11 @@ Filters work with all reader types: `RowReader`, `ColumnReader`, `AvroRowReader`
   alongside statistics, and skips a row group when the value is provably absent. For `FLOAT` /
   `DOUBLE`, `eq(NaN)` is not pruned by the Bloom filter — raw-bit hashing distinguishes NaN
   payloads that `Float.compare` / `Double.compare` treat as equal, so a Bloom miss cannot prove a
-  NaN absent; `eq(-0.0)` is pruned normally. Range predicates (`lt`, `gt`, …) and `notEq` are
-  unaffected — a Bloom filter answers only membership.
+  NaN absent; `eq(-0.0)` is pruned normally. A `BigDecimal` `eq` on a `DECIMAL` stored as
+  `BYTE_ARRAY` is pruned by neither the Bloom filter nor the dictionary: such a column may hold
+  the same number under more than one byte string, so a miss on the literal's own bytes does not
+  prove the value absent. Range predicates (`lt`, `gt`, …) and `notEq` are unaffected — a Bloom
+  filter answers only membership.
 - **Dictionary-based filtering is not supported
   ([#196](https://github.com/hardwood-hq/hardwood/issues/196)).** Dictionary-encoded columns
   are not checked for predicate matches before decoding.

--- a/docs/content/reference/accessors.md
+++ b/docs/content/reference/accessors.md
@@ -38,7 +38,7 @@ All accessors are available in two forms — name-based (`getInt("column_name")`
 | `getTime` | INT32 or INT64 | TIME | `LocalTime` |
 | `getTimestamp` | INT64, or legacy INT96 | TIMESTAMP (`isAdjustedToUTC = true`) | `Instant` |
 | `getLocalTimestamp` | INT64 | TIMESTAMP (`isAdjustedToUTC = false`) | `LocalDateTime` |
-| `getDecimal` | INT32, INT64, or FIXED_LEN_BYTE_ARRAY | DECIMAL | `BigDecimal` |
+| `getDecimal` | INT32, INT64, BYTE_ARRAY, or FIXED_LEN_BYTE_ARRAY | DECIMAL | `BigDecimal` |
 | `getUuid` | FIXED_LEN_BYTE_ARRAY | UUID | `UUID` |
 | `getInterval` | FIXED_LEN_BYTE_ARRAY(12) | INTERVAL | `PqInterval` |
 | `getStruct` | | | `PqStruct` |

--- a/docs/content/reference/query-controls.md
+++ b/docs/content/reference/query-controls.md
@@ -33,9 +33,7 @@ row-group and page skipping.
 The logical-type factories validate the column's logical type at reader creation: `BigDecimal`
 predicates require a `DECIMAL` column and `UUID` predicates require a `UUID` column. Applying them
 to a plain `FIXED_LEN_BYTE_ARRAY` column without the corresponding logical-type annotation throws
-`IllegalArgumentException`. A `BigDecimal` predicate reads a `DECIMAL` stored as `INT32`, `INT64`
-or `FIXED_LEN_BYTE_ARRAY`; one stored as `BYTE_ARRAY` is rejected with the same exception.
-Raw physical-type predicates (`int`, `long`, etc.) remain available for
+`IllegalArgumentException`. Raw physical-type predicates (`int`, `long`, etc.) remain available for
 columns without logical types or for filtering on the underlying physical value directly. Filters
 work with all reader types — `RowReader`, `ColumnReader`, `AvroRowReader`, and across multi-file
 readers.


### PR DESCRIPTION
Fixes #1082.

**Stacked on #1081** — review that one first; this PR's diff is the single commit on top, and its base moves to `main` once #1081 lands.

- [x] This change is coming from a human who understands what it does and why, and can discuss it in review

## What changes

A `BigDecimal` predicate padded its literal to the column's `type_length`, which a `BYTE_ARRAY` column does not have, so the predicate threw an unboxing `NullPointerException` before the read started. #1081 turns that into a named rejection; this makes the predicates work.

Padding was the wrong shape regardless. The format asks a `BYTE_ARRAY` decimal to store each unscaled value in the fewest bytes that hold it, so values of one column differ in length and length does not track magnitude — `127` is `0x7F`, `128` is `0x00 0x80`, and a byte-wise comparison ranks the first above the second. The order the format defines for `DECIMAL` is signed comparison of the represented value, so the shorter operand is sign-extended before the bytes are compared.

The writer already did this to compute bounds (`BinaryStatisticsCollector.compareSignedBigEndian`); the reader's `BinaryComparator.compareSigned` refused unequal lengths outright. Both now go through one implementation, so the two cannot drift.

## Equality needs more than the order

"Fewest bytes" is a *should*, not a *must*, so a writer may pad and the same number may appear under more than one encoding. Bloom filters hash the literal's bytes and dictionary membership compares them — for this column shape a miss proves nothing, and dropping a row group on it is a silently wrong answer rather than a slow one.

`BinaryPredicate` now carries whether its encoding is the only one the column can hold — true for every fixed-width column and for byte strings compared as themselves, false for a `BYTE_ARRAY` `DECIMAL` — and `RowGroupFilterEvaluator` takes those two shortcuts only when it holds. Statistics and per-record evaluation compare in the column's order and are unaffected.

Dictionary pruning could be restored later by comparing dictionary entries numerically rather than byte-wise; bloom filters cannot be recovered that way.

## Tests

`BinaryDecimalFilterTest` filters a `BYTE_ARRAY` decimal column over values chosen at the length boundaries and across zero (`0`, `127`, `128`, `300`, `-100`, `-256`), reads back a file whose values are deliberately padded, and pins which predicates are marked byte-exact.

The byte-exact gate has no end-to-end test: `RowGroupDictionaryFilterSource` needs `encoding_stats` to expose a dictionary, and the writer does not emit that field (#1083), so a hardwood-written fixture cannot reach the dictionary path at all. It is pinned at the resolver level instead.

## Checklist

- [x] `./mvnw clean verify` passes
- [x] The commit message is prefixed with the issue key
- [x] Code changes are covered by tests
- [x] `docs/` updated (`reference/query-controls.md`)
