### PR TITLE
#1104 Carry the reader's new shapes into the performance modules

### DIFF
--- a/core/src/main/java/dev/hardwood/internal/reader/PageIterator.java
+++ b/core/src/main/java/dev/hardwood/internal/reader/PageIterator.java
@@ -24,7 +24,7 @@ import java.io.IOException;
 /// what had happened. Nothing above here needs it: [PageSource#next] already
 /// declares `IOException`, and the pipeline carries a failure across its thread
 /// boundary as a `Throwable`, which a checked exception is.
-interface PageIterator {
+public interface PageIterator {
 
     /// Whether another page is available, fetching whatever is needed to know.
     ///

--- a/performance-testing/end-to-end/src/test/java/dev/hardwood/perf/NestedPerformanceTest.java
+++ b/performance-testing/end-to-end/src/test/java/dev/hardwood/perf/NestedPerformanceTest.java
@@ -764,7 +764,8 @@ class NestedPerformanceTest {
     /// Compute list sizes from a nested leaf column using the outermost
     /// REPEATED layer's offsets. Returns totalCount, and populates
     /// `sizes[0]`=totalCount, `sizes[1]`=maxCount.
-    private long computeListSizes(ParquetFileReader reader, int colIdx, long[] sizes) {
+    private long computeListSizes(ParquetFileReader reader, int colIdx, long[] sizes)
+            throws IOException {
         long totalCount = 0;
         int maxCount = 0;
 

--- a/performance-testing/end-to-end/src/test/java/dev/hardwood/perf/PageDecodeAllocationProfileTest.java
+++ b/performance-testing/end-to-end/src/test/java/dev/hardwood/perf/PageDecodeAllocationProfileTest.java
@@ -25,6 +25,7 @@ import dev.hardwood.internal.reader.MappedInputFile;
 import dev.hardwood.internal.reader.Page;
 import dev.hardwood.internal.reader.PageDecoder;
 import dev.hardwood.internal.reader.PageInfo;
+import dev.hardwood.internal.reader.PageIterator;
 import dev.hardwood.internal.reader.SequentialFetchPlan;
 import dev.hardwood.metadata.ColumnChunk;
 import dev.hardwood.metadata.ColumnMetaData;
@@ -149,7 +150,7 @@ public class PageDecodeAllocationProfileTest {
                             inputFile, columnSchema, columnChunk,
                             context, rgIdx, inputFile.name(), 0);
                     List<PageInfo> pages = new ArrayList<>();
-                    java.util.Iterator<PageInfo> iter = plan.pages();
+                    PageIterator iter = plan.pages();
                     while (iter.hasNext()) {
                         pages.add(iter.next());
                     }

--- a/performance-testing/micro-benchmarks/src/main/java/dev/hardwood/benchmarks/FixedSizeListDecodeBenchmark.java
+++ b/performance-testing/micro-benchmarks/src/main/java/dev/hardwood/benchmarks/FixedSizeListDecodeBenchmark.java
@@ -37,6 +37,7 @@ import dev.hardwood.internal.reader.FixedSizeListDetector;
 import dev.hardwood.internal.reader.FixedSizeListShape;
 import dev.hardwood.internal.reader.HardwoodContextImpl;
 import dev.hardwood.internal.reader.PageInfo;
+import dev.hardwood.internal.reader.PageIterator;
 import dev.hardwood.internal.reader.SequentialFetchPlan;
 import dev.hardwood.internal.thrift.PageHeaderReader;
 import dev.hardwood.internal.thrift.ThriftCompactReader;
@@ -203,7 +204,7 @@ public class FixedSizeListDecodeBenchmark {
                     ColumnSchema columnSchema = schema.getColumn(col);
                     SequentialFetchPlan plan = SequentialFetchPlan.build(
                             inputFile, columnSchema, chunk, context, rg, inputFile.name(), 0);
-                    Iterator<PageInfo> pages = plan.pages();
+                    PageIterator pages = plan.pages();
                     while (pages.hasNext()) {
                         PageInfo pageInfo = pages.next();
                         ByteBuffer pageBuffer = pageInfo.pageData();

--- a/performance-testing/micro-benchmarks/src/main/java/dev/hardwood/benchmarks/PageHandlingBenchmark.java
+++ b/performance-testing/micro-benchmarks/src/main/java/dev/hardwood/benchmarks/PageHandlingBenchmark.java
@@ -35,6 +35,7 @@ import dev.hardwood.internal.reader.HardwoodContextImpl;
 import dev.hardwood.internal.reader.Page;
 import dev.hardwood.internal.reader.PageDecoder;
 import dev.hardwood.internal.reader.PageInfo;
+import dev.hardwood.internal.reader.PageIterator;
 import dev.hardwood.internal.reader.SequentialFetchPlan;
 import dev.hardwood.internal.thrift.PageHeaderReader;
 import dev.hardwood.internal.thrift.ThriftCompactReader;
@@ -108,7 +109,7 @@ public class PageHandlingBenchmark {
                     SequentialFetchPlan plan = SequentialFetchPlan.build(
                             inputFile, columnSchema, columnChunk,
                             context, rgIdx, inputFile.name(), 0);
-                    java.util.Iterator<PageInfo> iter = plan.pages();
+                    PageIterator iter = plan.pages();
                     while (iter.hasNext()) {
                         allPages.add(iter.next());
                     }

--- a/performance-testing/micro-benchmarks/src/main/java/dev/hardwood/benchmarks/PageScanBenchmark.java
+++ b/performance-testing/micro-benchmarks/src/main/java/dev/hardwood/benchmarks/PageScanBenchmark.java
@@ -31,6 +31,7 @@ import org.openjdk.jmh.infra.Blackhole;
 import dev.hardwood.InputFile;
 import dev.hardwood.internal.reader.HardwoodContextImpl;
 import dev.hardwood.internal.reader.PageInfo;
+import dev.hardwood.internal.reader.PageIterator;
 import dev.hardwood.internal.reader.SequentialFetchPlan;
 import dev.hardwood.metadata.ColumnChunk;
 import dev.hardwood.metadata.ColumnMetaData;
@@ -116,7 +117,7 @@ public class PageScanBenchmark {
             SequentialFetchPlan plan = SequentialFetchPlan.build(
                     inputFile, target.columnSchema, target.columnChunk,
                     context, target.rowGroupIndex, inputFile.name(), 0);
-            java.util.Iterator<PageInfo> iter = plan.pages();
+            PageIterator iter = plan.pages();
             while (iter.hasNext()) {
                 blackhole.consume(iter.next());
             }


### PR DESCRIPTION
Fixes the `performance-tests` job on `main`, red since #1115 ([run](https://github.com/hardwood-hq/hardwood/actions/runs/34137796150)).

`performance-testing/*` builds only under `-Pperformance-test`, so `./mvnw verify` — which the PR gate runs — never compiled it. Six call sites in those modules stopped typing when the exception model changed, and nothing before the merge could have noticed.

- `NestedPerformanceTest.computeListSizes` needs `throws IOException`, since `ColumnReader.nextBatch` now declares it.
- Four `Iterator<PageInfo>` locals become `PageIterator`.
- `PageIterator` becomes public. `FetchPlan` is public and `pages()` returns this type, so leaving the interface package-private made the return type unnameable outside `dev.hardwood.internal.reader` — legal Java, and useless to anyone holding a plan. `FetchPlan`, `PageInfo` and `SequentialFetchPlan` are all public; this was an oversight. `var` is not an escape hatch here either, since the `NoVar` check forbids it.

## Checks

- `./mvnw -Pperformance-test -Dquick test-compile` — `BUILD SUCCESS`. `-Dquick` only to skip the ~100 MB-per-dataset downloads; this is a compile check, not a timing run.
- `./mvnw clean verify` — 3014 core and 1031 parquet-testing-runner tests, green.

## Worth deciding separately

The gap that let this reach `main` is still open: a change can pass the PR gate and break `main` because the gate does not build `performance-testing/*`. Either the profile joins the gate, or those modules compile under the default build with only their execution behind the profile. Happy to open an issue if you want it tracked rather than fixed here.
