### PR TITLE
[infra] Stop shielding release-notes branches from the pruner

### DIFF
--- a/tools/prune-branches.sh
+++ b/tools/prune-branches.sh
@@ -187,8 +187,8 @@ provably_merged() { # $1 = ref, $2 = display name, $3 = merge oid, $4 = pr numbe
 #                     match a merged PR head and pass every content check. Deleting
 #                     the trunk would be "safe" and catastrophic. Also covers the
 #                     origin/HEAD symref, which resolves to the trunk tip.
-#   docs / release    Publishing jobs track these by name. Their content is
-#                     merged; their job is to keep existing.
+#   docs              docs-publish.yml is dispatched against these by ref. Their
+#                     content is merged; their job is to keep existing.
 
 is_protected() { # $1 = bare branch name (no remote prefix)
   local b=$1
@@ -196,7 +196,6 @@ is_protected() { # $1 = bare branch name (no remote prefix)
     main|master|HEAD|'') return 0 ;;
     *-docs)              return 0 ;;   # 1.0.0.CR1-docs, v1.0.0.Final-docs, ...
     v[0-9]*|[0-9]*.[0-9]*) return 0 ;; # v1.0.0.CR2, 1.0.0.Beta2, ...
-    *[Rr]elease*)        return 0 ;;   # aalmiray_releases, release-*, ...
   esac
   return 1
 }


### PR DESCRIPTION
The `*[Rr]elease*` case in `is_protected()` was added for publish-tracked refs such as `release-*` and `aalmiray_releases`. No ref in the repository matches that description any more — the only branches a publishing job is dispatched against by ref are the `*-docs` ones, which the preceding pattern already matches.

Its sole remaining effect was to hold `release-notes-<version>` out of every category of the pruner, both as a local branch and on `origin`. That is an ordinary feature branch that carries a release's notes into main; it has no reason to outlive its PR, and the containment proof clears it on its own.

Verified against the current repository state with `--dry-run` before and after. The only refs newly offered are the two the guard was hiding:

```
== Local branches (merged) ==
  release-notes-1.1.0.Beta1  (PR #1070)  c977f26c [release] 1.1.0.Beta1 release notes

== origin branches you own (merged) ==
  origin/release-notes-1.1.0.Beta1  (PR #1070)  c977f26c [release] 1.1.0.Beta1 release notes
```

Nothing that was offered before stops being offered, and no `*-docs` or version branch changes status.