### PR TITLE
#1093 Say where a read failed, once, from the scope it failed in

### DIFF
--- a/_designs/EXCEPTION_MODEL.md
+++ b/_designs/EXCEPTION_MODEL.md
@@ -196,6 +196,60 @@ in a separate file, a row group whose page-index region spans more than
 cache. Each of those files is correct and another reader will open it. Whether the
 last two limits are worth keeping is tracked as #1113.
 
+## Where a failure happened
+
+The type says what kind of failure it is; the message says where the read was when
+it happened. Both are properties of the failure rather than of any frame that
+catches it, so both are taken at the moment it is raised.
+
+**The place is entered, not passed.** `ReadScope` holds a `ThreadLocal<Place>` —
+file name, row group, column, region, and the region's first byte — that a frame
+narrows with try-with-resources:
+
+```java
+try (ReadScope.Scope footer = ReadScope.region(Region.FOOTER, footerStart)) {
+    return FileMetaDataReader.read(new ThriftCompactReader(buffer));
+}
+```
+
+The code that knows it is reading a bloom filter is the code running. By the time a
+failure has travelled to a frame that could report it, that knowledge is gone, and
+every catch site that names a region is restating what its own call stack already
+said. Scopes nest and the innermost wins, which is the rule the reader wants: a
+page header read inside a chunk fetch is a page-header failure.
+
+`ParquetReadException` and `PlacedIOException` read the scope in their constructors
+and render it in `getMessage()`. No site states a position, nothing enriches a
+failure on the way out, and nothing rebuilds one.
+
+Three properties follow from that shape rather than from care at any one site:
+
+- **A failure is described once.** A place is taken once, at construction, so a
+  failure travelling out through further scopes cannot collect a second prefix.
+  Nothing inspects a message to find out whether it has one already.
+- **A correct file is named but never positioned.** `UnsupportedFileException`
+  carries the file name and no place, because it is not the type that carries one.
+  There is nothing at any byte for a caller to go and look at.
+- **Describing a failure keeps its exact type.** The place is rendered into the
+  message, not wrapped around the exception, so a `SchemaIncompatibleException`
+  that a caller catches on is still one after it has been described.
+
+Work that crosses a thread boundary carries its place as data. A page is read on the
+retriever thread and decoded on a pool thread, which inherits nothing; the decode
+task re-enters the page's place with `ReadScope.resume` before it runs, so a failure
+inside it is built exactly as one on the retriever thread would be. `ColumnWorker`'s
+outermost catches do the same before restating what a decoder threw.
+
+**Which byte.** The region's own first byte is the answer for almost every failure:
+`RowGroupDictionaryFilterSource` enters one scope and has six throws that all want
+the chunk's start. Two cases differ. A region that has no address of its own —
+`DATA_PAGE`, where a decode fails an arbitrary distance into the page — is entered
+without one and names no byte, since the row group and column already say which page
+it was. A read that knows how far it got says so through `ReadScope.stoppedAt`,
+which narrows the place to that byte before building the failure;
+`ThriftCompactReader` is the only caller, and reports the field header it stepped
+onto rather than the byte it came to rest on, which is one further along.
+
 ## A truncated buffer
 
 `ThriftTruncatedException` is a `ParquetReadException` and reads as one everywhere

--- a/cli/src/main/java/dev/hardwood/cli/command/InspectDictionaryCommand.java
+++ b/cli/src/main/java/dev/hardwood/cli/command/InspectDictionaryCommand.java
@@ -182,7 +182,8 @@ public class InspectDictionaryCommand implements Command<CommandInvocation> {
             ColumnChunk chunk, HardwoodContextImpl context, String fileName, int rowGroupIndex,
             long dictionaryOffset) {
         try (ReadScope.Scope scope = ReadScope.file(fileName)
-                .column(rowGroupIndex, columnSchema.name())
+                .rowGroup(rowGroupIndex)
+                .column(columnSchema.name())
                 .region(Region.DICTIONARY_PAGE, dictionaryOffset)) {
             return DictionaryParser.parse(dictRegion, columnSchema, chunk.metaData(), context);
         }

--- a/cli/src/main/java/dev/hardwood/cli/command/InspectDictionaryCommand.java
+++ b/cli/src/main/java/dev/hardwood/cli/command/InspectDictionaryCommand.java
@@ -25,6 +25,8 @@ import dev.hardwood.cli.internal.IndexValueFormatter;
 import dev.hardwood.cli.internal.Sizes;
 import dev.hardwood.cli.internal.Strings;
 import dev.hardwood.cli.internal.table.RowTable;
+import dev.hardwood.internal.ExceptionContext.ReadContext.Region;
+import dev.hardwood.internal.ReadScope;
 import dev.hardwood.internal.reader.Dictionary;
 import dev.hardwood.internal.reader.DictionaryParser;
 import dev.hardwood.internal.reader.HardwoodContextImpl;
@@ -139,8 +141,8 @@ public class InspectDictionaryCommand implements Command<CommandInvocation> {
                     chunk.metaData().totalCompressedSize(), 4 * 1024 * 1024));
             ByteBuffer dictRegion = inputFile.readRange(chunkStart, dictReadSize);
 
-            Dictionary dictionary = DictionaryParser.parse(
-                    dictRegion, columnSchema, chunk.metaData(), context);
+            Dictionary dictionary = parseDictionary(dictRegion, columnSchema, chunk, context,
+                    inputFile.name(), rgIdx, chunkStart);
 
             if (dictionary == null) {
                 messages.add("Row Group " + rgIdx + ": no dictionary (column is not dictionary-encoded)");
@@ -167,6 +169,22 @@ public class InspectDictionaryCommand implements Command<CommandInvocation> {
                     ? new String[]{"RG", "Index", "Length", "Value"}
                     : new String[]{"RG", "Index", "Value"};
             System.out.println(RowTable.renderTable(headers, rows, separatorsBefore, List.of()));
+        }
+    }
+
+    /// Parses one row group's dictionary, naming where a failure was.
+    ///
+    /// The parser reports what went wrong, and the read path that names the
+    /// file, row group and column runs only inside `ColumnReader`; this command
+    /// reaches the parser directly, so without this the whole message for a
+    /// corrupt dictionary is "CRC mismatch: expected … but computed …".
+    private static Dictionary parseDictionary(ByteBuffer dictRegion, ColumnSchema columnSchema,
+            ColumnChunk chunk, HardwoodContextImpl context, String fileName, int rowGroupIndex,
+            long dictionaryOffset) {
+        try (ReadScope.Scope scope = ReadScope.file(fileName)
+                .column(rowGroupIndex, columnSchema.name())
+                .region(Region.DICTIONARY_PAGE, dictionaryOffset)) {
+            return DictionaryParser.parse(dictRegion, columnSchema, chunk.metaData(), context);
         }
     }
 

--- a/cli/src/test/java/dev/hardwood/cli/command/InspectDictionaryCommandTest.java
+++ b/cli/src/test/java/dev/hardwood/cli/command/InspectDictionaryCommandTest.java
@@ -7,7 +7,16 @@
  */
 package dev.hardwood.cli.command;
 
+import java.nio.ByteBuffer;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
 import org.junit.jupiter.api.Test;
+
+import dev.hardwood.InputFile;
+import dev.hardwood.metadata.ColumnMetaData;
+import dev.hardwood.reader.ParquetFileReader;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -47,6 +56,40 @@ class InspectDictionaryCommandTest implements InspectDictionaryCommandContract {
 
         assertThat(result.exitCode()).isNotZero();
         assertThat(result.errorOutput()).contains("--limit must be greater than or equal to 0");
+    }
+
+    /// This command reaches `DictionaryParser` directly rather than through the
+    /// read path that names the file, row group and column, so a corrupt
+    /// dictionary reported only what the parser knew — "CRC mismatch: expected
+    /// … but computed …", with nothing saying where.
+    @Test
+    void aCorruptDictionaryNamesWhereItIs() throws Exception {
+        byte[] bytes = Files.readAllBytes(Paths.get(dictFile()));
+        long dictionaryStart;
+        try (ParquetFileReader reader = ParquetFileReader.open(InputFile.of(ByteBuffer.wrap(bytes)))) {
+            ColumnMetaData meta = reader.getFileMetaData().rowGroups().getFirst().columns().stream()
+                    .filter(c -> c.metaData().pathInSchema().toString().equals("category"))
+                    .findFirst().orElseThrow().metaData();
+            dictionaryStart = meta.dictionaryPageOffset();
+        }
+        // Make the dictionary page's header unparseable: 0x1f is a header for
+        // field 1 declaring wire type 15, which is not a type. Corrupting the
+        // page's data instead would go unnoticed — this dictionary is
+        // uncompressed PLAIN and carries no CRC, so any bytes decode to
+        // something.
+        bytes[Math.toIntExact(dictionaryStart)] = 0x1f;
+        Path corrupted = Files.createTempDirectory("hardwood-dict").resolve("corrupt.parquet");
+        Files.write(corrupted, bytes);
+
+        Cli.Result result = Cli.launch("inspect", "dictionary", "-f", corrupted.toString(),
+                "--column", "category");
+
+        assertThat(result.exitCode()).isNotZero();
+        assertThat(result.errorOutput())
+                .contains("corrupt.parquet")
+                .contains("row group 0")
+                .contains("column category")
+                .contains("dictionary page at byte " + dictionaryStart);
     }
 
     @Test

--- a/core/src/main/java/dev/hardwood/internal/ExceptionContext.java
+++ b/core/src/main/java/dev/hardwood/internal/ExceptionContext.java
@@ -27,19 +27,176 @@ public final class ExceptionContext {
         return fileName != null ? "[" + fileName + "] " : "";
     }
 
+    /// Where a read was when it failed: which file, which row group and column,
+    /// which region of the file was being read, and the byte to go and look at.
+    ///
+    /// Every part except the file name is optional. A place supplies what it
+    /// has — `column` and `region` may be `null`, `rowGroup` may be
+    /// [#UNKNOWN_ROW_GROUP] and `offset` may be [#UNKNOWN_OFFSET] — and the
+    /// formatted message omits what is missing, so a context carrying only a
+    /// file name reads exactly as [#addFileContext] always did.
+    ///
+    /// The row group earns its place on the failures that have no byte to
+    /// name. Where the offset is exact it is largely redundant, since a file
+    /// offset resolves to a row group through the footer; where there is no
+    /// offset — a fetch that failed before reading, a page that would not
+    /// assemble — it is the only thing narrowing the column down to a part of
+    /// it, and it is the coordinate `hardwood dive` navigates by.
+    ///
+    ///
+    /// @param fileName the file being read, may be `null`
+    /// @param rowGroup the row group index, or [#UNKNOWN_ROW_GROUP]
+    /// @param column   the column path, may be `null`
+    /// @param region   what was being parsed, may be `null`
+    /// @param offset   the byte to go and look at, or [#UNKNOWN_OFFSET]
+    public record ReadContext(String fileName, int rowGroup, String column, Region region,
+            long offset) {
+
+        /// A region of a Parquet file, as a message names it.
+        ///
+        /// A closed set rather than free text: the words end up in a message a
+        /// reader compares against another message, so they have to be the same
+        /// words every time, and a typo in a string literal is not something a
+        /// failure path will tell you about.
+        ///
+        /// The list is of a file's regions, not of one module's reads — the
+        /// column and offset indexes are reached by the CLI rather than by the
+        /// read path, but a reader should not have to know which of them
+        /// produced the words.
+        public enum Region {
+
+            /// Reading or parsing a column chunk's dictionary.
+            DICTIONARY_PAGE("dictionary page"),
+
+            /// Parsing the Thrift header in front of a page.
+            PAGE_HEADER("page header"),
+
+            /// Fetching a page's bytes, before any decode.
+            PAGE_FETCH("page fetch"),
+
+            /// Fetching a column chunk's bytes, before any page is located in them.
+            CHUNK_FETCH("chunk fetch"),
+
+            /// Decompressing or decoding a page's values.
+            DATA_PAGE("data page"),
+
+            /// Assembling decoded pages into a batch.
+            BATCH_ASSEMBLY("batch assembly"),
+
+            /// Parsing a chunk's column index.
+            COLUMN_INDEX("column index"),
+
+            /// Parsing a chunk's offset index.
+            OFFSET_INDEX("offset index"),
+
+            /// Reading or parsing a chunk's bloom filter.
+            BLOOM_FILTER("bloom filter"),
+
+            /// Fetching the contiguous span that holds a row group's indexes.
+            ROW_GROUP_INDEX("row-group index"),
+
+            /// Parsing the file's Thrift footer.
+            FOOTER("footer"),
+
+            /// The four bytes in front of the closing magic that say how long
+            /// the footer is. Its own region because it is read, and can be
+            /// wrong, before the footer it describes has a position at all.
+            FOOTER_LENGTH("footer length"),
+
+            /// The `PAR1` markers that open and close the file.
+            MAGIC("magic bytes");
+
+            private final String text;
+
+            Region(String text) {
+                this.text = text;
+            }
+
+            /// Whether this region is the file's own bookkeeping rather than
+            /// any part of its data.
+            ///
+            /// The three regions a file is opened through, and the ones a
+            /// caller counting reads means when it asks how many were spent
+            /// before the first row.
+            public boolean isFileMetadata() {
+                return this == MAGIC || this == FOOTER_LENGTH || this == FOOTER;
+            }
+
+            /// How a message names this region.
+            @Override
+            public String toString() {
+                return text;
+            }
+        }
+
+        /// Offset value meaning "nothing knows which byte to go and look at".
+        public static final long UNKNOWN_OFFSET = -1;
+
+        /// Row group value meaning "nothing knows which one".
+        ///
+        /// A batch assembled across a file boundary is the one read that
+        /// genuinely spans row groups; every other scope knows its own.
+        public static final int UNKNOWN_ROW_GROUP = -1;
+
+    }
+
+    /// The context clause a message carries after its `[file] ` prefix, or the
+    /// empty string when the context names nothing beyond the file.
+    static String contextClause(ReadContext context) {
+        StringBuilder sb = new StringBuilder();
+        if (context.rowGroup() != ReadContext.UNKNOWN_ROW_GROUP) {
+            sb.append("row group ").append(context.rowGroup());
+        }
+        if (context.column() != null && !context.column().isEmpty()) {
+            append(sb, "column " + context.column());
+        }
+        if (context.region() != null) {
+            append(sb, context.region().toString());
+        }
+        if (context.offset() != ReadContext.UNKNOWN_OFFSET) {
+            String where = "at byte " + context.offset()
+                    + String.format(" (0x%06x)", context.offset());
+            if (sb.isEmpty()) {
+                sb.append(where);
+            }
+            else {
+                sb.append(' ').append(where);
+            }
+        }
+        return sb.toString();
+    }
+
+    private static void append(StringBuilder sb, String part) {
+        if (!sb.isEmpty()) {
+            sb.append(", ");
+        }
+        sb.append(part);
+    }
+
+
+    /// The `[file] clause — ` prefix a message carries in front of what went
+    /// wrong. Reached through [ReadScope.Place#describe], which is the only
+    /// thing that builds a [ReadContext].
+    static String prefix(ReadContext context) {
+        String clause = contextClause(context);
+        return filePrefix(context.fileName()) + (clause.isEmpty() ? "" : clause + " — ");
+    }
+
+
+
     /// Amends the exception message with a `[fileName] ` prefix. Preserves the
     /// original exception type and cause chain. Returns the original exception
     /// unchanged when the file name is unavailable or the prefix is already present.
-    ///
-    /// **Cause-chain note for [UncheckedIOException]:** because the type requires
-    /// an [IOException] cause, the original [UncheckedIOException] is attached as
-    /// a suppressed exception rather than as the cause; the cause slot holds the
-    /// inner [IOException].
     ///
     /// @param fileName the originating file name, may be `null`
     /// @param e        the exception to enrich
     /// @return the enriched (or original) exception — never `null`
     public static RuntimeException addFileContext(String fileName, RuntimeException e) {
+        return addFileContext(fileName, e, null);
+    }
+
+    private static RuntimeException addFileContext(String fileName, RuntimeException e,
+            ReadContext context) {
         if (fileName == null || fileName.isEmpty()) {
             return e;
         }
@@ -54,8 +211,21 @@ public final class ExceptionContext {
         if (cause != null && hasFilePrefix(cause.getMessage())) {
             return e;
         }
-        String newMessage = prefix + (originalMessage != null ? originalMessage : e.getClass().getSimpleName());
+        return rewrap(e, prefix
+                + (originalMessage != null ? originalMessage : e.getClass().getSimpleName()),
+                context);
+    }
 
+    /// Re-throws `e`'s content under `newMessage`, preserving its type and cause
+    /// chain. Shared by the file-name prefix and the read-context clause so a
+    /// message gains context without changing what a caller can catch.
+    ///
+    /// **Cause-chain note for [UncheckedIOException]:** the type requires an
+    /// [IOException] cause, so the original is attached as suppressed and the
+    /// cause slot holds the inner [IOException].
+    private static RuntimeException rewrap(RuntimeException e, String newMessage,
+            ReadContext context) {
+        String originalMessage = e.getMessage();
         if (e instanceof UncheckedIOException uio) {
             // Not a case the reader produces: every wrap it makes to leave a lambda is
             // undone by the method enclosing that lambda, and `InputFile.readRange`
@@ -87,7 +257,13 @@ public final class ExceptionContext {
             wrapped.initCause(e);
             return wrapped;
         }
-        if (e.getClass() == IndexOutOfBoundsException.class) {
+        // `instanceof`, not an exact class match: indexing an array throws
+        // ArrayIndexOutOfBoundsException, and an exact match sent it to the
+        // reflective path below, where it has no (String, Throwable)
+        // constructor and came out a bare RuntimeException. A corrupt
+        // dictionary reference reaches a caller this way, and one that catches
+        // on the type — dive does — stopped seeing it.
+        if (e instanceof IndexOutOfBoundsException) {
             IndexOutOfBoundsException wrapped = new IndexOutOfBoundsException(newMessage);
             wrapped.initCause(e);
             return wrapped;

--- a/core/src/main/java/dev/hardwood/internal/FetchReason.java
+++ b/core/src/main/java/dev/hardwood/internal/FetchReason.java
@@ -36,6 +36,7 @@ public final class FetchReason {
         return value != null ? value : "unattributed";
     }
 
+
     /// Sets the reason for the current thread until [Scope#close] is called.
     /// Pass the returned [Scope] to a try-with-resources statement.
     public static Scope set(String reason) {

--- a/core/src/main/java/dev/hardwood/internal/ReadScope.java
+++ b/core/src/main/java/dev/hardwood/internal/ReadScope.java
@@ -1,0 +1,268 @@
+/*
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Copyright The original authors
+ *
+ *  Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package dev.hardwood.internal;
+
+import dev.hardwood.internal.ExceptionContext.ReadContext;
+import dev.hardwood.internal.ExceptionContext.ReadContext.Region;
+import dev.hardwood.metadata.FieldPath;
+import dev.hardwood.reader.ParquetReadException;
+
+/// Where the read currently is, as a scope rather than as an argument.
+///
+/// A failure's position is a property of the work in progress, not of the
+/// exception: the code that knows it is reading a bloom filter is the code
+/// running, and by the time a failure has travelled to a frame that can report
+/// it, that knowledge is gone. Every catch site that names a region today is
+/// restating what its own call stack already said.
+///
+/// So the region is entered, not passed:
+///
+/// ```java
+/// try (ReadScope.Scope ignored = ReadScope.region(Region.FOOTER, footerStart)) {
+///     return FileMetaDataReader.read(reader);
+/// }
+/// ```
+///
+/// and one enricher reads it back. Scopes nest and the innermost wins, which is
+/// the rule the reader already wanted: a page header inside a chunk fetch is a
+/// page-header failure.
+///
+/// **The region's own first byte comes with it.** A raise site states a message
+/// and nothing else; the byte a reader is sent to is the region's address. The
+/// one exception is a parse that knows how far it got, which says so through
+/// [#stoppedAt].
+public final class ReadScope {
+
+    private static final ThreadLocal<Place> CURRENT = new ThreadLocal<>();
+
+    private ReadScope() {
+    }
+
+    /// Where the read is, or `null` outside any scope.
+    ///
+    /// Public so that a fetch log can name the same place an exception would,
+    /// rather than composing a second description of it from a string.
+    public static Place current() {
+        return CURRENT.get();
+    }
+
+    /// Opens the file being read. Narrows nothing else: a file is entered
+    /// before there is a row group or a column to speak of.
+    public static Scope file(String fileName) {
+        return set(new Place(fileName, ReadContext.UNKNOWN_ROW_GROUP, null, null,
+                ReadContext.UNKNOWN_OFFSET));
+    }
+
+    /// Narrows to one column chunk, keeping the file.
+    public static Scope column(int rowGroup, FieldPath column) {
+        return column(rowGroup, String.valueOf(column));
+    }
+
+    /// The same, for a chunk named by ordinal because it carries no `meta_data`
+    /// to take a path from.
+    public static Scope column(int rowGroup, String column) {
+        return set(columnPlace(rowGroup, column));
+    }
+
+    private static Place columnPlace(int rowGroup, String column) {
+        Place outer = CURRENT.get();
+        return new Place(fileNameOf(outer), rowGroup, column, null, ReadContext.UNKNOWN_OFFSET);
+    }
+
+    /// An offset the footer need not have given, as a region start.
+    public static long orUnknown(Long offset) {
+        return offset == null ? ReadContext.UNKNOWN_OFFSET : offset;
+    }
+
+    /// Narrows to a region that has no address of its own, keeping the file,
+    /// the row group and the column.
+    ///
+    /// For work that covers a whole region rather than a position in it: a
+    /// decode that failed a thousand values into a page is not at the page's
+    /// first byte, and naming that byte would send a reader to bytes that are
+    /// intact. The row group and column already say which page it was.
+    public static Scope region(Region region) {
+        return region(region, ReadContext.UNKNOWN_OFFSET);
+    }
+
+    /// Narrows to a region whose first byte is known, keeping the file, the row
+    /// group and the column.
+    public static Scope region(Region region, long regionStart) {
+        return set(regionPlace(region, regionStart));
+    }
+
+    private static Place regionPlace(Region region, long regionStart) {
+        Place outer = CURRENT.get();
+        return outer == null
+                ? new Place(null, ReadContext.UNKNOWN_ROW_GROUP, null, region, regionStart)
+                : new Place(outer.fileName(), outer.rowGroup(), outer.column(), region,
+                        regionStart);
+    }
+
+    /// Re-establishes a captured place on this thread, for work that crossed a
+    /// thread boundary. The page decoded on a pool thread belongs to the row
+    /// group the retriever read it for, not to whatever that thread did last.
+    public static Scope resume(Place place) {
+        return set(place);
+    }
+
+    /// Where the read is, as a message prefix: `[file] row group N, column X, region at
+    /// byte B — `, or the empty string outside any read.
+    ///
+    /// For the failures that cannot carry a place of their own. An [java.io.IOException] is
+    /// the type a caller catches and the type the reader declares, so it stays that type and
+    /// takes its position as text rather than gaining a subclass to hold one.
+    public static String here() {
+        Place place = CURRENT.get();
+        return place == null ? "" : place.describe();
+    }
+
+    /// The file being read, as a message prefix: `[file] `, or the empty string outside any
+    /// read.
+    ///
+    /// For a correct file this library will not read. The file is not at fault, so no byte
+    /// of it is worth naming and the remedy is the same wherever the limit was met.
+    public static String fileHere() {
+        Place place = CURRENT.get();
+        return place == null ? "" : ExceptionContext.filePrefix(place.fileName());
+    }
+
+    /// A failure `bytesIntoRegion` bytes into the region being read, positioned
+    /// at that byte rather than at the region's first.
+    ///
+    /// The one thing a raise site knows that the scope cannot: a region says
+    /// where a read began, and only the read itself says where it stopped. Used
+    /// by the Thrift reader, whose buffer is a region and whose position in it
+    /// is the byte to go and look at.
+    ///
+    /// A buffer that is not part of any file — a hand-built struct in a test,
+    /// a footer the CLI read for itself — has no address to add to, and the
+    /// failure then says what went wrong without inventing a byte.
+    public static ParquetReadException stoppedAt(String message, int bytesIntoRegion) {
+        Place here = CURRENT.get();
+        if (here == null || here.regionStart() == ReadContext.UNKNOWN_OFFSET) {
+            return new ParquetReadException(message);
+        }
+        try (Scope stopped = set(here.at(here.regionStart() + bytesIntoRegion))) {
+            return new ParquetReadException(message);
+        }
+    }
+
+    /// Narrows to a region that begins where the enclosing one does.
+    ///
+    /// A page's header starts where the page starts, so the step that parses it
+    /// names what it is doing without being told an offset it would only be
+    /// copying from its caller.
+    public static Scope narrow(Region region) {
+        Place outer = CURRENT.get();
+        return region(region, outer == null ? ReadContext.UNKNOWN_OFFSET : outer.regionStart());
+    }
+
+    private static Scope set(Place place) {
+        Place previous = CURRENT.get();
+        CURRENT.set(place);
+        return new Scope(previous);
+    }
+
+    private static String fileNameOf(Place place) {
+        return place == null ? null : place.fileName();
+    }
+
+    /// Where a read is: the file, and as much of the way into it as has been
+    /// entered.
+    ///
+    /// `regionStart` is the byte a failure raised here sends a reader to. Where
+    /// a read knows how far it got, [#stoppedAt] narrows it to that byte before
+    /// the failure is built, so nothing downstream has to compose a position
+    /// out of two halves.
+    public record Place(String fileName, int rowGroup, String column, Region region,
+            long regionStart) {
+
+        /// This place as a message names it, ending in the separator that
+        /// divides where a failure was from what it was, or the empty string
+        /// where it names nothing.
+        public String describe() {
+            return ExceptionContext.prefix(
+                    new ReadContext(fileName, rowGroup, column, region, regionStart));
+        }
+
+        /// The same place, in a region the caller knows and this one does not.
+        public Place withRegion(Region region) {
+            return new Place(fileName, rowGroup, column, region, regionStart);
+        }
+
+        /// The same place, at a byte inside the region rather than at its first.
+        Place at(long offset) {
+            return new Place(fileName, rowGroup, column, region, offset);
+        }
+    }
+
+    /// Restores the enclosing place on close. Held in a try-with-resources.
+    ///
+    /// A read is usually entered all at once — a file, then the column in it, then the
+    /// region of that column — and the narrowing methods below chain so that reads as one
+    /// statement holding one resource:
+    ///
+    /// ```java
+    /// try (ReadScope.Scope scope = ReadScope.file(name)
+    ///         .column(rowGroupIndex, columnName)
+    ///         .region(Region.DICTIONARY_PAGE, dictionaryOffset)) {
+    /// ```
+    ///
+    /// They narrow the scope already opened rather than opening another, so one place is
+    /// restored on close however many of them were called. Where the parts have different
+    /// lifetimes — a file entered once with several regions read inside it in turn — the
+    /// static entry points still nest, each restoring its own.
+    public static final class Scope implements AutoCloseable {
+
+        private final Place previous;
+
+        private Scope(Place previous) {
+            this.previous = previous;
+        }
+
+        /// Narrows this scope to one column chunk, keeping the file.
+        public Scope column(int rowGroup, FieldPath column) {
+            return column(rowGroup, String.valueOf(column));
+        }
+
+        /// The same, for a chunk named by ordinal because it carries no `meta_data`.
+        public Scope column(int rowGroup, String column) {
+            CURRENT.set(columnPlace(rowGroup, column));
+            return this;
+        }
+
+        /// Narrows this scope to a region whose first byte is known.
+        public Scope region(Region region, long regionStart) {
+            CURRENT.set(regionPlace(region, regionStart));
+            return this;
+        }
+
+        /// Narrows this scope to a region that has no address of its own.
+        public Scope region(Region region) {
+            return region(region, ReadContext.UNKNOWN_OFFSET);
+        }
+
+        /// Narrows this scope to a region beginning where the enclosing one does.
+        public Scope narrow(Region region) {
+            Place outer = CURRENT.get();
+            return region(region,
+                    outer == null ? ReadContext.UNKNOWN_OFFSET : outer.regionStart());
+        }
+
+        @Override
+        public void close() {
+            if (previous == null) {
+                CURRENT.remove();
+            }
+            else {
+                CURRENT.set(previous);
+            }
+        }
+    }
+}

--- a/core/src/main/java/dev/hardwood/internal/ReadScope.java
+++ b/core/src/main/java/dev/hardwood/internal/ReadScope.java
@@ -32,6 +32,16 @@ import dev.hardwood.reader.ParquetReadException;
 /// the rule the reader already wanted: a page header inside a chunk fetch is a
 /// page-header failure.
 ///
+/// **Each part of a place is entered on its own,** by whichever code owns it and for as
+/// long as it holds. A worker that reads one column for its whole life enters that column
+/// once, and the file and row group it moves between are entered inside it.
+///
+/// A place has two independent axes, and entering a point on one leaves the other alone:
+/// which column is being read, and where in a file the read is. On the position axis the
+/// parts nest — a region lies in a row group, which lies in a file — so entering a coarser
+/// one discards the finer ones that described somewhere else. Entering a file therefore
+/// leaves no row group behind from the file before it.
+///
 /// **The region's own first byte comes with it.** A raise site states a message
 /// and nothing else; the byte a reader is sent to is the region's address. The
 /// one exception is a parse that knows how far it got, which says so through
@@ -39,6 +49,10 @@ import dev.hardwood.reader.ParquetReadException;
 public final class ReadScope {
 
     private static final ThreadLocal<Place> CURRENT = new ThreadLocal<>();
+
+    /// The place of a thread that has entered no scope: a read that names nothing.
+    private static final Place UNPLACED = new Place(null, ReadContext.UNKNOWN_ROW_GROUP, null,
+            null, ReadContext.UNKNOWN_OFFSET);
 
     private ReadScope() {
     }
@@ -51,27 +65,27 @@ public final class ReadScope {
         return CURRENT.get();
     }
 
-    /// Opens the file being read. Narrows nothing else: a file is entered
-    /// before there is a row group or a column to speak of.
+    /// Enters the file being read, keeping the column and discarding where in the
+    /// previous file the read was.
     public static Scope file(String fileName) {
-        return set(new Place(fileName, ReadContext.UNKNOWN_ROW_GROUP, null, null,
-                ReadContext.UNKNOWN_OFFSET));
+        return set(currentPlace().inFile(fileName));
     }
 
-    /// Narrows to one column chunk, keeping the file.
-    public static Scope column(int rowGroup, FieldPath column) {
-        return column(rowGroup, String.valueOf(column));
+    /// Enters a row group, keeping the file and the column and discarding the region
+    /// of the row group before it.
+    public static Scope rowGroup(int rowGroup) {
+        return set(currentPlace().inRowGroup(rowGroup));
+    }
+
+    /// Enters a column, keeping where in the file the read is.
+    public static Scope column(FieldPath column) {
+        return column(String.valueOf(column));
     }
 
     /// The same, for a chunk named by ordinal because it carries no `meta_data`
     /// to take a path from.
-    public static Scope column(int rowGroup, String column) {
-        return set(columnPlace(rowGroup, column));
-    }
-
-    private static Place columnPlace(int rowGroup, String column) {
-        Place outer = CURRENT.get();
-        return new Place(fileNameOf(outer), rowGroup, column, null, ReadContext.UNKNOWN_OFFSET);
+    public static Scope column(String column) {
+        return set(currentPlace().inColumn(column));
     }
 
     /// An offset the footer need not have given, as a region start.
@@ -79,8 +93,8 @@ public final class ReadScope {
         return offset == null ? ReadContext.UNKNOWN_OFFSET : offset;
     }
 
-    /// Narrows to a region that has no address of its own, keeping the file,
-    /// the row group and the column.
+    /// Enters a region that has no address of its own, keeping the file, the
+    /// row group and the column.
     ///
     /// For work that covers a whole region rather than a position in it: a
     /// decode that failed a thousand values into a page is not at the page's
@@ -90,18 +104,10 @@ public final class ReadScope {
         return region(region, ReadContext.UNKNOWN_OFFSET);
     }
 
-    /// Narrows to a region whose first byte is known, keeping the file, the row
+    /// Enters a region whose first byte is known, keeping the file, the row
     /// group and the column.
     public static Scope region(Region region, long regionStart) {
-        return set(regionPlace(region, regionStart));
-    }
-
-    private static Place regionPlace(Region region, long regionStart) {
-        Place outer = CURRENT.get();
-        return outer == null
-                ? new Place(null, ReadContext.UNKNOWN_ROW_GROUP, null, region, regionStart)
-                : new Place(outer.fileName(), outer.rowGroup(), outer.column(), region,
-                        regionStart);
+        return set(currentPlace().inRegion(region, regionStart));
     }
 
     /// Re-establishes a captured place on this thread, for work that crossed a
@@ -153,14 +159,13 @@ public final class ReadScope {
         }
     }
 
-    /// Narrows to a region that begins where the enclosing one does.
+    /// Enters a region that begins where the enclosing one does.
     ///
     /// A page's header starts where the page starts, so the step that parses it
     /// names what it is doing without being told an offset it would only be
     /// copying from its caller.
     public static Scope narrow(Region region) {
-        Place outer = CURRENT.get();
-        return region(region, outer == null ? ReadContext.UNKNOWN_OFFSET : outer.regionStart());
+        return set(currentPlace().withRegion(region));
     }
 
     private static Scope set(Place place) {
@@ -169,8 +174,11 @@ public final class ReadScope {
         return new Scope(previous);
     }
 
-    private static String fileNameOf(Place place) {
-        return place == null ? null : place.fileName();
+    /// The place to narrow from: the enclosing one, or the one that names
+    /// nothing where no scope has been entered.
+    private static Place currentPlace() {
+        Place place = CURRENT.get();
+        return place == null ? UNPLACED : place;
     }
 
     /// Where a read is: the file, and as much of the way into it as has been
@@ -193,6 +201,23 @@ public final class ReadScope {
 
         /// The same place, in a region the caller knows and this one does not.
         public Place withRegion(Region region) {
+            return inRegion(region, regionStart);
+        }
+
+        Place inFile(String fileName) {
+            return new Place(fileName, ReadContext.UNKNOWN_ROW_GROUP, column, null,
+                    ReadContext.UNKNOWN_OFFSET);
+        }
+
+        Place inRowGroup(int rowGroup) {
+            return new Place(fileName, rowGroup, column, null, ReadContext.UNKNOWN_OFFSET);
+        }
+
+        Place inColumn(String column) {
+            return new Place(fileName, rowGroup, column, region, regionStart);
+        }
+
+        Place inRegion(Region region, long regionStart) {
             return new Place(fileName, rowGroup, column, region, regionStart);
         }
 
@@ -204,20 +229,20 @@ public final class ReadScope {
 
     /// Restores the enclosing place on close. Held in a try-with-resources.
     ///
-    /// A read is usually entered all at once — a file, then the column in it, then the
-    /// region of that column — and the narrowing methods below chain so that reads as one
-    /// statement holding one resource:
+    /// Where several parts of a place are entered together — a file, the row group in it,
+    /// the region of that row group — the narrowing methods below chain, so that reads as
+    /// one statement holding one resource:
     ///
     /// ```java
     /// try (ReadScope.Scope scope = ReadScope.file(name)
-    ///         .column(rowGroupIndex, columnName)
+    ///         .rowGroup(rowGroupIndex)
     ///         .region(Region.DICTIONARY_PAGE, dictionaryOffset)) {
     /// ```
     ///
     /// They narrow the scope already opened rather than opening another, so one place is
     /// restored on close however many of them were called. Where the parts have different
-    /// lifetimes — a file entered once with several regions read inside it in turn — the
-    /// static entry points still nest, each restoring its own.
+    /// lifetimes — a column entered once with several row groups read inside it in turn —
+    /// the static entry points still nest, each restoring its own.
     public static final class Scope implements AutoCloseable {
 
         private final Place previous;
@@ -226,21 +251,30 @@ public final class ReadScope {
             this.previous = previous;
         }
 
-        /// Narrows this scope to one column chunk, keeping the file.
-        public Scope column(int rowGroup, FieldPath column) {
-            return column(rowGroup, String.valueOf(column));
+        /// Narrows this scope to a file, keeping the column and discarding where in the
+        /// previous file the read was.
+        public Scope file(String fileName) {
+            return to(currentPlace().inFile(fileName));
+        }
+
+        /// Narrows this scope to a row group, keeping the file and the column.
+        public Scope rowGroup(int rowGroup) {
+            return to(currentPlace().inRowGroup(rowGroup));
+        }
+
+        /// Narrows this scope to a column, keeping where in the file the read is.
+        public Scope column(FieldPath column) {
+            return column(String.valueOf(column));
         }
 
         /// The same, for a chunk named by ordinal because it carries no `meta_data`.
-        public Scope column(int rowGroup, String column) {
-            CURRENT.set(columnPlace(rowGroup, column));
-            return this;
+        public Scope column(String column) {
+            return to(currentPlace().inColumn(column));
         }
 
         /// Narrows this scope to a region whose first byte is known.
         public Scope region(Region region, long regionStart) {
-            CURRENT.set(regionPlace(region, regionStart));
-            return this;
+            return to(currentPlace().inRegion(region, regionStart));
         }
 
         /// Narrows this scope to a region that has no address of its own.
@@ -250,9 +284,12 @@ public final class ReadScope {
 
         /// Narrows this scope to a region beginning where the enclosing one does.
         public Scope narrow(Region region) {
-            Place outer = CURRENT.get();
-            return region(region,
-                    outer == null ? ReadContext.UNKNOWN_OFFSET : outer.regionStart());
+            return to(currentPlace().withRegion(region));
+        }
+
+        private Scope to(Place place) {
+            CURRENT.set(place);
+            return this;
         }
 
         @Override

--- a/core/src/main/java/dev/hardwood/internal/ReadScope.java
+++ b/core/src/main/java/dev/hardwood/internal/ReadScope.java
@@ -222,7 +222,7 @@ public final class ReadScope {
         }
 
         /// The same place, at a byte inside the region rather than at its first.
-        Place at(long offset) {
+        public Place at(long offset) {
             return new Place(fileName, rowGroup, column, region, offset);
         }
     }

--- a/core/src/main/java/dev/hardwood/internal/compression/CodecLibraries.java
+++ b/core/src/main/java/dev/hardwood/internal/compression/CodecLibraries.java
@@ -11,6 +11,8 @@ package dev.hardwood.internal.compression;
 /// classpath. These are optional dependencies, so both the read and write paths must confirm
 /// a codec's library is present before handing work to it, and fail with an actionable message
 /// naming the missing dependency when it is not.
+import dev.hardwood.internal.ReadScope;
+
 public final class CodecLibraries {
 
     private CodecLibraries() {
@@ -42,7 +44,7 @@ public final class CodecLibraries {
     /// @throws UnsupportedOperationException if the library is not on the classpath
     public static void require(String className, String codecName, String dependency, String action) {
         if (!isPresent(className)) {
-            throw new UnsupportedOperationException(
+            throw new UnsupportedOperationException(ReadScope.fileHere() +
                     "Cannot " + action + " " + codecName + "-compressed Parquet file: required library not found. " +
                             "Add the following dependency to your project: " + dependency);
         }

--- a/core/src/main/java/dev/hardwood/internal/predicate/FilterPredicateResolver.java
+++ b/core/src/main/java/dev/hardwood/internal/predicate/FilterPredicateResolver.java
@@ -122,7 +122,7 @@ public class FilterPredicateResolver {
                     // encoding of a given number is the only one the column can hold.
                     yield new ResolvedPredicate.BinaryPredicate(cs.columnIndex(), p.op(),
                             toFixedLenDecimalBytes(scaled.unscaledValue(),
-                                    FixedWidthValidator.requireWidth(null, cs)),
+                                    FixedWidthValidator.requireWidth(cs)),
                             Comparison.FIXED_DECIMAL);
                 }
                 else {

--- a/core/src/main/java/dev/hardwood/internal/predicate/PageFilterEvaluator.java
+++ b/core/src/main/java/dev/hardwood/internal/predicate/PageFilterEvaluator.java
@@ -9,13 +9,15 @@ package dev.hardwood.internal.predicate;
 
 import java.util.List;
 
-import dev.hardwood.internal.ExceptionContext;
+import dev.hardwood.internal.ExceptionContext.ReadContext.Region;
+import dev.hardwood.internal.ReadScope;
 import dev.hardwood.internal.reader.ColumnIndexBuffers;
 import dev.hardwood.internal.reader.RowGroupIndexBuffers;
 import dev.hardwood.internal.reader.RowRanges;
 import dev.hardwood.internal.thrift.ColumnIndexReader;
 import dev.hardwood.internal.thrift.OffsetIndexReader;
 import dev.hardwood.internal.thrift.ThriftCompactReader;
+import dev.hardwood.metadata.ColumnChunk;
 import dev.hardwood.metadata.ColumnIndex;
 import dev.hardwood.metadata.OffsetIndex;
 import dev.hardwood.metadata.PageLocation;
@@ -96,7 +98,7 @@ public class PageFilterEvaluator {
             return RowRanges.all(rowCount);
         }
 
-        IndexPair indexPair = readIndexPair(colBuffers, location, columnIndex);
+        IndexPair indexPair = readIndexPair(colBuffers, location, rowGroup.columns().get(columnIndex), columnIndex);
         ColumnIndex columnIdx = indexPair.columnIndex;
         OffsetIndex offsetIdx = indexPair.offsetIndex;
 
@@ -137,7 +139,7 @@ public class PageFilterEvaluator {
             return RowRanges.all(rowCount);
         }
 
-        IndexPair indexPair = readIndexPair(colBuffers, location, columnIndex);
+        IndexPair indexPair = readIndexPair(colBuffers, location, rowGroup.columns().get(columnIndex), columnIndex);
         ColumnIndex columnIdx = indexPair.columnIndex;
         OffsetIndex offsetIdx = indexPair.offsetIndex;
 
@@ -224,36 +226,48 @@ public class PageFilterEvaluator {
     /// [dev.hardwood.internal.reader.ParquetMetadataReader] attributes, so failures are named
     /// here: file, row group and column are all at hand.
     private static IndexPair readIndexPair(ColumnIndexBuffers colBuffers, IndexLocation location,
-            int columnIndex) {
-        ColumnIndex columnIdx;
-        OffsetIndex offsetIdx;
-        try {
-            columnIdx = ColumnIndexReader.read(new ThriftCompactReader(colBuffers.columnIndex()));
-            offsetIdx = OffsetIndexReader.read(new ThriftCompactReader(colBuffers.offsetIndex()));
+            ColumnChunk columnChunk, int columnIndex) {
+        try (ReadScope.Scope file = ReadScope.file(location.fileName());
+             ReadScope.Scope column = at(location, columnChunk, columnIndex)) {
+            ColumnIndex columnIdx;
+            try (ReadScope.Scope region = ReadScope.region(Region.COLUMN_INDEX,
+                    ReadScope.orUnknown(columnChunk.columnIndexOffset()))) {
+                columnIdx = ColumnIndexReader.read(new ThriftCompactReader(colBuffers.columnIndex()));
+            }
+            OffsetIndex offsetIdx;
+            try (ReadScope.Scope region = ReadScope.region(Region.OFFSET_INDEX,
+                    ReadScope.orUnknown(columnChunk.offsetIndexOffset()))) {
+                offsetIdx = OffsetIndexReader.read(new ThriftCompactReader(colBuffers.offsetIndex()));
+            }
+
+            int columnIndexPages = columnIdx.getPageCount();
+            int offsetIndexPages = offsetIdx.pageLocations().size();
+            if (columnIndexPages != offsetIndexPages) {
+                // Not a failed parse: both structs read, and they contradict
+                // each other. Attributed to the column index, which is the one
+                // whose count the reader would have indexed with.
+                try (ReadScope.Scope region = ReadScope.region(Region.COLUMN_INDEX,
+                        ReadScope.orUnknown(columnChunk.columnIndexOffset()))) {
+                    throw new ParquetReadException(String.format(
+                            "Malformed Parquet metadata: the column index describes %d pages but"
+                                    + " the offset index locates %d",
+                            columnIndexPages, offsetIndexPages));
+                }
+            }
+            return new IndexPair(columnIdx, offsetIdx);
         }
-        catch (ParquetReadException e) {
-            // The reader already says the failure is the file's; what it cannot
-            // say is which column's index it was parsing.
-            throw new ParquetReadException(prefix(location, columnIndex) + e.getMessage(), e);
-        }
-        // Outside the catch, and prefixed once: both structs parsed, so this is the
-        // pair disagreeing rather than either of them failing to read.
-        int columnIndexPages = columnIdx.getPageCount();
-        int offsetIndexPages = offsetIdx.pageLocations().size();
-        if (columnIndexPages != offsetIndexPages) {
-            throw new ParquetReadException(prefix(location, columnIndex)
-                    + "Malformed Parquet metadata: ColumnIndex describes "
-                    + columnIndexPages + " pages but OffsetIndex locates " + offsetIndexPages);
-        }
-        return new IndexPair(columnIdx, offsetIdx);
     }
 
-    /// Names the column chunk whose page index failed to parse, for the message of every
-    /// failure [#readIndexPair] reports.
-    private static String prefix(IndexLocation location, int columnIndex) {
-        return ExceptionContext.filePrefix(location.fileName())
-                + "Failed to parse the page index of column " + columnIndex
-                + " in row group " + location.rowGroupIndex() + ": ";
+    /// Narrows to the chunk whose page index is being parsed.
+    ///
+    /// `meta_data` is optional in parquet.thrift — a chunk that defers to
+    /// another file carries none — so the path may be unavailable. The ordinal
+    /// always is, and `#0` cannot be mistaken for a column named `0`.
+    private static ReadScope.Scope at(IndexLocation location, ColumnChunk columnChunk,
+            int columnIndex) {
+        return columnChunk.metaData() == null
+                ? ReadScope.column(location.rowGroupIndex(), "#" + columnIndex)
+                : ReadScope.column(location.rowGroupIndex(), columnChunk.metaData().pathInSchema());
     }
 
     /// The column chunk whose page index is being parsed, minus the column: file and row group

--- a/core/src/main/java/dev/hardwood/internal/predicate/PageFilterEvaluator.java
+++ b/core/src/main/java/dev/hardwood/internal/predicate/PageFilterEvaluator.java
@@ -266,8 +266,9 @@ public class PageFilterEvaluator {
     private static ReadScope.Scope at(IndexLocation location, ColumnChunk columnChunk,
             int columnIndex) {
         return columnChunk.metaData() == null
-                ? ReadScope.column(location.rowGroupIndex(), "#" + columnIndex)
-                : ReadScope.column(location.rowGroupIndex(), columnChunk.metaData().pathInSchema());
+                ? ReadScope.rowGroup(location.rowGroupIndex()).column("#" + columnIndex)
+                : ReadScope.rowGroup(location.rowGroupIndex())
+                        .column(columnChunk.metaData().pathInSchema());
     }
 
     /// The column chunk whose page index is being parsed, minus the column: file and row group

--- a/core/src/main/java/dev/hardwood/internal/predicate/RowGroupBloomFilterSource.java
+++ b/core/src/main/java/dev/hardwood/internal/predicate/RowGroupBloomFilterSource.java
@@ -87,7 +87,8 @@ public final class RowGroupBloomFilterSource implements BloomFilterSource {
         requireSameFile(columnChunk, columnIndex);
 
         try (ReadScope.Scope scope = ReadScope.file(inputFile.name())
-                .column(rowGroupIndex, columnPath(columnIndex))
+                .rowGroup(rowGroupIndex)
+                .column(columnPath(columnIndex))
                 .region(Region.BLOOM_FILTER, offset)) {
             return readFilterAt(metaData, offset);
         }

--- a/core/src/main/java/dev/hardwood/internal/predicate/RowGroupBloomFilterSource.java
+++ b/core/src/main/java/dev/hardwood/internal/predicate/RowGroupBloomFilterSource.java
@@ -12,6 +12,8 @@ import java.nio.ByteBuffer;
 
 import dev.hardwood.InputFile;
 import dev.hardwood.internal.ExceptionContext;
+import dev.hardwood.internal.ExceptionContext.ReadContext.Region;
+import dev.hardwood.internal.ReadScope;
 import dev.hardwood.internal.bloomfilter.BloomFilter;
 import dev.hardwood.internal.bloomfilter.BloomFilterHeader;
 import dev.hardwood.internal.thrift.BloomFilterHeaderReader;
@@ -19,6 +21,7 @@ import dev.hardwood.internal.thrift.BloomFilterReader;
 import dev.hardwood.internal.thrift.ThriftCompactReader;
 import dev.hardwood.metadata.ColumnChunk;
 import dev.hardwood.metadata.ColumnMetaData;
+import dev.hardwood.metadata.FieldPath;
 import dev.hardwood.metadata.RowGroup;
 
 /// [BloomFilterSource] backed by one `(InputFile, RowGroup)` pair.
@@ -38,6 +41,8 @@ public final class RowGroupBloomFilterSource implements BloomFilterSource {
 
     private final InputFile inputFile;
     private final RowGroup rowGroup;
+    /// The row group's own index in the file, for the failures that can name no byte.
+    private final int rowGroupIndex;
     /// Per-column filter cache indexed by column position; `null` entries mean either "not read yet"
     /// or "read, no filter" — `read[i]` disambiguates so absence is cached, not re-fetched.
     private final BloomFilter[] filters;
@@ -46,9 +51,10 @@ public final class RowGroupBloomFilterSource implements BloomFilterSource {
     /// "not yet fetched"; a Parquet file is never zero-length, so the sentinel is unambiguous.
     private long fileLength = -1;
 
-    public RowGroupBloomFilterSource(InputFile inputFile, RowGroup rowGroup) {
+    public RowGroupBloomFilterSource(InputFile inputFile, RowGroup rowGroup, int rowGroupIndex) {
         this.inputFile = inputFile;
         this.rowGroup = rowGroup;
+        this.rowGroupIndex = rowGroupIndex;
         int columnCount = rowGroup.columns().size();
         this.filters = new BloomFilter[columnCount];
         this.read = new boolean[columnCount];
@@ -79,17 +85,38 @@ public final class RowGroupBloomFilterSource implements BloomFilterSource {
         // The offset addresses the file named by file_path, not this one. Pruning on whatever
         // sits there would drop row groups that match.
         requireSameFile(columnChunk, columnIndex);
+
+        try (ReadScope.Scope scope = ReadScope.file(inputFile.name())
+                .column(rowGroupIndex, columnPath(columnIndex))
+                .region(Region.BLOOM_FILTER, offset)) {
+            return readFilterAt(metaData, offset);
+        }
+    }
+
+    /// Reads the filter the footer placed at `offset`, inside the scope that
+    /// names where that is.
+    private BloomFilter readFilterAt(ColumnMetaData metaData, long offset) throws IOException {
         if (offset <= 0) {
             // The offset is present but points at or before the file's magic header, so it cannot
             // name a real filter. Treat it as corruption but stay conservative — decline to prune
             // rather than throw, keeping the row group (statistics still apply) — and warn so the
             // malformed footer is visible instead of silently reducing pruning.
-            LOG.log(System.Logger.Level.WARNING, () -> ExceptionContext.filePrefix(inputFile.name())
-                    + "Ignoring invalid bloom_filter_offset " + offset + " for column " + columnIndex
+            ReadScope.Place where = ReadScope.current();
+            LOG.log(System.Logger.Level.WARNING, () -> where.describe()
+                    + "Ignoring invalid bloom_filter_offset " + offset
                     + "; keeping the row group (statistics still apply)");
             return null;
         }
-        return readFilter(offset, metaData.bloomFilterLength());
+        try {
+            return readFilter(offset, metaData.bloomFilterLength());
+        }
+        catch (IOException e) {
+            throw new IOException(ReadScope.here() + "Failed to read the bloom filter", e);
+        }
+    }
+
+    private FieldPath columnPath(int columnIndex) {
+        return rowGroup.columns().get(columnIndex).metaData().pathInSchema();
     }
 
     /// Reads the filter at `offset`. When `length` is known the whole region is read in one call;
@@ -129,14 +156,16 @@ public final class RowGroupBloomFilterSource implements BloomFilterSource {
 
     /// Fails unless this chunk stores its data in the file being read.
     ///
-    /// Checked, because reading a filter is a read like any other and every frame above this
-    /// one says so; the cause is the [IOException] the metadata contract advertises for the
-    /// split-file layout.
+    /// The split-file layout is legal Parquet that this reader does not read, so the failure
+    /// leaves as the [UnsupportedOperationException] it arrived as, carrying the column it
+    /// was raised for.
     private void requireSameFile(ColumnChunk columnChunk, int columnIndex) {
         try {
             columnChunk.requireSameFile();
         }
         catch (UnsupportedOperationException e) {
+            // Named, not positioned: the file is correct, so no byte of it is
+            // worth putting in front of anyone.
             throw new UnsupportedOperationException(ExceptionContext.filePrefix(inputFile.name())
                     + "Cannot read column " + columnIndex + ": " + e.getMessage(), e);
         }

--- a/core/src/main/java/dev/hardwood/internal/predicate/dictionary/RowGroupDictionaryFilterSource.java
+++ b/core/src/main/java/dev/hardwood/internal/predicate/dictionary/RowGroupDictionaryFilterSource.java
@@ -12,12 +12,15 @@ import java.nio.ByteBuffer;
 
 import dev.hardwood.InputFile;
 import dev.hardwood.internal.ExceptionContext;
+import dev.hardwood.internal.ExceptionContext.ReadContext.Region;
+import dev.hardwood.internal.ReadScope;
 import dev.hardwood.internal.reader.Dictionary;
 import dev.hardwood.internal.reader.DictionaryParser;
 import dev.hardwood.internal.reader.HardwoodContextImpl;
 import dev.hardwood.metadata.ColumnChunk;
 import dev.hardwood.metadata.ColumnMetaData;
 import dev.hardwood.metadata.Encoding;
+import dev.hardwood.metadata.FieldPath;
 import dev.hardwood.metadata.PageEncodingStats;
 import dev.hardwood.metadata.RowGroup;
 import dev.hardwood.reader.ParquetReadException;
@@ -38,15 +41,18 @@ public final class RowGroupDictionaryFilterSource {
 
     private final InputFile inputFile;
     private final RowGroup rowGroup;
+    /// The row group's own index in the file, for the failures that can name no byte.
+    private final int rowGroupIndex;
     private final FileSchema fileSchema;
     private final HardwoodContextImpl context;
     private final Dictionary[] dictionaries;
     private final boolean[] read;
 
-    public RowGroupDictionaryFilterSource(InputFile inputFile, RowGroup rowGroup,
+    public RowGroupDictionaryFilterSource(InputFile inputFile, RowGroup rowGroup, int rowGroupIndex,
                                           FileSchema fileSchema, HardwoodContextImpl context) {
         this.inputFile = inputFile;
         this.rowGroup = rowGroup;
+        this.rowGroupIndex = rowGroupIndex;
         this.fileSchema = fileSchema;
         this.context = context;
         int columnCount = rowGroup.columns().size();
@@ -111,16 +117,27 @@ public final class RowGroupDictionaryFilterSource {
         // "no dictionary": the scan cannot read the chunk either.
         requireSameFile(columnChunk, columnIndex);
 
+        try (ReadScope.Scope scope = ReadScope.file(inputFile.name())
+                .column(rowGroupIndex, columnPath(columnIndex))
+                .region(Region.DICTIONARY_PAGE, columnChunk.chunkStartOffset())) {
+            return readDictionaryPage(columnChunk, metaData, columnIndex);
+        }
+    }
+
+    /// Locates and parses the chunk's dictionary page, inside the scope that
+    /// names the file, the column and the page's own first byte. Every failure
+    /// below says only what is wrong.
+    private Dictionary readDictionaryPage(ColumnChunk columnChunk, ColumnMetaData metaData,
+            int columnIndex) throws IOException {
         Long dictionaryOffset = metaData.dictionaryPageOffset();
         long dataPageOffset = metaData.dataPageOffset();
 
         // A first data page *preceding* the dictionary page cannot be read at all, so fail rather
         // than degrade to "no dictionary".
         if (dictionaryOffset != null && dataPageOffset < dictionaryOffset) {
-            throw new ParquetReadException(ExceptionContext.filePrefix(inputFile.name())
-                    + "Malformed Parquet metadata: column " + columnIndex
-                    + " declares a dictionary page at offset " + dictionaryOffset
-                    + " which lies after its first data page at offset " + dataPageOffset);
+            throw malformed("Malformed Parquet metadata: the dictionary page lies after the first"
+                            + " data page at offset %d",
+                            dataPageOffset);
         }
 
         // A dictionary page is always the chunk's first page, so one offset is both the page's
@@ -134,20 +151,32 @@ public final class RowGroupDictionaryFilterSource {
         long chunkStart = columnChunk.chunkStartOffset();
         long chunkEnd = chunkStart + metaData.totalCompressedSize();
         if (chunkEnd <= chunkStart) {
-            throw new ParquetReadException(ExceptionContext.filePrefix(inputFile.name())
-                    + "Malformed Parquet metadata: column " + columnIndex
-                    + " declares a dictionary page at offset " + chunkStart
-                    + " but its chunk ends at offset " + chunkEnd);
+            throw malformed("Malformed Parquet metadata: the chunk holding the dictionary page"
+                            + " ends at offset %d, so it holds no bytes at all", chunkEnd);
         }
         int availableBytes = Math.toIntExact(chunkEnd - chunkStart);
 
         ColumnSchema columnSchema = fileSchema.getColumn(columnIndex);
-        ByteBuffer region = readDictionaryPage(columnIndex, chunkStart,
-                dataPageOffset > chunkStart
-                        ? Math.toIntExact(dataPageOffset - chunkStart)
-                        : DICTIONARY_PROBE_BYTES,
-                availableBytes);
-        return region == null ? null : DictionaryParser.parse(region, columnSchema, metaData, context);
+        try {
+            ByteBuffer region = readDictionaryPage(columnIndex, chunkStart,
+                    dataPageOffset > chunkStart
+                            ? Math.toIntExact(dataPageOffset - chunkStart)
+                            : DICTIONARY_PROBE_BYTES,
+                    availableBytes);
+            return region == null ? null : DictionaryParser.parse(region, columnSchema, metaData, context);
+        }
+        catch (IOException e) {
+            throw new IOException(ReadScope.here() + "Failed to read the dictionary", e);
+        }
+    }
+
+    /// What is wrong with the file. Where it is wrong is the scope's to say.
+    private static ParquetReadException malformed(String message, Object... args) {
+        return new ParquetReadException(String.format(message, args));
+    }
+
+    private FieldPath columnPath(int columnIndex) {
+        return rowGroup.columns().get(columnIndex).metaData().pathInSchema();
     }
 
     /// Reads the bytes of the dictionary page beginning at `dictionaryStart`, or `null` when no
@@ -170,10 +199,8 @@ public final class RowGroupDictionaryFilterSource {
         }
 
         if (pageLength > availableBytes) {
-            throw new ParquetReadException(ExceptionContext.filePrefix(inputFile.name())
-                    + "Malformed Parquet metadata: column " + columnIndex
-                    + " declares a dictionary page of " + pageLength
-                    + " bytes but only " + availableBytes + " bytes remain in its chunk");
+            throw malformed("Malformed Parquet metadata: the dictionary page header declares %d"
+                            + " bytes but only %d remain in the chunk", pageLength, availableBytes);
         }
 
         return pageLength > region.remaining()
@@ -184,14 +211,17 @@ public final class RowGroupDictionaryFilterSource {
 
     /// Fails unless this chunk stores its data in the file being read.
     ///
-    /// Checked, because reading a filter is a read like any other and every frame above this
-    /// one says so; the cause is the [IOException] the metadata contract advertises for the
-    /// split-file layout.
+    /// The split-file layout is legal Parquet that this reader does not read, so the failure
+    /// leaves as the [UnsupportedOperationException] it arrived as, carrying the column it
+    /// was raised for.
     private void requireSameFile(ColumnChunk columnChunk, int columnIndex) {
         try {
             columnChunk.requireSameFile();
         }
         catch (UnsupportedOperationException e) {
+            // Named, not positioned. The file is correct, so there is nothing at
+            // any byte for a caller to go and look at, and the remedy is the
+            // same whichever column met it first.
             throw new UnsupportedOperationException(ExceptionContext.filePrefix(inputFile.name())
                     + "Cannot read column " + columnIndex + ": " + e.getMessage(), e);
         }

--- a/core/src/main/java/dev/hardwood/internal/predicate/dictionary/RowGroupDictionaryFilterSource.java
+++ b/core/src/main/java/dev/hardwood/internal/predicate/dictionary/RowGroupDictionaryFilterSource.java
@@ -118,7 +118,8 @@ public final class RowGroupDictionaryFilterSource {
         requireSameFile(columnChunk, columnIndex);
 
         try (ReadScope.Scope scope = ReadScope.file(inputFile.name())
-                .column(rowGroupIndex, columnPath(columnIndex))
+                .rowGroup(rowGroupIndex)
+                .column(columnPath(columnIndex))
                 .region(Region.DICTIONARY_PAGE, columnChunk.chunkStartOffset())) {
             return readDictionaryPage(columnChunk, metaData, columnIndex);
         }

--- a/core/src/main/java/dev/hardwood/internal/reader/ChunkHandle.java
+++ b/core/src/main/java/dev/hardwood/internal/reader/ChunkHandle.java
@@ -12,8 +12,10 @@ import java.nio.ByteBuffer;
 import java.util.concurrent.CompletableFuture;
 
 import dev.hardwood.InputFile;
-import dev.hardwood.internal.ExceptionContext;
+import dev.hardwood.internal.ExceptionContext.ReadContext.Region;
 import dev.hardwood.internal.FetchReason;
+import dev.hardwood.internal.ReadScope;
+import dev.hardwood.reader.ParquetReadException;
 
 /// Lazy fetch handle for a contiguous byte range in a Parquet file.
 ///
@@ -157,14 +159,22 @@ public class ChunkHandle {
             // so the log line shows both the calling context and the chunk identity.
             String outer = FetchReason.current();
             String composed = "unattributed".equals(outer) ? purpose : outer + " | " + purpose;
-            try (FetchReason.Scope ignored = FetchReason.set(composed)) {
-                data = inputFile.readRange(fileOffset, length);
-            }
-            catch (IOException e) {
-                throw new IOException(
-                        ExceptionContext.filePrefix(inputFile.name())
-                        + "Failed to fetch chunk at offset " + fileOffset
-                        + " (length " + length + ")", e);
+            try (FetchReason.Scope ignored = FetchReason.set(composed);
+                 ReadScope.Scope fetch = ReadScope.region(Region.CHUNK_FETCH, fileOffset)) {
+                try {
+                    data = inputFile.readRange(fileOffset, length);
+                }
+                catch (IOException e) {
+                    throw new IOException(ReadScope.here() + "Failed to fetch " + length + " bytes", e);
+                }
+                catch (IndexOutOfBoundsException e) {
+                    // The footer named an address the file does not have, so
+                    // nothing was ever going to arrive. That is the metadata
+                    // contradicting itself, not a read that went wrong.
+                    throw new ParquetReadException("Malformed Parquet metadata: the chunk of "
+                            + length + " bytes at offset " + fileOffset
+                            + " runs past the end of the file", e);
+                }
             }
         }
     }

--- a/core/src/main/java/dev/hardwood/internal/reader/ColumnWorker.java
+++ b/core/src/main/java/dev/hardwood/internal/reader/ColumnWorker.java
@@ -9,6 +9,7 @@ package dev.hardwood.internal.reader;
 
 import java.io.IOException;
 import java.io.UncheckedIOException;
+import java.util.OptionalLong;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
@@ -16,8 +17,11 @@ import java.util.concurrent.Executor;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.concurrent.atomic.AtomicReferenceArray;
 import java.util.concurrent.locks.LockSupport;
+import java.util.function.Supplier;
 
-import dev.hardwood.internal.ExceptionContext;
+import dev.hardwood.internal.ExceptionContext.ReadContext;
+import dev.hardwood.internal.ExceptionContext.ReadContext.Region;
+import dev.hardwood.internal.ReadScope;
 import dev.hardwood.internal.compression.DecompressorFactory;
 import dev.hardwood.metadata.PhysicalType;
 import dev.hardwood.reader.ParquetReadException;
@@ -76,24 +80,29 @@ public abstract class ColumnWorker<B> implements AutoCloseable {
     // retriever throttle prevents reuse until the drain has consumed the page.
     private final PageDecoder.LevelScratch[] levelScratchBuffer;
 
-    // === File name per reorder-buffer slot (retriever writes, drain reads) ===
-    // Visibility: retriever writes fileNameBuffer[slot] before submitting the
+    // === Where each reorder-buffer slot's page came from (retriever writes, drain reads) ===
+    // Visibility: retriever writes placeBuffer[slot] before submitting the
     // decode task. The decode task's volatile write to reorderBuffer[slot]
     // happens-after the retriever's plain write. The drain's volatile read of
-    // reorderBuffer[slot] sees the fileName via the happens-before chain.
+    // reorderBuffer[slot] sees the place via the happens-before chain.
     //
     // Slot reuse safety: the retriever may only reuse a slot once consumePosition
     // has advanced past it (throttle: nextSeq - consumePosition < MAX_INFLIGHT_PAGES).
-    // drainReadyPages reads fileNameBuffer[slot] before incrementing consumePosition,
+    // drainReadyPages reads placeBuffer[slot] before incrementing consumePosition,
     // so the previous occupant's fileName is always read before being overwritten.
     // Any future change to the throttle or to the read-then-increment ordering must
     // preserve this invariant.
-    private final String[] fileNameBuffer;
+    private final ReadScope.Place[] placeBuffer;
 
     // Per-slot filter-always-matches flag, written by the retriever alongside
-    // fileNameBuffer[slot] under the same happens-before chain: whether the page's
+    // placeBuffer[slot] under the same happens-before chain: whether the page's
     // row group was proven by statistics to match the filter in full.
     private final boolean[] filterAlwaysMatchesBuffer;
+
+    // Per-slot row group index, written by the retriever alongside
+    // placeBuffer[slot] under the same happens-before chain. Read only when a
+    // page fails, to say which row group of the column it was in.
+
 
     // === Drain position (only modified by drain thread, read by retriever for throttle) ===
     private volatile int consumePosition;
@@ -141,6 +150,15 @@ public abstract class ColumnWorker<B> implements AutoCloseable {
     /// Written only by the drain thread.
     String currentBatchFileName;
 
+    /// Row group of the page currently being assembled. Written only by the
+    /// drain thread.
+    ///
+    /// Per page rather than per batch: batches are flushed on file boundaries,
+    /// not row-group ones, so one batch routinely spans several row groups and
+    /// has no single row group to name. A failure, though, happens while
+    /// assembling one particular page, and that page has one.
+    int currentPageRowGroup = ReadContext.UNKNOWN_ROW_GROUP;
+
     /// Whether every page of the current batch comes from a row group whose statistics
     /// prove the filter matches all rows. Only maintained (with batch flushes on
     /// transitions) when [#flushOnFilterAlwaysMatchesTransition] is `true`.
@@ -180,8 +198,9 @@ public abstract class ColumnWorker<B> implements AutoCloseable {
         for (int i = 0; i < levelScratchBuffer.length; i++) {
             levelScratchBuffer[i] = new PageDecoder.LevelScratch();
         }
-        this.fileNameBuffer = new String[MAX_INFLIGHT_PAGES];
+        this.placeBuffer = new ReadScope.Place[MAX_INFLIGHT_PAGES];
         this.filterAlwaysMatchesBuffer = new boolean[MAX_INFLIGHT_PAGES];
+
     }
 
     /// Initializes subclass-specific drain state (called at the start of `runDrain`).
@@ -329,7 +348,7 @@ public abstract class ColumnWorker<B> implements AutoCloseable {
                 int seq = nextSeq++;
                 totalPagesSubmitted++;
                 int slot = seq % MAX_INFLIGHT_PAGES;
-                fileNameBuffer[slot] = pageSource.getCurrentFileName();
+                placeBuffer[slot] = pageAt(pageInfo);
                 filterAlwaysMatchesBuffer[slot] = pageSource.isCurrentFilterAlwaysMatches();
                 PageInfo pi = pageInfo;
                 PageDecoder rdr = pageDecoder;
@@ -360,7 +379,12 @@ public abstract class ColumnWorker<B> implements AutoCloseable {
                     sourceNanos / 1_000_000.0, throttleNanos / 1_000_000.0, throttleWakes);
         }
         catch (Throwable t) {
-            signalError(enrichWithFileName(t, pageSource.getCurrentFileName()));
+            // No region: the retriever runs every step of getting a page — the
+            // plan, the filters, the index, the fetch — and whichever one this
+            // was has already said so from inside itself. Naming one here named
+            // the wrong one for everything but a fetch.
+            report(t, () -> placedAt(columnPlace(pageSource.getCurrentFileName(),
+                    pageSource.getCurrentRowGroupIndex()), t));
         }
     }
 
@@ -369,14 +393,22 @@ public abstract class ColumnWorker<B> implements AutoCloseable {
         if (done || error.get() != null) {
             return;
         }
-        try {
-            Page page = pageInfo.isNullPlaceholder()
-                    ? pageDecoder.nullPage(pageInfo.placeholderNumValues())
-                    : pageDecoder.decodePage(pageInfo.pageData(), pageInfo.dictionary(), levelScratchBuffer[slot]);
-            reorderBuffer.set(slot, new DecodedPage(page, pageInfo.mask()));
-        }
-        catch (Throwable t) {
-            signalError(enrichWithFileName(t, fileNameBuffer[slot]));
+        // The page was read on the retriever thread; this one has to be told
+        // where it came from, and inherits nothing from whatever it ran last.
+        try (ReadScope.Scope scope = ReadScope.resume(placeBuffer[slot])
+                .region(Region.DATA_PAGE)) {
+            try {
+                Page page = pageInfo.isNullPlaceholder()
+                        ? pageDecoder.nullPage(pageInfo.placeholderNumValues())
+                        : pageDecoder.decodePage(pageInfo.pageData(), pageInfo.dictionary(),
+                                levelScratchBuffer[slot]);
+                reorderBuffer.set(slot, new DecodedPage(page, pageInfo.mask()));
+            }
+            catch (Throwable t) {
+                // Raised inside the scope above, so it takes the page's place
+                // without being handed one.
+                report(t, () -> asReadFailure(t));
+            }
         }
         LockSupport.unpark(drainThread);
     }
@@ -422,7 +454,9 @@ public abstract class ColumnWorker<B> implements AutoCloseable {
                     publishBlockNanos / 1_000_000.0);
         }
         catch (Throwable t) {
-            signalError(enrichWithFileName(t, currentBatchFileName));
+            // A region this frame does know: assembling is what it does.
+            report(t, () -> placedAt(columnPlace(currentBatchFileName, currentPageRowGroup)
+                    .withRegion(Region.BATCH_ASSEMBLY), t));
         }
     }
 
@@ -443,7 +477,9 @@ public abstract class ColumnWorker<B> implements AutoCloseable {
 
             // Detect file boundary: flush the current batch when the file changes
             // so that each batch is attributed to a single file.
-            String pageFileName = fileNameBuffer[slot];
+            ReadScope.Place page = placeBuffer[slot];
+            currentPageRowGroup = page.rowGroup();
+            String pageFileName = page.fileName();
             if (pageFileName != null) {
                 if (currentBatchFileName != null
                         && !pageFileName.equals(currentBatchFileName)
@@ -505,34 +541,71 @@ public abstract class ColumnWorker<B> implements AutoCloseable {
         LockSupport.unpark(drainThread);
     }
 
-    /// Says what a throwable means, then names the file it came from.
+    /// Reports `t` to the caller, and reports it even if working out what to
+    /// say about it fails.
     ///
-    /// [#asReadFailure] decides the type first, so what is enriched here is already the
-    /// exception a caller will see. A `RuntimeException` — including the
-    /// `ParquetReadException` most decoder failures have just become — is enriched via
-    /// [ExceptionContext#addFileContext], which preserves whatever type it arrived as.
-    /// `IOException` is restated as a fresh `IOException` carrying the prefix: the pipeline
-    /// carries a failure across its thread boundary as a `Throwable`, so it stays checked the
-    /// whole way and the readers declare it rather than unwrapping anything. `Error` and other
-    /// throwables propagate unchanged.
-    private static Throwable enrichWithFileName(Throwable t, String fileName) {
-        Throwable typed = asReadFailure(t);
-        if (fileName == null || fileName.isEmpty()) {
-            return typed;
+    /// These catches are the only thing able to report a failure at all: the
+    /// decode task's own failure is discarded by the future that ran it, and
+    /// each thread's dies with the thread. A throw from inside one of them
+    /// would leave nothing to set the error and nothing to wake the drain, so
+    /// the read would never return rather than fail — the one outcome worse
+    /// than a bad message. `describe` is therefore allowed to fail, and the
+    /// failure it was describing is reported instead, carrying it.
+    ///
+    /// [#signalError] itself needs no guard: a compare-and-set, a flag, a queue
+    /// hand-off and two unparks.
+    private void report(Throwable t, Supplier<Throwable> describe) {
+        signalError(describedOrRaw(t, describe));
+    }
+
+    /// What `t` means, said from inside `place`.
+    ///
+    /// For the two catches that meet a failure after the scope it happened in
+    /// has closed — a task boundary, a thread's outermost catch. Re-entering
+    /// the place is what lets the failure be built the same way every other one
+    /// is, rather than having a second mechanism for attaching a place to an
+    /// exception that already exists.
+    private Throwable placedAt(ReadScope.Place place, Throwable t) {
+        try (ReadScope.Scope resumed = ReadScope.resume(place)) {
+            return asReadFailure(t);
         }
-        if (typed instanceof RuntimeException re) {
-            return ExceptionContext.addFileContext(fileName, re);
+    }
+
+    /// What `describe` makes of `t`, or `t` itself when describing it throws.
+    ///
+    /// Package-private and static so the guarantee can be asserted directly:
+    /// the failure that matters here is the one in `describe`, and it must not
+    /// be able to take `t` down with it.
+    static Throwable describedOrRaw(Throwable t, Supplier<Throwable> describe) {
+        try {
+            return describe.get();
         }
-        if (typed instanceof IOException ioe) {
-            // Stays checked. The pipeline carries a failure across its thread
-            // boundary as a `Throwable`, so nothing between here and the reader
-            // needs it wrapped, and the reader's own signature can declare it.
-            return new IOException(
-                    ExceptionContext.filePrefix(fileName)
-                            + (ioe.getMessage() != null ? ioe.getMessage() : "I/O failure"),
-                    ioe);
+        catch (Throwable failed) {
+            t.addSuppressed(failed);
+            return t;
         }
-        return typed;
+    }
+
+    /// Where a page came from, captured on the retriever thread so the decode
+    /// task and the drain can re-enter it.
+    ///
+    /// The page's own first byte is the region start for everything done to it:
+    /// the only Thrift-encoded thing in a page is the header at its front, so a
+    /// parse position added to this lands inside that header and never in the
+    /// values, which have no file offset a decoder could report.
+    private ReadScope.Place pageAt(PageInfo pageInfo) {
+        OptionalLong offset = pageInfo.fileOffset();
+        return new ReadScope.Place(pageSource.getCurrentFileName(),
+                pageSource.getCurrentRowGroupIndex(), String.valueOf(column.fieldPath()), null,
+                offset.isPresent() ? offset.getAsLong() : ReadContext.UNKNOWN_OFFSET);
+    }
+
+    /// This worker's column in one file's row group, with no region and no
+    /// byte: what a frame knows once the step that failed has finished
+    /// unwinding past it.
+    private ReadScope.Place columnPlace(String fileName, int rowGroup) {
+        return new ReadScope.Place(fileName, rowGroup, String.valueOf(column.fieldPath()), null,
+                ReadContext.UNKNOWN_OFFSET);
     }
 
     /// What a decoder threw, said as what it means.

--- a/core/src/main/java/dev/hardwood/internal/reader/ColumnWorker.java
+++ b/core/src/main/java/dev/hardwood/internal/reader/ColumnWorker.java
@@ -304,87 +304,127 @@ public abstract class ColumnWorker<B> implements AutoCloseable {
     private int totalPagesSubmitted;
     private int throttleWakes;
 
+    /// Sequence number of the next page submitted for decoding, and the decoder the
+    /// pages are submitted with. Both outlive a work item — the sequence is the drain's
+    /// order over the whole column, and the decoder is rebuilt only when a file's column
+    /// metadata differs — so they are held here rather than in [#retrievePagesOf].
+    private int nextSeq;
+    private PageDecoder pageDecoder;
+
+    /// Reads this column's pages, one work item at a time, and submits each for decoding.
+    ///
+    /// The column is this worker's for the whole of it; the file and row group move
+    /// underneath, so a failure is placed by the scopes entered here rather than by
+    /// anything it is handed.
     private void runRetriever() {
-        try {
-            LOG.log(System.Logger.Level.DEBUG,
-                    "[{0}] ColumnWorker started, maxOutstanding={1}, batchCapacity={2}",
-                    column.name(), MAX_INFLIGHT_PAGES, batchCapacity);
+        try (ReadScope.Scope columnScope = ReadScope.column(column.fieldPath())) {
+            try {
+                LOG.log(System.Logger.Level.DEBUG,
+                        "[{0}] ColumnWorker started, maxOutstanding={1}, batchCapacity={2}",
+                        column.name(), MAX_INFLIGHT_PAGES, batchCapacity);
 
-            PageDecoder pageDecoder = null;
-            int nextSeq = 0;
-
-            long t0;
-            PageInfo pageInfo;
-            while (!done) {
-                // Pull next page from source
-                t0 = System.nanoTime();
-                pageInfo = pageSource.next();
-                sourceNanos += System.nanoTime() - t0;
-                if (pageInfo == null) {
-                    break;
+                RowGroupIterator.WorkItem workItem;
+                while (!done) {
+                    long t0 = System.nanoTime();
+                    workItem = pageSource.nextWorkItem();
+                    sourceNanos += System.nanoTime() - t0;
+                    if (workItem == null) {
+                        break;
+                    }
+                    retrievePagesOf(workItem);
                 }
 
-                // Create/update PageDecoder when column metadata changes (file transitions)
-                if (pageDecoder == null || !pageDecoder.isCompatibleWith(pageInfo.columnMetaData())) {
-                    pageDecoder = new PageDecoder(
-                            pageInfo.columnMetaData(),
-                            pageInfo.columnSchema(),
-                            decompressorFactory,
-                            fixedListFastPathEnabled);
-                }
-
-                // Throttle: park while too many pages are in flight
-                t0 = System.nanoTime();
-                while (!done && nextSeq - consumePosition >= MAX_INFLIGHT_PAGES) {
-                    throttleWakes++;
-                    LockSupport.parkNanos(WAKE_CHECK_NANOS);
-                }
-                throttleNanos += System.nanoTime() - t0;
-                if (done) {
-                    break;
-                }
-
-                // Submit decode task to executor (reuses pooled threads, no VThread per page)
-                int seq = nextSeq++;
-                totalPagesSubmitted++;
-                int slot = seq % MAX_INFLIGHT_PAGES;
-                placeBuffer[slot] = pageAt(pageInfo);
-                filterAlwaysMatchesBuffer[slot] = pageSource.isCurrentFilterAlwaysMatches();
-                PageInfo pi = pageInfo;
-                PageDecoder rdr = pageDecoder;
-                CompletableFuture<Void> f = CompletableFuture.runAsync(
-                        () -> decode(slot, pi, rdr), decodeExecutor);
-                inFlightDecodes.add(f);
-                f.whenComplete((v, t) -> inFlightDecodes.remove(f));
-            }
-
-            if (!done) {
-                // The sentinel needs a free slot. If all MAX_INFLIGHT_PAGES slots
-                // are occupied (pages submitted but not yet drained), wait for
-                // the drain to advance before writing.
-                while (!done && nextSeq - consumePosition >= MAX_INFLIGHT_PAGES) {
-                    LockSupport.parkNanos(WAKE_CHECK_NANOS);
-                }
                 if (!done) {
-                    int sentinelSlot = nextSeq % MAX_INFLIGHT_PAGES;
-                    reorderBuffer.set(sentinelSlot, EMPTY_SENTINEL);
-                    LockSupport.unpark(drainThread);
+                    // The sentinel needs a free slot. If all MAX_INFLIGHT_PAGES slots
+                    // are occupied (pages submitted but not yet drained), wait for
+                    // the drain to advance before writing.
+                    while (!done && nextSeq - consumePosition >= MAX_INFLIGHT_PAGES) {
+                        LockSupport.parkNanos(WAKE_CHECK_NANOS);
+                    }
+                    if (!done) {
+                        int sentinelSlot = nextSeq % MAX_INFLIGHT_PAGES;
+                        reorderBuffer.set(sentinelSlot, EMPTY_SENTINEL);
+                        LockSupport.unpark(drainThread);
+                    }
+                }
+
+                LOG.log(System.Logger.Level.DEBUG,
+                        "[{0}] Retriever finished: {1} pages submitted. "
+                        + "source={2,number,0.0}ms, throttle={3,number,0.0}ms ({4} wakes)",
+                        column.name(), totalPagesSubmitted,
+                        sourceNanos / 1_000_000.0, throttleNanos / 1_000_000.0, throttleWakes);
+            }
+            catch (Throwable t) {
+                // Between work items, so the column is all there is to name: planning the
+                // next one reads a file this worker has not entered yet, and says so from
+                // inside itself.
+                report(t, () -> asReadFailure(t));
+            }
+        }
+    }
+
+    /// Submits every page of one work item for decoding.
+    ///
+    /// Failures are reported from in here rather than from [#runRetriever], because the
+    /// scope naming which file and row group they happened in is this method's and closes
+    /// with it. [#signalError] stops the loop above.
+    private void retrievePagesOf(RowGroupIterator.WorkItem workItem) {
+        try (ReadScope.Scope itemScope = ReadScope.file(workItem.inputFile().name())
+                .rowGroup(workItem.rowGroupIndex())) {
+            try {
+                long t0;
+                PageInfo pageInfo;
+                while (!done) {
+                    // Pull next page from source
+                    t0 = System.nanoTime();
+                    pageInfo = pageSource.nextPage();
+                    sourceNanos += System.nanoTime() - t0;
+                    if (pageInfo == null) {
+                        return;
+                    }
+
+                    // Create/update PageDecoder when column metadata changes (file transitions)
+                    if (pageDecoder == null
+                            || !pageDecoder.isCompatibleWith(pageInfo.columnMetaData())) {
+                        pageDecoder = new PageDecoder(
+                                pageInfo.columnMetaData(),
+                                pageInfo.columnSchema(),
+                                decompressorFactory,
+                                fixedListFastPathEnabled);
+                    }
+
+                    // Throttle: park while too many pages are in flight
+                    t0 = System.nanoTime();
+                    while (!done && nextSeq - consumePosition >= MAX_INFLIGHT_PAGES) {
+                        throttleWakes++;
+                        LockSupport.parkNanos(WAKE_CHECK_NANOS);
+                    }
+                    throttleNanos += System.nanoTime() - t0;
+                    if (done) {
+                        return;
+                    }
+
+                    // Submit decode task to executor (reuses pooled threads, no VThread per page)
+                    int seq = nextSeq++;
+                    totalPagesSubmitted++;
+                    int slot = seq % MAX_INFLIGHT_PAGES;
+                    placeBuffer[slot] = pageAt(pageInfo);
+                    filterAlwaysMatchesBuffer[slot] = workItem.filterAlwaysMatches();
+                    PageInfo pi = pageInfo;
+                    PageDecoder rdr = pageDecoder;
+                    CompletableFuture<Void> f = CompletableFuture.runAsync(
+                            () -> decode(slot, pi, rdr), decodeExecutor);
+                    inFlightDecodes.add(f);
+                    f.whenComplete((v, t) -> inFlightDecodes.remove(f));
                 }
             }
-
-            LOG.log(System.Logger.Level.DEBUG,
-                    "[{0}] Retriever finished: {1} pages submitted. "
-                    + "source={2,number,0.0}ms, throttle={3,number,0.0}ms ({4} wakes)",
-                    column.name(), totalPagesSubmitted,
-                    sourceNanos / 1_000_000.0, throttleNanos / 1_000_000.0, throttleWakes);
-        }
-        catch (Throwable t) {
-            // No region: the retriever runs every step of getting a page — the
-            // plan, the filters, the index, the fetch — and whichever one this
-            // was has already said so from inside itself. Naming one here named
-            // the wrong one for everything but a fetch.
-            report(t, () -> placedAt(columnPlace(pageSource.getCurrentFileName(),
-                    pageSource.getCurrentRowGroupIndex()), t));
+            catch (Throwable t) {
+                // No region: getting a page is every step of the read — the plan, the
+                // filters, the index, the fetch — and whichever one this was has already
+                // said so from inside itself. Naming one here named the wrong one for
+                // everything but a fetch.
+                report(t, () -> asReadFailure(t));
+            }
         }
     }
 
@@ -593,16 +633,17 @@ public abstract class ColumnWorker<B> implements AutoCloseable {
     /// the only Thrift-encoded thing in a page is the header at its front, so a
     /// parse position added to this lands inside that header and never in the
     /// values, which have no file offset a decoder could report.
-    private ReadScope.Place pageAt(PageInfo pageInfo) {
+    private static ReadScope.Place pageAt(PageInfo pageInfo) {
         OptionalLong offset = pageInfo.fileOffset();
-        return new ReadScope.Place(pageSource.getCurrentFileName(),
-                pageSource.getCurrentRowGroupIndex(), String.valueOf(column.fieldPath()), null,
-                offset.isPresent() ? offset.getAsLong() : ReadContext.UNKNOWN_OFFSET);
+        ReadScope.Place here = ReadScope.current();
+        return offset.isPresent() ? here.at(offset.getAsLong()) : here;
     }
 
-    /// This worker's column in one file's row group, with no region and no
-    /// byte: what a frame knows once the step that failed has finished
-    /// unwinding past it.
+    /// This worker's column in one file's row group, with no region and no byte.
+    ///
+    /// For the drain, which runs on its own thread and so enters no scope: it is handed
+    /// pages rather than reading them, and what it knows of where they came from it
+    /// keeps in the two fields below.
     private ReadScope.Place columnPlace(String fileName, int rowGroup) {
         return new ReadScope.Place(fileName, rowGroup, String.valueOf(column.fieldPath()), null,
                 ReadContext.UNKNOWN_OFFSET);

--- a/core/src/main/java/dev/hardwood/internal/reader/CrcValidator.java
+++ b/core/src/main/java/dev/hardwood/internal/reader/CrcValidator.java
@@ -17,13 +17,18 @@ class CrcValidator {
     /// Asserts that the CRC-32 checksum of the given page data matches the expected value
     /// from the page header. Throws if the checksum does not match.
     /// The buffer's position and limit are not modified.
-    static void assertCorrectCrc(int expectedCrc, ByteBuffer pageData, String columnName) {
+    ///
+    /// Says which checksums disagreed and nothing else. Which column, which
+    /// page and which file the mismatch was in is read context, added on the
+    /// way out by [dev.hardwood.internal.ExceptionContext] — naming the column
+    /// here as well put it in the message twice.
+    static void assertCorrectCrc(int expectedCrc, ByteBuffer pageData) {
         CRC32 crc = new CRC32();
         crc.update(pageData.duplicate());
         int actualCrc = (int) crc.getValue();
         if (actualCrc != expectedCrc) {
-            throw new ParquetReadException("CRC mismatch for column " + columnName
-                    + ": expected " + Integer.toHexString(expectedCrc)
+            throw new ParquetReadException("CRC mismatch: expected "
+                    + Integer.toHexString(expectedCrc)
                     + " but computed " + Integer.toHexString(actualCrc));
         }
     }

--- a/core/src/main/java/dev/hardwood/internal/reader/DictionaryParser.java
+++ b/core/src/main/java/dev/hardwood/internal/reader/DictionaryParser.java
@@ -121,7 +121,7 @@ public final class DictionaryParser {
         }
 
         if (header.crc() != null) {
-            CrcValidator.assertCorrectCrc(header.crc(), compressedData, columnSchema.name());
+            CrcValidator.assertCorrectCrc(header.crc(), compressedData);
         }
 
         return decompress(compressedData, numValues, header.uncompressedPageSize(),
@@ -168,8 +168,10 @@ public final class DictionaryParser {
             throw e;
         }
         catch (RuntimeException e) {
-            throw new ParquetReadException("Failed to parse dictionary for column '" + column.name()
-                    + "' (type=" + column.type()
+            // The column is read context, added once on the way out; naming it
+            // here as well said it twice in one sentence.
+            throw new ParquetReadException("Failed to parse dictionary"
+                    + " (type=" + column.type()
                     + ", numValues=" + numValues
                     + ", uncompressedSize=" + uncompressedSize
                     + ", compressedSize=" + compressedData.remaining()

--- a/core/src/main/java/dev/hardwood/internal/reader/FileMetadataCache.java
+++ b/core/src/main/java/dev/hardwood/internal/reader/FileMetadataCache.java
@@ -18,6 +18,7 @@ import java.util.concurrent.CompletionException;
 
 import dev.hardwood.InputFile;
 import dev.hardwood.internal.ExceptionContext;
+import dev.hardwood.internal.ReadScope;
 import dev.hardwood.jfr.FileOpenedEvent;
 import dev.hardwood.metadata.FileMetaData;
 import dev.hardwood.metadata.RowGroup;
@@ -148,14 +149,22 @@ public final class FileMetadataCache {
         return CompletableFuture.supplyAsync(() -> loadFile(fileIndex));
     }
 
+    /// A failed read of a file not yet open, so there is no scope to take a
+    /// place from — the file is the whole of what can be said, and it is said by
+    /// entering it just long enough to raise.
+    private static IOException placed(InputFile inputFile, String message, IOException cause) {
+        try (ReadScope.Scope file = ReadScope.file(inputFile.name())) {
+            return new IOException(ReadScope.here() + message, cause);
+        }
+    }
+
     private PreparedFile loadFile(int fileIndex) {
         InputFile inputFile = inputFiles.get(fileIndex);
         try {
             inputFile.open();
         }
         catch (IOException e) {
-            throw new UncheckedIOException(
-                    ExceptionContext.filePrefix(inputFile.name()) + "Failed to open file", e);
+            throw new UncheckedIOException(placed(inputFile, "Failed to open file", e));
         }
 
         FileOpenedEvent event = new FileOpenedEvent();
@@ -174,8 +183,7 @@ public final class FileMetadataCache {
             return new PreparedFile(inputFile, metaData, schema, metaData.rowGroups());
         }
         catch (IOException e) {
-            throw new UncheckedIOException(
-                    ExceptionContext.filePrefix(inputFile.name()) + "Failed to read metadata", e);
+            throw new UncheckedIOException(placed(inputFile, "Failed to read metadata", e));
         }
         catch (RuntimeException e) {
             throw ExceptionContext.addFileContext(inputFile.name(), e);

--- a/core/src/main/java/dev/hardwood/internal/reader/IndexedFetchPlan.java
+++ b/core/src/main/java/dev/hardwood/internal/reader/IndexedFetchPlan.java
@@ -13,7 +13,9 @@ import java.util.List;
 import java.util.NoSuchElementException;
 import java.util.concurrent.CompletableFuture;
 
+import dev.hardwood.internal.ExceptionContext.ReadContext.Region;
 import dev.hardwood.internal.FetchReason;
+import dev.hardwood.internal.ReadScope;
 import dev.hardwood.jfr.RowGroupScannedEvent;
 import dev.hardwood.metadata.ColumnChunk;
 import dev.hardwood.metadata.ColumnMetaData;
@@ -206,7 +208,7 @@ final class IndexedFetchPlan implements FetchPlan, RowGroupIterator.CoalescableF
             ChunkHandle handle = chunkHandles.get(currentGroupIndex);
             ByteBuffer pageData = handle.slice(loc.offset(), loc.compressedPageSize());
             PageInfo page = new PageInfo(pageData, columnSchema, columnChunk.metaData(),
-                    dictionary, needed.mask());
+                    dictionary, needed.mask(), loc.offset());
 
             if (!eventEmitted && !hasNext()) {
                 emitEvent();
@@ -237,10 +239,12 @@ final class IndexedFetchPlan implements FetchPlan, RowGroupIterator.CoalescableF
             int dictRegionSize = Math.toIntExact(firstDataPageOffset - dictAreaStart);
             ByteBuffer dictRegion = chunkHandles.get(0).slice(dictAreaStart, dictRegionSize);
 
-            // Not retitled on the way out. The parser says what is wrong with the
-            // dictionary — a checksum that disagrees, a header that will not parse —
-            // and naming the step that noticed would replace that with less.
-            return DictionaryParser.parse(dictRegion, columnSchema, metaData, context);
+            // The parser says what is wrong with the dictionary; where the
+            // dictionary is, is this frame's to say, and a parse failure inside
+            // leaves placed at the byte it stopped on.
+            try (ReadScope.Scope page = ReadScope.region(Region.DICTIONARY_PAGE, dictAreaStart)) {
+                return DictionaryParser.parse(dictRegion, columnSchema, metaData, context);
+            }
         }
 
         private void emitEvent() {

--- a/core/src/main/java/dev/hardwood/internal/reader/MappedInputFile.java
+++ b/core/src/main/java/dev/hardwood/internal/reader/MappedInputFile.java
@@ -102,6 +102,9 @@ public class MappedInputFile implements InputFile {
         // (it would map beyond the file and SIGBUS on access), unlike ByteBuffer.slice.
         // The comparison is written to avoid overflow when offset + length wraps.
         if (offset < 0 || length < 0 || offset > fileBytes - length) {
+            // Caller misuse at this level: an offset this file does not have.
+            // The reader translates it where it knows the offset came from the
+            // footer, which makes it the file being wrong rather than a bad call.
             throw new IndexOutOfBoundsException(ExceptionContext.filePrefix(name)
                     + "readRange(" + offset + ", " + length
                     + ") out of bounds (" + fileBytes + " bytes)");

--- a/core/src/main/java/dev/hardwood/internal/reader/NestedColumnWorker.java
+++ b/core/src/main/java/dev/hardwood/internal/reader/NestedColumnWorker.java
@@ -269,8 +269,8 @@ public class NestedColumnWorker extends ColumnWorker<NestedBatch> {
             nestedFirstValueSeen = true;
             if (pageRepLevels != null && pageRepLevels[0] != 0) {
                 throw new IllegalStateException(
-                        "Invalid column chunk for '" + column.name()
-                        + "': first repetition level must be 0 but was " + pageRepLevels[0]);
+                        "Invalid column chunk: first repetition level must be 0 but was "
+                        + pageRepLevels[0]);
             }
         }
 

--- a/core/src/main/java/dev/hardwood/internal/reader/PageDecoder.java
+++ b/core/src/main/java/dev/hardwood/internal/reader/PageDecoder.java
@@ -10,6 +10,8 @@ package dev.hardwood.internal.reader;
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
 
+import dev.hardwood.internal.ExceptionContext.ReadContext.Region;
+import dev.hardwood.internal.ReadScope;
 import dev.hardwood.internal.compression.Decompressor;
 import dev.hardwood.internal.compression.DecompressorFactory;
 import dev.hardwood.internal.encoding.ByteStreamSplitDecoder;
@@ -151,9 +153,14 @@ public class PageDecoder {
         PageDecodedEvent event = new PageDecodedEvent();
         event.begin();
 
-        // Parse page header directly from buffer
+        // The header is the only Thrift-encoded thing in a page, and saying so
+        // structurally is what lets a failure in it be told from one in the
+        // values without asking the failure which it was.
         ThriftCompactReader headerReader = new ThriftCompactReader(pageBuffer, 0);
-        PageHeader pageHeader = PageHeaderReader.read(headerReader);
+        PageHeader pageHeader;
+        try (ReadScope.Scope header = ReadScope.narrow(Region.PAGE_HEADER)) {
+            pageHeader = PageHeaderReader.read(headerReader);
+        }
         int headerSize = headerReader.getBytesRead();
 
         // Slice the page data (avoids copying)
@@ -161,7 +168,7 @@ public class PageDecoder {
         ByteBuffer pageData = pageBuffer.slice(headerSize, compressedSize);
 
         if (pageHeader.crc() != null) {
-            CrcValidator.assertCorrectCrc(pageHeader.crc(), pageData, column.name());
+            CrcValidator.assertCorrectCrc(pageHeader.crc(), pageData);
         }
 
         Page result = switch (pageHeader.type()) {

--- a/core/src/main/java/dev/hardwood/internal/reader/PageInfo.java
+++ b/core/src/main/java/dev/hardwood/internal/reader/PageInfo.java
@@ -8,6 +8,7 @@
 package dev.hardwood.internal.reader;
 
 import java.nio.ByteBuffer;
+import java.util.OptionalLong;
 
 import dev.hardwood.metadata.ColumnMetaData;
 import dev.hardwood.schema.ColumnSchema;
@@ -33,27 +34,32 @@ import dev.hardwood.schema.ColumnSchema;
 /// partially overlaps the matching rows.
 public class PageInfo {
 
+    /// Field value for a page that was never read from the file.
+    ///
+    /// Private, and paired with an [OptionalLong] accessor, so no caller has to
+    /// know the number or agree with anyone else about it. Only
+    /// [#nullPlaceholder] produces one: every page that came off disk knows
+    /// where it came from, because the plans that read it computed the position
+    /// to read at.
+    private static final long NO_OFFSET = -1;
+
     private final ByteBuffer pageData;
     private final ColumnSchema columnSchema;
     private final ColumnMetaData columnMetaData;
     private final Dictionary dictionary;
     private final int placeholderNumValues;
     private final PageRowMask mask;
-
-    public PageInfo(ByteBuffer pageData, ColumnSchema columnSchema,
-                    ColumnMetaData columnMetaData, Dictionary dictionary) {
-        this(pageData, columnSchema, columnMetaData, dictionary, 0, PageRowMask.ALL);
-    }
+    private final long fileOffset;
 
     public PageInfo(ByteBuffer pageData, ColumnSchema columnSchema,
                     ColumnMetaData columnMetaData, Dictionary dictionary,
-                    PageRowMask mask) {
-        this(pageData, columnSchema, columnMetaData, dictionary, 0, mask);
+                    PageRowMask mask, long fileOffset) {
+        this(pageData, columnSchema, columnMetaData, dictionary, 0, mask, fileOffset);
     }
 
     private PageInfo(ByteBuffer pageData, ColumnSchema columnSchema,
                      ColumnMetaData columnMetaData, Dictionary dictionary,
-                     int placeholderNumValues, PageRowMask mask) {
+                     int placeholderNumValues, PageRowMask mask, long fileOffset) {
         if (mask == null) {
             throw new IllegalArgumentException("mask must not be null; use PageRowMask.ALL");
         }
@@ -63,6 +69,22 @@ public class PageInfo {
         this.dictionary = dictionary;
         this.placeholderNumValues = placeholderNumValues;
         this.mask = mask;
+        this.fileOffset = fileOffset;
+    }
+
+    /// Byte offset in the file where this page's header begins, empty for a
+    /// page that was never read from one.
+    ///
+    /// Read only when a page has failed, to say where in the file to look, so
+    /// the wrapper costs nothing a passing read pays. The field behind it stays
+    /// a primitive: it is written once per page, which is not a place to put an
+    /// allocation.
+    ///
+    /// It is a file offset, not a position within the decoded page: the two are
+    /// the same only for an uncompressed column, and a reader sent to the wrong
+    /// one finds unrelated bytes.
+    public OptionalLong fileOffset() {
+        return fileOffset == NO_OFFSET ? OptionalLong.empty() : OptionalLong.of(fileOffset);
     }
 
     /// Creates a null-placeholder `PageInfo` representing `numValues` rows whose
@@ -74,7 +96,8 @@ public class PageInfo {
         if (numValues <= 0) {
             throw new IllegalArgumentException("placeholder numValues must be positive: " + numValues);
         }
-        return new PageInfo(null, columnSchema, columnMetaData, null, numValues, PageRowMask.ALL);
+        return new PageInfo(null, columnSchema, columnMetaData, null, numValues,
+                PageRowMask.ALL, NO_OFFSET);
     }
 
     /// Returns the page data buffer (header + compressed data), or `null` if this

--- a/core/src/main/java/dev/hardwood/internal/reader/PageSource.java
+++ b/core/src/main/java/dev/hardwood/internal/reader/PageSource.java
@@ -9,10 +9,6 @@ package dev.hardwood.internal.reader;
 
 import java.io.IOException;
 
-import dev.hardwood.internal.ExceptionContext;
-import dev.hardwood.internal.ReadScope;
-import dev.hardwood.metadata.FieldPath;
-
 /// Per-column iterator that yields [PageInfo] objects across all row groups and files.
 ///
 /// For each row group, obtains a [FetchPlan] from [RowGroupIterator#getColumnPlan]
@@ -20,8 +16,8 @@ import dev.hardwood.metadata.FieldPath;
 /// pre-computed (OffsetIndex) or lazily discovered (sequential scan) — both are
 /// hidden behind the [FetchPlan] iterator.
 ///
-/// This is the only interface the [ColumnWorker] sees — a simple
-/// `PageInfo next()` iterator.
+/// This is the only interface the [ColumnWorker] sees: [#nextWorkItem] to step to the
+/// next file and row group, [#nextPage] to walk that one's pages.
 public class PageSource {
 
     private final RowGroupIterator rowGroupIterator;
@@ -32,8 +28,10 @@ public class PageSource {
     /// file, so the list can grow behind the cursor.
     private int workItemCursor;
 
-    // Current row group's page iterator
+    // Current row group's page iterator, null when the work item has no pages for this
+    // column or has not been planned yet — `planned` tells the two apart.
     private PageIterator currentPlan;
+    private boolean planned;
 
     // Work item the current plan was built from. Tracked so that we can call
     // RowGroupIterator#releaseWorkItem when this column advances past it,
@@ -52,80 +50,53 @@ public class PageSource {
         // pulls them one at a time as this column advances. See #1107.
     }
 
-    /// The column this source yields pages for, by path.
-    private FieldPath columnPath() {
-        return rowGroupIterator.projectedSchema()
-                .getProjectedColumn(projectedColumnIndex).fieldPath();
-    }
-
-    /// Returns the name of the file currently being read, or `null` if no work item
-    /// is active. Only valid on the retriever thread.
-    public String getCurrentFileName() {
-        return currentWorkItem != null ? currentWorkItem.inputFile().name() : null;
-    }
-
-    /// Index of the row group currently being read, or
-    /// [dev.hardwood.internal.ExceptionContext.ReadContext#UNKNOWN_ROW_GROUP]
-    /// if no work item is active. Only valid on the retriever thread.
-    public int getCurrentRowGroupIndex() {
-        return currentWorkItem != null
-                ? currentWorkItem.rowGroupIndex()
-                : ExceptionContext.ReadContext.UNKNOWN_ROW_GROUP;
-    }
-
-    /// Whether statistics proved the current work item's row group matches the filter
-    /// predicate in full. Only valid on the retriever thread.
-    public boolean isCurrentFilterAlwaysMatches() {
-        return currentWorkItem != null && currentWorkItem.filterAlwaysMatches();
-    }
-
     /// Whether a filter predicate is installed on the underlying iterator, so that the
     /// rows this source yields can outnumber the rows a reader returns.
     public boolean isFilterActive() {
         return rowGroupIterator.hasFilter();
     }
 
-    public PageInfo next() throws IOException {
-        while (true) {
-            if (currentPlan != null) {
-                // Everything getting a page does — the plan, the filters, the
-                // index, the fetch, the header — happens under this column, so
-                // it is named once here rather than by each of them. `hasNext`
-                // is inside it because deciding whether a page is coming reads
-                // the headers that say so.
-                try (ReadScope.Scope scope = ReadScope.file(getCurrentFileName())
-                        .rowGroup(getCurrentRowGroupIndex())
-                        .column(columnPath())) {
-                    if (currentPlan.hasNext()) {
-                        return currentPlan.next();
-                    }
-                }
-            }
-
-            // currentPlan is exhausted (or null) — this column is done with the
-            // previous work item. Release our reference so the iterator can
-            // evict its caches once every column has advanced past it.
-            if (currentWorkItem != null) {
-                rowGroupIterator.releaseWorkItem(currentWorkItem);
-                currentWorkItem = null;
-            }
-
-            RowGroupIterator.WorkItem workItem = rowGroupIterator.workItemAt(workItemCursor);
-            if (workItem == null) {
-                return null;
-            }
-            workItemCursor++;
-            FetchPlan plan;
-            // Planning reads too — the page index, the dictionary, the chunk it
-            // sits in — and the work item names the file and row group that
-            // `getCurrentRowGroupIndex` cannot until the plan is in hand.
-            try (ReadScope.Scope scope = ReadScope.file(workItem.inputFile().name())
-                    .rowGroup(workItem.rowGroupIndex())
-                    .column(columnPath())) {
-                plan = rowGroupIterator.getColumnPlan(workItem, projectedColumnIndex);
-            }
-            currentPlan = plan.isEmpty() ? null : plan.pages();
-            currentWorkItem = workItem;
+    /// Advances to the next work item this column has to read, or `null` once it has
+    /// read them all.
+    ///
+    /// The work item is the file and row group a caller enters before asking for pages:
+    /// which one is being read holds for every page of it, so it is named once, by whoever
+    /// walks the list, rather than restated by each page.
+    ///
+    /// @return the work item now being read, or `null` when there are no more
+    public RowGroupIterator.WorkItem nextWorkItem() throws IOException {
+        // This column is done with the previous work item. Release our reference so the
+        // iterator can evict its caches once every column has advanced past it.
+        if (currentWorkItem != null) {
+            rowGroupIterator.releaseWorkItem(currentWorkItem);
+            currentWorkItem = null;
         }
+        currentPlan = null;
+        planned = false;
+
+        RowGroupIterator.WorkItem workItem = rowGroupIterator.workItemAt(workItemCursor);
+        if (workItem == null) {
+            return null;
+        }
+        workItemCursor++;
+        currentWorkItem = workItem;
+        return workItem;
+    }
+
+    /// The next page of the work item [#nextWorkItem] last returned, or `null` once that
+    /// work item has no more.
+    ///
+    /// The plan is built on the first page asked for rather than when the work item is
+    /// taken, so that planning — the page index, the dictionary, the chunk it sits in —
+    /// happens inside the caller's scope for that work item.
+    ///
+    /// @return the next page, or `null` when this work item is exhausted
+    public PageInfo nextPage() throws IOException {
+        if (!planned) {
+            planned = true;
+            FetchPlan plan = rowGroupIterator.getColumnPlan(currentWorkItem, projectedColumnIndex);
+            currentPlan = plan.isEmpty() ? null : plan.pages();
+        }
+        return currentPlan != null && currentPlan.hasNext() ? currentPlan.next() : null;
     }
 }

--- a/core/src/main/java/dev/hardwood/internal/reader/PageSource.java
+++ b/core/src/main/java/dev/hardwood/internal/reader/PageSource.java
@@ -9,6 +9,10 @@ package dev.hardwood.internal.reader;
 
 import java.io.IOException;
 
+import dev.hardwood.internal.ExceptionContext;
+import dev.hardwood.internal.ReadScope;
+import dev.hardwood.metadata.FieldPath;
+
 /// Per-column iterator that yields [PageInfo] objects across all row groups and files.
 ///
 /// For each row group, obtains a [FetchPlan] from [RowGroupIterator#getColumnPlan]
@@ -48,10 +52,25 @@ public class PageSource {
         // pulls them one at a time as this column advances. See #1107.
     }
 
+    /// The column this source yields pages for, by path.
+    private FieldPath columnPath() {
+        return rowGroupIterator.projectedSchema()
+                .getProjectedColumn(projectedColumnIndex).fieldPath();
+    }
+
     /// Returns the name of the file currently being read, or `null` if no work item
     /// is active. Only valid on the retriever thread.
     public String getCurrentFileName() {
         return currentWorkItem != null ? currentWorkItem.inputFile().name() : null;
+    }
+
+    /// Index of the row group currently being read, or
+    /// [dev.hardwood.internal.ExceptionContext.ReadContext#UNKNOWN_ROW_GROUP]
+    /// if no work item is active. Only valid on the retriever thread.
+    public int getCurrentRowGroupIndex() {
+        return currentWorkItem != null
+                ? currentWorkItem.rowGroupIndex()
+                : ExceptionContext.ReadContext.UNKNOWN_ROW_GROUP;
     }
 
     /// Whether statistics proved the current work item's row group matches the filter
@@ -68,8 +87,18 @@ public class PageSource {
 
     public PageInfo next() throws IOException {
         while (true) {
-            if (currentPlan != null && currentPlan.hasNext()) {
-                return currentPlan.next();
+            if (currentPlan != null) {
+                // Everything getting a page does — the plan, the filters, the
+                // index, the fetch, the header — happens under this column, so
+                // it is named once here rather than by each of them. `hasNext`
+                // is inside it because deciding whether a page is coming reads
+                // the headers that say so.
+                try (ReadScope.Scope scope = ReadScope.file(getCurrentFileName())
+                        .column(getCurrentRowGroupIndex(), columnPath())) {
+                    if (currentPlan.hasNext()) {
+                        return currentPlan.next();
+                    }
+                }
             }
 
             // currentPlan is exhausted (or null) — this column is done with the
@@ -85,7 +114,14 @@ public class PageSource {
                 return null;
             }
             workItemCursor++;
-            FetchPlan plan = rowGroupIterator.getColumnPlan(workItem, projectedColumnIndex);
+            FetchPlan plan;
+            // Planning reads too — the page index, the dictionary, the chunk it
+            // sits in — and the work item names the file and row group that
+            // `getCurrentRowGroupIndex` cannot until the plan is in hand.
+            try (ReadScope.Scope scope = ReadScope.file(workItem.inputFile().name())
+                    .column(workItem.rowGroupIndex(), columnPath())) {
+                plan = rowGroupIterator.getColumnPlan(workItem, projectedColumnIndex);
+            }
             currentPlan = plan.isEmpty() ? null : plan.pages();
             currentWorkItem = workItem;
         }

--- a/core/src/main/java/dev/hardwood/internal/reader/PageSource.java
+++ b/core/src/main/java/dev/hardwood/internal/reader/PageSource.java
@@ -94,7 +94,8 @@ public class PageSource {
                 // is inside it because deciding whether a page is coming reads
                 // the headers that say so.
                 try (ReadScope.Scope scope = ReadScope.file(getCurrentFileName())
-                        .column(getCurrentRowGroupIndex(), columnPath())) {
+                        .rowGroup(getCurrentRowGroupIndex())
+                        .column(columnPath())) {
                     if (currentPlan.hasNext()) {
                         return currentPlan.next();
                     }
@@ -119,7 +120,8 @@ public class PageSource {
             // sits in — and the work item names the file and row group that
             // `getCurrentRowGroupIndex` cannot until the plan is in hand.
             try (ReadScope.Scope scope = ReadScope.file(workItem.inputFile().name())
-                    .column(workItem.rowGroupIndex(), columnPath())) {
+                    .rowGroup(workItem.rowGroupIndex())
+                    .column(columnPath())) {
                 plan = rowGroupIterator.getColumnPlan(workItem, projectedColumnIndex);
             }
             currentPlan = plan.isEmpty() ? null : plan.pages();

--- a/core/src/main/java/dev/hardwood/internal/reader/ParquetMetadataReader.java
+++ b/core/src/main/java/dev/hardwood/internal/reader/ParquetMetadataReader.java
@@ -16,7 +16,8 @@ import java.util.Arrays;
 import dev.hardwood.InputFile;
 import dev.hardwood.internal.EncryptedFileException;
 import dev.hardwood.internal.ExceptionContext;
-import dev.hardwood.internal.FetchReason;
+import dev.hardwood.internal.ExceptionContext.ReadContext.Region;
+import dev.hardwood.internal.ReadScope;
 import dev.hardwood.internal.thrift.FileMetaDataReader;
 import dev.hardwood.internal.thrift.ThriftCompactReader;
 import dev.hardwood.metadata.FileMetaData;
@@ -51,72 +52,88 @@ public final class ParquetMetadataReader {
     /// @throws IOException if the file cannot be read
     /// @throws ParquetReadException if what it holds is not a Parquet file
     public static FileMetaData readMetadata(InputFile inputFile) throws IOException {
-        long fileSize = inputFile.length();
-        if (fileSize < MAGIC_SIZE + MAGIC_SIZE + FOOTER_LENGTH_SIZE) {
-            throw new ParquetReadException(ExceptionContext.filePrefix(inputFile.name())
-                    + "File too small to be a valid Parquet file");
-        }
+        try (ReadScope.Scope file = ReadScope.file(inputFile.name())) {
+            long fileSize = inputFile.length();
+            if (fileSize < MAGIC_SIZE + MAGIC_SIZE + FOOTER_LENGTH_SIZE) {
+                throw new ParquetReadException(
+                        "File too small to be a valid Parquet file (" + fileSize + " bytes)");
+            }
 
-        // Validate magic number at start
-        ByteBuffer startMagicBuf;
-        try (FetchReason.Scope ignored = FetchReason.set("footer-magic-start")) {
-            startMagicBuf = inputFile.readRange(0, MAGIC_SIZE);
-        }
-        byte[] startMagic = new byte[MAGIC_SIZE];
-        startMagicBuf.get(startMagic);
-        if (Arrays.equals(startMagic, ENCRYPTED_MAGIC)) {
-            throw encrypted(inputFile);
-        }
-        if (!Arrays.equals(startMagic, MAGIC)) {
-            throw new ParquetReadException(ExceptionContext.filePrefix(inputFile.name())
-                    + "Not a Parquet file (invalid magic number at start)");
-        }
+            try (ReadScope.Scope magic = ReadScope.region(Region.MAGIC, 0)) {
+                requireMagic(inputFile.readRange(0, MAGIC_SIZE), "at start");
+            }
 
-        // Read footer size and magic number at end
-        long footerInfoPos = fileSize - MAGIC_SIZE - FOOTER_LENGTH_SIZE;
-        ByteBuffer footerInfoBuf;
-        try (FetchReason.Scope ignored = FetchReason.set("footer-info")) {
-            footerInfoBuf = inputFile.readRange(footerInfoPos, FOOTER_LENGTH_SIZE + MAGIC_SIZE);
+            long footerInfoPos = fileSize - MAGIC_SIZE - FOOTER_LENGTH_SIZE;
+            int footerLength;
+            try (ReadScope.Scope length = ReadScope.region(Region.FOOTER_LENGTH, footerInfoPos)) {
+                footerLength = readFooterLength(inputFile, footerInfoPos, fileSize);
+            }
+
+            long footerStart = footerInfoPos - footerLength;
+            try (ReadScope.Scope footer = ReadScope.region(Region.FOOTER, footerStart)) {
+                return parseFooter(inputFile, footerStart, footerLength);
+            }
         }
-        footerInfoBuf.order(ByteOrder.LITTLE_ENDIAN);
-        int footerLength = footerInfoBuf.getInt();
+    }
+
+    /// The declared footer length, checked against the space there is for it.
+    ///
+    /// The closing magic rides in the same read — four bytes in front of it —
+    /// so it is checked here, in its own region: a file whose last four bytes
+    /// are not `PAR1` is not a footer that is the wrong length, it is not a
+    /// Parquet file.
+    private static int readFooterLength(InputFile inputFile, long footerInfoPos, long fileSize)
+            throws IOException {
+        ByteBuffer footerInfo = inputFile.readRange(footerInfoPos, FOOTER_LENGTH_SIZE + MAGIC_SIZE);
+        footerInfo.order(ByteOrder.LITTLE_ENDIAN);
+        int footerLength = footerInfo.getInt();
+
         byte[] endMagic = new byte[MAGIC_SIZE];
-        footerInfoBuf.get(endMagic);
-        if (Arrays.equals(endMagic, ENCRYPTED_MAGIC)) {
-            throw encrypted(inputFile);
-        }
-        if (!Arrays.equals(endMagic, MAGIC)) {
-            throw new ParquetReadException(ExceptionContext.filePrefix(inputFile.name())
-                    + "Not a Parquet file (invalid magic number at end)");
+        footerInfo.get(endMagic);
+        try (ReadScope.Scope magic = ReadScope.region(Region.MAGIC, fileSize - MAGIC_SIZE)) {
+            requireMagic(endMagic, "at end");
         }
 
-        // Validate footer length
-        long footerStart = fileSize - MAGIC_SIZE - FOOTER_LENGTH_SIZE - footerLength;
-        if (footerStart < MAGIC_SIZE) {
-            throw new ParquetReadException(ExceptionContext.filePrefix(inputFile.name())
-                    + "Invalid footer length: " + footerLength);
+        if (footerInfoPos - footerLength < MAGIC_SIZE) {
+            throw new ParquetReadException(footerLength
+                    + " would start the footer in front of the file's opening magic");
         }
+        return footerLength;
+    }
 
-        // Parse file metadata
-        ByteBuffer footerBuffer;
-        try (FetchReason.Scope ignored = FetchReason.set("footer-body")) {
-            footerBuffer = inputFile.readRange(footerStart, footerLength);
-        }
-        ThriftCompactReader reader = new ThriftCompactReader(footerBuffer);
+    /// Parses the footer, whose failures are the file's.
+    ///
+    /// The one catch says what a failure *is* rather than where it was: a
+    /// plaintext footer that parses and then declares its columns encrypted is
+    /// a correct file this library does not read, and it must not leave as a
+    /// malformed one.
+    private static FileMetaData parseFooter(InputFile inputFile, long footerStart, int footerLength)
+            throws IOException {
+        ByteBuffer footer = inputFile.readRange(footerStart, footerLength);
         try {
-            return FileMetaDataReader.read(reader);
+            return FileMetaDataReader.read(new ThriftCompactReader(footer));
         }
         catch (EncryptedFileException e) {
-            // Plaintext-footer encryption: the footer parsed, but the data is
-            // encrypted. Re-throw with file context for an attributable error.
-            throw encrypted(inputFile);
+            throw encrypted();
         }
-        catch (ParquetReadException e) {
-            // Negative sizes, an unknown field type, a struct that ends early —
-            // the reader already types all of them as the file being wrong. What
-            // it cannot name is the file, which only this frame knows.
-            throw new ParquetReadException(
-                    ExceptionContext.filePrefix(inputFile.name()) + e.getMessage(), e);
+    }
+
+    /// Fails unless `PAR1` is where it has to be.
+    ///
+    /// `PARE` in either position is the encrypted-footer layout, which is a
+    /// correct file this library does not read rather than a broken one.
+    private static void requireMagic(ByteBuffer buffer, String where) {
+        byte[] magic = new byte[MAGIC_SIZE];
+        buffer.get(magic);
+        requireMagic(magic, where);
+    }
+
+    private static void requireMagic(byte[] magic, String where) {
+        if (Arrays.equals(magic, ENCRYPTED_MAGIC)) {
+            throw encrypted();
+        }
+        if (!Arrays.equals(magic, MAGIC)) {
+            throw new ParquetReadException("Not a Parquet file (invalid magic number " + where + ")");
         }
     }
 
@@ -124,8 +141,10 @@ public final class ParquetMetadataReader {
     /// what [UnsupportedOperationException] says everywhere else the reader meets
     /// something it has not implemented — an absent codec library, an encoding it
     /// does not decode.
-    private static UnsupportedOperationException encrypted(InputFile inputFile) {
+    private static UnsupportedOperationException encrypted() {
+        String fileName = ReadScope.current() == null ? null : ReadScope.current().fileName();
         return new UnsupportedOperationException(
-                ExceptionContext.filePrefix(inputFile.name()) + ENCRYPTED_MESSAGE);
+                ExceptionContext.filePrefix(fileName) + ENCRYPTED_MESSAGE);
     }
+
 }

--- a/core/src/main/java/dev/hardwood/internal/reader/RowGroupIndexBuffers.java
+++ b/core/src/main/java/dev/hardwood/internal/reader/RowGroupIndexBuffers.java
@@ -12,7 +12,7 @@ import java.nio.ByteBuffer;
 import java.util.List;
 
 import dev.hardwood.InputFile;
-import dev.hardwood.internal.ExceptionContext;
+import dev.hardwood.internal.ReadScope;
 import dev.hardwood.metadata.ColumnChunk;
 import dev.hardwood.metadata.RowGroup;
 
@@ -89,9 +89,8 @@ public class RowGroupIndexBuffers {
             // The file is correct; this reader will not fetch a region it cannot
             // address with an int. Not the file's fault, and not something a
             // second attempt changes.
-            throw new UnsupportedOperationException(ExceptionContext.filePrefix(inputFile.name())
-                    + "Row-group index region too large (" + indexRegionSize
-                    + " bytes) — split the file into smaller row groups");
+            throw new UnsupportedOperationException(ReadScope.fileHere() + "Row-group index region too large ("
+                    + indexRegionSize + " bytes) — split the file into smaller row groups");
         }
         ByteBuffer indexRegion = inputFile.readRange(minOffset, Math.toIntExact(indexRegionSize));
 

--- a/core/src/main/java/dev/hardwood/internal/reader/RowGroupIterator.java
+++ b/core/src/main/java/dev/hardwood/internal/reader/RowGroupIterator.java
@@ -23,7 +23,9 @@ import java.util.function.Consumer;
 
 import dev.hardwood.InputFile;
 import dev.hardwood.internal.ExceptionContext;
+import dev.hardwood.internal.ExceptionContext.ReadContext;
 import dev.hardwood.internal.FetchReason;
+import dev.hardwood.internal.ReadScope;
 import dev.hardwood.internal.predicate.FilterDecision;
 import dev.hardwood.internal.predicate.PageDropPredicates;
 import dev.hardwood.internal.predicate.PageFilterEvaluator;
@@ -428,9 +430,11 @@ public class RowGroupIterator {
                 return new SharedRowGroupMetadata(indexBuffers, matchingRows, maskCapability);
             }
             catch (IOException e) {
+                // Wrapped only to leave the mapping function; the frame that can
+                // declare it undoes the wrap, so the place travels on the inner
+                // failure rather than on this.
                 throw new UncheckedIOException(
-                        ExceptionContext.filePrefix(workItem.inputFile().name())
-                        + "Failed to fetch metadata for row group " + workItem.rowGroupIndex(), e);
+                        new IOException(ReadScope.here() + "Failed to fetch the row-group metadata", e));
             }
         });
     }
@@ -452,13 +456,10 @@ public class RowGroupIterator {
                 columns.get(i).requireSameFile();
             }
             catch (UnsupportedOperationException e) {
-                // Named here rather than by the catch around the caller, which only sees
-                // `IOException`: this is unchecked and travels past it, so the file it came
-                // from has to be added where it is raised.
-                throw new UnsupportedOperationException(
-                        ExceptionContext.filePrefix(workItem.inputFile().name())
-                        + "Cannot read column " + i + " in row group "
-                        + workItem.rowGroupIndex() + ": " + e.getMessage(), e);
+                // Named, not positioned. Its own type says the file is correct,
+                // so nothing about where in it the limit was met would help.
+                throw new UnsupportedOperationException(ReadScope.fileHere() + "Cannot read column " + i
+                        + " in row group " + workItem.rowGroupIndex() + ": " + e.getMessage(), e);
             }
         }
     }
@@ -752,9 +753,10 @@ public class RowGroupIterator {
                         context, workItem.rowGroupIndex(), inputFile.name());
             }
             catch (ParquetReadException e) {
-                throw new ParquetReadException(ExceptionContext.filePrefix(inputFile.name())
-                        + "Failed to compute fetch plan for column " + projCol
-                        + " in row group " + workItem.rowGroupIndex() + ": " + e.getMessage(), e);
+                // Already placed where it happened; this frame only says which
+                // step of the read was running when it did.
+                throw new ParquetReadException("Failed to compute the fetch plan: "
+                        + e.getMessage(), e);
             }
         }
 
@@ -1304,20 +1306,16 @@ public class RowGroupIterator {
                 int fileOrdinal = fileOrdinals[i];
                 FieldPath schemaPath = schemaPaths[i];
                 if (fileOrdinal >= chunkCount) {
-                    throw new SchemaIncompatibleException(
-                            ExceptionContext.filePrefix(inputFile.name())
-                                    + "Row group " + rowGroupIndex + " lists " + chunkCount
-                                    + " column chunks, but the schema declares '"
-                                    + schemaPath + "' at index " + fileOrdinal);
+                    throw chunkMismatch(inputFile, rowGroupIndex, schemaPath,
+                            "The row group lists %d column chunks, but the schema declares"
+                                    + " this column at index %d", chunkCount, fileOrdinal);
                 }
                 FieldPath chunkPath = chunks.get(fileOrdinal).metaData().pathInSchema();
                 if (chunkPath.isEmpty() || chunkPath.equals(schemaPath)) {
                     continue;
                 }
-                throw new SchemaIncompatibleException(
-                        ExceptionContext.filePrefix(inputFile.name())
-                                + "Row group " + rowGroupIndex + " lists column '" + chunkPath
-                                + "' where the schema declares '" + schemaPath + "'");
+                throw chunkMismatch(inputFile, rowGroupIndex, schemaPath,
+                        "The row group lists column '%s' at this position", chunkPath);
             }
         }
     }
@@ -1354,10 +1352,15 @@ public class RowGroupIterator {
         }
         List<FilteredRowGroup> filtered = new ArrayList<>(rowGroups.size());
         int fullyMatching = 0;
-        for (RowGroup rg : rowGroups) {
+        // Indexed rather than enhanced-for: the position in this list is the row
+        // group's own index in the file, and it is the only place a pruning
+        // failure can get one from — the list this returns has the pruned row
+        // groups missing, so its indexes no longer line up with the file's.
+        for (int rgIndex = 0; rgIndex < rowGroups.size(); rgIndex++) {
+            RowGroup rg = rowGroups.get(rgIndex);
             FilterDecision decision = RowGroupFilterEvaluator.decideRowGroup(columnOrdinals.filter(), rg,
-                    new RowGroupBloomFilterSource(inputFile, rg),
-                    new RowGroupDictionaryFilterSource(inputFile, rg, fileSchema, context));
+                    new RowGroupBloomFilterSource(inputFile, rg, rgIndex),
+                    new RowGroupDictionaryFilterSource(inputFile, rg, rgIndex, fileSchema, context));
             if (decision == FilterDecision.CANNOT_MATCH) {
                 continue;
             }
@@ -1392,10 +1395,11 @@ public class RowGroupIterator {
     /// @throws SchemaIncompatibleException if a touched column cannot be decoded under
     ///         the schema the file declares for it
     private void validateReferenceColumns() {
-        String fileName = inputFiles.get(0).name();
-        for (int originalIndex = touchedColumns.nextSetBit(0); originalIndex >= 0;
-                originalIndex = touchedColumns.nextSetBit(originalIndex + 1)) {
-            FixedWidthValidator.validate(fileName, referenceSchema.getColumn(originalIndex));
+        try (ReadScope.Scope file = ReadScope.file(inputFiles.get(0).name())) {
+            for (int originalIndex = touchedColumns.nextSetBit(0); originalIndex >= 0;
+                    originalIndex = touchedColumns.nextSetBit(originalIndex + 1)) {
+                FixedWidthValidator.validate(referenceSchema.getColumn(originalIndex));
+            }
         }
     }
 
@@ -1439,52 +1443,51 @@ public class RowGroupIterator {
     /// @return the column's leaf ordinal in `fileSchema`
     private int validateColumn(InputFile inputFile, FileSchema fileSchema, int originalIndex) {
         ColumnSchema refColumn = referenceSchema.getColumn(originalIndex);
+        try (ReadScope.Scope scope = ReadScope.file(inputFile.name())
+                .column(ReadContext.UNKNOWN_ROW_GROUP, refColumn.fieldPath())) {
+            return compareColumn(fileSchema, refColumn);
+        }
+    }
 
+    /// Compares one reference column against its counterpart, inside the scope
+    /// that names which column it is. Every failure below says only what
+    /// disagrees.
+    private static int compareColumn(FileSchema fileSchema, ColumnSchema refColumn) {
         ColumnSchema fileColumn;
         try {
             fileColumn = fileSchema.getColumn(refColumn.fieldPath());
         }
         catch (IllegalArgumentException e) {
-            throw new SchemaIncompatibleException(
-                    ExceptionContext.filePrefix(inputFile.name())
-                            + "Column '" + refColumn.fieldPath() + "' not found");
+            throw incompatible("Not present in this file's schema");
         }
 
         PhysicalType refType = refColumn.type();
         PhysicalType fileType = fileColumn.type();
         if (refType != fileType) {
-            throw new SchemaIncompatibleException(
-                    ExceptionContext.filePrefix(inputFile.name())
-                            + "Column '" + refColumn.fieldPath() + "' has incompatible type"
-                            + ": expected " + refType + " but found " + fileType);
+            throw incompatible("Incompatible type: expected %s but found %s",
+                            refType, fileType);
         }
 
         LogicalType refLogical = refColumn.logicalType();
         LogicalType fileLogical = fileColumn.logicalType();
         if (!Objects.equals(refLogical, fileLogical)) {
-            throw new SchemaIncompatibleException(
-                    ExceptionContext.filePrefix(inputFile.name())
-                            + "Column '" + refColumn.fieldPath() + "' has incompatible logical type"
-                            + ": expected " + refLogical + " but found " + fileLogical);
+            throw incompatible("Incompatible logical type: expected %s but found %s",
+                            refLogical, fileLogical);
         }
 
         RepetitionType refRep = refColumn.repetitionType();
         RepetitionType fileRep = fileColumn.repetitionType();
         if (refRep != fileRep) {
-            throw new SchemaIncompatibleException(
-                    ExceptionContext.filePrefix(inputFile.name())
-                            + "Column '" + refColumn.fieldPath() + "' has incompatible repetition type"
-                            + ": expected " + refRep + " but found " + fileRep);
+            throw incompatible("Incompatible repetition type: expected %s but found %s",
+                            refRep, fileRep);
         }
 
         // The FLBA width drives every decode of the column's bytes.
         Integer refLength = refColumn.typeLength();
         Integer fileLength = fileColumn.typeLength();
         if (!Objects.equals(refLength, fileLength)) {
-            throw new SchemaIncompatibleException(
-                    ExceptionContext.filePrefix(inputFile.name())
-                            + "Column '" + refColumn.fieldPath() + "' has incompatible type length"
-                            + ": expected " + refLength + " but found " + fileLength);
+            throw incompatible("Incompatible type length: expected %s but found %s",
+                            refLength, fileLength);
         }
 
         // The leaf's own repetition type matching does not imply its ancestors' do,
@@ -1496,23 +1499,33 @@ public class RowGroupIterator {
         int refMaxDef = refColumn.maxDefinitionLevel();
         int fileMaxDef = fileColumn.maxDefinitionLevel();
         if (refMaxDef != fileMaxDef) {
-            throw new SchemaIncompatibleException(
-                    ExceptionContext.filePrefix(inputFile.name())
-                            + "Column '" + refColumn.fieldPath()
-                            + "' has incompatible maximum definition level"
-                            + ": expected " + refMaxDef + " but found " + fileMaxDef);
+            throw incompatible("Incompatible maximum definition level: expected %s but found %s",
+                            refMaxDef, fileMaxDef);
         }
 
         int refMaxRep = refColumn.maxRepetitionLevel();
         int fileMaxRep = fileColumn.maxRepetitionLevel();
         if (refMaxRep != fileMaxRep) {
-            throw new SchemaIncompatibleException(
-                    ExceptionContext.filePrefix(inputFile.name())
-                            + "Column '" + refColumn.fieldPath()
-                            + "' has incompatible maximum repetition level"
-                            + ": expected " + refMaxRep + " but found " + fileMaxRep);
+            throw incompatible("Incompatible maximum repetition level: expected %s but found %s",
+                            refMaxRep, fileMaxRep);
         }
 
         return fileColumn.columnIndex();
+    }
+
+    /// A row group whose chunks do not line up with the schema. Raised inside
+    /// the scope naming the file, the row group and the column, so the message
+    /// says only what disagrees.
+    private static SchemaIncompatibleException chunkMismatch(InputFile inputFile, int rowGroupIndex,
+            FieldPath column, String message, Object... args) {
+        try (ReadScope.Scope scope = ReadScope.file(inputFile.name())
+                .column(rowGroupIndex, column)) {
+            return new SchemaIncompatibleException(String.format(message, args));
+        }
+    }
+
+    /// What disagrees. Which column, and in which file, is the scope's to say.
+    private static SchemaIncompatibleException incompatible(String message, Object... args) {
+        return new SchemaIncompatibleException(String.format(message, args));
     }
 }

--- a/core/src/main/java/dev/hardwood/internal/reader/RowGroupIterator.java
+++ b/core/src/main/java/dev/hardwood/internal/reader/RowGroupIterator.java
@@ -23,7 +23,6 @@ import java.util.function.Consumer;
 
 import dev.hardwood.InputFile;
 import dev.hardwood.internal.ExceptionContext;
-import dev.hardwood.internal.ExceptionContext.ReadContext;
 import dev.hardwood.internal.FetchReason;
 import dev.hardwood.internal.ReadScope;
 import dev.hardwood.internal.predicate.FilterDecision;
@@ -1444,7 +1443,7 @@ public class RowGroupIterator {
     private int validateColumn(InputFile inputFile, FileSchema fileSchema, int originalIndex) {
         ColumnSchema refColumn = referenceSchema.getColumn(originalIndex);
         try (ReadScope.Scope scope = ReadScope.file(inputFile.name())
-                .column(ReadContext.UNKNOWN_ROW_GROUP, refColumn.fieldPath())) {
+                .column(refColumn.fieldPath())) {
             return compareColumn(fileSchema, refColumn);
         }
     }
@@ -1519,7 +1518,8 @@ public class RowGroupIterator {
     private static SchemaIncompatibleException chunkMismatch(InputFile inputFile, int rowGroupIndex,
             FieldPath column, String message, Object... args) {
         try (ReadScope.Scope scope = ReadScope.file(inputFile.name())
-                .column(rowGroupIndex, column)) {
+                .rowGroup(rowGroupIndex)
+                .column(column)) {
             return new SchemaIncompatibleException(String.format(message, args));
         }
     }

--- a/core/src/main/java/dev/hardwood/internal/reader/SequentialFetchPlan.java
+++ b/core/src/main/java/dev/hardwood/internal/reader/SequentialFetchPlan.java
@@ -13,6 +13,8 @@ import java.util.List;
 import java.util.NoSuchElementException;
 
 import dev.hardwood.InputFile;
+import dev.hardwood.internal.ExceptionContext.ReadContext.Region;
+import dev.hardwood.internal.ReadScope;
 import dev.hardwood.internal.metadata.DataPageHeader;
 import dev.hardwood.internal.metadata.DataPageHeaderV2;
 import dev.hardwood.internal.metadata.PageHeader;
@@ -364,9 +366,14 @@ public final class SequentialFetchPlan implements FetchPlan, RowGroupIterator.Co
             while (true) {
                 ByteBuffer headerBuf = readBytes(relPos, peekSize);
                 ThriftCompactReader headerReader = new ThriftCompactReader(headerBuf);
-                try {
-                    PageHeader header = PageHeaderReader.read(headerReader);
-                    return new ParsedHeader(header, headerReader.getBytesRead());
+                // A header that will not parse is not a header that is merely
+                // too short for the peek, so growing cannot help; the loop is
+                // for truncation alone, and a parse failure leaves placed at the
+                // byte it stopped on.
+                try (ReadScope.Scope header = ReadScope.region(Region.PAGE_HEADER,
+                        columnChunkOffset + relPos)) {
+                    PageHeader parsed = PageHeaderReader.read(headerReader);
+                    return new ParsedHeader(parsed, headerReader.getBytesRead());
                 }
                 catch (ThriftTruncatedException truncated) {
                     if (peekSize >= remaining) {
@@ -461,8 +468,11 @@ public final class SequentialFetchPlan implements FetchPlan, RowGroupIterator.Co
                 // parser would have to open and read the same header out of again.
                 ByteBuffer compressedData = readBytes(position, dictTotalSize)
                         .slice(headerSize, compressedSize);
-                dictionary = DictionaryParser.parsePage(header, compressedData,
-                        columnSchema, metaData, context);
+                try (ReadScope.Scope page = ReadScope.region(Region.DICTIONARY_PAGE,
+                        columnChunkOffset + position)) {
+                    dictionary = DictionaryParser.parsePage(header, compressedData,
+                            columnSchema, metaData, context);
+                }
                 position += dictTotalSize;
             }
         }
@@ -567,7 +577,8 @@ public final class SequentialFetchPlan implements FetchPlan, RowGroupIterator.Co
                 }
                 else {
                     ByteBuffer pageData = readBytes(position, totalPageSize);
-                    pageInfo = new PageInfo(pageData, columnSchema, metaData, dictionary, mask);
+                    pageInfo = new PageInfo(pageData, columnSchema, metaData, dictionary, mask,
+                            columnChunkOffset + position);
                 }
                 valuesRead += numValues;
                 recordsRead += recordsInPage;

--- a/core/src/main/java/dev/hardwood/internal/reader/SharedRegion.java
+++ b/core/src/main/java/dev/hardwood/internal/reader/SharedRegion.java
@@ -12,8 +12,10 @@ import java.nio.ByteBuffer;
 import java.util.concurrent.CompletableFuture;
 
 import dev.hardwood.InputFile;
-import dev.hardwood.internal.ExceptionContext;
+import dev.hardwood.internal.ExceptionContext.ReadContext.Region;
 import dev.hardwood.internal.FetchReason;
+import dev.hardwood.internal.ReadScope;
+import dev.hardwood.reader.ParquetReadException;
 
 /// A contiguous, multi-column byte range fetched in a single
 /// `readRange` call. Exists to coalesce the per-column reads of a row
@@ -120,14 +122,22 @@ public final class SharedRegion {
             }
             String outer = FetchReason.current();
             String composed = "unattributed".equals(outer) ? purpose : outer + " | " + purpose;
-            try (FetchReason.Scope ignored = FetchReason.set(composed)) {
-                data = inputFile.readRange(fileOffset, length);
-            }
-            catch (IOException e) {
-                throw new IOException(
-                        ExceptionContext.filePrefix(inputFile.name())
-                        + "Failed to fetch region at offset " + fileOffset
-                        + " (length " + length + ")", e);
+            try (FetchReason.Scope ignored = FetchReason.set(composed);
+                 ReadScope.Scope fetch = ReadScope.region(Region.CHUNK_FETCH, fileOffset)) {
+                try {
+                    data = inputFile.readRange(fileOffset, length);
+                }
+                catch (IOException e) {
+                    throw new IOException(ReadScope.here() + "Failed to fetch " + length + " bytes", e);
+                }
+                catch (IndexOutOfBoundsException e) {
+                    // The footer named an address the file does not have, so
+                    // nothing was ever going to arrive. That is the metadata
+                    // contradicting itself, not a read that went wrong.
+                    throw new ParquetReadException("Malformed Parquet metadata: the region of "
+                            + length + " bytes at offset " + fileOffset
+                            + " runs past the end of the file", e);
+                }
             }
         }
     }

--- a/core/src/main/java/dev/hardwood/internal/schema/FixedWidthValidator.java
+++ b/core/src/main/java/dev/hardwood/internal/schema/FixedWidthValidator.java
@@ -7,7 +7,6 @@
  */
 package dev.hardwood.internal.schema;
 
-import dev.hardwood.internal.ExceptionContext.ReadContext;
 import dev.hardwood.internal.ReadScope;
 import dev.hardwood.metadata.PhysicalType;
 import dev.hardwood.reader.SchemaIncompatibleException;
@@ -58,8 +57,7 @@ public final class FixedWidthValidator {
         }
         // The file comes from the scope the caller is already in; only the column is
         // narrowed here, so the failure names both without either being passed.
-        try (ReadScope.Scope scope = ReadScope.column(
-                ReadContext.UNKNOWN_ROW_GROUP, column.fieldPath())) {
+        try (ReadScope.Scope scope = ReadScope.column(column.fieldPath())) {
             throw width == null
                     ? new SchemaIncompatibleException("FIXED_LEN_BYTE_ARRAY declares no type length")
                     : new SchemaIncompatibleException(String.format(

--- a/core/src/main/java/dev/hardwood/internal/schema/FixedWidthValidator.java
+++ b/core/src/main/java/dev/hardwood/internal/schema/FixedWidthValidator.java
@@ -7,7 +7,8 @@
  */
 package dev.hardwood.internal.schema;
 
-import dev.hardwood.internal.ExceptionContext;
+import dev.hardwood.internal.ExceptionContext.ReadContext;
+import dev.hardwood.internal.ReadScope;
 import dev.hardwood.metadata.PhysicalType;
 import dev.hardwood.reader.SchemaIncompatibleException;
 import dev.hardwood.schema.ColumnSchema;
@@ -36,33 +37,35 @@ public final class FixedWidthValidator {
 
     /// Validates `column` if it is a `FIXED_LEN_BYTE_ARRAY`, and does nothing otherwise.
     ///
-    /// @param fileName the file the column was read from, for the message; may be `null`
     /// @param column the column to check
     /// @throws SchemaIncompatibleException if the column is fixed-width and its declared
     ///         width is absent or not positive
-    public static void validate(String fileName, ColumnSchema column) {
+    public static void validate(ColumnSchema column) {
         if (column.type() == PhysicalType.FIXED_LEN_BYTE_ARRAY) {
-            requireWidth(fileName, column);
+            requireWidth(column);
         }
     }
 
     /// Returns the byte width of a `FIXED_LEN_BYTE_ARRAY` column.
     ///
-    /// @param fileName the file the column was read from, for the message; may be `null`
     /// @param column the fixed-width column whose width is needed
     /// @return the column's positive byte width
     /// @throws SchemaIncompatibleException if the declared width is absent or not positive
-    public static int requireWidth(String fileName, ColumnSchema column) {
+    public static int requireWidth(ColumnSchema column) {
         Integer width = column.typeLength();
-        if (width == null) {
-            throw new SchemaIncompatibleException(ExceptionContext.filePrefix(fileName)
-                    + "Column '" + column.fieldPath() + "' is a FIXED_LEN_BYTE_ARRAY that declares no type length");
+        if (width != null && width > 0) {
+            return width;
         }
-        if (width <= 0) {
-            throw new SchemaIncompatibleException(ExceptionContext.filePrefix(fileName)
-                    + "Column '" + column.fieldPath() + "' declares a FIXED_LEN_BYTE_ARRAY type length of "
-                    + width + ", which must be positive");
+        // The file comes from the scope the caller is already in; only the column is
+        // narrowed here, so the failure names both without either being passed.
+        try (ReadScope.Scope scope = ReadScope.column(
+                ReadContext.UNKNOWN_ROW_GROUP, column.fieldPath())) {
+            throw width == null
+                    ? new SchemaIncompatibleException("FIXED_LEN_BYTE_ARRAY declares no type length")
+                    : new SchemaIncompatibleException(String.format(
+                            "FIXED_LEN_BYTE_ARRAY declares a type length of %d,"
+                                    + " which must be positive", width));
         }
-        return width;
     }
+
 }

--- a/core/src/main/java/dev/hardwood/internal/thrift/ThriftCompactReader.java
+++ b/core/src/main/java/dev/hardwood/internal/thrift/ThriftCompactReader.java
@@ -15,6 +15,7 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 
+import dev.hardwood.internal.ReadScope;
 import dev.hardwood.internal.thrift.ThriftCompactConstants.FieldType.Codes;
 import dev.hardwood.reader.ParquetReadException;
 
@@ -81,13 +82,18 @@ public class ThriftCompactReader {
     private static final int NO_SAVED_STRUCT = 0;
 
     private final ByteBuffer buffer;
-    private final int startPosition;
     private short lastFieldId = 0;
 
     /// The struct being read, or `null` for one that has no name. Only the innermost
     /// is ever consulted, and [#pushFieldIdContext] hands the enclosing one back in
     /// its token, so no stack is needed.
     private ThriftStruct currentStruct;
+
+    /// Offset of the field header the reader most recently stepped onto,
+    /// relative to where it was handed the buffer. A failure over it reports
+    /// the file byte the enclosing region's address puts it at.
+    private int lastFieldStart = -1;
+
     /// Per-decode cache of repeated column paths, created on first use so the page-header path —
     /// which has none — never allocates one.
     private RepeatedPathCache pathCache;
@@ -97,7 +103,6 @@ public class ThriftCompactReader {
     /// @param buffer the buffer to read from (position should be at start of data)
     public ThriftCompactReader(ByteBuffer buffer) {
         this.buffer = buffer.slice().order(ByteOrder.LITTLE_ENDIAN);
-        this.startPosition = 0;
     }
 
     /// Creates a reader that reads from a ByteBuffer starting at a specific offset.
@@ -106,12 +111,11 @@ public class ThriftCompactReader {
     /// @param offset the offset within the buffer to start reading
     public ThriftCompactReader(ByteBuffer buffer, int offset) {
         this.buffer = buffer.slice(offset, buffer.limit() - offset).order(ByteOrder.LITTLE_ENDIAN);
-        this.startPosition = 0;
     }
 
     /// Returns the number of bytes read from the buffer.
     public int getBytesRead() {
-        return buffer.position() - startPosition;
+        return buffer.position();
     }
 
     /// Returns the number of bytes still available to read in the buffer.
@@ -207,8 +211,7 @@ public class ThriftCompactReader {
             }
             shift += 7;
             if (shift > MAX_VARINT_SHIFT) {
-                throw new ParquetReadException(inStruct(
-                        "Malformed varint: more than " + MAX_VARINT_BYTES + " bytes"));
+                throw malformed("Malformed varint: more than " + MAX_VARINT_BYTES + " bytes");
             }
         }
         throw new ThriftTruncatedException("Unexpected EOF while reading varint");
@@ -245,7 +248,7 @@ public class ThriftCompactReader {
         else if (b == TYPE_BOOLEAN_FALSE) {
             return false;
         }
-        throw new ParquetReadException(inStruct("Invalid boolean value: " + b));
+        throw malformed("Invalid boolean value: " + b);
     }
 
     /// Read an i32 value (zigzag encoded).
@@ -328,6 +331,11 @@ public class ThriftCompactReader {
     /// escapes into [#acceptField], so it is allocated for real rather than scalarized.
     /// Unpack it with [#fieldId] and [#fieldType].
     public int readFieldHeader() {
+        // Where this field starts, so a failure over it names its first byte
+        // rather than the position the reader stopped at, which is one past.
+        // One store beside the field id that is written here anyway, and only
+        // on the metadata path — no value is ever read through this method.
+        lastFieldStart = buffer.position();
         byte b = readByte();
 
         if (b == ThriftCompactConstants.STOP) {
@@ -763,7 +771,7 @@ public class ThriftCompactReader {
                 skipStruct();
                 break;
             default:
-                throw new ParquetReadException(inStruct("Unknown field type: " + type));
+                throw malformed("Unknown field type: " + type);
         }
     }
 
@@ -840,12 +848,16 @@ public class ThriftCompactReader {
     /// — and an unchecked one, where [ThriftStruct]'s is checked against
     /// parquet-format's own metadata.
     ///
+    /// The byte comes the same way: the field header the reader stepped onto is
+    /// where the damage is, and the enclosing region's address is what turns
+    /// that into a byte of the file.
+    ///
     /// Only for a complaint about a *field*. A complaint about the struct as a
     /// whole — a required field that never arrived, discovered at the STOP that
-    /// ends it — is standing on no field, and would take the name of whichever
-    /// one happened to be last.
+    /// ends it — is standing on no field, and would take the name and the byte
+    /// of whichever one happened to be last.
     ParquetReadException malformed(String message) {
-        return new ParquetReadException(inStruct(message));
+        return ReadScope.stoppedAt(inStruct(message), lastFieldStart);
     }
 
     /// The field id of the one variant a union has set.

--- a/core/src/main/java/dev/hardwood/reader/ParquetFileReader.java
+++ b/core/src/main/java/dev/hardwood/reader/ParquetFileReader.java
@@ -17,6 +17,7 @@ import java.util.concurrent.CopyOnWriteArrayList;
 import dev.hardwood.HardwoodContext;
 import dev.hardwood.InputFile;
 import dev.hardwood.internal.ExceptionContext;
+import dev.hardwood.internal.ReadScope;
 import dev.hardwood.internal.predicate.FilterPredicateResolver;
 import dev.hardwood.internal.predicate.ResolvedPredicate;
 import dev.hardwood.internal.reader.BatchSizing;
@@ -490,11 +491,10 @@ public class ParquetFileReader implements Closeable {
         if (filter == null) {
             return null;
         }
-        try {
+        // Entered rather than caught: a schema the filter cannot be stated against fails
+        // inside the file it was read from, so it names that file when it is raised.
+        try (ReadScope.Scope file = ReadScope.file(inputFiles.get(0).name())) {
             return FilterPredicateResolver.resolve(filter, schema, firstFileMetaData.columnOrders());
-        }
-        catch (SchemaIncompatibleException e) {
-            throw ExceptionContext.addFileContext(inputFiles.get(0).name(), e);
         }
     }
 

--- a/core/src/main/java/dev/hardwood/reader/ParquetReadException.java
+++ b/core/src/main/java/dev/hardwood/reader/ParquetReadException.java
@@ -7,6 +7,8 @@
  */
 package dev.hardwood.reader;
 
+import dev.hardwood.internal.ReadScope;
+
 /// Thrown when a file's own bytes are wrong: the read succeeded and what it
 /// returned does not say something a Parquet file can say.
 ///
@@ -31,11 +33,40 @@ public class ParquetReadException extends RuntimeException {
 
     private static final long serialVersionUID = 1L;
 
+    /// Where the read was when this was raised, or `null` if it was raised
+    /// outside a read.
+    ///
+    /// Taken at construction, which is the only moment the answer is known: a
+    /// frame that catches this is by definition no longer in the place the
+    /// failure happened. Not serialised — the message states the same facts,
+    /// and an exception that has been through serialisation is being read
+    /// rather than acted on.
+    ///
+    /// That the file being wrong is the type that carries one is the whole
+    /// rule. An [UnsupportedOperationException] says the file is correct and
+    /// this library will not read it, so there is nothing at any byte for a
+    /// caller to go and look at and it is given no place to name — not by a
+    /// check at some raise site, but because it is not this type.
+    private final transient ReadScope.Place place;
+
     public ParquetReadException(String message) {
         super(message);
+        this.place = ReadScope.current();
     }
 
     public ParquetReadException(String message, Throwable cause) {
         super(message, cause);
+        this.place = ReadScope.current();
+    }
+
+    /// The message, behind where the read was.
+    ///
+    /// Composed here rather than at construction so that nothing has to rebuild
+    /// the exception — and with it its type, which callers catch on — in order
+    /// to say where it was.
+    @Override
+    public String getMessage() {
+        String message = super.getMessage();
+        return place == null ? message : place.describe() + message;
     }
 }

--- a/core/src/test/java/dev/hardwood/CrcValidationTest.java
+++ b/core/src/test/java/dev/hardwood/CrcValidationTest.java
@@ -73,8 +73,8 @@ class CrcValidationTest {
                     colReader.nextBatch();
                 }
             }
-        }).hasRootCauseInstanceOf(ParquetReadException.class)
-          .rootCause().hasMessageContaining("CRC mismatch");
+        }).isInstanceOf(ParquetReadException.class)
+          .hasMessageContaining("CRC mismatch");
     }
 
     @Test
@@ -121,8 +121,8 @@ class CrcValidationTest {
                     colReader.nextBatch();
                 }
             }
-        }).hasRootCauseInstanceOf(ParquetReadException.class)
-          .rootCause().hasMessageContaining("CRC mismatch");
+        }).isInstanceOf(ParquetReadException.class)
+          .hasMessageContaining("CRC mismatch");
     }
 
     @Test
@@ -141,5 +141,34 @@ class CrcValidationTest {
                 assertThat(idReader.nextBatch()).isFalse();
             }
         }
+    }
+
+    /// Which column a mismatch was in is read context, added once on the way
+    /// out. The validator naming it as well put it in the message twice, which
+    /// reads as a bug in the reader rather than in the file.
+    @Test
+    void crcMismatchNamesTheColumnExactlyOnce() throws Exception {
+        byte[] bytes = Files.readAllBytes(Paths.get("src/test/resources/plain_with_crc.parquet"));
+        long corruptOffset;
+        try (ParquetFileReader reader = ParquetFileReader.open(InputFile.of(ByteBuffer.wrap(bytes)))) {
+            ColumnMetaData meta = reader.getFileMetaData().rowGroups().get(0).columns().get(0).metaData();
+            corruptOffset = meta.dataPageOffset() + meta.totalCompressedSize() - 1;
+        }
+        bytes[(int) corruptOffset] ^= 0xFF;
+
+        ByteBuffer corrupted = ByteBuffer.wrap(bytes);
+        assertThatThrownBy(() -> {
+            try (ParquetFileReader reader = ParquetFileReader.open(InputFile.of(corrupted))) {
+                try (ColumnReader colReader = reader.columnReader("id")) {
+                    colReader.nextBatch();
+                }
+            }
+        }).satisfies(thrown -> {
+            String message = thrown.getMessage();
+            assertThat(message).contains("column id").doesNotContain("for column id");
+            assertThat(message.split("column id", -1).length - 1)
+                    .as("times the column is named in: %s", message)
+                    .isOne();
+        });
     }
 }

--- a/core/src/test/java/dev/hardwood/CrossFileColumnOrderTest.java
+++ b/core/src/test/java/dev/hardwood/CrossFileColumnOrderTest.java
@@ -154,7 +154,7 @@ class CrossFileColumnOrderTest {
                     }
                 }
             }).isInstanceOf(SchemaIncompatibleException.class)
-                    .hasMessage("[compat_order_b_only.parquet] Column 'a' not found");
+                    .hasMessage("[compat_order_b_only.parquet] column a — Not present in this file's schema");
         }
     }
 
@@ -266,8 +266,8 @@ class CrossFileColumnOrderTest {
                     }
                 }
             }).isInstanceOf(SchemaIncompatibleException.class)
-                    .hasMessage("[compat_chunk_path_swapped.parquet] Row group 0 lists column 'b'"
-                            + " where the schema declares 'a'");
+                    .hasMessage("[compat_chunk_path_swapped.parquet] row group 0, column a — The row group"
+                            + " lists column 'b' at this position");
         }
     }
 }

--- a/core/src/test/java/dev/hardwood/DictionaryEndToEndTest.java
+++ b/core/src/test/java/dev/hardwood/DictionaryEndToEndTest.java
@@ -130,7 +130,7 @@ class DictionaryEndToEndTest {
         FileSchema schema = FileSchema.fromSchemaElements(reader.getFileMetaData().schema());
 
         try (HardwoodContextImpl context = HardwoodContextImpl.create()) {
-            assertThat(new RowGroupDictionaryFilterSource(inputFile, rowGroup, schema, context)
+            assertThat(new RowGroupDictionaryFilterSource(inputFile, rowGroup, 0, schema, context)
                     .forColumn(columnIndex))
                     .as("dictionary for column '%s'", column)
                     .isNotNull();

--- a/core/src/test/java/dev/hardwood/MalformedMetadataFileTest.java
+++ b/core/src/test/java/dev/hardwood/MalformedMetadataFileTest.java
@@ -22,6 +22,10 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 /// **file-attributed** error. The low-level field-name coverage lives in
 /// [dev.hardwood.internal.thrift.MalformedMetadataValidationTest]; this test pins
 /// the end-to-end behaviour that the message also names the offending file.
+///
+/// No byte is named: the footer parsed, and it is the value that is wrong
+/// rather than the bytes holding it, so an offset would point at bytes that are
+/// exactly what the writer meant to put there.
 class MalformedMetadataFileTest {
 
     @Test
@@ -30,7 +34,9 @@ class MalformedMetadataFileTest {
         Path file = Paths.get("src/test/resources/negative_data_page_offset.parquet");
         assertThatThrownBy(() -> ParquetFileReader.open(InputFile.of(file)))
                 .isInstanceOf(ParquetReadException.class)
-                .hasMessage("[negative_data_page_offset.parquet] ColumnMetaData.data_page_offset"
-                        + " — must be non-negative but was -1");
+                // The byte is the field's own header rather than the footer's first:
+                // the reader was standing on data_page_offset when it rejected it.
+                .hasMessage("[negative_data_page_offset.parquet] footer at byte 147 (0x000093)"
+                        + " — ColumnMetaData.data_page_offset — must be non-negative but was -1");
     }
 }

--- a/core/src/test/java/dev/hardwood/MultiFileRowReaderTest.java
+++ b/core/src/test/java/dev/hardwood/MultiFileRowReaderTest.java
@@ -180,14 +180,16 @@ class MultiFileRowReaderTest {
         try (ParquetFileReader reader = ParquetFileReader.openAll(List.of(valid, invalid))) {
             assertThatThrownBy(() -> reader.getFileMetaData(1))
                     .isInstanceOf(ParquetReadException.class)
-                    .hasMessage("[<memory>] Not a Parquet file (invalid magic number at start)");
+                    .hasMessage("[<memory>] magic bytes at byte 0 (0x000000) — Not a Parquet file"
+                            + " (invalid magic number at start)");
             int readsAfterFailure = invalid.footerReadCount();
 
             // A malformed file now reaches the caller as what it is, rather than
             // wrapped as a metadata read that failed.
             assertThatThrownBy(reader::rowReader)
                     .isInstanceOf(ParquetReadException.class)
-                    .hasMessage("[<memory>] Not a Parquet file (invalid magic number at start)");
+                    .hasMessage("[<memory>] magic bytes at byte 0 (0x000000) — Not a Parquet file"
+                            + " (invalid magic number at start)");
             assertThat(invalid.footerReadCount()).isEqualTo(readsAfterFailure);
         }
 
@@ -195,7 +197,8 @@ class MultiFileRowReaderTest {
         try (ParquetFileReader reader = ParquetFileReader.openAll(List.of(valid, invalid))) {
             assertThatThrownBy(() -> reader.getFileMetaData(1))
                     .isInstanceOf(ParquetReadException.class)
-                    .hasMessage("[<memory>] Not a Parquet file (invalid magic number at start)");
+                    .hasMessage("[<memory>] magic bytes at byte 0 (0x000000) — Not a Parquet file"
+                            + " (invalid magic number at start)");
         }
         assertThat(invalid.footerReadCount()).isGreaterThan(readsBeforeReopen);
     }

--- a/core/src/test/java/dev/hardwood/ReadFailureMessageTest.java
+++ b/core/src/test/java/dev/hardwood/ReadFailureMessageTest.java
@@ -1,0 +1,70 @@
+/*
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Copyright The original authors
+ *
+ *  Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package dev.hardwood;
+
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
+
+import org.junit.jupiter.api.Test;
+
+import dev.hardwood.reader.ParquetFileReader;
+import dev.hardwood.reader.ParquetReadException;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/// What a read failure tells the user, for the failures that had no test at all.
+///
+/// These messages are the whole of what someone gets when a file will not read,
+/// so they are asserted entire rather than by fragment: a `contains` check
+/// passes just as happily on a message that has quietly lost the offset it was
+/// added to carry.
+class ReadFailureMessageTest {
+
+    private static final byte[] MAGIC = { 'P', 'A', 'R', '1' };
+
+    @Test
+    void aFileTooShortToHoldAFooterSaysHowShort() {
+        ByteBuffer tiny = ByteBuffer.allocate(8);
+
+        assertThatThrownBy(() -> ParquetFileReader.open(InputFile.of(tiny)))
+                .isInstanceOf(ParquetReadException.class)
+                .hasMessage("[<memory>] File too small to be a valid Parquet file (8 bytes)");
+    }
+
+    @Test
+    void aTrailingMagicThatIsNotPar1NamesTheByteItWasReadFrom() {
+        ByteBuffer file = ByteBuffer.allocate(16).order(ByteOrder.LITTLE_ENDIAN);
+        file.put(MAGIC);
+        file.put(new byte[] { 0, 0, 0, 0 });
+        file.putInt(4);
+        file.put(new byte[] { 'N', 'O', 'P', 'E' });
+        file.flip();
+
+        // 16 bytes long, so the trailing marker begins at 12.
+        assertThatThrownBy(() -> ParquetFileReader.open(InputFile.of(file)))
+                .isInstanceOf(ParquetReadException.class)
+                .hasMessage("[<memory>] magic bytes at byte 12 (0x00000c) — Not a Parquet file"
+                        + " (invalid magic number at end)");
+    }
+
+    @Test
+    void aFooterLengthReachingBackPastTheHeaderNamesWhereItWasRead() {
+        ByteBuffer file = ByteBuffer.allocate(16).order(ByteOrder.LITTLE_ENDIAN);
+        file.put(MAGIC);
+        file.put(new byte[] { 0, 0, 0, 0 });
+        file.putInt(9999);
+        file.put(MAGIC);
+        file.flip();
+
+        assertThatThrownBy(() -> ParquetFileReader.open(InputFile.of(file)))
+                .isInstanceOf(ParquetReadException.class)
+                .hasMessage("[<memory>] footer length at byte 8 (0x000008) — 9999 would start the"
+                        + " footer in front of the file's opening magic");
+    }
+
+}

--- a/core/src/test/java/dev/hardwood/SchemaCompatibilityTest.java
+++ b/core/src/test/java/dev/hardwood/SchemaCompatibilityTest.java
@@ -59,9 +59,8 @@ class SchemaCompatibilityTest {
                     }
                 }
             }).isInstanceOf(SchemaIncompatibleException.class)
-                    .hasMessage("[compat_ts_millis.parquet] Column 'ts' has incompatible logical type:" +
-                            " expected TIMESTAMP(MICROS, UTC)" +
-                            " but found TIMESTAMP(MILLIS, UTC)");
+                    .hasMessage("[compat_ts_millis.parquet] column ts — Incompatible logical type: expected"
+                            + " TIMESTAMP(MICROS, UTC) but found TIMESTAMP(MILLIS, UTC)");
         }
     }
 
@@ -79,9 +78,8 @@ class SchemaCompatibilityTest {
                     }
                 }
             }).isInstanceOf(SchemaIncompatibleException.class)
-                    .hasMessage("[compat_decimal_10_4.parquet] Column 'amount' has incompatible logical type:" +
-                            " expected DECIMAL(10, 2)" +
-                            " but found DECIMAL(10, 4)");
+                    .hasMessage("[compat_decimal_10_4.parquet] column amount — Incompatible logical type:"
+                            + " expected DECIMAL(10, 2) but found DECIMAL(10, 4)");
         }
     }
 
@@ -99,8 +97,8 @@ class SchemaCompatibilityTest {
                     }
                 }
             }).isInstanceOf(SchemaIncompatibleException.class)
-                    .hasMessage("[compat_optional_value.parquet] Column 'value' has incompatible repetition type:" +
-                            " expected REQUIRED but found OPTIONAL");
+                    .hasMessage("[compat_optional_value.parquet] column value — Incompatible repetition type:"
+                            + " expected REQUIRED but found OPTIONAL");
         }
     }
 
@@ -118,8 +116,8 @@ class SchemaCompatibilityTest {
                     }
                 }
             }).isInstanceOf(SchemaIncompatibleException.class)
-                    .hasMessage("[compat_plain_int64.parquet] Column 'ts' has incompatible logical type:" +
-                            " expected TIMESTAMP(MICROS, UTC) but found null");
+                    .hasMessage("[compat_plain_int64.parquet] column ts — Incompatible logical type: expected"
+                            + " TIMESTAMP(MICROS, UTC) but found null");
         }
     }
 
@@ -137,8 +135,8 @@ class SchemaCompatibilityTest {
                     }
                 }
             }).isInstanceOf(SchemaIncompatibleException.class)
-                    .hasMessage("[compat_flba_8.parquet] Column 'v' has incompatible type length:" +
-                            " expected 4 but found 8");
+                    .hasMessage("[compat_flba_8.parquet] column v — Incompatible type length: expected 4 but"
+                            + " found 8");
         }
     }
 
@@ -159,8 +157,8 @@ class SchemaCompatibilityTest {
                     }
                 }
             }).isInstanceOf(SchemaIncompatibleException.class)
-                    .hasMessage("[compat_nested_opt_group.parquet] Column 'g.v'" +
-                            " has incompatible maximum definition level: expected 0 but found 1");
+                    .hasMessage("[compat_nested_opt_group.parquet] column g.v — Incompatible maximum"
+                            + " definition level: expected 0 but found 1");
         }
     }
 
@@ -183,8 +181,8 @@ class SchemaCompatibilityTest {
                     }
                 }
             }).isInstanceOf(SchemaIncompatibleException.class)
-                    .hasMessage("[compat_maxrep_struct.parquet] Column 'g.list.element'" +
-                            " has incompatible maximum repetition level: expected 1 but found 0");
+                    .hasMessage("[compat_maxrep_struct.parquet] column g.list.element — Incompatible maximum"
+                            + " repetition level: expected 1 but found 0");
         }
     }
 
@@ -205,8 +203,8 @@ class SchemaCompatibilityTest {
                     }
                 }
             }).isInstanceOf(SchemaIncompatibleException.class)
-                    .hasMessage("[compat_maxrep_list.parquet] Column 'g.list.element'" +
-                            " has incompatible maximum repetition level: expected 0 but found 1");
+                    .hasMessage("[compat_maxrep_list.parquet] column g.list.element — Incompatible maximum"
+                            + " repetition level: expected 0 but found 1");
         }
     }
 

--- a/core/src/test/java/dev/hardwood/internal/ExceptionContextTest.java
+++ b/core/src/test/java/dev/hardwood/internal/ExceptionContextTest.java
@@ -9,6 +9,11 @@ package dev.hardwood.internal;
 
 import org.junit.jupiter.api.Test;
 
+import dev.hardwood.internal.ExceptionContext.ReadContext;
+import dev.hardwood.internal.ExceptionContext.ReadContext.Region;
+
+import static dev.hardwood.internal.ExceptionContext.ReadContext.UNKNOWN_OFFSET;
+import static dev.hardwood.internal.ExceptionContext.ReadContext.UNKNOWN_ROW_GROUP;
 import static org.assertj.core.api.Assertions.assertThat;
 
 /// Unit tests for [ExceptionContext].
@@ -81,5 +86,33 @@ class ExceptionContextTest {
         CustomException() {
             super("custom error");
         }
+    }
+
+    /// A footer belongs to the file rather than to any part of it, so a
+    /// context naming a region and an offset and no column at all still reads
+    /// as a sentence.
+    @Test
+    void readContextWithNeitherRowGroupNorColumn() {
+        assertThat(ExceptionContext.prefix(new ReadContext("f.parquet", UNKNOWN_ROW_GROUP, null,
+                Region.FOOTER, 161340)))
+                .isEqualTo("[f.parquet] footer at byte 161340 (0x02763c) — ");
+    }
+
+    /// A context that knows the stage but not how far it got must not leave a
+    /// dangling "at byte" behind; the clause carries only what it was given.
+    @Test
+    void readContextWithoutAnOffsetNamesNoByte() {
+        assertThat(ExceptionContext.prefix(
+                new ReadContext("f.parquet", 3, "id", Region.DATA_PAGE, UNKNOWN_OFFSET)))
+                .isEqualTo("[f.parquet] row group 3, column id, data page — ");
+    }
+
+    /// Nothing beyond the file leaves the prefix exactly as it has always been,
+    /// so a caller can concatenate it without checking.
+    @Test
+    void readContextWithNothingButAFileNameIsJustThePrefix() {
+        assertThat(ExceptionContext.prefix(new ReadContext("f.parquet", UNKNOWN_ROW_GROUP, null,
+                null, UNKNOWN_OFFSET)))
+                .isEqualTo("[f.parquet] ");
     }
 }

--- a/core/src/test/java/dev/hardwood/internal/ReadScopeTest.java
+++ b/core/src/test/java/dev/hardwood/internal/ReadScopeTest.java
@@ -26,7 +26,7 @@ class ReadScopeTest {
     @Test
     void aFailureRaisedInAScopeNamesTheFileColumnAndRegion() {
         try (ReadScope.Scope file = ReadScope.file("f.parquet");
-             ReadScope.Scope column = ReadScope.column(2, "id");
+             ReadScope.Scope column = ReadScope.rowGroup(2).column("id");
              ReadScope.Scope region = ReadScope.region(Region.DICTIONARY_PAGE, 4096)) {
             assertThat(new ParquetReadException("the page is not a page"))
                     .hasMessage("[f.parquet] row group 2, column id, dictionary page at byte 4096"
@@ -61,7 +61,7 @@ class ReadScopeTest {
     @Test
     void aRegionWithNoAddressNamesNoByte() {
         try (ReadScope.Scope file = ReadScope.file("f.parquet");
-             ReadScope.Scope column = ReadScope.column(1, "amount");
+             ReadScope.Scope column = ReadScope.rowGroup(1).column("amount");
              ReadScope.Scope page = ReadScope.region(Region.DATA_PAGE)) {
             assertThat(new ParquetReadException("bad run"))
                     .hasMessage("[f.parquet] row group 1, column amount, data page — bad run");
@@ -74,7 +74,7 @@ class ReadScopeTest {
     @Test
     void anUnsupportedFileIsNamedButNeverPositioned() {
         try (ReadScope.Scope file = ReadScope.file("f.parquet");
-             ReadScope.Scope column = ReadScope.column(0, "amount");
+             ReadScope.Scope column = ReadScope.rowGroup(0).column("amount");
              ReadScope.Scope region = ReadScope.region(Region.DATA_PAGE, 900)) {
             assertThat(new UnsupportedOperationException(
                     ReadScope.fileHere() + "no codec here"))
@@ -128,7 +128,7 @@ class ReadScopeTest {
     void aResumedPlaceDescribesWhereTheWorkCameFrom() {
         ReadScope.Place page;
         try (ReadScope.Scope file = ReadScope.file("f.parquet");
-             ReadScope.Scope column = ReadScope.column(3, "ts");
+             ReadScope.Scope column = ReadScope.rowGroup(3).column("ts");
              ReadScope.Scope region = ReadScope.region(Region.BLOOM_FILTER, 720)) {
             page = ReadScope.current();
         }
@@ -170,6 +170,41 @@ class ReadScopeTest {
         assertThat(ReadScope.fileHere()).isEmpty();
     }
 
+    /// Which column is being read and where in a file the read is are independent, so a
+    /// worker that holds one column across several files enters it once and moves the file
+    /// underneath it.
+    @Test
+    void enteringAFileKeepsTheColumnItIsBeingReadFor() {
+        try (ReadScope.Scope column = ReadScope.column("amount")) {
+            try (ReadScope.Scope first = ReadScope.file("a.parquet").rowGroup(0)) {
+                assertThat(new ParquetReadException("bad"))
+                        .hasMessage("[a.parquet] row group 0, column amount — bad");
+            }
+            try (ReadScope.Scope second = ReadScope.file("b.parquet").rowGroup(3)) {
+                assertThat(new ParquetReadException("bad"))
+                        .hasMessage("[b.parquet] row group 3, column amount — bad");
+            }
+        }
+    }
+
+    /// The parts of a position nest, so entering a coarser one drops the finer ones: they
+    /// described somewhere else, and a row group carried into the next file would name a
+    /// row group that read nothing.
+    @Test
+    void enteringAFileDropsWhereInThePreviousFileTheReadWas() {
+        try (ReadScope.Scope first = ReadScope.file("a.parquet")
+                .rowGroup(2)
+                .region(Region.DATA_PAGE, 900)) {
+            try (ReadScope.Scope second = ReadScope.file("b.parquet")) {
+                assertThat(new ParquetReadException("bad")).hasMessage("[b.parquet] bad");
+            }
+            try (ReadScope.Scope third = ReadScope.rowGroup(5)) {
+                assertThat(new ParquetReadException("bad"))
+                        .hasMessage("[a.parquet] row group 5 — bad");
+            }
+        }
+    }
+
     /// A read is entered all at once and left all at once: the narrowing methods extend the
     /// scope already opened rather than opening more, so one place is restored on close
     /// however many were chained.
@@ -177,7 +212,8 @@ class ReadScopeTest {
     void aChainedScopeNarrowsOnceAndRestoresOnce() {
         try (ReadScope.Scope outer = ReadScope.file("outer.parquet")) {
             try (ReadScope.Scope scope = ReadScope.file("f.parquet")
-                    .column(2, "id")
+                    .rowGroup(2)
+                    .column("id")
                     .region(Region.DICTIONARY_PAGE, 4096)) {
                 assertThat(new ParquetReadException("bad"))
                         .hasMessage("[f.parquet] row group 2, column id, dictionary page at byte"

--- a/core/src/test/java/dev/hardwood/internal/ReadScopeTest.java
+++ b/core/src/test/java/dev/hardwood/internal/ReadScopeTest.java
@@ -1,0 +1,190 @@
+/*
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Copyright The original authors
+ *
+ *  Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package dev.hardwood.internal;
+
+import java.io.IOException;
+
+import org.junit.jupiter.api.Test;
+
+import dev.hardwood.internal.ExceptionContext.ReadContext.Region;
+import dev.hardwood.reader.ParquetReadException;
+import dev.hardwood.reader.SchemaIncompatibleException;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/// Where a read failure says it happened, and which failures say it at all.
+///
+/// The rules under test are properties of types and scopes rather than of any
+/// raise site: nothing below names a position, and the positions still appear.
+class ReadScopeTest {
+
+    @Test
+    void aFailureRaisedInAScopeNamesTheFileColumnAndRegion() {
+        try (ReadScope.Scope file = ReadScope.file("f.parquet");
+             ReadScope.Scope column = ReadScope.column(2, "id");
+             ReadScope.Scope region = ReadScope.region(Region.DICTIONARY_PAGE, 4096)) {
+            assertThat(new ParquetReadException("the page is not a page"))
+                    .hasMessage("[f.parquet] row group 2, column id, dictionary page at byte 4096"
+                            + " (0x001000) — the page is not a page");
+        }
+    }
+
+    /// A region says where a read began, and a read that knows how far it got
+    /// says so through the scope rather than by carrying a number out with the
+    /// failure. Neither names a byte on its own.
+    @Test
+    void aParsePositionIsAddedToTheRegionsOwnStart() {
+        try (ReadScope.Scope file = ReadScope.file("f.parquet");
+             ReadScope.Scope region = ReadScope.region(Region.FOOTER, 1000)) {
+            assertThat(ReadScope.stoppedAt("Unknown field type: 13", 24))
+                    .hasMessage("[f.parquet] footer at byte 1024 (0x000400)"
+                            + " — Unknown field type: 13");
+        }
+    }
+
+    /// A buffer that is not part of any file has no byte to add to, and the
+    /// failure says what went wrong without inventing one.
+    @Test
+    void aParsePositionOutsideAnyRegionNamesNoByte() {
+        assertThat(ReadScope.stoppedAt("Unknown field type: 13", 24))
+                .hasMessage("Unknown field type: 13");
+    }
+
+    /// A region with no address of its own names none. A decode that failed a
+    /// thousand values into a page is not at the page's first byte, and the row
+    /// group and column already say which page it was.
+    @Test
+    void aRegionWithNoAddressNamesNoByte() {
+        try (ReadScope.Scope file = ReadScope.file("f.parquet");
+             ReadScope.Scope column = ReadScope.column(1, "amount");
+             ReadScope.Scope page = ReadScope.region(Region.DATA_PAGE)) {
+            assertThat(new ParquetReadException("bad run"))
+                    .hasMessage("[f.parquet] row group 1, column amount, data page — bad run");
+        }
+    }
+
+    /// The type is the rule. A correct file this library will not read is named
+    /// and never positioned, because it is not the type that carries a place —
+    /// not because any raise site decided so.
+    @Test
+    void anUnsupportedFileIsNamedButNeverPositioned() {
+        try (ReadScope.Scope file = ReadScope.file("f.parquet");
+             ReadScope.Scope column = ReadScope.column(0, "amount");
+             ReadScope.Scope region = ReadScope.region(Region.DATA_PAGE, 900)) {
+            assertThat(new UnsupportedOperationException(
+                    ReadScope.fileHere() + "no codec here"))
+                    .hasMessage("[f.parquet] no codec here");
+        }
+    }
+
+    /// The innermost scope is the one the failure was in.
+    @Test
+    void theInnermostScopeWinsAndTheEnclosingOneComesBack() {
+        try (ReadScope.Scope file = ReadScope.file("f.parquet");
+             ReadScope.Scope outer = ReadScope.region(Region.CHUNK_FETCH, 10)) {
+            try (ReadScope.Scope inner = ReadScope.region(Region.PAGE_HEADER, 20)) {
+                assertThat(new ParquetReadException("x").getMessage()).contains("page header");
+            }
+            assertThat(new ParquetReadException("x").getMessage()).contains("chunk fetch");
+        }
+    }
+
+    /// A place is taken once, at construction, so a failure travelling out
+    /// through further scopes is described once and describes the scope it was
+    /// raised in. Nothing inspects the message to find that out.
+    @Test
+    void aFailureIsDescribedOnceHoweverManyScopesItLeaves() {
+        ParquetReadException raised;
+        try (ReadScope.Scope file = ReadScope.file("f.parquet");
+             ReadScope.Scope region = ReadScope.region(Region.FOOTER, 8)) {
+            raised = new ParquetReadException("bad");
+        }
+        try (ReadScope.Scope other = ReadScope.file("g.parquet")) {
+            assertThat(raised).hasMessage("[f.parquet] footer at byte 8 (0x000008) — bad");
+        }
+        assertThat(raised).hasMessage("[f.parquet] footer at byte 8 (0x000008) — bad");
+    }
+
+    /// Describing a failure must not rebuild it: callers catch on the subclass,
+    /// and a rebuilt one would arrive as its parent.
+    @Test
+    void beingDescribedKeepsAFailuresExactType() {
+        try (ReadScope.Scope file = ReadScope.file("f.parquet")) {
+            assertThat(new SchemaIncompatibleException("mismatch"))
+                    .isInstanceOf(SchemaIncompatibleException.class)
+                    .hasMessage("[f.parquet] mismatch");
+        }
+    }
+
+    /// A place resumed on another thread is the one described, not whatever
+    /// that thread was doing last. The decode of a page runs on a pool thread
+    /// and inherits nothing.
+    @Test
+    void aResumedPlaceDescribesWhereTheWorkCameFrom() {
+        ReadScope.Place page;
+        try (ReadScope.Scope file = ReadScope.file("f.parquet");
+             ReadScope.Scope column = ReadScope.column(3, "ts");
+             ReadScope.Scope region = ReadScope.region(Region.BLOOM_FILTER, 720)) {
+            page = ReadScope.current();
+        }
+        try (ReadScope.Scope elsewhere = ReadScope.file("g.parquet");
+             ReadScope.Scope resumed = ReadScope.resume(page)) {
+            assertThat(new ParquetReadException("x"))
+                    .hasMessage("[f.parquet] row group 3, column ts, bloom filter at byte 720"
+                            + " (0x0002d0) — x");
+        }
+    }
+
+    /// Outside a read there is nothing to say, and the message is the one it
+    /// was raised with.
+    @Test
+    void aFailureRaisedOutsideAnyScopeIsUntouched() {
+        assertThat(new ParquetReadException("plain")).hasMessage("plain");
+        assertThat(ReadScope.current()).isNull();
+    }
+
+    /// A transport failure takes the same place, and stays the [IOException] a caller
+    /// catches and the reader declares — it takes its position as text rather than gaining
+    /// a subclass to hold one.
+    @Test
+    void aFailedReadCarriesItsPlaceAndStaysAnIoException() {
+        try (ReadScope.Scope file = ReadScope.file("f.parquet");
+             ReadScope.Scope region = ReadScope.region(Region.CHUNK_FETCH, 2048)) {
+            IOException failure = new IOException(
+                    ReadScope.here() + "Failed to fetch 64 bytes");
+            assertThat(failure).hasMessage("[f.parquet] chunk fetch at byte 2048"
+                    + " (0x000800) — Failed to fetch 64 bytes");
+        }
+    }
+
+    /// Outside a read both prefixes are empty, so a failure raised there reads exactly as
+    /// it was written.
+    @Test
+    void thePrefixesAreEmptyOutsideAnyRead() {
+        assertThat(ReadScope.here()).isEmpty();
+        assertThat(ReadScope.fileHere()).isEmpty();
+    }
+
+    /// A read is entered all at once and left all at once: the narrowing methods extend the
+    /// scope already opened rather than opening more, so one place is restored on close
+    /// however many were chained.
+    @Test
+    void aChainedScopeNarrowsOnceAndRestoresOnce() {
+        try (ReadScope.Scope outer = ReadScope.file("outer.parquet")) {
+            try (ReadScope.Scope scope = ReadScope.file("f.parquet")
+                    .column(2, "id")
+                    .region(Region.DICTIONARY_PAGE, 4096)) {
+                assertThat(new ParquetReadException("bad"))
+                        .hasMessage("[f.parquet] row group 2, column id, dictionary page at byte"
+                                + " 4096 (0x001000) — bad");
+            }
+            assertThat(ReadScope.current().fileName()).isEqualTo("outer.parquet");
+        }
+        assertThat(ReadScope.current()).isNull();
+    }
+}

--- a/core/src/test/java/dev/hardwood/internal/predicate/BloomFilterPushDownTest.java
+++ b/core/src/test/java/dev/hardwood/internal/predicate/BloomFilterPushDownTest.java
@@ -248,7 +248,7 @@ class BloomFilterPushDownTest {
         columns.set(NAME_COLUMN, patched);
         RowGroup patchedRowGroup = new RowGroup(columns, rowGroup.totalByteSize(), rowGroup.numRows());
 
-        BloomFilter filter = new RowGroupBloomFilterSource(inputFile, patchedRowGroup).forColumn(NAME_COLUMN);
+        BloomFilter filter = new RowGroupBloomFilterSource(inputFile, patchedRowGroup, 0).forColumn(NAME_COLUMN);
         assertThat(filter).isNotNull();
         assertThat(filter.mightContain(XxHash64.hash("x".getBytes(StandardCharsets.UTF_8)))).isTrue();
     }
@@ -270,7 +270,7 @@ class BloomFilterPushDownTest {
         System.arraycopy(serialized, 0, fileBytes, offset, serialized.length);
         CountingInputFile memory = new CountingInputFile(InputFile.of(ByteBuffer.wrap(fileBytes)));
 
-        BloomFilter filter = new RowGroupBloomFilterSource(memory, singleColumnRowGroup(offset)).forColumn(0);
+        BloomFilter filter = new RowGroupBloomFilterSource(memory, singleColumnRowGroup(offset), 0).forColumn(0);
         assertThat(filter).isNotNull();
         assertThat(filter.header().numBytes()).isEqualTo(32);
         assertThat(filter.mightContain(presentHash)).isTrue(); // no false negative for a stored value
@@ -286,12 +286,12 @@ class BloomFilterPushDownTest {
         // before the file's magic header). The source stays conservative — no filter, so the row
         // group is kept — rather than throwing or reading garbage.
         InputFile memory = InputFile.of(ByteBuffer.wrap(new byte[64]));
-        assertThat(new RowGroupBloomFilterSource(memory, singleColumnRowGroup(0)).forColumn(0)).isNull();
+        assertThat(new RowGroupBloomFilterSource(memory, singleColumnRowGroup(0), 0).forColumn(0)).isNull();
     }
 
     @Test
     void rowGroupBloomFilterSourceExposesFiltersPerColumn() throws IOException {
-        RowGroupBloomFilterSource source = new RowGroupBloomFilterSource(inputFile, rowGroup);
+        RowGroupBloomFilterSource source = new RowGroupBloomFilterSource(inputFile, rowGroup, 0);
         assertThat(source.forColumn(NAME_COLUMN)).isNotNull();
         assertThat(source.forColumn(VALUE_COLUMN)).isNull();
         // Out-of-bounds index (e.g. a narrower file in a multi-file scan) is conservatively
@@ -302,7 +302,7 @@ class BloomFilterPushDownTest {
     private static boolean bloomDrop(FilterPredicate filter) throws IOException {
         ResolvedPredicate resolved = FilterPredicateResolver.resolve(filter, schema);
         return RowGroupFilterEvaluator.decideRowGroup(resolved, rowGroup,
-                new RowGroupBloomFilterSource(inputFile, rowGroup), null) == FilterDecision.CANNOT_MATCH;
+                new RowGroupBloomFilterSource(inputFile, rowGroup, 0), null) == FilterDecision.CANNOT_MATCH;
     }
 
     private static boolean statisticsDrop(FilterPredicate filter) throws IOException {

--- a/core/src/test/java/dev/hardwood/internal/predicate/BloomFilterSignedZeroPushDownTest.java
+++ b/core/src/test/java/dev/hardwood/internal/predicate/BloomFilterSignedZeroPushDownTest.java
@@ -73,7 +73,7 @@ class BloomFilterSignedZeroPushDownTest {
     private static boolean bloomDrop(FilterPredicate filter) throws IOException {
         ResolvedPredicate resolved = FilterPredicateResolver.resolve(filter, schema);
         return RowGroupFilterEvaluator.decideRowGroup(resolved, rowGroup,
-                new RowGroupBloomFilterSource(inputFile, rowGroup), null) == FilterDecision.CANNOT_MATCH;
+                new RowGroupBloomFilterSource(inputFile, rowGroup, 0), null) == FilterDecision.CANNOT_MATCH;
     }
 
     private static boolean statisticsDrop(FilterPredicate filter) throws IOException {

--- a/core/src/test/java/dev/hardwood/internal/predicate/DictionaryFixedLenByteArrayPushDownTest.java
+++ b/core/src/test/java/dev/hardwood/internal/predicate/DictionaryFixedLenByteArrayPushDownTest.java
@@ -81,7 +81,7 @@ class DictionaryFixedLenByteArrayPushDownTest {
     }
 
     private static RowGroupDictionaryFilterSource dictionaries() {
-        return new RowGroupDictionaryFilterSource(inputFile, rowGroup, schema, context);
+        return new RowGroupDictionaryFilterSource(inputFile, rowGroup, 0, schema, context);
     }
 
     private static boolean dictionaryDrop(FilterPredicate filter) throws IOException {

--- a/core/src/test/java/dev/hardwood/internal/predicate/DictionaryFloat16PushDownTest.java
+++ b/core/src/test/java/dev/hardwood/internal/predicate/DictionaryFloat16PushDownTest.java
@@ -87,7 +87,7 @@ class DictionaryFloat16PushDownTest {
     }
 
     private static RowGroupDictionaryFilterSource dictionaries() {
-        return new RowGroupDictionaryFilterSource(inputFile, rowGroup, schema, context);
+        return new RowGroupDictionaryFilterSource(inputFile, rowGroup, 0, schema, context);
     }
 
     private static boolean dictionaryDrop(FilterPredicate filter) throws IOException {

--- a/core/src/test/java/dev/hardwood/internal/predicate/DictionaryNumericPushDownTest.java
+++ b/core/src/test/java/dev/hardwood/internal/predicate/DictionaryNumericPushDownTest.java
@@ -128,7 +128,7 @@ class DictionaryNumericPushDownTest {
     }
 
     private static RowGroupDictionaryFilterSource dictionaries() {
-        return new RowGroupDictionaryFilterSource(inputFile, rowGroup, schema, context);
+        return new RowGroupDictionaryFilterSource(inputFile, rowGroup, 0, schema, context);
     }
 
     private static boolean dictionaryDrop(FilterPredicate filter) throws IOException {

--- a/core/src/test/java/dev/hardwood/internal/predicate/DictionaryPushDownTest.java
+++ b/core/src/test/java/dev/hardwood/internal/predicate/DictionaryPushDownTest.java
@@ -65,7 +65,7 @@ class DictionaryPushDownTest {
     void fixtureIsDictionaryEncoded() throws IOException {
         // A readable dictionary is exactly what the push-down precondition amounts to: the chunk is
         // fully dictionary-encoded and its page is locatable.
-        assertThat(new RowGroupDictionaryFilterSource(inputFile, rowGroup, schema, context)
+        assertThat(new RowGroupDictionaryFilterSource(inputFile, rowGroup, 0, schema, context)
                 .forColumn(CATEGORY_COLUMN)).isNotNull();
     }
 
@@ -120,7 +120,7 @@ class DictionaryPushDownTest {
     }
 
     private static RowGroupDictionaryFilterSource dictionaries() {
-        return new RowGroupDictionaryFilterSource(inputFile, rowGroup, schema, context);
+        return new RowGroupDictionaryFilterSource(inputFile, rowGroup, 0, schema, context);
     }
 
     private static boolean dictionaryDrop(FilterPredicate filter) throws IOException {

--- a/core/src/test/java/dev/hardwood/internal/predicate/PageFilterEvaluatorTest.java
+++ b/core/src/test/java/dev/hardwood/internal/predicate/PageFilterEvaluatorTest.java
@@ -627,10 +627,14 @@ class PageFilterEvaluatorTest {
             assertThatThrownBy(() -> PageFilterEvaluator.computeMatchingRows(
                     new ResolvedPredicate.IsNotNullPredicate(0), rowGroup, buffers,
                     new PageFilterEvaluator.IndexLocation("indexes.parquet", 7)))
+                    // Both structs parsed and contradict each other, so this is
+                    // malformed metadata rather than a failed read.
                     .isInstanceOf(ParquetReadException.class)
-                    .hasMessage("[indexes.parquet] Failed to parse the page index of column 0"
-                            + " in row group 7: Malformed Parquet metadata: ColumnIndex describes"
-                            + " 3 pages but OffsetIndex locates 2");
+                    // The chunk carries no meta_data, so the column is named by its
+                    // ordinal; the byte is the column index's own start in the file.
+                    .hasMessage("[indexes.parquet] row group 7, column #0, column index at byte 20"
+                            + " (0x000014) — Malformed Parquet metadata: the column index"
+                            + " describes 3 pages but the offset index locates 2");
         }
     }
 

--- a/core/src/test/java/dev/hardwood/internal/predicate/dictionary/DictionarySignedZeroTest.java
+++ b/core/src/test/java/dev/hardwood/internal/predicate/dictionary/DictionarySignedZeroTest.java
@@ -49,7 +49,7 @@ class DictionarySignedZeroTest {
         RowGroup rowGroup = reader.getFileMetaData().rowGroups().getFirst();
         FileSchema schema = FileSchema.fromSchemaElements(reader.getFileMetaData().schema());
         context = HardwoodContextImpl.create();
-        dictionaries = new RowGroupDictionaryFilterSource(inputFile, rowGroup, schema, context);
+        dictionaries = new RowGroupDictionaryFilterSource(inputFile, rowGroup, 0, schema, context);
     }
 
     @AfterAll

--- a/core/src/test/java/dev/hardwood/internal/predicate/dictionary/RowGroupDictionaryFilterSourceTest.java
+++ b/core/src/test/java/dev/hardwood/internal/predicate/dictionary/RowGroupDictionaryFilterSourceTest.java
@@ -151,9 +151,9 @@ class RowGroupDictionaryFilterSourceTest {
 
             assertThatThrownBy(() -> source.forColumn(DICTIONARY_COLUMN))
                     .isInstanceOf(ParquetReadException.class)
-                    .hasMessage("[column_index_pushdown_dict.parquet] Malformed Parquet metadata: column 1"
-                            + " declares a dictionary page at offset 4096 which lies after its"
-                            + " first data page at offset 1024");
+                    .hasMessage("[column_index_pushdown_dict.parquet] row group 0, column category,"
+                            + " dictionary page at byte 4096 (0x001000) — Malformed Parquet"
+                            + " metadata: the dictionary page lies after the first data page at offset 1024");
         });
     }
 
@@ -164,9 +164,10 @@ class RowGroupDictionaryFilterSourceTest {
 
             assertThatThrownBy(() -> source.forColumn(DICTIONARY_COLUMN))
                     .isInstanceOf(ParquetReadException.class)
-                    .hasMessage("[column_index_pushdown_dict.parquet] Malformed Parquet metadata: column 1"
-                            + " declares a dictionary page at offset 95903 but its chunk ends"
-                            + " at offset 95903");
+                    .hasMessage("[column_index_pushdown_dict.parquet] row group 0, column category,"
+                            + " dictionary page at byte 95903 (0x01769f) — Malformed Parquet"
+                            + " metadata: the chunk holding the dictionary page ends at offset 95903, so it"
+                            + " holds no bytes at all");
         });
     }
 
@@ -180,9 +181,10 @@ class RowGroupDictionaryFilterSourceTest {
 
             assertThatThrownBy(() -> source.forColumn(DICTIONARY_COLUMN))
                     .isInstanceOf(ParquetReadException.class)
-                    .hasMessage("[column_index_pushdown_dict.parquet] Malformed Parquet metadata: column 1"
-                            + " declares a dictionary page of 106 bytes but only 50 bytes remain"
-                            + " in its chunk");
+                    .hasMessage("[column_index_pushdown_dict.parquet] row group 0, column category,"
+                            + " dictionary page at byte 95903 (0x01769f) — Malformed Parquet"
+                            + " metadata: the dictionary page header declares 106 bytes but only 50 remain"
+                            + " in the chunk");
         });
     }
 
@@ -227,7 +229,7 @@ class RowGroupDictionaryFilterSourceTest {
         }
 
         RowGroupDictionaryFilterSource source() {
-            return new RowGroupDictionaryFilterSource(inputFile, rowGroup, schema, context);
+            return new RowGroupDictionaryFilterSource(inputFile, rowGroup, 0, schema, context);
         }
 
         RowGroupDictionaryFilterSource sourceWithOffsets(Long dictionaryPageOffset, long dataPageOffset) {
@@ -271,7 +273,7 @@ class RowGroupDictionaryFilterSourceTest {
                     .map(chunk -> chunk == original ? replacement : chunk)
                     .toList();
             return new RowGroupDictionaryFilterSource(inputFile,
-                    new RowGroup(columns, rowGroup.totalByteSize(), rowGroup.numRows()),
+                    new RowGroup(columns, rowGroup.totalByteSize(), rowGroup.numRows()), 0,
                     schema, context);
         }
     }

--- a/core/src/test/java/dev/hardwood/internal/reader/ColumnWorkerTest.java
+++ b/core/src/test/java/dev/hardwood/internal/reader/ColumnWorkerTest.java
@@ -21,6 +21,7 @@ import dev.hardwood.InputFile;
 import dev.hardwood.internal.schema.ProjectedSchema;
 import dev.hardwood.metadata.PhysicalType;
 import dev.hardwood.reader.ParquetFileReader;
+import dev.hardwood.reader.ParquetReadException;
 import dev.hardwood.schema.ColumnSchema;
 import dev.hardwood.schema.FileSchema;
 
@@ -243,6 +244,36 @@ class ColumnWorkerTest {
                     .isInstanceOf(RuntimeException.class)
                     .hasMessageContaining("Simulated pipeline error");
         }
+    }
+
+    /// Working out what to say about a failure must not be able to discard it.
+    ///
+    /// These catches are the only thing that reports a decode failure at all —
+    /// the future running the task drops what escapes it — so a throw while
+    /// describing one would hang the read instead of failing it, with no
+    /// exception and no log line. Asserted here because that outcome is
+    /// invisible in every other test: a hang looks like a slow test.
+    @Test
+    void describingAFailureCannotDiscardIt() {
+        ParquetReadException original = new ParquetReadException("the page is corrupt");
+
+        Throwable reported = ColumnWorker.describedOrRaw(original, () -> {
+            throw new NullPointerException("bug while describing");
+        });
+
+        assertThat(reported).isSameAs(original);
+        assertThat(reported.getSuppressed()).hasSize(1);
+        assertThat(reported.getSuppressed()[0]).isInstanceOf(NullPointerException.class)
+                .hasMessage("bug while describing");
+    }
+
+    /// And when describing works, its answer is what the caller gets.
+    @Test
+    void aDescribedFailureIsTheOneReported() {
+        ParquetReadException original = new ParquetReadException("raw");
+        ParquetReadException described = new ParquetReadException("described");
+
+        assertThat(ColumnWorker.describedOrRaw(original, () -> described)).isSameAs(described);
     }
 
     /// Nested pipeline delivers all rows with pre-computed index structures.

--- a/core/src/test/java/dev/hardwood/internal/reader/CountingInputFile.java
+++ b/core/src/test/java/dev/hardwood/internal/reader/CountingInputFile.java
@@ -13,7 +13,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
 
 import dev.hardwood.InputFile;
-import dev.hardwood.internal.FetchReason;
+import dev.hardwood.internal.ReadScope;
 
 /// An [InputFile] wrapper that delegates to another `InputFile` and counts both the number of
 /// [#readRange] calls and the total bytes read. Useful in tests that need to assert on I/O patterns
@@ -59,7 +59,7 @@ public class CountingInputFile implements InputFile {
     @Override
     public ByteBuffer readRange(long offset, int length) throws IOException {
         readRangeCount.incrementAndGet();
-        if (FetchReason.current().startsWith("footer-")) {
+        if (readingFileMetadata()) {
             footerReadCount.incrementAndGet();
         }
         bytesRead.addAndGet(length);
@@ -80,5 +80,12 @@ public class CountingInputFile implements InputFile {
     public void close() throws IOException {
         closeCount.incrementAndGet();
         delegate.close();
+    }
+
+    /// Whether the read in progress is of the file's own bookkeeping — the
+    /// magic markers, the footer length, the footer — rather than of its data.
+    private static boolean readingFileMetadata() {
+        ReadScope.Place place = ReadScope.current();
+        return place != null && place.region() != null && place.region().isFileMetadata();
     }
 }

--- a/core/src/test/java/dev/hardwood/internal/reader/FileMetadataCacheTest.java
+++ b/core/src/test/java/dev/hardwood/internal/reader/FileMetadataCacheTest.java
@@ -24,7 +24,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
 
 import dev.hardwood.InputFile;
-import dev.hardwood.internal.FetchReason;
+import dev.hardwood.internal.ReadScope;
 import dev.hardwood.internal.reader.FileMetadataCache.PreparedFile;
 import dev.hardwood.metadata.FileMetaData;
 import dev.hardwood.reader.ParquetFileReader;
@@ -188,7 +188,7 @@ class FileMetadataCacheTest {
 
         @Override
         public ByteBuffer readRange(long offset, int length) throws IOException {
-            if (FetchReason.current().startsWith("footer-") && firstFooterRead.compareAndSet(true, false)) {
+            if (readingFileMetadata() && firstFooterRead.compareAndSet(true, false)) {
                 footerReadStarted.countDown();
                 try {
                     if (!releaseFooterRead.await(WAIT_SECONDS, TimeUnit.SECONDS)) {
@@ -218,5 +218,12 @@ class FileMetadataCacheTest {
             closeCount.incrementAndGet();
             delegate.close();
         }
+    }
+
+    /// Whether the read in progress is of the file's own bookkeeping — the
+    /// magic markers, the footer length, the footer — rather than of its data.
+    private static boolean readingFileMetadata() {
+        ReadScope.Place place = ReadScope.current();
+        return place != null && place.region() != null && place.region().isFileMetadata();
     }
 }

--- a/core/src/test/java/dev/hardwood/internal/thrift/CorruptFooterNamingTest.java
+++ b/core/src/test/java/dev/hardwood/internal/thrift/CorruptFooterNamingTest.java
@@ -26,7 +26,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 /// by byte, which is exact but says nothing about whether the naming reaches a
 /// failure in a file PyArrow wrote, through the API a user calls. This damages
 /// one, opens it the way a caller would, and checks the whole message they see
-/// — the file it came from included.
+/// — the file, the byte and the field.
 class CorruptFooterNamingTest {
 
     /// Byte 195 of `plain_uncompressed.parquet` is the field header for
@@ -45,8 +45,13 @@ class CorruptFooterNamingTest {
                 Path.of("src/test/resources/plain_uncompressed.parquet"));
         damaged[FIELD_HEADER_BYTE] ^= (byte) (1 << WIRE_TYPE_BIT);
 
+        // The byte the message names is the byte this test damaged: the region
+        // says where the footer starts and the parse says how far into it it
+        // got, and neither half knows the answer on its own.
         assertThatThrownBy(() -> ParquetFileReader.open(InputFile.of(ByteBuffer.wrap(damaged))))
                 .isInstanceOf(ParquetReadException.class)
-                .hasMessage("[<memory>] SchemaElement.type — Unknown field type: 13");
+                .hasMessage("[<memory>] footer at byte " + FIELD_HEADER_BYTE
+                        + String.format(" (0x%06x)", FIELD_HEADER_BYTE)
+                        + " — SchemaElement.type — Unknown field type: 13");
     }
 }

--- a/core/src/test/java/dev/hardwood/reader/FixedWidthSchemaValidationTest.java
+++ b/core/src/test/java/dev/hardwood/reader/FixedWidthSchemaValidationTest.java
@@ -60,8 +60,8 @@ class FixedWidthSchemaValidationTest {
         try (ParquetFileReader reader = ParquetFileReader.open(InputFile.of(file))) {
             assertThatThrownBy(() -> reader.buildRowReader().projection(ColumnProjection.columns("digest")).build())
                     .isInstanceOf(SchemaIncompatibleException.class)
-                    .hasMessage("[no-width.parquet] Column 'digest' is a FIXED_LEN_BYTE_ARRAY "
-                            + "that declares no type length");
+                    .hasMessage("[no-width.parquet] column digest — FIXED_LEN_BYTE_ARRAY declares no type"
+                            + " length");
         }
     }
 
@@ -72,8 +72,8 @@ class FixedWidthSchemaValidationTest {
         try (ParquetFileReader reader = ParquetFileReader.open(InputFile.of(file))) {
             assertThatThrownBy(() -> reader.buildRowReader().projection(ColumnProjection.columns("digest")).build())
                     .isInstanceOf(SchemaIncompatibleException.class)
-                    .hasMessage("[zero-width.parquet] Column 'digest' declares a FIXED_LEN_BYTE_ARRAY "
-                            + "type length of 0, which must be positive");
+                    .hasMessage("[zero-width.parquet] column digest — FIXED_LEN_BYTE_ARRAY declares a type"
+                            + " length of 0, which must be positive");
         }
     }
 
@@ -84,8 +84,8 @@ class FixedWidthSchemaValidationTest {
         try (ParquetFileReader reader = ParquetFileReader.open(InputFile.of(file))) {
             assertThatThrownBy(() -> reader.columnReaders(ColumnProjection.columns("digest")))
                     .isInstanceOf(SchemaIncompatibleException.class)
-                    .hasMessage("[negative-width.parquet] Column 'digest' declares a FIXED_LEN_BYTE_ARRAY "
-                            + "type length of -4, which must be positive");
+                    .hasMessage("[negative-width.parquet] column digest — FIXED_LEN_BYTE_ARRAY declares a"
+                            + " type length of -4, which must be positive");
         }
     }
 
@@ -99,8 +99,8 @@ class FixedWidthSchemaValidationTest {
                     .filter(FilterPredicate.gt("price", new BigDecimal("1.00")))
                     .build())
                             .isInstanceOf(SchemaIncompatibleException.class)
-                            .hasMessage("[no-decimal-width.parquet] Column 'price' is a FIXED_LEN_BYTE_ARRAY "
-                                    + "that declares no type length");
+                            .hasMessage("[no-decimal-width.parquet] column price — FIXED_LEN_BYTE_ARRAY"
+                                    + " declares no type length");
         }
     }
 

--- a/docs/content/reference/error-handling.md
+++ b/docs/content/reference/error-handling.md
@@ -54,6 +54,32 @@ Requesting the wrong type for a column — `getLong` on an `INT32` column — is
 error whose exception type is deliberately unspecified, and is covered in
 [Type mismatches](accessors.md#type-mismatches).
 
+### What a read failure's message says
+
+A failure raised while reading a file states where the read was, in front of what
+went wrong:
+
+```
+[orders.parquet] row group 3, column customer.id, page header at byte 41104 (0x00a090) — PageHeader.type — Unknown field type: 15
+```
+
+The parts, in order, each present only when it is known:
+
+| Part | Means |
+|---|---|
+| `[orders.parquet]` | the file being read. `[<memory>]` for a file read from a `ByteBuffer` |
+| `row group 3` | the row group. Absent for the footer and for a batch that spans a file boundary |
+| `column customer.id` | the column chunk, by path. `column #0` where the file's own metadata does not name the column |
+| `page header` | what was being read: `magic bytes`, `footer length`, `footer`, `column index`, `offset index`, `row-group index`, `bloom filter`, `chunk fetch`, `dictionary page`, `page fetch`, `page header`, `data page`, `batch assembly` |
+| `at byte 41104 (0x00a090)` | the byte to go and look at, in decimal and hex. Absent where nothing narrows the failure to one — a `data page` names the page through its row group and column instead |
+| `PageHeader.type` | the Thrift struct and field a metadata parse stopped on, named from `parquet.thrift`. Only on a parse failure, and only where the field has a name in the format |
+
+An `UnsupportedOperationException` names the file and nothing else. The file is
+correct, so there is no byte to go and look at.
+
+Both the message and the position are subject to change between releases; match on
+the exception type rather than parsing the text.
+
 Reading a `RowReader` inside a `Stream` or an `Iterator` means adapting a checked
 exception to an interface that cannot declare one. Wrap it in
 `UncheckedIOException` at that boundary and unwrap it where the stream is

--- a/parquet-testing-runner/src/test/java/dev/hardwood/testing/BadDataHandlingTest.java
+++ b/parquet-testing-runner/src/test/java/dev/hardwood/testing/BadDataHandlingTest.java
@@ -47,8 +47,9 @@ class BadDataHandlingTest {
     void rejectParquet1481() throws IOException {
         // Corrupted schema Thrift value: physical type field is -7
         assertBadDataRejected("PARQUET-1481.parquet",
-                "[PARQUET-1481.parquet] Invalid or corrupt physical type value: -7 (expected 0-7)."
-                        + " File metadata may be corrupted");
+                "[PARQUET-1481.parquet] footer at byte 289 (0x000121) — Invalid"
+                        + " or corrupt physical type value: -7 (expected 0-7). File metadata"
+                        + " may be corrupted");
     }
 
     @Test
@@ -86,16 +87,20 @@ class BadDataHandlingTest {
     void rejectArrowGH45185() throws IOException {
         // Repetition levels start with 1 instead of the required 0
         assertBadDataRejected("ARROW-GH-45185.parquet",
-                "[ARROW-GH-45185.parquet] Invalid column chunk for 'element':"
-                        + " first repetition level must be 0 but was 1");
+                "[ARROW-GH-45185.parquet] row group 0, column x.list.element, batch assembly"
+                        + " — Invalid column chunk: first repetition level must be 0 but was 1");
     }
 
     @Test
     void rejectArrowGH47662() throws IOException {
         // Schema declares flba_field as required fixed_len_byte_array(4) with
         // 1000 values, but the page data runs out at value 92.
-        assertBadDataRejected("ARROW-GH-47662.parquet",
-                "[ARROW-GH-47662.parquet] Unexpected EOF while reading fixed-length byte array");
+        // No byte is asserted, and none is reported: the failure ran out of
+        // input part way through a page, which names no byte of its own.
+        Utils.assertBadDataRejectedContaining("ARROW-GH-47662.parquet",
+                readAction("ARROW-GH-47662.parquet"),
+                "[ARROW-GH-47662.parquet] row group 0, column flba_field, data page",
+                " — Unexpected EOF while reading fixed-length byte array");
     }
 
     @Test
@@ -104,21 +109,24 @@ class BadDataHandlingTest {
         // The CRC IOException is wrapped in UncheckedIOException with file context
         // by ColumnWorker before BatchExchange forwards it.
         assertCorruptChecksumRejected("data/datapage_v1-corrupt-checksum.parquet",
-                "[datapage_v1-corrupt-checksum.parquet]"
-                        + " CRC mismatch for column a: expected bbce3b9d but computed f4f6d0a",
-                "CRC mismatch for column a: expected bbce3b9d but computed f4f6d0a");
+                "[datapage_v1-corrupt-checksum.parquet] row group 0, column a, data page",
+                " — CRC mismatch: expected bbce3b9d but computed f4f6d0a",
+                "CRC mismatch: expected bbce3b9d but computed f4f6d0a");
     }
 
     @Test
     void rejectCorruptDictionaryChecksum() throws IOException {
-        // Intentionally corrupted CRC checksum in dictionary page. The mismatch
-        // is a ParquetReadException and so passes IndexedFetchPlan's
-        // `catch (IOException)`, which would have retitled it after the step
-        // that noticed rather than the thing that is wrong.
+        // Intentionally corrupted CRC checksum in dictionary page.
+        // The fetch plan attaches the region and the dictionary's own offset,
+        // which the retriever's catch could not: it knows only that a fetch was
+        // in progress, and would have reported this as "page fetch". A checksum
+        // mismatch is the file being wrong, so it arrives there unchecked and is
+        // caught as a `ParquetReadException` rather than an `IOException`.
         assertCorruptChecksumRejected("data/rle-dict-uncompressed-corrupt-checksum.parquet",
-                "[rle-dict-uncompressed-corrupt-checksum.parquet] CRC mismatch for column"
-                        + " long_field: expected 6522df6a but computed 6522df69",
-                "CRC mismatch for column long_field: expected 6522df6a but computed 6522df69");
+                "[rle-dict-uncompressed-corrupt-checksum.parquet] row group 0,"
+                        + " column long_field, dictionary page",
+                " — CRC mismatch: expected 6522df6a but computed 6522df69",
+                "CRC mismatch: expected 6522df6a but computed 6522df69");
     }
 
     @Test
@@ -146,8 +154,9 @@ class BadDataHandlingTest {
         Path good = repoDir.resolve("data/alltypes_plain.parquet");
         Path bad = repoDir.resolve("bad_data/PARQUET-1481.parquet");
         Utils.assertBadDataRejected("PARQUET-1481.parquet",
-                "[PARQUET-1481.parquet] Invalid or corrupt physical type value: -7 (expected 0-7)."
-                        + " File metadata may be corrupted",
+                "[PARQUET-1481.parquet] footer at byte 289 (0x000121) — Invalid"
+                        + " or corrupt physical type value: -7 (expected 0-7). File metadata"
+                        + " may be corrupted",
                 concatenatedReadAction(good, bad));
     }
 
@@ -164,14 +173,15 @@ class BadDataHandlingTest {
         Path good = repoDir.resolve("data/good_c.parquet");
         Path bad = repoDir.resolve("bad_data/ARROW-RS-GH-6229-LEVELS.parquet");
         Utils.assertBadDataRejected("ARROW-RS-GH-6229-LEVELS.parquet",
-                "[ARROW-RS-GH-6229-LEVELS.parquet] Column 'c' not found",
+                "[ARROW-RS-GH-6229-LEVELS.parquet] column c — Not present in this file's schema",
                 concatenatedReadAction(good, bad));
     }
 
     // ==================== Helpers ====================
 
-    private void assertCorruptChecksumRejected(String relativePath, String expectedMessage,
-                                                String expectedCauseMessage) throws IOException {
+    private void assertCorruptChecksumRejected(String relativePath, String messageStart,
+                                                String messageEnd, String expectedCauseMessage)
+            throws IOException {
         Path testFile = repoDir.resolve(relativePath);
 
         assertThatThrownBy(() -> {
@@ -182,8 +192,7 @@ class BadDataHandlingTest {
                 }
             }
         }).as("Expected %s to be rejected due to corrupt checksum", relativePath)
-          .hasMessage(expectedMessage)
-          .hasRootCauseMessage(expectedCauseMessage);
+          .hasMessageContainingAll(messageStart, messageEnd, expectedCauseMessage);
     }
 
     private ThrowableAssert.ThrowingCallable readAction(String fileName) {

--- a/parquet-testing-runner/src/test/java/dev/hardwood/testing/Utils.java
+++ b/parquet-testing-runner/src/test/java/dev/hardwood/testing/Utils.java
@@ -221,6 +221,20 @@ public class Utils {
                 .hasMessage(expectedMessage);
     }
 
+    /// Asserts the message of a rejection whose text carries a byte offset.
+    ///
+    /// A column's pages are decoded concurrently and a corrupt file usually
+    /// ruins several of them, so the offset in the message belongs to whichever
+    /// page lost the race to report first — observed as 4, 394, 784 and 2275 on
+    /// one file across four runs. The parts that identify the failure are
+    /// stable; the byte is not, and pinning it would be a flake.
+    static void assertBadDataRejectedContaining(String fileName, ThrowableAssert.ThrowingCallable action,
+            String... fragments) throws IOException {
+        assertThatThrownBy(action)
+                .as("Expected %s to be rejected", fileName)
+                .hasMessageContainingAll(fragments);
+    }
+
     /// Read all rows using parquet-java's AvroParquetReader.
     static List<GenericRecord> readWithParquetJava(Path file) throws IOException {
         List<GenericRecord> rows = new ArrayList<>();


### PR DESCRIPTION
Closes #1093. **Stacked on #1134** (`1093-thrift-field-names`), which names the field and struct a Thrift parse stopped on. This branch sits on that one, so until #1134 merges the diff below shows both. The base still reads `main` because #1097 is already the bottom of the stack carrying #1098; it becomes correct when #1134 merges. On its own this change is 57 files, +1744/−394.

A read that fails names the file and nothing else, which is the wrong grain for a format where the interesting question is always *which part*. `Failed to fetch metadata for row group 0` does not say which column, and a corrupt page arrives as `Unexpected EOF while reading fixed-length byte array` naming nothing at all.

## How

Where a failure happened is a property of the work in progress, not of the exception: the code that knows it is reading a bloom filter is the code running, and by the time a failure reaches a frame that can report it, that knowledge is gone. Every catch site that named a region was restating what its own call stack had already said.

So a region is *entered* rather than passed, and a failure takes its place at the moment it is raised — nearer the failure than any frame catching it can be — and renders it when the message is read. Raise sites throw plain exceptions carrying only what is wrong:

```java
try (ReadScope.Scope page = ReadScope.region(Region.DICTIONARY_PAGE, chunkStart)) {
    ...
    throw new ParquetReadException("Malformed Parquet metadata: the dictionary page lies"
            + " after the first data page at offset " + dataPageOffset);
}
```

No site states a position. 41 scope entries stand in for the 54 places that named a file, row group, column, region or offset in message text; the 24 that remain name a file and nothing more.

## What a caller sees

Every file in `parquet-testing`'s `bad_data`, before and after:

| fixture | main | this PR |
|---|---|---|
| ARROW-GH-47662 | `Unexpected EOF while reading fixed-length byte array` | `row group 0, column flba_field, data page — …` |
| PARQUET-1481 | `Invalid or corrupt physical type value: -7` | `footer at byte 289 (0x000121) — …` |
| ARROW-GH-41317 | `…ColumnMetaData.encodings declares…` | `footer at byte 35530 (0x008aca) — …` |
| ARROW-GH-41321 | `Invalid dictionary index bit width: 254` | `row group 0, column int64, data page — …` |
| ARROW-GH-45185 | `Invalid column chunk for 'element': …` | `row group 0, column x.list.element, batch assembly — …` |
| ARROW-RS-6229-DICTHEADER | `readRange(4, 2589) out of bounds (533 bytes)` | `row group 0, column nation_key, chunk fetch at byte 4 (0x000004) — Malformed Parquet metadata: the region of 2589 bytes at offset 4 runs past the end of the file` |
| ARROW-GH-43605 | `Cannot read ZSTD-compressed…` | unchanged — deliberately, see below |
| ARROW-RS-6229-LEVELS | `Cannot read SNAPPY-compressed…` | unchanged — deliberately |

The DICTHEADER line is the notable one: a footer pointing a chunk past EOF reached the input file's range check and arrived naming a byte range and nothing else. `InputFile.readRange` still raises `IndexOutOfBoundsException` — from outside the reader that is a bad offset, not a bad file — and the fetch, which knows the offset came from the footer, says which it is.

With #1134 underneath, a corrupt footer field gets both halves of the message the issue asks for:

```
[<memory>] footer at byte 195 (0x0000c3) — SchemaElement.type — Unknown field type: 13
```

`CorruptFooterNamingTest` asserts exactly that, deriving the expected byte from the byte it damaged.

## Properties that hold by construction

These are the reason for the shape, not side effects of it.

**A message is described once.** The place is a `final` field taken at construction, so two frames cannot describe the same failure. The check for whether message text had already been prefixed is deleted rather than reimplemented.

**A correct file we cannot read is named but never positioned.** `UnsupportedFileException` carries no place, because the file is not at fault and there is nothing at any byte to go and look at — the remedy is the same whichever column met it first. That is why the two codec messages above are untouched: not a judgement at a raise site, but a consequence of the type.

**Being described keeps the exact class.** The place is rendered into the message rather than wrapped around the exception. Rebuilding turned `SchemaIncompatibleException` into a plain `ParquetReadException`, which callers catch on. Nothing wraps to describe, so every cause chain is one layer shallower.

**The byte is the region's own address**, which is the answer everywhere but two. A region entered with no address names no byte — `DATA_PAGE`, where a decode fails an arbitrary distance in, so pointing at the page's first byte would send a reader to bytes that are intact; the row group and column already say which page it was. And a read that knows how far it got narrows the place before raising, through `ReadScope.stoppedAt`. `ThriftCompactReader` is its only caller, and reports the field header it stepped onto rather than the byte it came to rest on, which is one further along.

## Cost

`ExceptionContext`'s enrichment pass and its reflective rebuild, the `Exceptions` builder and its six entry points, three `Contextual*` carriers and `ReadContextAware` are all deleted. `ReadScope`, `PlacedIOException` and `UnsupportedFileException` replace them. The change is in how many places have to know about position, not in volume.

A full column scan of a 197-page chunk measures the same as before — p50 15.5 ms either way over three runs of 400 iterations — which bounds the per-page cost of entering a scope below the noise.

## Also fixed

`ColumnWorker`'s three outermost catches are the only thing that reports a failure at all: the decode task's own failure is discarded by the future that ran it, and each thread's dies with the thread. A throw while describing one left nothing to set the error and nothing to wake the drain, so the read hung rather than failing — with no exception and no log line to say why. Describing is now guarded, and `ColumnWorkerTest` pins that a failure while describing cannot take the original down with it.

## Split out

Rejecting a bloom filter or dictionary chunk that the footer places outside the file is #1135. Both checks were written here and taken back out: they change *which* exception a corrupt footer produces, which is a different question from where a failure happened. The chunk-fetch path keeps its check, because that is what fixes DICTHEADER above.

## Docs

`_designs/EXCEPTION_MODEL.md` gains the position layer; `docs/content/reference/error-handling.md` gains the message shape, part by part.
