### PR TITLE
#1096 Parse a dictionary page's header once, where the page is first met

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -9,7 +9,9 @@ When a CLI tool is missing from the dev container (e.g. `cmp: command not found`
 
 Several Claude sessions may be running against this repository at once. Git allows one HEAD per working tree, so two sessions sharing a checkout also share HEAD, the index and the files: a `git checkout` in one silently relocates the other, and work gets committed to the wrong branch.
 
-Before any branch work, move into your own worktree. Treat `/workspace` as a reference checkout that stays on `main` — it is where every session lands by default, which is exactly why it must not be where any session commits. Name the worktree directory after its branch, so `git worktree list` reads as a registry of what is in flight.
+Before committing to a branch, move into your own worktree. Reading needs no worktree — review a PR or a branch from wherever you already are, with `gh pr diff`, or `git fetch` and then `git log` / `git diff` / `git range-diff` against `FETCH_HEAD`. None of those move HEAD. Treat `/workspace` as a reference checkout that stays on `main`, since it is where every session lands by default — but that is a default for you to hold to, not a rule to hold against the user. Asked for a branch or a PR in the workspace itself, put it there, and say once what it means for the other sessions. Name the worktree directory after its branch, so `git worktree list` reads as a registry of what is in flight.
+
+Remove your worktree once its work is pushed. Never leave one behind for a review that is over — a list that keeps merged branches and finished reviews is not a registry of anything.
 
 Stage explicit paths. Never `git add -A` or `git commit -a`: another session's uncommitted files may be sitting in the tree, and a catch-all stage sweeps them into your commit.
 

--- a/avro/pom.xml
+++ b/avro/pom.xml
@@ -54,6 +54,17 @@
   </dependencyManagement>
 
   <dependencies>
+    <!-- Not used by any code here. Declared so the reactor builds the Error Prone checks
+         before this module compiles: they reach javac through the compiler plugin's
+         annotationProcessorPaths, which the reactor does not read when ordering modules,
+         so under `-T` there is otherwise nothing stopping the two running at once. -->
+    <dependency>
+      <groupId>dev.hardwood</groupId>
+      <artifactId>hardwood-error-prone-checks</artifactId>
+      <version>${project.version}</version>
+      <scope>test</scope>
+    </dependency>
+
     <dependency>
       <groupId>dev.hardwood</groupId>
       <artifactId>hardwood-core</artifactId>

--- a/aws-auth/pom.xml
+++ b/aws-auth/pom.xml
@@ -61,6 +61,17 @@
   </dependencyManagement>
 
   <dependencies>
+    <!-- Not used by any code here. Declared so the reactor builds the Error Prone checks
+         before this module compiles: they reach javac through the compiler plugin's
+         annotationProcessorPaths, which the reactor does not read when ordering modules,
+         so under `-T` there is otherwise nothing stopping the two running at once. -->
+    <dependency>
+      <groupId>dev.hardwood</groupId>
+      <artifactId>hardwood-error-prone-checks</artifactId>
+      <version>${project.version}</version>
+      <scope>test</scope>
+    </dependency>
+
     <dependency>
       <groupId>dev.hardwood</groupId>
       <artifactId>hardwood-s3</artifactId>

--- a/cli/pom.xml
+++ b/cli/pom.xml
@@ -121,6 +121,17 @@
   </dependencyManagement>
 
   <dependencies>
+    <!-- Not used by any code here. Declared so the reactor builds the Error Prone checks
+         before this module compiles: they reach javac through the compiler plugin's
+         annotationProcessorPaths, which the reactor does not read when ordering modules,
+         so under `-T` there is otherwise nothing stopping the two running at once. -->
+    <dependency>
+      <groupId>dev.hardwood</groupId>
+      <artifactId>hardwood-error-prone-checks</artifactId>
+      <version>${project.version}</version>
+      <scope>test</scope>
+    </dependency>
+
     <!-- Hardwood Core -->
     <dependency>
       <groupId>dev.hardwood</groupId>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -50,6 +50,17 @@
   </dependencyManagement>
 
   <dependencies>
+    <!-- Not used by any code here. Declared so the reactor builds the Error Prone checks
+         before this module compiles: they reach javac through the compiler plugin's
+         annotationProcessorPaths, which the reactor does not read when ordering modules,
+         so under `-T` there is otherwise nothing stopping the two running at once. -->
+    <dependency>
+      <groupId>dev.hardwood</groupId>
+      <artifactId>hardwood-error-prone-checks</artifactId>
+      <version>${project.version}</version>
+      <scope>test</scope>
+    </dependency>
+
     <!-- Test dependencies -->
     <dependency>
       <groupId>org.junit.jupiter</groupId>

--- a/core/src/main/java/dev/hardwood/internal/reader/DictionaryParser.java
+++ b/core/src/main/java/dev/hardwood/internal/reader/DictionaryParser.java
@@ -10,6 +10,7 @@ package dev.hardwood.internal.reader;
 import java.nio.ByteBuffer;
 
 import dev.hardwood.internal.compression.Decompressor;
+import dev.hardwood.internal.metadata.DictionaryPageHeader;
 import dev.hardwood.internal.metadata.PageHeader;
 import dev.hardwood.internal.thrift.PageHeaderReader;
 import dev.hardwood.internal.thrift.ThriftCompactReader;
@@ -64,15 +65,67 @@ public final class DictionaryParser {
         }
 
         int headerSize = probeReader.getBytesRead();
+        ByteBuffer compressedData = dictRegion.slice(headerSize, header.compressedPageSize());
+
+        return parsePage(header, compressedData, columnSchema, metaData, context);
+    }
+
+    /// Parses a dictionary page whose header the caller has already read.
+    ///
+    /// A caller scanning a column chunk page by page parses the header anyway, to learn where
+    /// the page ends. Handing it back here is what keeps the header from being parsed — and its
+    /// CRC computed — a second time.
+    ///
+    /// This is the one place the page's own claims are checked, so every entry point validates
+    /// them alike: [#parse] reaches it too, once it has found a dictionary page to hand over.
+    ///
+    /// Both the page type and the body's length are checked rather than trusted: a body that is
+    /// not the one the header describes — a region handed over whole, say — decodes to values
+    /// that are wrong rather than absent, and on the files that carry no page CRC there is
+    /// nothing else left to catch it.
+    ///
+    /// @param header the page header, already parsed, with [PageType#DICTIONARY_PAGE] as its type
+    /// @param compressedData the page body alone, `header.compressedPageSize()` bytes,
+    ///        with the header excluded
+    /// @param columnSchema the column schema (for type info)
+    /// @param metaData the column metadata (for codec)
+    /// @param context the hardwood context (for decompressor)
+    /// @return the parsed dictionary
+    /// @throws ParquetReadException if the page is not the one the header describes, if the
+    ///         header contradicts itself, or if the body cannot be decoded
+    public static Dictionary parsePage(PageHeader header, ByteBuffer compressedData,
+                            ColumnSchema columnSchema, ColumnMetaData metaData,
+                            HardwoodContextImpl context) {
+        if (header.type() != PageType.DICTIONARY_PAGE) {
+            throw new ParquetReadException("Invalid dictionary page for column '"
+                    + columnSchema.name() + "': page type is " + header.type());
+        }
+
         int compressedSize = header.compressedPageSize();
-        ByteBuffer compressedData = dictRegion.slice(headerSize, compressedSize);
+        if (compressedData.remaining() != compressedSize) {
+            throw new ParquetReadException("Invalid dictionary page for column '"
+                    + columnSchema.name() + "': body of " + compressedData.remaining()
+                    + " bytes, header claims " + compressedSize);
+        }
+
+        DictionaryPageHeader dictionaryPageHeader = header.dictionaryPageHeader();
+        if (dictionaryPageHeader == null) {
+            throw new ParquetReadException("Invalid dictionary page for column '"
+                    + columnSchema.name() + "': no dictionary_page_header");
+        }
+
+        int numValues = dictionaryPageHeader.numValues();
+        if (numValues < 0) {
+            throw new ParquetReadException("Invalid dictionary page for column '"
+                    + columnSchema.name() + "': negative numValues (" + numValues + ")");
+        }
 
         if (header.crc() != null) {
             CrcValidator.assertCorrectCrc(header.crc(), compressedData, columnSchema.name());
         }
 
-        return decompress(compressedData, header.dictionaryPageHeader().numValues(),
-                header.uncompressedPageSize(), columnSchema, metaData.codec(), context);
+        return decompress(compressedData, numValues, header.uncompressedPageSize(),
+                columnSchema, metaData.codec(), context);
     }
 
     /// Parses a dictionary from a buffer given the chunk layout. Locates the

--- a/core/src/main/java/dev/hardwood/internal/reader/SequentialFetchPlan.java
+++ b/core/src/main/java/dev/hardwood/internal/reader/SequentialFetchPlan.java
@@ -456,18 +456,13 @@ public final class SequentialFetchPlan implements FetchPlan, RowGroupIterator.Co
 
             if (header.type() == PageType.DICTIONARY_PAGE) {
                 int compressedSize = header.compressedPageSize();
-                int numValues = header.dictionaryPageHeader().numValues();
-                if (numValues < 0) {
-                    throw new ParquetReadException("Invalid dictionary page for column '"
-                            + columnSchema.name() + "': negative numValues (" + numValues + ")");
-                }
                 int dictTotalSize = headerSize + compressedSize;
-                ByteBuffer dictRegion = readBytes(position, dictTotalSize);
-                ByteBuffer compressedData = dictRegion.slice(headerSize, compressedSize);
-                if (header.crc() != null) {
-                    CrcValidator.assertCorrectCrc(header.crc(), compressedData, columnSchema.name());
-                }
-                dictionary = DictionaryParser.parse(dictRegion, columnSchema, metaData, context);
+                // The header is already parsed, so hand it over rather than a region the
+                // parser would have to open and read the same header out of again.
+                ByteBuffer compressedData = readBytes(position, dictTotalSize)
+                        .slice(headerSize, compressedSize);
+                dictionary = DictionaryParser.parsePage(header, compressedData,
+                        columnSchema, metaData, context);
                 position += dictTotalSize;
             }
         }

--- a/core/src/test/java/dev/hardwood/CrcValidationTest.java
+++ b/core/src/test/java/dev/hardwood/CrcValidationTest.java
@@ -102,11 +102,13 @@ class CrcValidationTest {
         Path source = Paths.get("src/test/resources/dictionary_with_crc.parquet");
         byte[] bytes = Files.readAllBytes(source);
 
-        // Read metadata to find the dictionary page corruption offset
+        // The last byte of the dictionary page, which ends where the first data page begins.
+        // Anything at or past dataPageOffset is a data page byte, and a flip there is caught by
+        // the data page's own checksum instead — which is what testCorruptedDataDetected covers.
         long corruptOffset;
         try (ParquetFileReader reader = ParquetFileReader.open(InputFile.of(ByteBuffer.wrap(bytes)))) {
             ColumnMetaData meta = reader.getFileMetaData().rowGroups().get(0).columns().get(1).metaData();
-            corruptOffset = meta.dictionaryPageOffset() + meta.totalCompressedSize() - 1;
+            corruptOffset = meta.dataPageOffset() - 1;
         }
 
         // Flip a byte to corrupt the dictionary page

--- a/core/src/test/java/dev/hardwood/MultiFilePlanningTest.java
+++ b/core/src/test/java/dev/hardwood/MultiFilePlanningTest.java
@@ -60,11 +60,16 @@ class MultiFilePlanningTest {
         }
     }
 
+    /// The cap is what bounds planning, not the caller walking away after one row. An
+    /// abandoned loop leaves the retriever free to run on, so without `head` this asserts
+    /// only that the calling thread reached the assertion first — which on a loaded
+    /// machine it does not. See [#anUncappedFilteredReadYieldsWithoutPlanningTheWholeRead],
+    /// which is the same read without a cap and therefore asserts no bound at all.
     @Test
     void aReadThatStopsEarlyDoesNotOpenEveryFile() throws IOException {
         List<CountingInputFile> files = countingFiles();
         try (ParquetFileReader reader = ParquetFileReader.openAll(files);
-             RowReader rows = reader.buildRowReader().build()) {
+             RowReader rows = reader.buildRowReader().head(1).build()) {
             if (rows.hasNext()) {
                 rows.next();
             }

--- a/core/src/test/java/dev/hardwood/internal/reader/DictionaryParserTest.java
+++ b/core/src/test/java/dev/hardwood/internal/reader/DictionaryParserTest.java
@@ -1,0 +1,166 @@
+/*
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Copyright The original authors
+ *
+ *  Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package dev.hardwood.internal.reader;
+
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
+import org.junit.jupiter.api.Test;
+
+import dev.hardwood.InputFile;
+import dev.hardwood.internal.metadata.DictionaryPageHeader;
+import dev.hardwood.internal.metadata.PageHeader;
+import dev.hardwood.internal.thrift.PageHeaderReader;
+import dev.hardwood.internal.thrift.ThriftCompactReader;
+import dev.hardwood.metadata.ColumnMetaData;
+import dev.hardwood.metadata.Encoding;
+import dev.hardwood.metadata.PageType;
+import dev.hardwood.reader.ParquetFileReader;
+import dev.hardwood.reader.ParquetReadException;
+import dev.hardwood.schema.ColumnSchema;
+import dev.hardwood.schema.FileSchema;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/// Covers [DictionaryParser]'s entry point for callers that have already parsed the page header.
+class DictionaryParserTest {
+
+    private static final Path FIXTURE = Paths.get("src/test/resources/column_index_pushdown_dict.parquet");
+
+    /// A caller that scans page headers hands its parsed header and the page body to
+    /// [DictionaryParser#parsePage]. The body it passes is the body alone — so a parser that
+    /// went looking for a header in those bytes would decode the dictionary's first entries as
+    /// a page header and fail, rather than agreeing by accident.
+    @Test
+    void parsesAPageFromAnAlreadyParsedHeaderAndItsBodyAlone() throws Exception {
+        DictionaryPage page = firstDictionaryPage();
+
+        try (HardwoodContextImpl context = HardwoodContextImpl.create()) {
+            Dictionary fromHeaderAndBody = DictionaryParser.parsePage(page.header(), page.body(),
+                    page.columnSchema(), page.metaData(), context);
+            Dictionary fromWholeRegion = DictionaryParser.parse(page.region(),
+                    page.columnSchema(), page.metaData(), context);
+
+            assertThat(fromHeaderAndBody.size())
+                    .isEqualTo(page.header().dictionaryPageHeader().numValues());
+            assertThat(((Dictionary.LongDictionary) fromHeaderAndBody).values())
+                    .as("the entries the region-based entry point decodes, value for value")
+                    .containsExactly(((Dictionary.LongDictionary) fromWholeRegion).values());
+        }
+    }
+
+    /// A header describes a body of a given length, so that is the only body it can vouch for.
+    /// Handed the whole region instead — the header still in front of the entries — the parser
+    /// would decode header bytes as values, and on a file carrying no page CRC nothing further
+    /// would catch it.
+    @Test
+    void rejectsABodyThatIsNotTheOneTheHeaderDescribes() throws Exception {
+        DictionaryPage page = firstDictionaryPage();
+
+        try (HardwoodContextImpl context = HardwoodContextImpl.create()) {
+            assertThatThrownBy(() -> DictionaryParser.parsePage(page.header(), page.region(),
+                    page.columnSchema(), page.metaData(), context))
+                    .isInstanceOf(ParquetReadException.class)
+                    .hasMessage("Invalid dictionary page for column '" + page.columnSchema().name()
+                            + "': body of " + page.region().remaining()
+                            + " bytes, header claims " + page.header().compressedPageSize());
+        }
+    }
+
+    /// A page of another type is the caller having handed over the wrong page altogether, which
+    /// reads better as that than as a dictionary page missing its dictionary header.
+    @Test
+    void rejectsAPageThatIsNotADictionaryPage() throws Exception {
+        DictionaryPage page = firstDictionaryPage();
+        PageHeader dataPage = withType(page.header(), PageType.DATA_PAGE);
+
+        try (HardwoodContextImpl context = HardwoodContextImpl.create()) {
+            assertThatThrownBy(() -> DictionaryParser.parsePage(dataPage, page.body(),
+                    page.columnSchema(), page.metaData(), context))
+                    .isInstanceOf(ParquetReadException.class)
+                    .hasMessage("Invalid dictionary page for column '" + page.columnSchema().name()
+                            + "': page type is DATA_PAGE");
+        }
+    }
+
+    /// A page header claiming to be a dictionary page but carrying no `dictionary_page_header`
+    /// has nothing to say how many values follow. Reading it out would dereference null.
+    @Test
+    void rejectsADictionaryPageWithoutItsDictionaryHeader() throws Exception {
+        DictionaryPage page = firstDictionaryPage();
+        PageHeader headerless = withDictionaryHeader(page.header(), null);
+
+        try (HardwoodContextImpl context = HardwoodContextImpl.create()) {
+            assertThatThrownBy(() -> DictionaryParser.parsePage(headerless, page.body(),
+                    page.columnSchema(), page.metaData(), context))
+                    .isInstanceOf(ParquetReadException.class)
+                    .hasMessage("Invalid dictionary page for column '" + page.columnSchema().name()
+                            + "': no dictionary_page_header");
+        }
+    }
+
+    /// `numValues` sizes the decoded dictionary, so a negative count has to be refused before it
+    /// reaches the decoder rather than surfacing there as an array-sizing failure.
+    @Test
+    void rejectsANegativeValueCount() throws Exception {
+        DictionaryPage page = firstDictionaryPage();
+        PageHeader negative = withDictionaryHeader(page.header(),
+                new DictionaryPageHeader(-1, page.header().dictionaryPageHeader().encoding()));
+
+        try (HardwoodContextImpl context = HardwoodContextImpl.create()) {
+            assertThatThrownBy(() -> DictionaryParser.parsePage(negative, page.body(),
+                    page.columnSchema(), page.metaData(), context))
+                    .isInstanceOf(ParquetReadException.class)
+                    .hasMessage("Invalid dictionary page for column '" + page.columnSchema().name()
+                            + "': negative numValues (-1)");
+        }
+    }
+
+    private static PageHeader withType(PageHeader header, PageType type) {
+        return new PageHeader(type, header.uncompressedPageSize(), header.compressedPageSize(),
+                header.dataPageHeader(), header.dataPageHeaderV2(), header.dictionaryPageHeader(), header.crc());
+    }
+
+    private static PageHeader withDictionaryHeader(PageHeader header, DictionaryPageHeader dictionaryPageHeader) {
+        return new PageHeader(header.type(), header.uncompressedPageSize(), header.compressedPageSize(),
+                header.dataPageHeader(), header.dataPageHeaderV2(), dictionaryPageHeader, header.crc());
+    }
+
+    /// The dictionary page of the fixture's first column chunk, in the three shapes the parser's
+    /// entry points take: the whole region, its parsed header, and its body alone.
+    private record DictionaryPage(ByteBuffer region, PageHeader header, ByteBuffer body,
+            ColumnSchema columnSchema, ColumnMetaData metaData) {}
+
+    private static DictionaryPage firstDictionaryPage() throws IOException {
+        ByteBuffer file = ByteBuffer.wrap(Files.readAllBytes(FIXTURE));
+
+        ColumnMetaData metaData;
+        ColumnSchema columnSchema;
+        try (ParquetFileReader reader = ParquetFileReader.open(InputFile.of(file))) {
+            metaData = reader.getFileMetaData().rowGroups().getFirst().columns().getFirst().metaData();
+            columnSchema = FileSchema.fromSchemaElements(reader.getFileMetaData().schema()).getColumn(0);
+        }
+
+        long dictionaryOffset = metaData.dictionaryPageOffset();
+        int regionSize = Math.toIntExact(metaData.dataPageOffset() - dictionaryOffset);
+        ByteBuffer region = file.slice(Math.toIntExact(dictionaryOffset), regionSize);
+
+        ThriftCompactReader headerReader = new ThriftCompactReader(region, 0);
+        PageHeader header = PageHeaderReader.read(headerReader);
+        assertThat(header.type()).isEqualTo(PageType.DICTIONARY_PAGE);
+        assertThat(header.dictionaryPageHeader().encoding())
+                .isIn(Encoding.PLAIN, Encoding.PLAIN_DICTIONARY);
+
+        ByteBuffer body = region.slice(headerReader.getBytesRead(), header.compressedPageSize());
+        return new DictionaryPage(region, header, body, columnSchema, metaData);
+    }
+}

--- a/integration-test/pom.xml
+++ b/integration-test/pom.xml
@@ -46,6 +46,17 @@
   </dependencyManagement>
 
   <dependencies>
+    <!-- Not used by any code here. Declared so the reactor builds the Error Prone checks
+         before this module compiles: they reach javac through the compiler plugin's
+         annotationProcessorPaths, which the reactor does not read when ordering modules,
+         so under `-T` there is otherwise nothing stopping the two running at once. -->
+    <dependency>
+      <groupId>dev.hardwood</groupId>
+      <artifactId>hardwood-error-prone-checks</artifactId>
+      <version>${project.version}</version>
+      <scope>test</scope>
+    </dependency>
+
     <!-- Hardwood (module under test) -->
     <dependency>
       <groupId>dev.hardwood</groupId>

--- a/parquet-java-compat/pom.xml
+++ b/parquet-java-compat/pom.xml
@@ -54,6 +54,17 @@
   </dependencyManagement>
 
   <dependencies>
+    <!-- Not used by any code here. Declared so the reactor builds the Error Prone checks
+         before this module compiles: they reach javac through the compiler plugin's
+         annotationProcessorPaths, which the reactor does not read when ordering modules,
+         so under `-T` there is otherwise nothing stopping the two running at once. -->
+    <dependency>
+      <groupId>dev.hardwood</groupId>
+      <artifactId>hardwood-error-prone-checks</artifactId>
+      <version>${project.version}</version>
+      <scope>test</scope>
+    </dependency>
+
     <!-- Only runtime dependency: hardwood-core -->
     <dependency>
       <groupId>dev.hardwood</groupId>

--- a/parquet-testing-runner/pom.xml
+++ b/parquet-testing-runner/pom.xml
@@ -46,6 +46,17 @@
   </dependencyManagement>
 
   <dependencies>
+    <!-- Not used by any code here. Declared so the reactor builds the Error Prone checks
+         before this module compiles: they reach javac through the compiler plugin's
+         annotationProcessorPaths, which the reactor does not read when ordering modules,
+         so under `-T` there is otherwise nothing stopping the two running at once. -->
+    <dependency>
+      <groupId>dev.hardwood</groupId>
+      <artifactId>hardwood-error-prone-checks</artifactId>
+      <version>${project.version}</version>
+      <scope>test</scope>
+    </dependency>
+
     <!-- Hardwood (module under test) -->
     <dependency>
       <groupId>dev.hardwood</groupId>

--- a/performance-testing/micro-benchmarks/README.md
+++ b/performance-testing/micro-benchmarks/README.md
@@ -36,6 +36,7 @@ allocation profiling, `-rf json -rff out.json` for machine-readable results,
 | `ValidityIterationBenchmark` | Null-bitmap iteration strategies over a `long[]` column | none (in-memory) |
 | `AlwaysMatchReadBenchmark` | Filtered end-to-end reads when statistics prove row groups match in full (#795) | `generate_filter_pushdown_data.py` |
 | `DictionaryStringReadBenchmark` | Allocation per full-column scan of a dictionary-encoded string column (run with `-prof gc`) | `generate_dict_string_data.py` |
+| `DictionaryPageParseBenchmark` | One dictionary page set up through each of the parser's two entry points, against the decode floor (#1096) | self-generating |
 | `DictionaryPageSetupBenchmark` | Per-column-chunk dictionary setup — page-header parse and checksum — over many row groups (#1096) | self-generating |
 | `PageScanBenchmark` | Sequential header-based page scan vs. offset-index lookup | `generate_benchmark_data.py` |
 | `PageHandlingBenchmark` | Per-page decompression vs. full page decode | taxi data, downloaded by `./mvnw verify -Pperformance-test` |

--- a/performance-testing/micro-benchmarks/README.md
+++ b/performance-testing/micro-benchmarks/README.md
@@ -36,6 +36,7 @@ allocation profiling, `-rf json -rff out.json` for machine-readable results,
 | `ValidityIterationBenchmark` | Null-bitmap iteration strategies over a `long[]` column | none (in-memory) |
 | `AlwaysMatchReadBenchmark` | Filtered end-to-end reads when statistics prove row groups match in full (#795) | `generate_filter_pushdown_data.py` |
 | `DictionaryStringReadBenchmark` | Allocation per full-column scan of a dictionary-encoded string column (run with `-prof gc`) | `generate_dict_string_data.py` |
+| `DictionaryPageSetupBenchmark` | Per-column-chunk dictionary setup — page-header parse and checksum — over many row groups (#1096) | self-generating |
 | `PageScanBenchmark` | Sequential header-based page scan vs. offset-index lookup | `generate_benchmark_data.py` |
 | `PageHandlingBenchmark` | Per-page decompression vs. full page decode | taxi data, downloaded by `./mvnw verify -Pperformance-test` |
 | `MemoryMapBenchmark` | Raw I/O floor: mmap + copy of a whole file, no decode | taxi data, downloaded by `./mvnw verify -Pperformance-test` |

--- a/performance-testing/micro-benchmarks/src/main/java/dev/hardwood/benchmarks/DictionaryPageParseBenchmark.java
+++ b/performance-testing/micro-benchmarks/src/main/java/dev/hardwood/benchmarks/DictionaryPageParseBenchmark.java
@@ -1,0 +1,193 @@
+/*
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Copyright The original authors
+ *
+ *  Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package dev.hardwood.benchmarks;
+
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.concurrent.TimeUnit;
+import java.util.zip.CRC32;
+
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.TearDown;
+import org.openjdk.jmh.annotations.Warmup;
+
+import dev.hardwood.InputFile;
+import dev.hardwood.OutputFile;
+import dev.hardwood.internal.metadata.PageHeader;
+import dev.hardwood.internal.reader.Dictionary;
+import dev.hardwood.internal.reader.DictionaryParser;
+import dev.hardwood.internal.reader.HardwoodContextImpl;
+import dev.hardwood.internal.thrift.PageHeaderReader;
+import dev.hardwood.internal.thrift.ThriftCompactReader;
+import dev.hardwood.metadata.ColumnMetaData;
+import dev.hardwood.metadata.CompressionCodec;
+import dev.hardwood.metadata.PhysicalType;
+import dev.hardwood.metadata.RepetitionType;
+import dev.hardwood.reader.ParquetFileReader;
+import dev.hardwood.schema.ColumnSchema;
+import dev.hardwood.schema.FileSchema;
+import dev.hardwood.writer.ParquetFileWriter;
+import dev.hardwood.writer.WriterConfig;
+
+/// Setting up one dictionary page, through each of [DictionaryParser]'s two entry points.
+///
+/// A caller scanning a column chunk parses each page header to learn where the page ends, so by
+/// the time it reaches the dictionary it holds the header, the body it delimits, and everything
+/// needed to check the page over. `parsePage` takes all of that; `parse` takes the undivided
+/// region and works it out again from the bytes. Both are on the read path — the scanning callers
+/// take the first, callers holding only an offset take the second — and the gap between them is
+/// what a caller pays for handing over a region it has already been through.
+///
+/// Single-threaded and allocation-light by construction: one page, no file, no reader pool. The
+/// end-to-end counterpart, [DictionaryPageSetupBenchmark], puts the same work inside a real scan,
+/// where a thread pool and several hundred thousand decoded values sit on top of it.
+@BenchmarkMode(Mode.AverageTime)
+@OutputTimeUnit(TimeUnit.MICROSECONDS)
+@State(Scope.Benchmark)
+@Fork(value = 5, jvmArgsAppend = { "-Xms1g", "-Xmx1g", "--add-modules", "jdk.incubator.vector" })
+@Warmup(iterations = 5, time = 1)
+@Measurement(iterations = 5, time = 1)
+public class DictionaryPageParseBenchmark {
+
+    /// Rows written to build the page. Twice the widest dictionary, so every value repeats and
+    /// the writer keeps the column dictionary-encoded rather than falling back to `PLAIN`.
+    private static final int ROWS = 8192;
+
+    /// Bytes per value, which is what makes the dictionary body large enough for the checksum
+    /// over it to be worth anything.
+    private static final int VALUE_BYTES = 256;
+
+    /// Distinct values in the dictionary. The body, and the checksum over it, grow with this.
+    @Param({ "1024", "4096" })
+    private int dictionaryValues;
+
+    private HardwoodContextImpl context;
+    private ColumnSchema columnSchema;
+    private ColumnMetaData metaData;
+    /// The dictionary page whole: its header followed by its body.
+    private ByteBuffer region;
+    /// The same page's header, parsed, as a scanning caller would already hold it.
+    private PageHeader header;
+    /// Where the body sits inside [#region]. Held as bounds rather than as a buffer because
+    /// decoding advances the position of the buffer it is handed, so each invocation needs its
+    /// own slice — as it gets on the read path, where every page is read fresh.
+    private int bodyOffset;
+    private int bodyLength;
+
+    @Setup
+    public void setup() throws IOException {
+        Path file = Files.createTempFile("dict-page-parse", ".parquet");
+        file.toFile().deleteOnExit();
+        write(file, dictionaryValues);
+
+        ByteBuffer bytes = ByteBuffer.wrap(Files.readAllBytes(file));
+        Files.deleteIfExists(file);
+
+        try (ParquetFileReader reader = ParquetFileReader.open(InputFile.of(bytes))) {
+            metaData = reader.getFileMetaData().rowGroups().getFirst().columns().getFirst().metaData();
+            columnSchema = FileSchema.fromSchemaElements(reader.getFileMetaData().schema()).getColumn(0);
+        }
+
+        long dictionaryOffset = metaData.dictionaryPageOffset();
+        int regionSize = Math.toIntExact(metaData.dataPageOffset() - dictionaryOffset);
+        region = bytes.slice(Math.toIntExact(dictionaryOffset), regionSize);
+
+        ThriftCompactReader headerReader = new ThriftCompactReader(region, 0);
+        header = PageHeaderReader.read(headerReader);
+        bodyOffset = headerReader.getBytesRead();
+        bodyLength = header.compressedPageSize();
+
+        context = HardwoodContextImpl.create();
+    }
+
+    @TearDown
+    public void tearDown() {
+        context.close();
+    }
+
+    /// The scanning caller's path: parse the header to find the page's end, then set the page up
+    /// from that header and the body it delimits.
+    @Benchmark
+    public Dictionary fromParsedHeader() throws IOException {
+        ThriftCompactReader headerReader = new ThriftCompactReader(region, 0);
+        PageHeader parsed = PageHeaderReader.read(headerReader);
+        ByteBuffer pageBody = region.slice(headerReader.getBytesRead(), parsed.compressedPageSize());
+        return DictionaryParser.parsePage(parsed, pageBody, columnSchema, metaData, context);
+    }
+
+    /// The same caller handing the undivided region over instead. It has the header and the body
+    /// in hand and checks the checksum itself, and then the parser opens the region, reads that
+    /// same header back out of it, cuts the same body and checksums it a second time.
+    @Benchmark
+    public Dictionary fromWholeRegion() throws IOException {
+        ThriftCompactReader headerReader = new ThriftCompactReader(region, 0);
+        PageHeader parsed = PageHeaderReader.read(headerReader);
+        ByteBuffer pageBody = region.slice(headerReader.getBytesRead(), parsed.compressedPageSize());
+        if (parsed.crc() != null) {
+            CRC32 crc = new CRC32();
+            crc.update(pageBody.duplicate());
+            if ((int) crc.getValue() != parsed.crc()) {
+                throw new IOException("CRC mismatch");
+            }
+        }
+        return DictionaryParser.parse(region, columnSchema, metaData, context);
+    }
+
+    /// The floor the two sit above: the header already in hand, leaving the one checksum a
+    /// page is worth and the decode both entry points end in. It is not decode alone — the
+    /// fixture's writer stamps a CRC on every page, and validating it once is work the read
+    /// path has to do — so what the two gaps measure is the second pass over the body, not
+    /// the first.
+    @Benchmark
+    public Dictionary decodeOnly() throws IOException {
+        return DictionaryParser.parsePage(header, region.slice(bodyOffset, bodyLength),
+                columnSchema, metaData, context);
+    }
+
+    private static void write(Path path, int dictionaryValues) throws IOException {
+        FileSchema schema = FileSchema.builder("dict_page_parse")
+                .addColumn("label", PhysicalType.BYTE_ARRAY, RepetitionType.REQUIRED)
+                .build();
+        // Uncompressed so the body the checksum covers is the dictionary itself, not whatever a
+        // codec squeezed it down to.
+        WriterConfig config = WriterConfig.builder()
+                .rowGroupTargetRows(ROWS)
+                .codec(CompressionCodec.UNCOMPRESSED)
+                .build();
+
+        byte[][] values = new byte[ROWS][];
+        for (int row = 0; row < ROWS; row++) {
+            values[row] = value(row % dictionaryValues);
+        }
+        try (ParquetFileWriter writer = ParquetFileWriter.create(OutputFile.of(path), schema, config)) {
+            writer.columnWriter().writeBatch(batch -> batch.bytes(0, values));
+        }
+    }
+
+    private static byte[] value(int ordinal) {
+        byte[] bytes = new byte[VALUE_BYTES];
+        byte[] prefix = ("label-" + ordinal + "-").getBytes(StandardCharsets.UTF_8);
+        System.arraycopy(prefix, 0, bytes, 0, Math.min(prefix.length, VALUE_BYTES));
+        for (int i = prefix.length; i < VALUE_BYTES; i++) {
+            bytes[i] = (byte) ('a' + (i % 26));
+        }
+        return bytes;
+    }
+}

--- a/performance-testing/micro-benchmarks/src/main/java/dev/hardwood/benchmarks/DictionaryPageSetupBenchmark.java
+++ b/performance-testing/micro-benchmarks/src/main/java/dev/hardwood/benchmarks/DictionaryPageSetupBenchmark.java
@@ -1,0 +1,151 @@
+/*
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Copyright The original authors
+ *
+ *  Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package dev.hardwood.benchmarks;
+
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.concurrent.TimeUnit;
+
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
+import org.openjdk.jmh.infra.Blackhole;
+
+import dev.hardwood.InputFile;
+import dev.hardwood.OutputFile;
+import dev.hardwood.metadata.CompressionCodec;
+import dev.hardwood.metadata.PhysicalType;
+import dev.hardwood.metadata.RepetitionType;
+import dev.hardwood.reader.ColumnReader;
+import dev.hardwood.reader.ParquetFileReader;
+import dev.hardwood.schema.FileSchema;
+import dev.hardwood.writer.ParquetFileWriter;
+import dev.hardwood.writer.WriterConfig;
+
+/// The per-column-chunk cost of setting up a dictionary on the sequential read path.
+///
+/// That cost is paid once per dictionary-encoded column chunk, so the fixture is shaped to put
+/// it in the foreground: many row groups, each carrying a wide dictionary of long values over
+/// few rows, which leaves the dictionary page an order of magnitude larger than the data page
+/// referencing it. An ordinary file pays exactly the same setup cost and buries it under value
+/// decoding, so a scan of one is a test of whether the setup regressed, not a measurement of it.
+///
+/// The fixture is written by Hardwood's own writer, which emits no page index — that is what
+/// puts the read on [dev.hardwood.internal.reader.SequentialFetchPlan] rather than the indexed
+/// plan — and which stamps a CRC on every page. The `dictionaryValues` sweep widens the
+/// dictionary the header describes and the checksum covers.
+///
+/// The fixture is read into memory once and scanned from there, because the cost under test is
+/// decode work: served off a file it is a rounding error next to the bytes moved.
+///
+/// Self-generating: fixtures are written under `dataDir` on first run and reused after. The
+/// widest is around 100 MB.
+///
+/// ```shell
+/// java -jar performance-testing/micro-benchmarks/target/benchmarks.jar DictionaryPageSetup \
+///     -p dataDir=performance-testing/test-data-setup/target/benchmark-data
+/// ```
+@BenchmarkMode(Mode.AverageTime)
+@OutputTimeUnit(TimeUnit.MILLISECONDS)
+@State(Scope.Benchmark)
+@Fork(value = 1, jvmArgsAppend = { "-Xms2g", "-Xmx2g", "--add-modules", "jdk.incubator.vector" })
+@Warmup(iterations = 3, time = 1)
+@Measurement(iterations = 5, time = 1)
+public class DictionaryPageSetupBenchmark {
+
+    /// Row groups in the fixture, and so dictionary pages the scan sets up.
+    private static final int ROW_GROUPS = 100;
+
+    /// Rows per row group. Twice the widest dictionary, so every value repeats and the writer
+    /// keeps the chunk dictionary-encoded rather than falling back to `PLAIN`.
+    private static final int ROWS_PER_ROW_GROUP = 8192;
+
+    /// Bytes per value. Long values are what make the dictionary page large next to the page of
+    /// indices pointing into it, which is the ratio this benchmark needs.
+    private static final int VALUE_BYTES = 256;
+
+    @Param({})
+    private String dataDir;
+
+    /// Distinct values per dictionary. The dictionary body grows with this, and so does the
+    /// checksum computed over it.
+    @Param({ "1024", "4096" })
+    private int dictionaryValues;
+
+    private ByteBuffer fixture;
+
+    @Setup
+    public void setup() throws IOException {
+        Path dir = Path.of(dataDir).toAbsolutePath().normalize();
+        Files.createDirectories(dir);
+        Path path = dir.resolve("dict_page_setup_" + dictionaryValues + ".parquet");
+        if (!Files.exists(path)) {
+            write(path, dictionaryValues);
+        }
+        fixture = ByteBuffer.wrap(Files.readAllBytes(path));
+    }
+
+    @Benchmark
+    public void scanDictionaryEncodedColumn(Blackhole blackhole) throws IOException {
+        try (ParquetFileReader reader = ParquetFileReader.open(InputFile.of(fixture));
+                ColumnReader column = reader.columnReader("label")) {
+            while (column.nextBatch()) {
+                blackhole.consume(column.getStrings());
+            }
+        }
+    }
+
+    private static void write(Path path, int dictionaryValues) throws IOException {
+        FileSchema schema = FileSchema.builder("dict_page_setup")
+                .addColumn("label", PhysicalType.BYTE_ARRAY, RepetitionType.REQUIRED)
+                .build();
+        // Uncompressed so the dictionary body the checksum covers is the dictionary itself,
+        // not whatever a codec squeezed it down to.
+        WriterConfig config = WriterConfig.builder()
+                .rowGroupTargetRows(ROWS_PER_ROW_GROUP)
+                .codec(CompressionCodec.UNCOMPRESSED)
+                .build();
+
+        byte[][] values = new byte[ROWS_PER_ROW_GROUP][];
+        try (ParquetFileWriter writer = ParquetFileWriter.create(OutputFile.of(path), schema, config)) {
+            for (int rowGroup = 0; rowGroup < ROW_GROUPS; rowGroup++) {
+                for (int row = 0; row < ROWS_PER_ROW_GROUP; row++) {
+                    // Distinct across row groups, so no dictionary is shared and each chunk
+                    // carries its own page of `dictionaryValues` entries.
+                    values[row] = value(rowGroup, row % dictionaryValues);
+                }
+                byte[][] batch = values;
+                writer.columnWriter().writeBatch(b -> b.bytes(0, batch));
+            }
+        }
+    }
+
+    /// A [#VALUE_BYTES]-long value, unique to the `(rowGroup, ordinal)` pair, padded out so that
+    /// what makes the dictionary large is value length rather than entry count alone.
+    private static byte[] value(int rowGroup, int ordinal) {
+        byte[] bytes = new byte[VALUE_BYTES];
+        byte[] prefix = ("rg" + rowGroup + "-label-" + ordinal + "-")
+                .getBytes(StandardCharsets.UTF_8);
+        System.arraycopy(prefix, 0, bytes, 0, Math.min(prefix.length, VALUE_BYTES));
+        for (int i = prefix.length; i < VALUE_BYTES; i++) {
+            bytes[i] = (byte) ('a' + (i % 26));
+        }
+        return bytes;
+    }
+}

--- a/s3/pom.xml
+++ b/s3/pom.xml
@@ -50,6 +50,17 @@
   </dependencyManagement>
 
   <dependencies>
+    <!-- Not used by any code here. Declared so the reactor builds the Error Prone checks
+         before this module compiles: they reach javac through the compiler plugin's
+         annotationProcessorPaths, which the reactor does not read when ordering modules,
+         so under `-T` there is otherwise nothing stopping the two running at once. -->
+    <dependency>
+      <groupId>dev.hardwood</groupId>
+      <artifactId>hardwood-error-prone-checks</artifactId>
+      <version>${project.version}</version>
+      <scope>test</scope>
+    </dependency>
+
     <dependency>
       <groupId>dev.hardwood</groupId>
       <artifactId>hardwood-core</artifactId>

--- a/test-support/pom.xml
+++ b/test-support/pom.xml
@@ -39,6 +39,17 @@
   </dependencyManagement>
 
   <dependencies>
+    <!-- Not used by any code here. Declared so the reactor builds the Error Prone checks
+         before this module compiles: they reach javac through the compiler plugin's
+         annotationProcessorPaths, which the reactor does not read when ordering modules,
+         so under `-T` there is otherwise nothing stopping the two running at once. -->
+    <dependency>
+      <groupId>dev.hardwood</groupId>
+      <artifactId>hardwood-error-prone-checks</artifactId>
+      <version>${project.version}</version>
+      <scope>test</scope>
+    </dependency>
+
     <dependency>
       <groupId>org.junit.jupiter</groupId>
       <artifactId>junit-jupiter-api</artifactId>


### PR DESCRIPTION
Closes #1096. Carries a build fix belonging to #1124, which was blocking this branch.

`SequentialFetchPlan.initialize()` has to parse the dictionary page header itself — it needs the header size to know where the page ends and the next one begins. It then handed the whole region, header included, to `DictionaryParser.parse`, which opened a reader at offset 0 and read that same header back out, cut the same body, and checked the same checksum. The second answer agreed with the first by construction, which is why nothing ever caught it.

`DictionaryParser` gains `parsePage`, taking the already-parsed header and the body it delimits. The region-based `parse` stays for callers that genuinely start from an unparsed region — `IndexedFetchPlan`, the dictionary filter source, and both CLI entry points — and now reaches the same code once it has found a dictionary page to hand over.

Ownership of the checksum moves with it, as the issue asked. Repo-wide there are now exactly two `CrcValidator.assertCorrectCrc` call sites: `DictionaryParser` for dictionary pages and `PageDecoder` for data pages. The value count is validated in the same place, so the two entry points cannot drift on what counts as a valid page — and a dictionary page whose header omits `dictionary_page_header`, which used to reach the decoder and dereference null, now fails with a message.

## What it is worth

The end-to-end scan cannot measure this, and it took two wrong answers to establish that. On a fixture built to foreground the dictionary — 100 row groups, each a megabyte of dictionary feeding twelve kilobytes of indices — before and after are indistinguishable: 281.0 ± 20.1 ms against 278.5 ± 18.2 ms. `perfnorm` first appeared to show −74M instructions/op, but the check that mattered killed it: the wide fixture carries four times the dictionary bytes of the narrow one, so a checksum-driven delta has to be about four times larger there, and instead it was smaller (74M against 111M). Repeating with five forks explained why — the error bars are ±120–230M. A read that spans a thread pool and decodes several hundred thousand values per operation, with its GC and JIT threads counted in, has no resolution at this scale.

One page on one thread does. Setting up a single dictionary page, against the decode floor both entry points end in:

| dictionary | decode floor | header handed over | region handed over | duplicated work |
| --- | --- | --- | --- | --- |
| 256 KB | 94.17 ± 0.57 | 94.42 ± 0.82 | 117.49 ± 0.38 | 23.1 µs (+24.5%) |
| 1 MB | 427.56 ± 1.30 | 427.81 ± 1.18 | 514.90 ± 1.56 | 87.1 µs (+20.4%) |

Four times the dictionary bytes, 3.8 times the saving. That linear scaling is what identifies the cost as the checksum rather than the header parse: it is roughly 12 GB/s of redundant CRC-32. Setup overhead above the decode floor falls from 23.3 µs and 87.3 µs to 0.25 µs.

The two measurements agree once the arithmetic is done. A hundred row groups at 87 µs is 8.7 ms of CPU, spread across the four threads the scan keeps busy — about 2 ms of a 280 ms read, or 0.8%, far inside the ±18 ms band. So this is a per-column-chunk win that shows on files with many row groups and large dictionaries, and is invisible on a single-row-group scan.

Measured on an Intel N300, clock pinned at 1.50 GHz (`profiling-setup.sh calibrate 90 --pin`), Temurin 25.

## Benchmarks

Both are self-generating and documented in the micro-benchmarks README.

`DictionaryPageParseBenchmark` is the measurement above: one page, one thread, no file and no pool, with `decodeOnly` as the floor so the two gaps read as fractions of the work that had to happen anyway.

`DictionaryPageSetupBenchmark` puts the same work inside a real scan. It is a regression guard rather than a measurement, and its javadoc says so.

## Testing

`DictionaryParserTest` covers a page parsed from header and body alone — which only works if nothing re-reads a header out of those bytes — and each of the four things the parser refuses: a page of the wrong type, a body that is not the length the header describes, a missing `dictionary_page_header`, and a negative value count. The equivalence between the two entry points is asserted entry by entry rather than by dictionary size, since size is the header's `numValues` on both sides whatever bytes were decoded.

That the body is checked at all matters because a wrong body does not fail on its own: the uncompressed codec copies whatever remains of the buffer, so a region handed over whole decodes its own header bytes as dictionary entries, and the checksum that would catch it is one almost no writer emits.

`CrcValidationTest.testCorruptedDictionaryPageDetected` now corrupts the last byte before the first data page. It was corrupting the last byte of the column chunk, which is a data page byte — so it went through `PageDecoder`, duplicated `testCorruptedDataDetected`, and left the dictionary path untested on the failing side. Its fixture carries no page index, so it runs through `SequentialFetchPlan`, the path this changes.

Full `./mvnw verify`, integration tests included, is green.

## Notes for review

`parsePage` is `public` only so the benchmark module can call it; every caller inside `core` is same-package. Package-private would be the tighter choice, at the cost of the isolated measurement.

The indexed path's dictionary checksum has no corrupt-fixture test, because the only dictionary-CRC fixture in the repo lacks a page index. That predates this change and the code path is now shared, so I have left it alone.

## The build fix (#1124)

The first CI run of this branch failed in `hardwood-test-support`, resolving `hardwood-error-prone-checks` for its annotationProcessorPath, while the same reactor reported the checks built four milliseconds earlier. That is #1124's `-T 1C` against an ordering the reactor cannot derive: a processor path is compiler-plugin configuration, not a declared dependency. Only a local repository without the artifact exposes it, so a fresh clone or a cold CI cache hits it every time and everyone else never does — `./mvnw verify` on a clean checkout fails on current main.

The nine compiling modules now declare the checks as a `test`-scoped dependency, which is an edge the reactor reads. The parent cannot carry it: the checks module would depend on itself, which Maven rejects whatever the scope.

A `[docs]` commit also rewords CLAUDE.md's worktree rule, which said "before any branch work" and so had sessions building a worktree to read a diff, stated the reference checkout's branch as a property of the directory rather than a default for the session, and never said when a worktree stops being useful.

Also here: `MultiFilePlanningTest.aReadThatStopsEarlyDoesNotOpenEveryFile` failed once and passed on a re-run of the same tree. It read one row from an uncapped reader, abandoned the loop, and asserted fewer than all eight files had been touched — the shape `anUncappedFilteredReadYieldsWithoutPlanningTheWholeRead` warns against two tests below, since walking away leaves the retriever running. Stalling the calling thread for five seconds shows what was measured: uncapped it reaches 8 of 8 files and fails, and with `head(1)` it settles at 2 and stays there. The cap is the stop the surrounding javadoc already credits the test with, so it now has one. That commit is attributed to #1107.

Verified by deleting `~/.m2/repository/dev/hardwood/hardwood-error-prone-checks` — before the fix the `build-core` command failed 3/3 and `-T 1` passed; after it, both that command and a full `./mvnw verify` succeed from cold. A deliberate `var` still trips `NoVar`, so the checks are still running rather than quietly skipped.
