### PR TITLE
#1086 Forbid Claude session links in pull request descriptions

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,6 +2,7 @@
 
 Avoid "not my department" thinking; if, for instance, there are build failures you consider unrelated to our current changes, still make an effort to fix them.
 Never add Claude (or any Anthropic identity) as a Co-Authored-By trailer on commit messages. Human co-authors are fine.
+Never put a Claude session link or session ID in a pull request description. It resolves only for the account that ran the session, so to everyone else reviewing the change it is a dead link.
 When a CLI tool is missing from the dev container (e.g. `cmp: command not found`), surface it to the user and propose adding the providing package to the `Dockerfile`'s `microdnf install` list — unless there is an obvious one-line alternative (e.g. `command -v` for `which`) or a Python equivalent that is just as terse. Do not silently work around it.
 
 # Multiple Sessions


### PR DESCRIPTION
Fixes #1086. One line in CLAUDE.md, no code.

- [x] This change is coming from a human who understands what it does and why, and can discuss it in review

Agent-authored PRs have been ending their description with a `https://claude.ai/code/session_…` link, which resolves only for the account that ran the session — for every other reader it is a dead link on the last line.

The rule sits beside the Co-Authored-By one because it is the same question, what an agent may stamp on the artifacts it produces, and the two get looked up together.

The `Claude-Session` trailer on commit messages is deliberately left alone: a trailer is the maintainer's own archaeology, where a PR description is read by whoever reviews the change. Say the word if you want that gone too.