### PR TITLE
#1111 Leave one way to ask what a row group's statistics decided

### DIFF
--- a/_designs/ALWAYS_MATCH_STATISTICS.md
+++ b/_designs/ALWAYS_MATCH_STATISTICS.md
@@ -6,7 +6,7 @@ follow-up, see "Boundaries" below).
 ## Problem
 
 Statistics evaluation is drop-only: `StatisticsFilterSupport.canDropLeaf`,
-`RowGroupFilterEvaluator.canDropRowGroup`, and `PageDropPredicates.canDropPage` answer
+`RowGroupFilterEvaluator.decideRowGroup`, and `PageDropPredicates.canDropPage` answer
 only "can no rows match?". Every surviving unit is then evaluated row by row — the
 compiled `RowMatcher` on the record path, per-column `ColumnBatchMatcher`s on the
 drain-side path.
@@ -18,16 +18,17 @@ evaluation over those groups reproduces a foregone conclusion at full decode-sid
 
 ## The decision model
 
-`FilterDecision` (internal.predicate) is the three-valued extension of the boolean drop:
+`FilterDecision` (internal.predicate) is the three-valued extension of the boolean drop it
+replaced:
 
-| decision         | meaning                             | today's equivalent |
-|------------------|-------------------------------------|--------------------|
-| `CANNOT_MATCH`   | no row matches; skip the unit       | `canDrop == true`  |
-| `MIGHT_MATCH`    | undecided; evaluate rows            | `canDrop == false` |
-| `ALWAYS_MATCHES` | every row matches; skip evaluation  | — (new)            |
+| decision         | meaning                             |
+|------------------|-------------------------------------|
+| `CANNOT_MATCH`   | no row matches; skip the unit       |
+| `MIGHT_MATCH`    | undecided; evaluate rows            |
+| `ALWAYS_MATCHES` | every row matches; skip evaluation  |
 
-`canDropRowGroup` is now defined as `decideRowGroup(...) == CANNOT_MATCH`; there is one
-evaluation implementation, not two.
+`decideRowGroup` is the one way to ask. A boolean answer cannot carry the third decision, so
+there is no boolean form of it to fall back to.
 
 ### Leaf rule
 

--- a/_designs/BLOOM_FILTER_PUSHDOWN.md
+++ b/_designs/BLOOM_FILTER_PUSHDOWN.md
@@ -50,7 +50,7 @@ A `bloomFilterOffset` that is present but non-positive cannot name a real filter
 
 ### `RowGroupFilterEvaluator`
 
-`canDropRowGroup` gains a `BloomFilterSource` parameter, threaded unchanged through the `And` / `Or` recursion. The existing two-argument overload delegates with a `null` source (statistics only), preserving current callers and tests.
+The decision gains a `BloomFilterSource` parameter, threaded unchanged through the `And` / `Or` recursion. A `null` source evaluates statistics only.
 
 For each eligible leaf the evaluator yields `statisticsDrop || bloomDrop`:
 
@@ -61,7 +61,7 @@ A `null` source short-circuits every bloom check to "cannot drop", so the bloom 
 
 ### Callers
 
-Bloom pruning is wired in a single place. `RowGroupIterator.filterRowGroups` constructs a `RowGroupBloomFilterSource` for each row group under test and passes it to `canDropRowGroup`. This is the only statistics/bloom evaluation site: both multi-file scans and the single-file reader path run through the same iterator, so the single-file path reaches it there too. `ParquetFileReader.filterRowGroups` applies only the byte-range `RowGroupPredicate` (split selection) and never constructs a bloom source or evaluates statistics.
+Bloom pruning is wired in a single place. `RowGroupIterator.filterRowGroups` constructs a `RowGroupBloomFilterSource` for each row group under test and passes it to `decideRowGroup`. This is the only statistics/bloom evaluation site: both multi-file scans and the single-file reader path run through the same iterator, so the single-file path reaches it there too. `ParquetFileReader.filterRowGroups` applies only the byte-range `RowGroupPredicate` (split selection) and never constructs a bloom source or evaluates statistics.
 
 Row groups dropped by a bloom filter are counted in the existing `RowGroupFilterEvent.rowGroupsSkipped`, alongside statistics drops.
 

--- a/_designs/PREDICATE_PUSHDOWN.md
+++ b/_designs/PREDICATE_PUSHDOWN.md
@@ -112,7 +112,8 @@ static int compareBinary(byte[] a, byte[] b); // unsigned lexicographic
 Given a `FilterPredicate` and a `RowGroup` + `FileSchema`, determines whether the row group can be skipped.
 
 ```java
-static boolean canDropRowGroup(FilterPredicate predicate, RowGroup rowGroup, FileSchema schema);
+static FilterDecision decideRowGroup(ResolvedPredicate predicate, RowGroup rowGroup,
+        BloomFilterSource bloomFilters, RowGroupDictionaryFilterSource dictionaries);
 ```
 
 Logic per operator:
@@ -234,7 +235,7 @@ Parses fields 6 (column_index_offset) and 7 (column_index_length).
 ### New file: `core/src/test/java/dev/hardwood/FilterPredicateTest.java`
 - Unit tests for each predicate type and operator
 - Tests for And/Or/Not composition
-- Tests for row group filter evaluation (canDropRowGroup) with constructed RowGroup/Statistics objects
+- Tests for row group filter evaluation (decideRowGroup) with constructed RowGroup/Statistics objects
 - Edge cases: negative ranges, boundary values, missing statistics, single-value ranges
 
 ### New file: `core/src/test/java/dev/hardwood/PredicatePushDownTest.java`

--- a/core/src/main/java/dev/hardwood/internal/predicate/RowGroupFilterEvaluator.java
+++ b/core/src/main/java/dev/hardwood/internal/predicate/RowGroupFilterEvaluator.java
@@ -37,44 +37,6 @@ import dev.hardwood.reader.FilterPredicate;
 /// All three sources are independent: whichever proves no match first drops the row group.
 public class RowGroupFilterEvaluator {
 
-    /// Determines whether a row group can be skipped using statistics only (no bloom filters and no
-    /// dictionaries).
-    ///
-    /// @param predicate the resolved predicate to evaluate
-    /// @param rowGroup the row group to check
-    /// @return `true` if the row group can be safely skipped (no matching rows),
-    ///         `false` if it may contain matching rows
-    public static boolean canDropRowGroup(ResolvedPredicate predicate, RowGroup rowGroup) {
-        return canDropRowGroup(predicate, rowGroup, null);
-    }
-
-    /// Determines whether a row group can be skipped based on the given resolved predicate,
-    /// consulting bloom filters but no dictionaries.
-    ///
-    /// @param predicate the resolved predicate to evaluate
-    /// @param rowGroup the row group to check
-    /// @param bloomFilters source of the row group's bloom filters, or `null` to evaluate
-    ///        statistics only
-    /// @return `true` if the row group can be safely skipped (no matching rows),
-    ///         `false` if it may contain matching rows
-    public static boolean canDropRowGroup(ResolvedPredicate predicate, RowGroup rowGroup,
-            BloomFilterSource bloomFilters) {
-        return decideRowGroup(predicate, rowGroup, bloomFilters) == FilterDecision.CANNOT_MATCH;
-    }
-
-    /// Evaluates the predicate against the row group's statistics and bloom filters as a
-    /// three-valued [FilterDecision], without consulting dictionaries.
-    ///
-    /// @param predicate the resolved predicate to evaluate
-    /// @param rowGroup the row group to check
-    /// @param bloomFilters source of the row group's bloom filters, or `null` to evaluate
-    ///        statistics only
-    /// @return the statistics decision for the row group
-    public static FilterDecision decideRowGroup(ResolvedPredicate predicate, RowGroup rowGroup,
-            BloomFilterSource bloomFilters) {
-        return decideRowGroup(predicate, rowGroup, bloomFilters, null);
-    }
-
     /// Evaluates the predicate against the row group's statistics, bloom filters and dictionaries
     /// as a three-valued [FilterDecision].
     ///

--- a/core/src/test/java/dev/hardwood/FilterPredicateTest.java
+++ b/core/src/test/java/dev/hardwood/FilterPredicateTest.java
@@ -24,6 +24,7 @@ import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.EnumSource;
 import org.junit.jupiter.params.provider.MethodSource;
 
+import dev.hardwood.internal.predicate.FilterDecision;
 import dev.hardwood.internal.predicate.FilterPredicateResolver;
 import dev.hardwood.internal.predicate.ResolvedPredicate;
 import dev.hardwood.internal.predicate.RowGroupFilterEvaluator;
@@ -1405,6 +1406,6 @@ class FilterPredicateTest {
     /// This mirrors the production code path: resolve first, then evaluate.
     private static boolean canDropRowGroup(FilterPredicate filter, RowGroup rg, FileSchema schema) {
         ResolvedPredicate resolved = FilterPredicateResolver.resolve(filter, schema);
-        return RowGroupFilterEvaluator.canDropRowGroup(resolved, rg);
+        return RowGroupFilterEvaluator.decideRowGroup(resolved, rg, null, null) == FilterDecision.CANNOT_MATCH;
     }
 }

--- a/core/src/test/java/dev/hardwood/internal/predicate/BloomFilterPushDownTest.java
+++ b/core/src/test/java/dev/hardwood/internal/predicate/BloomFilterPushDownTest.java
@@ -300,13 +300,13 @@ class BloomFilterPushDownTest {
 
     private static boolean bloomDrop(FilterPredicate filter) {
         ResolvedPredicate resolved = FilterPredicateResolver.resolve(filter, schema);
-        return RowGroupFilterEvaluator.canDropRowGroup(resolved, rowGroup,
-                new RowGroupBloomFilterSource(inputFile, rowGroup));
+        return RowGroupFilterEvaluator.decideRowGroup(resolved, rowGroup,
+                new RowGroupBloomFilterSource(inputFile, rowGroup), null) == FilterDecision.CANNOT_MATCH;
     }
 
     private static boolean statisticsDrop(FilterPredicate filter) {
         ResolvedPredicate resolved = FilterPredicateResolver.resolve(filter, schema);
-        return RowGroupFilterEvaluator.canDropRowGroup(resolved, rowGroup);
+        return RowGroupFilterEvaluator.decideRowGroup(resolved, rowGroup, null, null) == FilterDecision.CANNOT_MATCH;
     }
 
     /// A `BloomFilterHeader` thrift struct followed by a minimal one-block (32-byte) bitset holding

--- a/core/src/test/java/dev/hardwood/internal/predicate/BloomFilterSignedZeroPushDownTest.java
+++ b/core/src/test/java/dev/hardwood/internal/predicate/BloomFilterSignedZeroPushDownTest.java
@@ -71,12 +71,12 @@ class BloomFilterSignedZeroPushDownTest {
 
     private static boolean bloomDrop(FilterPredicate filter) {
         ResolvedPredicate resolved = FilterPredicateResolver.resolve(filter, schema);
-        return RowGroupFilterEvaluator.canDropRowGroup(resolved, rowGroup,
-                new RowGroupBloomFilterSource(inputFile, rowGroup));
+        return RowGroupFilterEvaluator.decideRowGroup(resolved, rowGroup,
+                new RowGroupBloomFilterSource(inputFile, rowGroup), null) == FilterDecision.CANNOT_MATCH;
     }
 
     private static boolean statisticsDrop(FilterPredicate filter) {
         ResolvedPredicate resolved = FilterPredicateResolver.resolve(filter, schema);
-        return RowGroupFilterEvaluator.canDropRowGroup(resolved, rowGroup);
+        return RowGroupFilterEvaluator.decideRowGroup(resolved, rowGroup, null, null) == FilterDecision.CANNOT_MATCH;
     }
 }

--- a/core/src/test/java/dev/hardwood/internal/predicate/DictionaryFixedLenByteArrayPushDownTest.java
+++ b/core/src/test/java/dev/hardwood/internal/predicate/DictionaryFixedLenByteArrayPushDownTest.java
@@ -91,6 +91,6 @@ class DictionaryFixedLenByteArrayPushDownTest {
 
     private static boolean statisticsDrop(FilterPredicate filter) {
         ResolvedPredicate resolved = FilterPredicateResolver.resolve(filter, schema);
-        return RowGroupFilterEvaluator.canDropRowGroup(resolved, rowGroup);
+        return RowGroupFilterEvaluator.decideRowGroup(resolved, rowGroup, null, null) == FilterDecision.CANNOT_MATCH;
     }
 }

--- a/core/src/test/java/dev/hardwood/internal/predicate/DictionaryFloat16PushDownTest.java
+++ b/core/src/test/java/dev/hardwood/internal/predicate/DictionaryFloat16PushDownTest.java
@@ -97,6 +97,6 @@ class DictionaryFloat16PushDownTest {
 
     private static boolean statisticsDrop(FilterPredicate filter) {
         ResolvedPredicate resolved = FilterPredicateResolver.resolve(filter, schema);
-        return RowGroupFilterEvaluator.canDropRowGroup(resolved, rowGroup);
+        return RowGroupFilterEvaluator.decideRowGroup(resolved, rowGroup, null, null) == FilterDecision.CANNOT_MATCH;
     }
 }

--- a/core/src/test/java/dev/hardwood/internal/predicate/DictionaryNumericPushDownTest.java
+++ b/core/src/test/java/dev/hardwood/internal/predicate/DictionaryNumericPushDownTest.java
@@ -138,6 +138,6 @@ class DictionaryNumericPushDownTest {
 
     private static boolean statisticsDrop(FilterPredicate filter) {
         ResolvedPredicate resolved = FilterPredicateResolver.resolve(filter, schema);
-        return RowGroupFilterEvaluator.canDropRowGroup(resolved, rowGroup);
+        return RowGroupFilterEvaluator.decideRowGroup(resolved, rowGroup, null, null) == FilterDecision.CANNOT_MATCH;
     }
 }

--- a/core/src/test/java/dev/hardwood/internal/predicate/DictionaryPushDownTest.java
+++ b/core/src/test/java/dev/hardwood/internal/predicate/DictionaryPushDownTest.java
@@ -130,6 +130,6 @@ class DictionaryPushDownTest {
 
     private static boolean statisticsDrop(FilterPredicate filter) {
         ResolvedPredicate resolved = FilterPredicateResolver.resolve(filter, schema);
-        return RowGroupFilterEvaluator.canDropRowGroup(resolved, rowGroup);
+        return RowGroupFilterEvaluator.decideRowGroup(resolved, rowGroup, null, null) == FilterDecision.CANNOT_MATCH;
     }
 }

--- a/core/src/test/java/dev/hardwood/internal/predicate/RowGroupDecideTest.java
+++ b/core/src/test/java/dev/hardwood/internal/predicate/RowGroupDecideTest.java
@@ -30,8 +30,8 @@ import static dev.hardwood.internal.predicate.FilterDecision.MIGHT_MATCH;
 import static org.assertj.core.api.Assertions.assertThat;
 
 /// [RowGroupFilterEvaluator#decideRowGroup] behavior over whole row groups: leaf decisions
-/// with row-group [Statistics], `AND`/`OR` composition, null predicates, and the
-/// equivalence of `canDropRowGroup` with the [FilterDecision#CANNOT_MATCH] decision.
+/// with row-group [Statistics], `AND`/`OR` composition, null predicates, and one cutoff per
+/// decision against a single row group.
 class RowGroupDecideTest {
 
     private static final int COL = 0;
@@ -97,16 +97,19 @@ class RowGroupDecideTest {
         // always-matching decision derived from statistics.
         RowGroup rg = intRowGroup(10, 20, 0L);
         BloomFilterSource noFilters = columnIndex -> null;
-        assertThat(RowGroupFilterEvaluator.decideRowGroup(intGt(5), rg, noFilters))
+        assertThat(RowGroupFilterEvaluator.decideRowGroup(intGt(5), rg, noFilters, null))
                 .isEqualTo(ALWAYS_MATCHES);
     }
 
     @Test
-    void canDropRowGroupIsTheCannotMatchDecision() {
+    void oneCutoffPerDecisionAgainstTheSameRowGroup() {
+        // Above the maximum, inside the range, below the minimum: the three answers a row
+        // group's statistics can give. Asserted as decisions rather than through a boolean,
+        // which could not tell the last two apart.
         RowGroup rg = intRowGroup(10, 20, 0L);
-        assertThat(RowGroupFilterEvaluator.canDropRowGroup(intGt(20), rg)).isTrue();
-        assertThat(RowGroupFilterEvaluator.canDropRowGroup(intGt(15), rg)).isFalse();
-        assertThat(RowGroupFilterEvaluator.canDropRowGroup(intGt(5), rg)).isFalse();
+        assertThat(decide(intGt(20), rg)).isEqualTo(CANNOT_MATCH);
+        assertThat(decide(intGt(15), rg)).isEqualTo(MIGHT_MATCH);
+        assertThat(decide(intGt(5), rg)).isEqualTo(ALWAYS_MATCHES);
     }
 
     @Test
@@ -119,7 +122,7 @@ class RowGroupDecideTest {
     // ==================== Fixtures ====================
 
     private static FilterDecision decide(ResolvedPredicate predicate, RowGroup rowGroup) {
-        return RowGroupFilterEvaluator.decideRowGroup(predicate, rowGroup, null);
+        return RowGroupFilterEvaluator.decideRowGroup(predicate, rowGroup, null, null);
     }
 
     private static ResolvedPredicate intGt(int value) {


### PR DESCRIPTION
Closes #1111.

`RowGroupFilterEvaluator` published four decision methods and production called one.

```java
public static boolean       canDropRowGroup(p, rowGroup)                      // no main caller
public static boolean       canDropRowGroup(p, rowGroup, bloomFilters)        // no main caller
public static FilterDecision decideRowGroup(p, rowGroup, bloomFilters)        // no main caller
public static FilterDecision decideRowGroup(p, rowGroup, bloom, dictionaries) // RowGroupIterator
```

`RowGroupIterator` is the only caller from outside the class and it passes both sources. The
other three are a delegation chain — two arguments to three to four, boolean to decision —
that only tests enter.

Keeping them costs more than the surface. `canDropRowGroup` collapses the answer to a
boolean, which cannot carry `ALWAYS_MATCHES`: it is the shape #795 moved past when it made
the decision three-valued, kept alive by callers who only ever asked whether a row group
could be dropped.

## Why this is smaller than it looks

There are 134 bare `canDropRowGroup(` calls in the test tree but only **19 qualified ones**.
Every test class that reaches for these already wraps the call in its own helper that
resolves the predicate first:

```java
private static boolean canDropRowGroup(FilterPredicate filter, RowGroup rg, FileSchema schema) {
    ResolvedPredicate resolved = FilterPredicateResolver.resolve(filter, schema);
    return RowGroupFilterEvaluator.canDropRowGroup(resolved, rg);      // the only real call site
}
```

So the convenience the tests want already exists where it is used, and the null sources and
the comparison to `CANNOT_MATCH` move into those helpers — one line each. No new shared test
API; the private helpers keep their names, which still read correctly in test code.

## One test lost its subject

`canDropRowGroupIsTheCannotMatchDecision` existed only to pin the boolean against
`CANNOT_MATCH`. What it actually exercises is three cutoffs against a `[10, 20]` row group,
so it asserts the decisions directly now:

```java
assertThat(decide(intGt(20), rg)).isEqualTo(CANNOT_MATCH);
assertThat(decide(intGt(15), rg)).isEqualTo(MIGHT_MATCH);
assertThat(decide(intGt(5), rg)).isEqualTo(ALWAYS_MATCHES);
```

That pins **more** than before — the boolean could not tell the last two apart, and both were
previously just `isFalse()`.

## Design docs

Three named the removed methods, and one was already stale: `BLOOM_FILTER_PUSHDOWN.md` said
`RowGroupIterator.filterRowGroups` "passes it to `canDropRowGroup`", which stopped being true
at #795. `ALWAYS_MATCH_STATISTICS.md` carried a "today's equivalent" column mapping each
decision back to `canDrop == true/false`; that column is the history of the thing being
deleted, so it goes with it.

## Sequencing

On `main` these methods declare no checked exception, so this is a pure surface change. On
the `exception-model` branch (#1105) each of them picks up `throws IOException`, so landing
this first takes three methods out of that PR's cascade before the rest of it is decided.

## Testing

`./mvnw clean verify` — 2989 core, 1031 parquet-testing-runner, all modules green. No test
asserts less than it did; `RowGroupDecideTest` asserts more.
