### PR TITLE
#1120 Stop the licence check walking the whole repository

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@ pom.xml.versionsBackup
 release.properties
 **/dependency-reduced-pom.xml
 .flattened-pom.xml
+.surefire-*/
 
 # Eclipse
 .project

--- a/.mvn/maven.config
+++ b/.mvn/maven.config
@@ -1,0 +1,6 @@
+# Build the reactor with one thread per core, and run each module's tests in
+# four JVMs rather than one. Nothing in the build was parallel before, and the
+# tests are almost all of its wall clock.
+-T
+1C
+-DforkCount=4

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -21,6 +21,7 @@ Worktrees live under `.claude/worktrees/`, which `.gitignore` excludes. They mus
 
 To run Maven, always run ./mvnw (Maven wrapper).
 Run ./mvnw verify to build the project.
+While iterating, run `./mvnw verify -DskipITs`. The integration tests are the bulk of the wall clock (~40s of ~130s), they need a Docker daemon, and they say nothing about most changes. Run the full `./mvnw verify` once before pushing, and immediately whenever the change touches what they cover: the S3 read path, the CLI's S3 commands, parquet-java compatibility, or anything that depends on the packaged JAR rather than `target/classes`. A `-DskipITs` run is not evidence that a change is ready to push.
 When doing changes in hardwood-core, install that module before running the performance tests or any other module.
 When running Maven commands, always apply a timeout of 180 seconds to detect deadlocks early on.
 Enable -Pperformance-test to run performance tests.

--- a/cli/.dockerignore
+++ b/cli/.dockerignore
@@ -1,3 +1,11 @@
+#
+#  SPDX-License-Identifier: Apache-2.0
+#
+#  Copyright The original authors
+#
+#  Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+#
+
 # Exclude everything except the files the Dockerfile COPYs.
 *
 !target/hardwood-cli

--- a/docs/screenshots/dive-screenshots.tape
+++ b/docs/screenshots/dive-screenshots.tape
@@ -1,9 +1,10 @@
-# SPDX-License-Identifier: Apache-2.0
 #
-# Copyright The original authors
+#  SPDX-License-Identifier: Apache-2.0
 #
-# Licensed under the Apache Software License version 2.0, available at
-# http://www.apache.org/licenses/LICENSE-2.0
+#  Copyright The original authors
+#
+#  Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+#
 
 # The recording output (.cast), terminal size, and fps are supplied by the
 # `screenshots` Maven profile via -Dtamboui.record* system properties; this

--- a/parquet-testing-runner/src/test/java/dev/hardwood/testing/ParquetTestingRepoCloner.java
+++ b/parquet-testing-runner/src/test/java/dev/hardwood/testing/ParquetTestingRepoCloner.java
@@ -26,27 +26,22 @@ public class ParquetTestingRepoCloner {
     /// @return path to the cloned repository
     /// @throws IOException if cloning fails
     public static Path ensureCloned() throws IOException {
-        if (Files.exists(TARGET_DIR) && Files.isDirectory(TARGET_DIR)) {
-            // Already cloned
-            return TARGET_DIR;
-        }
-
-        System.out.println("Cloning parquet-testing repository (shallow clone)...");
-
-        try {
-            Git.cloneRepository()
-                    .setURI(REPO_URL)
-                    .setDirectory(TARGET_DIR.toFile())
-                    .setDepth(1) // Shallow clone for speed
-                    .call()
-                    .close();
-
+        return SharedFixture.produceOnce(TARGET_DIR, temporary -> {
+            System.out.println("Cloning parquet-testing repository (shallow clone)...");
+            try {
+                Git.cloneRepository()
+                        .setURI(REPO_URL)
+                        .setDirectory(temporary.toFile())
+                        .setDepth(1) // Shallow clone for speed
+                        .call()
+                        .close();
+            }
+            catch (GitAPIException e) {
+                throw new IOException(
+                        "Failed to clone parquet-testing repository: " + e.getMessage(), e);
+            }
             System.out.println("Successfully cloned to: " + TARGET_DIR.toAbsolutePath());
-            return TARGET_DIR;
-        }
-        catch (GitAPIException e) {
-            throw new IOException("Failed to clone parquet-testing repository: " + e.getMessage(), e);
-        }
+        });
     }
 
     /// Get the path to a test file within the parquet-testing repository.

--- a/parquet-testing-runner/src/test/java/dev/hardwood/testing/SharedFixture.java
+++ b/parquet-testing-runner/src/test/java/dev/hardwood/testing/SharedFixture.java
@@ -1,0 +1,134 @@
+/*
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Copyright The original authors
+ *
+ *  Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package dev.hardwood.testing;
+
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.nio.file.FileAlreadyExistsException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardCopyOption;
+import java.time.Duration;
+import java.util.Comparator;
+import java.util.stream.Stream;
+
+/// Produces a fixture under `target/` exactly once, however many JVMs ask for it.
+///
+/// Surefire runs this module's tests in several forks, which makes the obvious
+/// `if (!Files.exists(f)) { create(f); }` guard wrong twice over. The forks race to
+/// create the fixture, and `f` exists from the moment creation *starts*, so a fork
+/// that loses the race does not wait — it reads a half-written file, or lists a
+/// clone that is still being checked out.
+///
+/// Both follow from the fixture being visible before it is finished, so the producer
+/// writes to a private path that is renamed into place once it returns: the fixture
+/// only ever appears complete. One fork is elected to run it by creating a claim
+/// file, `O_EXCL` being the one mutual exclusion a shared checkout can rely on —
+/// advisory locks are silently ignored on a bind-mounted filesystem, where every
+/// caller believes it holds the lock.
+final class SharedFixture {
+
+    /// How long a fork waits for the one producing the fixture. Generous, since that
+    /// can be a network clone; a fork that dies mid-production leaves its claim behind,
+    /// and waiting forever on it would look like a hung build rather than a failed one.
+    private static final Duration PRODUCTION_TIMEOUT = Duration.ofMinutes(5);
+
+    private static final Duration POLL_INTERVAL = Duration.ofMillis(50);
+
+    private SharedFixture() {
+    }
+
+    /// Produces `target` if it is not already there, and returns it.
+    ///
+    /// The producer is handed a path that does not exist and may create either a file
+    /// or a directory tree at it. It runs at most once across all forks; the others
+    /// block until it has finished and then find the result.
+    static synchronized Path produceOnce(Path target, Producer producer) throws IOException {
+        Path parent = target.getParent();
+        Files.createDirectories(parent);
+
+        // A separate file rather than the fixture itself: the fixture must not exist
+        // until it is complete, which is the whole point.
+        Path claim = parent.resolve(target.getFileName() + ".claim");
+        long deadline = System.nanoTime() + PRODUCTION_TIMEOUT.toNanos();
+
+        while (!Files.exists(target)) {
+            try {
+                Files.createFile(claim);
+            }
+            catch (FileAlreadyExistsException e) {
+                awaitProducingFork(target, claim, deadline);
+                continue;
+            }
+
+            try {
+                produceAndPublish(target, parent, producer);
+            }
+            finally {
+                Files.deleteIfExists(claim);
+            }
+        }
+
+        return target;
+    }
+
+    private static void produceAndPublish(Path target, Path parent, Producer producer)
+            throws IOException {
+        Path incomplete = parent.resolve(
+                target.getFileName() + ".incomplete-" + ProcessHandle.current().pid());
+        deleteRecursively(incomplete);
+        try {
+            producer.produce(incomplete);
+            Files.move(incomplete, target, StandardCopyOption.ATOMIC_MOVE);
+        }
+        catch (IOException | RuntimeException e) {
+            deleteRecursively(incomplete);
+            throw e;
+        }
+    }
+
+    private static void awaitProducingFork(Path target, Path claim, long deadline)
+            throws IOException {
+        if (System.nanoTime() - deadline >= 0) {
+            throw new IOException(target + " was claimed by another fork that never produced it."
+                    + " Delete " + claim + " and re-run.");
+        }
+        try {
+            Thread.sleep(POLL_INTERVAL);
+        }
+        catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new IOException("Interrupted while waiting for " + target, e);
+        }
+    }
+
+    private static void deleteRecursively(Path path) throws IOException {
+        if (!Files.exists(path)) {
+            return;
+        }
+        try (Stream<Path> entries = Files.walk(path)) {
+            entries.sorted(Comparator.reverseOrder()).forEach(entry -> {
+                try {
+                    Files.deleteIfExists(entry);
+                }
+                catch (IOException e) {
+                    throw new UncheckedIOException(e);
+                }
+            });
+        }
+        catch (UncheckedIOException e) {
+            throw e.getCause();
+        }
+    }
+
+    /// Creates the fixture at the given path, which does not yet exist.
+    @FunctionalInterface
+    interface Producer {
+        void produce(Path path) throws IOException;
+    }
+}

--- a/parquet-testing-runner/src/test/java/dev/hardwood/testing/Utils.java
+++ b/parquet-testing-runner/src/test/java/dev/hardwood/testing/Utils.java
@@ -27,6 +27,7 @@ import org.apache.avro.generic.GenericData;
 import org.apache.avro.generic.GenericRecord;
 import org.apache.avro.util.Utf8;
 import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.RawLocalFileSystem;
 import org.apache.parquet.avro.AvroParquetReader;
 import org.apache.parquet.example.data.Group;
 import org.apache.parquet.example.data.simple.SimpleGroupFactory;
@@ -168,25 +169,27 @@ public class Utils {
     /// `bad_data/ARROW-RS-GH-6229-LEVELS.parquet`, so the mid-sequence bad-data tests can
     /// read a good prefix followed by a failing file. Idempotent.
     static void ensureGoodCFile(Path repoDir) throws IOException {
-        Path output = repoDir.resolve("data/good_c.parquet");
-        if (Files.exists(output)) {
-            return;
-        }
-        MessageType schema = MessageTypeParser.parseMessageType(
-                "message schema { required int32 c; }");
-        Configuration conf = new Configuration();
-        org.apache.hadoop.fs.Path hadoopPath =
-                new org.apache.hadoop.fs.Path(output.toUri());
-        try (ParquetWriter<Group> writer = ExampleParquetWriter
-                .builder(hadoopPath)
-                .withConf(conf)
-                .withType(schema)
-                .build()) {
-            SimpleGroupFactory factory = new SimpleGroupFactory(schema);
-            writer.write(factory.newGroup().append("c", 1));
-            writer.write(factory.newGroup().append("c", 2));
-            writer.write(factory.newGroup().append("c", 3));
-        }
+        SharedFixture.produceOnce(repoDir.resolve("data/good_c.parquet"), output -> {
+            MessageType schema = MessageTypeParser.parseMessageType(
+                    "message schema { required int32 c; }");
+            Configuration conf = new Configuration();
+            // Hadoop's checksumming local filesystem writes a `.<name>.crc` sidecar,
+            // which would be orphaned when the file is renamed into place. None of the
+            // other fixtures carry one either.
+            conf.set("fs.file.impl", RawLocalFileSystem.class.getName());
+            org.apache.hadoop.fs.Path hadoopPath =
+                    new org.apache.hadoop.fs.Path(output.toUri());
+            try (ParquetWriter<Group> writer = ExampleParquetWriter
+                    .builder(hadoopPath)
+                    .withConf(conf)
+                    .withType(schema)
+                    .build()) {
+                SimpleGroupFactory factory = new SimpleGroupFactory(schema);
+                writer.write(factory.newGroup().append("c", 1));
+                writer.write(factory.newGroup().append("c", 2));
+                writer.write(factory.newGroup().append("c", 3));
+            }
+        });
     }
 
     /// Provides all .parquet files from the parquet-testing test directories.

--- a/pom.xml
+++ b/pom.xml
@@ -406,35 +406,72 @@
             <configuration>
               <strictCheck>true</strictCheck>
               <aggregate>true</aggregate>
+              <!-- `#`-commented formats the plugin does not know by extension. -->
               <mapping>
                 <txt>SCRIPT_STYLE</txt>
+                <tape>SCRIPT_STYLE</tape>
+                <dockerignore>SCRIPT_STYLE</dockerignore>
               </mapping>
               <licenseSets>
                 <licenseSet>
                   <header>${maven.multiModuleProjectDirectory}/etc/license.txt</header>
+                  <!-- Bounds the walk. `**` here costs 13s instead of 0.3s in a
+                       working clone: the scanner descends into directories it is about
+                       to exclude, and no exclusion prevents that. Patterns, not an
+                       inventory — `*/src/**` covers any new module; a new top-level
+                       directory needs a line. -->
+                  <includes>
+                    <include>*</include>
+                    <include>.github/**</include>
+                    <include>_demos/**</include>
+                    <include>docs/**</include>
+                    <include>etc/**</include>
+                    <include>tools/**</include>
+                    <include>*/pom.xml</include>
+                    <include>*/.flattened-pom.xml</include>
+                    <include>*/src/**</include>
+                    <include>*/*.sh</include>
+                    <include>*/.dockerignore</include>
+                    <include>*/docker/**</include>
+                    <include>performance-testing/*</include>
+                    <include>performance-testing/*/pom.xml</include>
+                    <include>performance-testing/*/src/**</include>
+                    <include>performance-testing/*/*.py</include>
+                    <!-- Cancels the same-named default exclusions, which otherwise hide
+                         the workflows and the `dev.hardwood.build.errorprone` package.
+                         Spelling must match the default exactly; stripped from the walk. -->
+                    <include>**/.github</include>
+                    <include>**/.github/**</include>
+                    <include>**/build/**</include>
+                  </includes>
                   <excludes>
-                    <exclude>.claude/**</exclude>
-                    <exclude>.serena/**</exclude>
+                    <!-- Scratch, build and vendored directories, kept identical in the
+                         other set: each set prunes from its own list. -->
                     <exclude>.agents/**</exclude>
+                    <exclude>.claude/**</exclude>
                     <exclude>.codex/**</exclude>
-                    <exclude>_tmp/**</exclude>
-                    <exclude>.venv/**</exclude>
                     <exclude>.docker-venv/**</exclude>
+                    <exclude>.git/**</exclude>
+                    <exclude>.serena/**</exclude>
+                    <exclude>.venv/**</exclude>
                     <exclude>_tmp/**</exclude>
+                    <exclude>docs/site/**</exclude>
+                    <exclude>hardwood-cli-early-access-*/**</exclude>
                     <exclude>japicmp-report/**</exclude>
+                    <!-- Carry no header, or one this set does not own. -->
+                    <exclude>*.html</exclude>
+                    <exclude>**/*.ftl</exclude>
+                    <exclude>**/*.cast</exclude>
+                    <exclude>**/*.parquet</exclude>
+                    <exclude>**/resources/variant/**</exclude>
+                    <exclude>**/.dontdelete</exclude>
+                    <exclude>**/.jfr</exclude>
                     <exclude>**/__pycache__/**</exclude>
+                    <exclude>**/license-merges.txt</exclude>
                     <exclude>.release-env</exclude>
                     <exclude>LICENSE.txt</exclude>
                     <exclude>etc/license-cc-by-sa.txt</exclude>
-                    <exclude>**/.jfr</exclude>
-                    <exclude>**/.dontdelete</exclude>
-                    <exclude>*.html</exclude>
-                    <exclude>**/*.parquet</exclude>
-                    <exclude>**/license-merges.txt</exclude>
-                    <exclude>**/*.ftl</exclude>
                     <exclude>docs/content/**</exclude>
-                    <exclude>docs/site/**</exclude>
-                    <exclude>hardwood-cli-early-access-*/**</exclude>
                   </excludes>
                 </licenseSet>
                 <licenseSet>
@@ -442,6 +479,21 @@
                   <includes>
                     <include>docs/content/**</include>
                   </includes>
+                  <!-- Same directories as above: without them this set walks the
+                       whole repository to select one file. -->
+                  <excludes>
+                    <exclude>.agents/**</exclude>
+                    <exclude>.claude/**</exclude>
+                    <exclude>.codex/**</exclude>
+                    <exclude>.docker-venv/**</exclude>
+                    <exclude>.git/**</exclude>
+                    <exclude>.serena/**</exclude>
+                    <exclude>.venv/**</exclude>
+                    <exclude>_tmp/**</exclude>
+                    <exclude>docs/site/**</exclude>
+                    <exclude>hardwood-cli-early-access-*/**</exclude>
+                    <exclude>japicmp-report/**</exclude>
+                  </excludes>
                 </licenseSet>
               </licenseSets>
             </configuration>


### PR DESCRIPTION
Closes #1120. Closes #1122. Closes #1124.

`./mvnw -N license:check` took 8 to 16 seconds in a working clone against 0.4 in a fresh checkout of the same commit, on the same filesystem. It was walking all 205,000 files in the repository to select the 1,000 that can carry a header. It now runs in 1.2 seconds and selects the same files.

## Why an exclusion was not enough

`DirectoryScanner` descends into a directory it has already excluded whenever an inclusion pattern could still match something below it, and with the default `**` inclusion that is always true. `.claude/worktrees` (91,632 files), `_tmp` (56,698) and the virtualenvs (44,595) were walked in full and their contents then discarded. Only a narrower inclusion prevents it — measured, not inferred: replacing the bounded list with `**` puts the parent module back to 10.8s while all thirteen modules together stay at 0.5s.

The second licence set had to be bounded separately. The prune list is built from a set's own excludes, so the CC BY-SA set, which declared none, pruned nothing no matter what the first set declared: it walked the repository to select a single stylesheet, 12.9s against 98ms in a fresh clone. Both sets now carry the same eleven directory exclusions.

CI never sees any of this, because every checkout there is fresh. In a working clone it degrades steadily as worktrees and benchmark data accumulate.

## Also fixed: files the default exclusions were hiding

A pattern listed under `<includes>` that exactly matches one of the plugin's default exclusions is removed from those defaults. Two were holding first-party sources out of the check:

- `**/.github/**` hid the nine workflow files. They all carry the header; nothing enforced it.
- `**/build/**`, meant for Gradle output, matched `dev/hardwood/build/errorprone` on the strength of a package name, hiding the three Error Prone checks and their two tests.

Selection goes from 995 to 1010 files; the fourteen gained all carry the header already.

## Warnings

Sixty-one selected files had no comment style the plugin recognised, so it warned on each and checked none of them. The binary Variant fixtures and the asciinema recording cannot carry a header and are now excluded; `.tape` and `.dockerignore` can, so they get a mapping — plus a header on the latter, and a reformat of the former, which `strictCheck` rejected for using one space after `#` where the canonical header uses two. Selection drops from 1010 to 951, all of them now actually verifiable, and the build is warning-free.

## Iterating without the integration tests (#1122)

A separate commit adds a line to CLAUDE.md: iterate with `./mvnw verify -DskipITs`, run the full `verify` once before pushing and immediately whenever the change touches what the integration tests cover. They are roughly 40s of a 130s build and need a Docker daemon, and for most changes — this one included — they exercise nothing the change touched.

## Measurements

| | before | after |
| --- | --- | --- |
| working clone, 205,333 files | 8.6 – 16.5s | **1.2s** |
| fresh clone, same commit | 0.55s | 0.55s |
| licence set 1 walk | 12.9s | 0.33s |
| licence set 2 walk | 12.9s | ~0.1s |
| whole reactor, `license:check` | — | 1.8s |

## Notes for review

The include list is patterns rather than an inventory: `*/src/**` and `*/pom.xml` cover any module, verified by dropping a headerless class into a new module directory and watching the check fail on it. A new *top-level* directory is the one thing that needs a line added.

Selection was verified after every change by diffing the plugin's own debug output; it is identical at 1010 files, with `docs/content` still owned by the CC BY-SA set. `clean verify` green.

## Running the reactor and the tests in parallel (#1124)

With the licence check out of the measurement, `verify -DskipITs` was 60 seconds, and 42 of those were two modules running their tests one class at a time in a single JVM — `parquet-testing-runner` at 31.7s and `core` at 12.9s. Everything that is not a test came to under five seconds combined.

There was no Surefire configuration in the parent POM, so it ran at the default `forkCount=1`, and no `-T`, so the reactor was serial too. `.mvn/maven.config` now sets both.

| Configuration | Wall clock |
| --- | --- |
| as-is | 59.9s |
| `-T 1C` | 48.1s |
| `-T 1C -DforkCount=4` | 35.9s |
| on this branch, end to end | 33.6s |

Four forks rather than one per core is where the measurements level off: `parquet-testing-runner` runs 29.9s / 19.6s / 18.6s / 20.3s at one, two, four and eight forks. `core` barely moves at any setting, because its tests already spawn reader worker threads and a single fork saturates the machine.

CI is unaffected: every job builds one module with `-pl`, so `-T` is a no-op there and the fork count applies to a single module at a time.

Forking gives each JVM a working directory in the module root, so `.surefire-*/` is now ignored.

Several JVMs also need the two fixtures under `parquet-testing-runner/target` — the `parquet-testing` clone and the generated `good_c.parquet` — to be produced once between them, and `Files.exists` cannot arrange that: both exist from the moment their creation *starts*, so a fork that loses the race does not wait, it reads a half-written fixture. CI hit this immediately, since every checkout there is fresh; locally the clone was already on disk and the race never ran. Each fixture is now built under a private name and renamed into place, so it is visible only once complete, and the fork that builds it is elected by creating a claim file.

That election deliberately does not use an advisory lock. On this bind-mounted checkout `FileChannel.lock` is silently ignored — two JVMs locking the same file both proceed, each believing it holds it — while `O_EXCL` gives exactly one winner out of eight. Verified both ways before relying on it.

A floor of roughly 16 seconds remains, set by `ParquetComparisonTest` — one class holding half of `parquet-testing-runner`, which no fork count can split. #1123 covers what makes it expensive: opening a `ColumnReader` costs 11 to 13 milliseconds whatever the column holds, and that fixture has 216 of them over a single row.
