### PR TITLE
#1118 Compile performance-testing in PR builds

### DIFF
--- a/.github/workflows/pr-build.yml
+++ b/.github/workflows/pr-build.yml
@@ -164,6 +164,50 @@ jobs:
           path: ~/.m2/repository/dev/hardwood/hardwood-cli/
           retention-days: 1
 
+  compile-performance-tests:
+    needs: build-s3
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+
+    steps:
+      - name: 'Check out repository'
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6 — https://github.com/actions/checkout/releases/tag/v6
+        with:
+          submodules: 'true'
+
+      - name: 'Set up Java'
+        uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654  # v5 — https://github.com/actions/setup-java/releases/tag/v5
+        with:
+          java-version: '25'
+          distribution: 'temurin'
+
+      - name: 'Cache Maven dependencies'
+        uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7  # v5 — https://github.com/actions/cache/releases/tag/v5
+        with:
+          path: ~/.m2/repository
+          key: maven-${{ runner.os }}-${{ github.job }}-${{ hashFiles('**/pom.xml') }}
+          restore-keys: |
+            maven-${{ runner.os }}-${{ github.job }}-
+            maven-${{ runner.os }}-build-s3-
+            maven-${{ runner.os }}-build-core-
+            maven-${{ runner.os }}-
+
+      - name: 'Download core and s3 artifacts'
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c  # v8 — https://github.com/actions/download-artifact/releases/tag/v8
+        with:
+          pattern: maven-repo-{core,s3}
+          path: ~/.m2/repository/dev/hardwood/
+          merge-multiple: true
+
+      - name: 'Compile performance-testing'
+        # These modules are in the reactor only under `-Pperformance-test`, so nothing
+        # else in this workflow compiles them and an API change can pass the gate and
+        # break `main`. Compiling is what catches that: every such break so far has
+        # been a compile error. Running the benchmarks is a separate workflow — they
+        # are slow and need ~100 MB per dataset — so this stops at `test-compile`, and
+        # `-Dquick` sets `testdata.download.skip` so no dataset is fetched.
+        run: ./mvnw -ntp -B -Pperformance-test -Dquick test-compile -pl :hardwood-performance-testing -amd
+
   build-parquet-java-compat:
     needs: build-s3
     runs-on: ubuntu-latest

--- a/performance-testing/micro-benchmarks/src/main/java/dev/hardwood/benchmarks/FixedSizeListDecodeBenchmark.java
+++ b/performance-testing/micro-benchmarks/src/main/java/dev/hardwood/benchmarks/FixedSizeListDecodeBenchmark.java
@@ -11,7 +11,6 @@ import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.nio.file.Path;
 import java.util.ArrayList;
-import java.util.Iterator;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
 

--- a/performance-testing/micro-benchmarks/src/main/java/dev/hardwood/benchmarks/PageScanBenchmark.java
+++ b/performance-testing/micro-benchmarks/src/main/java/dev/hardwood/benchmarks/PageScanBenchmark.java
@@ -30,7 +30,6 @@ import org.openjdk.jmh.infra.Blackhole;
 
 import dev.hardwood.InputFile;
 import dev.hardwood.internal.reader.HardwoodContextImpl;
-import dev.hardwood.internal.reader.PageInfo;
 import dev.hardwood.internal.reader.PageIterator;
 import dev.hardwood.internal.reader.SequentialFetchPlan;
 import dev.hardwood.metadata.ColumnChunk;


### PR DESCRIPTION
`performance-testing/*` is in the reactor only under `-Pperformance-test`, and no PR job enabled it, so a change could pass the gate and break `main` — which #1115 did, with six call sites that no longer typed once the reader's shapes changed.

Compiling is what catches this class of break: every failure of it so far has been a compile error. Running the benchmarks is a separate workflow and stays there, so the job stops at `test-compile`, and `-Dquick` sets `testdata.download.skip` so no dataset is fetched for a build that runs nothing.

This closes the gate for CI and not for a developer: `./mvnw verify` still leaves these modules out of the reactor. Moving them into the default modules and gating only their execution would close both, and is noted on the issue.