### PR TITLE
#1109 Give the match merge an owner, and give it to both consumers

### DIFF
--- a/_designs/DRAIN_SIDE_RECORD_FILTERING.md
+++ b/_designs/DRAIN_SIDE_RECORD_FILTERING.md
@@ -15,10 +15,10 @@ This design moves the eligible part of record-level filtering from the consumer 
 
 The architecture has four pieces:
 
-1. A `ColumnBatchMatcher` interface and per-`(type, op)` concrete classes that operate on a column's typed array + null `BitSet` and write a per-batch matches `long[]`.
+1. A `ColumnBatchMatcher` interface and per-`(type, op)` concrete classes that operate on a column's typed array + validity bitmap and write a per-batch matches `long[]`.
 2. A `BatchFilterCompiler` that decomposes an eligible `ResolvedPredicate` into per-column `ColumnBatchMatcher`s and returns `null` for any non-eligible shape (full fallback to the reader's record matcher).
 3. A `matches` field on `BatchExchange.Batch` and an extra step at the end of `FlatColumnWorker.publishCurrentBatch` to evaluate the column's matcher.
-4. Eligibility-gated changes in `FlatRowReader` to intersect per-column matches into a `combinedWords` array and iterate via `Long.numberOfTrailingZeros` instead of evaluating a `RowMatcher` per row.
+4. A `BatchMatchMerger` that combines the per-column matches into one per-batch survivor bitmap, which the consumer iterates via `Long.numberOfTrailingZeros` instead of evaluating a `RowMatcher` per row.
 
 Eligible queries take the drain-side path; ineligible queries fall back to the record matcher with no behavioural change. The eligibility decision is made once at `FlatRowReader.create` time via `BatchFilterCompiler.tryCompile`.
 
@@ -62,120 +62,60 @@ There is no separate leaf-count gate. The v1 prototype carried an `if (leaves.si
 
 ## `ColumnBatchMatcher` and per-`(type, op)` classes
 
-Sealed interface representing a per-column fragment over a single batch:
+A sealed interface representing a per-column fragment over a single batch: `test(Batch, long[] outWords)`, with one final implementation per `(type, op)` pair.
 
-```java
-public sealed interface ColumnBatchMatcher
-        permits LongBatchMatcher, DoubleBatchMatcher, IntBatchMatcher,
-                FloatBatchMatcher, BooleanBatchMatcher, NullBatchMatcher,
-                AndBatchMatcher, OrBatchMatcher {
-    void test(BatchExchange.Batch batch, long[] outWords);
-}
-```
+`outWords` is a `long[]` sized `(batchCapacity + 63) >>> 6`, owned by the caller. A bit at index `i` is set iff row `i` definitely matches (NULL → unset). The matcher overwrites every word it touches; the caller does not pre-clear.
 
-`outWords` is a `long[]` sized `(batchCapacity + 63) >>> 6`, owned by the `Batch`. A bit at index `i` is set iff row `i` definitely matches (NULL → unset). The matcher overwrites every word it touches; the caller does not pre-clear.
-
-Per-`(type, op)` final classes implement the typed body. The optimised inner loop uses a per-word accumulator pattern:
-
-```java
-final class LongGtBatchMatcher implements LongBatchMatcher {
-    private final long literal;
-    // ...
-
-    @Override
-    public void test(BatchExchange.Batch batch, long[] outWords) {
-        long[] vals = (long[]) batch.values;
-        BitSet nulls = batch.nulls;
-        int n = batch.recordCount;
-        long lit = literal;
-        int fullWords = n >>> 6;
-        int tail = n & 63;
-
-        if (nulls == null) {
-            for (int w = 0; w < fullWords; w++) {
-                int base = w << 6;
-                long word = 0L;
-                for (int b = 0; b < 64; b++) {
-                    word |= ((vals[base + b] > lit) ? 1L : 0L) << b;
-                }
-                outWords[w] = word;
-            }
-            // tail-word handling; bits past recordCount are left stale (see below)
-        }
-        // BitSet-null branch is structurally identical
-    }
-}
-```
-
-Key shape choices:
+Key shape choices in the typed inner loop:
 
 - **No `Arrays.fill`.** Each output word is written exactly once, in full, at the end of a 64-element block. Bits past `recordCount` in the tail word, and stale slots in words past `(recordCount + 63) >>> 6`, are intentionally left untouched — `nextSetBit` / `scanRunEnd` in `FlatRowReader` are bounded by `batchSize`, so any stale set bit at index `>= batchSize` is filtered by the `bit < limit` check.
 - **Branchless inner loop.** `(cond ? 1L : 0L) << b` lowers to `csel` on AArch64 / `setcc` on x86-64; the per-element cost stops depending on selectivity.
 - **Word-level accumulator.** `long word` lives in a register for 64 iterations — one store per 64 elements, not 64 read-modify-writes.
 - **Hoisted `literal`, `recordCount`, `fullWords`, `tail`.** The inner `for (b = 0; b < 64; b++)` is a constant-bound loop that the JIT unrolls.
-- **`nulls == null` specialised outside the per-word loops.** One branch per call, not per element.
+- **Presence specialised outside the per-word loops.** A batch whose leaves are all present takes a branch chosen once per call, not once per element. Presence is a packed `long[] validity` on the batch (set bit = present), so the null check is a load and a mask rather than a virtual call.
 
 NULL semantics: each fragment writes "definitely matches" — false on NULL. Word-wise AND of per-column matches gives SQL three-valued AND because any `unknown` conjunct unsets the bit; the same contract handles OR cleanly via word-wise OR (see the truth table under [Why `Or` is safe](#why-or-is-safe-under-definitely-matches-semantics)).
 
-`Null*BatchMatcher` short-circuits the per-bit loop entirely — `IsNullBatchMatcher.test` bulk-copies `nulls.toLongArray()`; `IsNotNullBatchMatcher.test` bulk-inverts the same. Like the typed matchers, bits past `recordCount` are left as-is and filtered by the consumer's `bit < limit` check.
+`Null*BatchMatcher` short-circuits the per-bit loop entirely — `IsNotNullBatchMatcher.test` bulk-copies the validity words; `IsNullBatchMatcher.test` bulk-inverts them. Like the typed matchers, bits past `recordCount` are left as-is and filtered by the consumer's `bit < limit` check.
 
 ---
 
 ## `Batch.matches` and drain-side evaluation
 
-`BatchExchange.Batch` gains a `long[] matches` field. Allocated once at construction (sized to `(batchCapacity + 63) >>> 6`) **only** for columns that actually have a fragment installed — other columns leave `matches == null`, which `FlatRowReader` interprets as "all-ones" during intersection.
+`BatchExchange.Batch` gains a `long[] matches` field. Allocated once at construction (sized to `(batchCapacity + 63) >>> 6`) **only** for columns that actually have a fragment installed — other columns leave `matches == null`, and the merge never reads them, because it visits exactly the columns its plan references.
 
-`FlatColumnWorker` gains a `final ColumnBatchMatcher columnFilter` field, constructor-injected so the contract is enforced by the type system rather than a "set before start" call order. At the end of `publishCurrentBatch`, immediately before pushing the batch onto the `readyQueue`:
-
-```java
-if (columnFilter != null) {
-    columnFilter.test(currentBatch, currentBatch.matches);
-}
-```
-
-Cost is paid on the drain thread, on hot data, in parallel with peer drains. When `columnFilter == null`, `publishCurrentBatch` is unchanged.
+`FlatColumnWorker` gains a `final ColumnBatchMatcher columnFilter` field, constructor-injected so the contract is enforced by the type system rather than a "set before start" call order. It runs the fragment into the batch's own `matches` array at the end of `publishCurrentBatch`, immediately before the batch goes onto the `readyQueue`. Cost is paid on the drain thread, on hot data, in parallel with peer drains. When statistics have already proved the batch's row group matches in full, the worker fills all-ones instead of running the fragment. With no fragment installed, `publishCurrentBatch` is unchanged.
 
 ---
 
-## Combine and iteration in `FlatRowReader`
+## Combine and iteration
 
 `FlatRowReader.create` calls `BatchFilterCompiler.tryCompile`. A non-null `CompiledBatchFilter` drives the drain-side path; otherwise the reader's record-matcher mode is used when a filter is set, and the plain cursor when not.
 
-The reader gains:
+### `BatchMatchMerger`
 
-- `long[] combinedWords` — the per-batch combined match mask.
-- `MergePlan mergePlan` — the consumer-side plan returned by the compiler. A top-level `MergePlan.Column` is the single-column fast path; everything else is evaluated by a shared evaluator (below).
-- `MergePlanEvaluator mergeEvaluator` — owns the depth-indexed scratch pool used by compound subtrees. Constructed once per reader; reused across all batches (zero allocations after warm-up).
-- `long[][] perColumnMatches` — preallocated `long[columnCount][]` whose entries are reseated each batch from `previousBatches[i].matches` and passed to the evaluator. Avoids coupling `MergePlanEvaluator` to the reader's `BatchExchange.Batch` type.
+One collaborator owns the whole per-batch merge: the plan, the `MergePlanEvaluator` and its scratch pool, the per-column bitmap slots and the combined buffer. Two axes are decided once at construction.
 
-`loadNextBatch`, after polling all column batches and when `drainSide` is true, calls `intersectMatches`:
+**Where the per-column bitmaps come from.** In *aliasing* mode the consumer's column workers have already run the fragments into each batch's own `matches` array, so the merge reseats pointers and copies nothing. In *owning* mode there are no workers, so the merger runs the fragments itself into buffers it allocates. `FlatRowReader` takes the first, `SelectionEngine` (the column-reader filter path, see [EXACT_COLUMN_READER_FILTERING.md](EXACT_COLUMN_READER_FILTERING.md)) the second; nothing else differs between them.
 
-```java
-private void intersectMatches() {
-    // Single-column fast path: alias the batch's matches array directly.
-    // No copy, no evaluator call, no owned combinedWords buffer needed.
-    if (mergePlan instanceof MergePlan.Column c) {
-        combinedWords = previousBatches[c.projectedIndex()].matches;
-        return;
-    }
-    // Multi-column: snapshot per-column matches references for this batch
-    // (one pointer per column — references shared, no data copied), then
-    // hand off to the shared evaluator.
-    for (int i = 0; i < columnCount; i++) {
-        perColumnMatches[i] = previousBatches[i].matches;
-    }
-    int activeWords = (batchSize + 63) >>> 6;
-    mergeEvaluator.eval(mergePlan, combinedWords, activeWords, perColumnMatches);
-}
-```
+**Plan shape.** A top-level `MergePlan.Column` has nothing to combine, so the merge yields that one column's bitmap directly — no combined buffer, no evaluator, no scratch pool. Any other plan goes to the evaluator, which populates the combined buffer in place.
 
-`MergePlanEvaluator.eval` is a recursive walk: a `Column` node arraycopies the column's bitmap into the output; an `And` node merges its children word-wise with the same all-zero short-circuit the previous shape used (skipping later children once the intersection collapses); an `Or` node word-ORs. Column children of an And/Or bypass scratch and merge directly from their `matches` array; only compound children get a depth-indexed scratch buffer. Sibling frames at the same depth reuse one buffer (their lives don't overlap), but a frame at depth+1 gets a distinct buffer (depth's is still in use). Pool entries persist across calls.
+The merger visits only the projected columns its plan references, collected once at construction by walking the plan. That set is the merge's contract with its caller: those are the only entries of the batch array it dereferences, so a consumer that stages that array itself need keep only those current. It is derived in one place, so the two consumers cannot disagree about which columns the plan reads.
 
-The evaluator is also used by `DrainSideOracleTest`'s drain-side path so the two implementations of the merge semantics can't drift; the oracle's independence comes from the **per-row** compile path (`RecordFilterCompiler` + `RowMatcher.test`), not from a duplicate evaluator.
+`merge` runs once per batch, never per row.
 
-Only the words covering `[0, batchSize)` are touched — bits past `batchSize` are not read by the consumer (`nextSetBit` is bounded), so leaving them stale is safe and avoids the trailing zero-fill the original shape paid every batch.
+### `MergePlanEvaluator`
 
-`hasNext()` / `next()` advance via a `nextSetBit` helper using `Long.numberOfTrailingZeros` over `combinedWords`. Accessors (`getLong(int)`, `isNull(int)`, etc.) are unchanged — they still index `flatValueArrays[idx][rowIndex]`; the only difference is which rows `rowIndex` visits.
+A recursive walk of the plan: a `Column` node arraycopies the column's bitmap into the output; an `And` node merges its children word-wise with an all-zero short-circuit (skipping later children once the intersection collapses); an `Or` node word-ORs. Column children of an And/Or merge directly from their bitmap; only compound children get a depth-indexed scratch buffer. Sibling frames at the same depth reuse one buffer (their lives don't overlap), while a frame at depth+1 gets a distinct buffer (depth's is still in use). Pool entries persist across calls, so the merge allocates nothing after warm-up.
+
+`DrainSideOracleTest` merges the bitmaps itself rather than through the merger; its independence comes from the **per-row** compile path (`RecordFilterCompiler` + `RowMatcher.test`) it compares against, not from a duplicate evaluator.
+
+Only the words covering `[0, batchSize)` are written — bits past `batchSize` are not read by the consumer, so leaving them stale is safe and avoids a trailing zero-fill every batch.
+
+### Iteration
+
+The reader caches the bitmap the merge returned and advances through it with a `nextSetBit` helper over `Long.numberOfTrailingZeros`, plus a run walk that skips the bit scan while inside a run of consecutive 1s. Accessors (`getLong(int)`, `isNull(int)`, etc.) are unchanged — they still index the batch's typed array; the only difference is which rows the cursor visits.
+
 
 ---
 
@@ -237,7 +177,7 @@ JMH, fork=1, warmup=3×1s, measurement=5×1s, single-threaded. `ns/op` is per-ro
 | intIn5   | 1.364          | gated → fallback | n/a              | Single-fragment IN-list.           |
 | intIn32  | 3.126          | gated → fallback | n/a              | Same.                              |
 
-The drain-side path is still slower single-threaded across every eligible shape — the codegen claim from v1 (that a hand-written batch loop would beat the inlined indexed-accessor leaf) does not hold even with the rewritten matchers. **But the gap shrinks as leaf count grows**: `and2` is 6.9× slower, `and4` is 3.8×. Larger leaf counts amortise the per-batch overhead (`Arrays.fill`-free output, per-word accumulator, `intersectMatches`) over more comparison work, while the compiled path's cost grows linearly in leaves. The per-leaf cost of drain-side has dropped to roughly half what v1 measured.
+The drain-side path is still slower single-threaded across every eligible shape — the codegen claim from v1 (that a hand-written batch loop would beat the inlined indexed-accessor leaf) does not hold even with the rewritten matchers. **But the gap shrinks as leaf count grows**: `and2` is 6.9× slower, `and4` is 3.8×. Larger leaf counts amortise the per-batch overhead (`Arrays.fill`-free output, per-word accumulator, the merge itself) over more comparison work, while the compiled path's cost grows linearly in leaves. The per-leaf cost of drain-side has dropped to roughly half what v1 measured.
 
 Why drain-side stays slower single-threaded:
 
@@ -287,6 +227,8 @@ One read of `vals[]`, one bitmap, no intersect. Strictly cheaper than two single
 **Difficulty.** Low. Two new matcher classes plus a grouping pass in `BatchFilterCompiler.tryCompile`. No changes to drain plumbing or intersect logic.
 
 ### `BitSet nulls` → `long[] notNullWords`
+
+**Status: done.** Landed as `BatchExchange.Batch.validity: long[]` (set bit = present), which is the `notNullWords` polarity described here. The rest of this entry is kept for the reasoning it records; the migration itself is no longer outstanding.
 
 **Why it matters.** The biggest remaining drag on single-threaded drain-side throughput. `BitSet.get(int)` is a virtual call into a non-final method that does its own shift, mask, bounds check, and array load — HotSpot will not autovectorise around it. Even though the value comparison in every matcher is now branchless (`(cond ? 1L : 0L) << b`), the null check inside that comparison blocks SIMD lowering. Compiled per-row doesn't have this problem because it uses indexed accessors the JIT inlines through.
 

--- a/_designs/EXACT_COLUMN_READER_FILTERING.md
+++ b/_designs/EXACT_COLUMN_READER_FILTERING.md
@@ -92,11 +92,13 @@ selection through one of two backends, chosen once at construction by
 `BatchFilterCompiler.tryCompile`:
 
 **Eligible backend (fast).** When `tryCompile` returns a `CompiledBatchFilter`
-(flat, top-level, supported `(type, op)`), the predicate columns' workers run
-their `ColumnBatchMatcher` on the drain thread and write `Batch.matches`, exactly
-as for the row reader. The engine merges the per-column bitmaps with the
-`MergePlan` via `MergePlanEvaluator`. This is the existing
-`FlatRowReader.intersectMatches` logic, extracted so both readers share it.
+(flat, top-level, supported `(type, op)`), the engine drives a `BatchMatchMerger`
+— the same collaborator the row reader's drain-side path uses, described in
+[DRAIN_SIDE_RECORD_FILTERING.md](DRAIN_SIDE_RECORD_FILTERING.md). It takes the
+merger in its *owning* mode: there are no worker threads here to have run the
+`ColumnBatchMatcher` fragments, so the merger runs them over the decoded batches
+itself, into buffers it owns, before combining them with the `MergePlan`. That
+mode is the only thing the two readers do differently at the merge.
 
 **Fallback backend (parity).** When `tryCompile` returns `null` — nested
 predicate paths, binary, geospatial, unsupported `(type, op)` — the engine

--- a/core/src/main/java/dev/hardwood/internal/predicate/CompiledBatchFilter.java
+++ b/core/src/main/java/dev/hardwood/internal/predicate/CompiledBatchFilter.java
@@ -7,6 +7,8 @@
  */
 package dev.hardwood.internal.predicate;
 
+import java.util.Objects;
+
 /// Result of compiling an eligible [ResolvedPredicate] for the drain-side
 /// filter path.
 ///
@@ -17,4 +19,9 @@ package dev.hardwood.internal.predicate;
 ///   [dev.hardwood.internal.reader.FlatRowReader] to combine the per-column
 ///   bitmaps into one per-batch survivor mask.
 public record CompiledBatchFilter(ColumnBatchMatcher[] columnMatchers, MergePlan mergePlan) {
+
+    public CompiledBatchFilter {
+        Objects.requireNonNull(columnMatchers, "columnMatchers");
+        Objects.requireNonNull(mergePlan, "mergePlan");
+    }
 }

--- a/core/src/main/java/dev/hardwood/internal/predicate/MergePlan.java
+++ b/core/src/main/java/dev/hardwood/internal/predicate/MergePlan.java
@@ -27,7 +27,14 @@ public sealed interface MergePlan {
         MergePlan[] children();
     }
 
-    record Column(int projectedIndex) implements MergePlan {}
+    record Column(int projectedIndex) implements MergePlan {
+        public Column {
+            if (projectedIndex < 0) {
+                throw new IllegalArgumentException(
+                        "Column requires a projected index, got " + projectedIndex);
+            }
+        }
+    }
 
     record And(MergePlan[] children) implements Compound {
         public And {

--- a/core/src/main/java/dev/hardwood/internal/predicate/MergePlanEvaluator.java
+++ b/core/src/main/java/dev/hardwood/internal/predicate/MergePlanEvaluator.java
@@ -16,9 +16,9 @@ package dev.hardwood.internal.predicate;
 /// gets a distinct buffer (the depth's buffer is still in use). Pool entries
 /// persist across calls — zero per-call allocations after warm-up.
 ///
-/// The same instance is used by [dev.hardwood.internal.reader.FlatRowReader]
-/// on the hot path and by `DrainSideOracleTest` to verify equivalence with the
-/// per-row compile path.
+/// Instances are owned by [dev.hardwood.internal.reader.BatchMatchMerger] on
+/// the hot path and by `DrainSideOracleTest`, which merges the bitmaps itself
+/// to verify equivalence with the per-row compile path.
 public final class MergePlanEvaluator {
 
     private final int wordsLen;

--- a/core/src/main/java/dev/hardwood/internal/predicate/matcher/nulls/IsNotNullBatchMatcher.java
+++ b/core/src/main/java/dev/hardwood/internal/predicate/matcher/nulls/IsNotNullBatchMatcher.java
@@ -28,7 +28,7 @@ public final class IsNotNullBatchMatcher implements NullBatchMatcher {
         }
         System.arraycopy(validity, 0, outWords, 0, wordsForN);
         // Bits past `n` in the last live word are intentionally left as-is —
-        // the consumer (FlatRowReader#intersectMatches) only touches the words
-        // covering `[0, n)`, so masking would be dead work.
+        // the consumer (BatchMatchMerger#merge) only touches the words covering
+        // `[0, n)`, so masking would be dead work.
     }
 }

--- a/core/src/main/java/dev/hardwood/internal/predicate/matcher/nulls/IsNullBatchMatcher.java
+++ b/core/src/main/java/dev/hardwood/internal/predicate/matcher/nulls/IsNullBatchMatcher.java
@@ -30,7 +30,7 @@ public final class IsNullBatchMatcher implements NullBatchMatcher {
             outWords[w] = ~validity[w];
         }
         // Bits past `n` in the last live word are intentionally left as-is —
-        // the consumer (FlatRowReader#intersectMatches) only touches the words
-        // covering `[0, n)`, so masking would be dead work.
+        // the consumer (BatchMatchMerger#merge) only touches the words covering
+        // `[0, n)`, so masking would be dead work.
     }
 }

--- a/core/src/main/java/dev/hardwood/internal/reader/BatchExchange.java
+++ b/core/src/main/java/dev/hardwood/internal/reader/BatchExchange.java
@@ -60,9 +60,9 @@ public class BatchExchange<B> {
         public String fileName;
         /// Per-batch matches mask, populated by [dev.hardwood.internal.predicate.ColumnBatchMatcher]
         /// on the drain thread when drain-side filtering is enabled. `null` means "no
-        /// fragment for this column" — interpreted as all-ones during intersection.
-        /// When non-null, sized to `(batchCapacity + 63) >>> 6` and overwritten on every
-        /// drain-side test call.
+        /// fragment for this column" — [BatchMatchMerger] never reads those columns, since
+        /// it visits exactly the ones its plan references. When non-null, sized to
+        /// `(batchCapacity + 63) >>> 6` and overwritten on every drain-side test call.
         public long[] matches;
 
         /// Whether statistics proved every record of this batch matches the filter

--- a/core/src/main/java/dev/hardwood/internal/reader/BatchMatchMerger.java
+++ b/core/src/main/java/dev/hardwood/internal/reader/BatchMatchMerger.java
@@ -1,0 +1,190 @@
+/*
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Copyright The original authors
+ *
+ *  Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package dev.hardwood.internal.reader;
+
+import dev.hardwood.internal.predicate.ColumnBatchMatcher;
+import dev.hardwood.internal.predicate.CompiledBatchFilter;
+import dev.hardwood.internal.predicate.MergePlan;
+import dev.hardwood.internal.predicate.MergePlanEvaluator;
+
+/// Combines the per-column [BatchExchange.Batch#matches] bitmaps a compiled
+/// batch filter produces into the one per-row survivor bitmap its consumer
+/// iterates.
+///
+/// Owns everything the merge needs — the plan, the evaluator and its scratch
+/// pool, the per-column bitmap slots and the combined buffer — so a consumer
+/// holds a single collaborator rather than five correlated fields.
+///
+/// Two axes, both decided once at construction:
+///
+/// - **Where the per-column bitmaps come from.** [#aliasing] serves a consumer
+///   whose column workers already ran the matchers into each batch's own
+///   `matches` array: the merge reseats pointers and copies nothing.
+///   [#owning] serves a consumer with no workers — it runs the matchers itself,
+///   into buffers allocated here.
+/// - **Plan shape.** A single-column plan has nothing to combine, so the merge
+///   yields that one column's bitmap: no combined buffer, no evaluator, no
+///   scratch pool. Any other plan goes to the evaluator, which populates the
+///   combined buffer in place.
+///
+/// [#merge] runs once per batch, never per row.
+public final class BatchMatchMerger {
+
+    /// Projected index of the single column [#merge] yields, or `-1` when the
+    /// plan is a compound and the bitmaps have to be combined. Resolved at
+    /// construction so the per-batch path is an int test rather than a type test.
+    private final int aliasedColumn;
+
+    /// Per-column matchers to run over each batch, indexed by projected column
+    /// index, or `null` when the consumer's workers already ran them.
+    private final ColumnBatchMatcher[] matchers;
+    /// Projected indices the plan reads. The only entries of [#merge]'s
+    /// `batches` argument it dereferences, so a caller staging that array need
+    /// keep only these current — and the only entries of [#perColumn] it
+    /// touches, so the per-batch cost scales with the filter width rather than
+    /// the projection width.
+    private final int[] referencedColumns;
+    /// Per-column bitmaps indexed by projected column index. Under [#owning]
+    /// the referenced entries are buffers allocated here and overwritten by the
+    /// matchers; under [#aliasing] they are reseated each batch to the batches'
+    /// own arrays.
+    private final long[][] perColumn;
+
+    // Compound-plan state; all null on the single-column path.
+
+    /// Plan describing how to combine the per-column bitmaps.
+    private final MergePlan plan;
+    /// Walks [#plan] each batch. Owns the depth-indexed scratch pool and is
+    /// reused across batches, so the merge allocates nothing after warm-up.
+    private final MergePlanEvaluator evaluator;
+    /// Destination for the combined bitmap, owned and reused across batches.
+    private final long[] combined;
+
+    /// A merger for a consumer whose column workers already wrote every batch's
+    /// `matches` array, as [FlatColumnWorker] does on the drain-side read path.
+    ///
+    /// @param plan how to combine the per-column bitmaps
+    /// @param columnCount number of projected columns
+    /// @param wordsLen words needed to cover the largest batch
+    public static BatchMatchMerger aliasing(MergePlan plan, int columnCount, int wordsLen) {
+        return new BatchMatchMerger(plan, null, columnCount, wordsLen);
+    }
+
+    /// A merger for a consumer with no column workers: [#merge] runs `filter`'s
+    /// per-column matchers over the batches itself, into buffers allocated here.
+    ///
+    /// @param filter the compiled filter, supplying both the matchers and the plan
+    /// @param columnCount number of projected columns
+    /// @param wordsLen words needed to cover the largest batch
+    public static BatchMatchMerger owning(CompiledBatchFilter filter, int columnCount, int wordsLen) {
+        return new BatchMatchMerger(filter.mergePlan(), filter.columnMatchers(), columnCount, wordsLen);
+    }
+
+    private BatchMatchMerger(MergePlan plan, ColumnBatchMatcher[] matchers, int columnCount, int wordsLen) {
+        this.matchers = matchers;
+        this.referencedColumns = referencedColumns(plan, columnCount);
+        this.perColumn = new long[columnCount][];
+        if (matchers != null) {
+            for (int c : referencedColumns) {
+                perColumn[c] = new long[wordsLen];
+            }
+        }
+        if (plan instanceof MergePlan.Column c) {
+            this.aliasedColumn = c.projectedIndex();
+            this.plan = null;
+            this.evaluator = null;
+            this.combined = null;
+        }
+        else {
+            this.aliasedColumn = -1;
+            this.plan = plan;
+            this.evaluator = new MergePlanEvaluator(wordsLen);
+            this.combined = new long[wordsLen];
+        }
+    }
+
+    /// The projected column indices [#merge] reads from its `batches` argument.
+    /// A caller that stages that array itself need only keep these entries
+    /// current. Returns a copy; call it once and keep the result.
+    public int[] referencedColumns() {
+        return referencedColumns.clone();
+    }
+
+    /// Returns the survivor bitmap for the batch now loaded, set bit = the row
+    /// matches. Valid until the next call; on the single-column
+    /// [#aliasing] path it is the batch's own array, which stays valid until
+    /// that batch is recycled.
+    ///
+    /// The combined buffer is written only over the words covering
+    /// `[0, recordCount)` — bits past `recordCount` are never read by the
+    /// consumer, so leaving them stale from an earlier, longer batch is safe
+    /// and saves a trailing zero-fill per batch. The same holds of the
+    /// per-column bitmaps, whether a worker or [#bitmap] filled them.
+    ///
+    /// @param batches the batches being served, indexed by projected column
+    ///         index; only [#referencedColumns] are dereferenced
+    /// @param recordCount rows in the batch
+    public long[] merge(BatchExchange.Batch[] batches, int recordCount) {
+        if (aliasedColumn >= 0) {
+            return bitmap(batches, aliasedColumn);
+        }
+        // Snapshot the bitmaps the plan reads for this batch and hand off to the
+        // evaluator. Only the plan-referenced columns are touched (one pointer
+        // each under aliasing); the indirection is negligible vs. the per-row
+        // merge work.
+        for (int i = 0; i < referencedColumns.length; i++) {
+            int c = referencedColumns[i];
+            perColumn[c] = bitmap(batches, c);
+        }
+        evaluator.eval(plan, combined, (recordCount + 63) >>> 6, perColumn);
+        return combined;
+    }
+
+    /// The bitmap for projected column `c`: the batch's own array when the
+    /// consumer's workers filled it, otherwise this merger's buffer, filled here.
+    private long[] bitmap(BatchExchange.Batch[] batches, int c) {
+        if (matchers == null) {
+            return batches[c].matches;
+        }
+        long[] words = perColumn[c];
+        matchers[c].test(batches[c], words);
+        return words;
+    }
+
+    /// Collects the projected column indices referenced by `plan`, so [#merge]
+    /// touches only those columns instead of all `columnCount` of them each batch.
+    private static int[] referencedColumns(MergePlan plan, int columnCount) {
+        boolean[] seen = new boolean[columnCount];
+        markReferenced(plan, seen);
+        int count = 0;
+        for (int i = 0; i < columnCount; i++) {
+            if (seen[i]) {
+                count++;
+            }
+        }
+        int[] result = new int[count];
+        int idx = 0;
+        for (int i = 0; i < columnCount; i++) {
+            if (seen[i]) {
+                result[idx++] = i;
+            }
+        }
+        return result;
+    }
+
+    private static void markReferenced(MergePlan node, boolean[] seen) {
+        switch (node) {
+            case MergePlan.Column c -> seen[c.projectedIndex()] = true;
+            case MergePlan.Compound compound -> {
+                for (MergePlan child : compound.children()) {
+                    markReferenced(child, seen);
+                }
+            }
+        }
+    }
+}

--- a/core/src/main/java/dev/hardwood/internal/reader/FlatRowReader.java
+++ b/core/src/main/java/dev/hardwood/internal/reader/FlatRowReader.java
@@ -22,8 +22,6 @@ import dev.hardwood.internal.conversion.LogicalTypeConverter;
 import dev.hardwood.internal.predicate.BatchFilterCompiler;
 import dev.hardwood.internal.predicate.ColumnBatchMatcher;
 import dev.hardwood.internal.predicate.CompiledBatchFilter;
-import dev.hardwood.internal.predicate.MergePlan;
-import dev.hardwood.internal.predicate.MergePlanEvaluator;
 import dev.hardwood.internal.predicate.RecordFilterCompiler;
 import dev.hardwood.internal.predicate.ResolvedPredicate;
 import dev.hardwood.internal.predicate.RowMatcher;
@@ -102,34 +100,17 @@ public final class FlatRowReader implements FileAwareRowReader {
     private boolean exhausted;
     private boolean closed;
 
-    // Drain-side filter path: when drainSide is true, iterate via nextSetBit over
-    // combinedWords. When false, the original rowIndex++ path is taken.
-    private final boolean drainSide;
-    /// Combined per-row matches for the current batch. `null` when `!drainSide`.
-    /// Multi-column case: an owned buffer that [#intersectMatches] hands to
-    /// [#mergeEvaluator] for in-place population. Single-column case
-    /// (`mergePlan instanceof MergePlan.Column`): aliased per batch to the
-    /// underlying [BatchExchange.Batch#matches] array (no copy, no evaluator
-    /// call — there is nothing to combine).
+    /// Owns the whole per-batch match merge — the plan, the evaluator and its
+    /// scratch, the per-column bitmap slots and the combined buffer. Non-null is
+    /// what makes this a drain-side read: [#hasNext] then iterates via
+    /// [#nextSetBit] over [#combinedWords] instead of the plain `rowIndex++`
+    /// cursor. `null` when the read has no drain-side filter.
+    private final BatchMatchMerger matchMerger;
+    /// The current batch's survivor bitmap, as [BatchMatchMerger#merge] returned
+    /// it when the batch loaded. Cached in the reader so the per-row
+    /// [#nextSetBit] and run walk read the array through one field rather than
+    /// reaching through the merger. `null` when there is no drain-side filter.
     private long[] combinedWords;
-    /// Plan describing how to merge the per-column [BatchExchange.Batch#matches]
-    /// bitmaps into [#combinedWords]. `null` when `!drainSide`.
-    private final MergePlan mergePlan;
-    /// Evaluator that walks [#mergePlan] each batch. Owns the scratch pool;
-    /// reused across batches (zero allocations after warm-up). `null` when the
-    /// single-column fast path applies (no merge to do).
-    private final MergePlanEvaluator mergeEvaluator;
-    /// Per-column matches bitmaps for the current batch, indexed by projected
-    /// column index. Repopulated each batch from `previousBatches[i].matches`;
-    /// passed to [#mergeEvaluator]. `null` when the single-column fast path
-    /// applies.
-    private final long[][] perColumnMatches;
-    /// Projected indices of the columns [#mergePlan] actually reads, computed
-    /// once at construction. [#intersectMatches] reseats only these entries of
-    /// [#perColumnMatches] each batch, so the per-batch cost scales with the
-    /// filter width rather than the full projection width. `null` when the
-    /// single-column fast path applies.
-    private final int[] referencedColumns;
     private int pendingRowIndex = -1;
     /// Cap on the number of *matching* rows yielded (SQL LIMIT over the filtered
     /// relation). [ColumnWorker#UNLIMITED] means no cap. Enforced on both filtering
@@ -152,9 +133,9 @@ public final class FlatRowReader implements FileAwareRowReader {
     /// filter and nothing evaluates records.
     private final RecordFilterTally tally;
 
-    public FlatRowReader(BatchExchange<BatchExchange.Batch>[] exchanges, FlatColumnWorker[] columnWorkers,
+    private FlatRowReader(BatchExchange<BatchExchange.Batch>[] exchanges, FlatColumnWorker[] columnWorkers,
                          FileSchema fileSchema, ProjectedSchema projectedSchema,
-                         boolean drainSide, int wordsLen, MergePlan mergePlan, long maxMatchedRows,
+                         BatchMatchMerger matchMerger, long maxMatchedRows,
                          RowMatcher recordMatcher, RecordFilterTally tally) {
         this.maxMatchedRows = maxMatchedRows;
         this.recordMatcher = recordMatcher;
@@ -167,17 +148,7 @@ public final class FlatRowReader implements FileAwareRowReader {
         this.flatValueArrays = new Object[columnCount];
         this.flatValidity = new long[columnCount][];
         this.previousBatches = new BatchExchange.Batch[columnCount];
-        this.drainSide = drainSide;
-        // Multi-column drain needs a private buffer for the combined words plus
-        // an evaluator that owns the depth-indexed scratch pool. A top-level
-        // Column aliases the batch's matches array directly (see
-        // intersectMatches) so neither buffer nor evaluator is needed.
-        boolean needsOwnedBuffer = drainSide && !(mergePlan instanceof MergePlan.Column);
-        this.combinedWords = needsOwnedBuffer ? new long[wordsLen] : null;
-        this.mergePlan = mergePlan;
-        this.mergeEvaluator = needsOwnedBuffer ? new MergePlanEvaluator(wordsLen) : null;
-        this.perColumnMatches = needsOwnedBuffer ? new long[columnCount][] : null;
-        this.referencedColumns = needsOwnedBuffer ? referencedColumns(mergePlan, columnCount) : null;
+        this.matchMerger = matchMerger;
 
         // Build name-to-index map and cache column metadata
         this.nameToIndex = new StringToIntMap(columnCount);
@@ -269,7 +240,7 @@ public final class FlatRowReader implements FileAwareRowReader {
             compiledFilter = BatchFilterCompiler.tryCompile(filter, schema, projectedSchema::toProjectedIndex);
         }
         ColumnBatchMatcher[] columnBatchMatchers = compiledFilter != null ? compiledFilter.columnMatchers() : null;
-        boolean drainSide = columnBatchMatchers != null;
+        final boolean drainSide = compiledFilter != null;
         final int wordsLen = (batchSize + 63) >>> 6;
 
         FlatColumnWorker[] workers = new FlatColumnWorker[projectedColumnCount];
@@ -306,10 +277,11 @@ public final class FlatRowReader implements FileAwareRowReader {
             worker.start();
         }
 
-        MergePlan mergePlan = compiledFilter != null ? compiledFilter.mergePlan() : null;
-        if (mergePlan == null) {
-            drainSide = false;
-        }
+        // The merger *is* the drain-side path in the reader: present exactly when the
+        // predicate compiled to one, absent when the record matcher takes over.
+        BatchMatchMerger matchMerger = drainSide
+                ? BatchMatchMerger.aliasing(compiledFilter.mergePlan(), projectedColumnCount, wordsLen)
+                : null;
 
         // Whatever the drain side could not compile, the reader evaluates a record at a
         // time. Indexed compile path: for flat schemas every leaf column is also a
@@ -326,7 +298,7 @@ public final class FlatRowReader implements FileAwareRowReader {
         // boundaries as it loads batches.
         RecordFilterTally tally = filter != null ? new RecordFilterTally() : null;
         FlatRowReader reader = new FlatRowReader(buffers, workers, schema, projectedSchema,
-                drainSide, wordsLen, mergePlan, readerMatchLimit, recordMatcher, tally);
+                matchMerger, readerMatchLimit, recordMatcher, tally);
         reader.initialize();
         return reader;
     }
@@ -338,7 +310,7 @@ public final class FlatRowReader implements FileAwareRowReader {
         if (exhausted) {
             return false;
         }
-        if (drainSide) {
+        if (matchMerger != null) {
             if (maxMatchedRows != ColumnWorker.UNLIMITED && matchedRowsYielded >= maxMatchedRows) {
                 exhausted = true;
                 return false;
@@ -419,7 +391,7 @@ public final class FlatRowReader implements FileAwareRowReader {
     public void next() throws IOException {
         // Both filtering modes park the row they picked in `pendingRowIndex`; this only
         // commits it. They differ in how `hasNext` finds the row, not in what `next` does.
-        if (drainSide || activeMatcher != null) {
+        if (matchMerger != null || activeMatcher != null) {
             if (pendingRowIndex < 0) {
                 throw new NoSuchElementException("No matching row available. Call hasNext() first.");
             }
@@ -915,8 +887,8 @@ public final class FlatRowReader implements FileAwareRowReader {
             }
         }
         rowIndex = -1;
-        if (drainSide) {
-            intersectMatches();
+        if (matchMerger != null) {
+            combinedWords = matchMerger.merge(previousBatches, batchSize);
             // pendingRowIndex is already -1 here: hasNext() only calls loadNextBatch
             // after nextSetBit returns -1, which happens only when pendingRowIndex < 0;
             // next() clears it before any further hasNext(); initialize() runs with the
@@ -927,7 +899,7 @@ public final class FlatRowReader implements FileAwareRowReader {
             // Ahead of any record of this batch being counted, so the counts land
             // on the file the batch came from. Batches never straddle files.
             tally.switchFile(currentFileName);
-            if (drainSide) {
+            if (matchMerger != null) {
                 // The whole batch was decided on the drain thread — count it here
                 // rather than as rows are yielded, so an early exit does not leave
                 // the batch reported as all-skipped.
@@ -944,38 +916,8 @@ public final class FlatRowReader implements FileAwareRowReader {
         return true;
     }
 
-    /// Combines per-column [BatchExchange.Batch.matches] arrays into [combinedWords]
-    /// by delegating to [#mergeEvaluator].
-    ///
-    /// Only the words covering `[0, batchSize)` are touched — bits past
-    /// `batchSize` are not read by the consumer (`nextSetBit` is bounded by
-    /// `batchSize`), so leaving them stale is safe and avoids the trailing
-    /// zero-fill the previous shape paid every batch.
-    ///
-    /// **Single-column fast path**: when the whole predicate is a single
-    /// [MergePlan.Column] there is nothing to merge, so [combinedWords] is
-    /// aliased directly to the batch's own `matches` array — no copy, no owned
-    /// buffer, no evaluator call. The alias is reseated each batch; the array
-    /// stays valid until the batch is recycled in the next [#loadNextBatch].
-    private void intersectMatches() {
-        if (mergePlan instanceof MergePlan.Column c) {
-            combinedWords = previousBatches[c.projectedIndex()].matches;
-            return;
-        }
-        // Snapshot the matches references the plan reads for this batch and hand
-        // off to the shared evaluator. Only the plan-referenced columns are
-        // reseated (one pointer each); the indirection is negligible vs. the
-        // per-row merge work.
-        for (int i = 0; i < referencedColumns.length; i++) {
-            int c = referencedColumns[i];
-            perColumnMatches[c] = previousBatches[c].matches;
-        }
-        int activeWords = (batchSize + 63) >>> 6;
-        mergeEvaluator.eval(mergePlan, combinedWords, activeWords, perColumnMatches);
-    }
-
     /// Counts the set bits of `words` below `limit`. The words past `limit` hold
-    /// stale bits from an earlier, longer batch (see [#intersectMatches]), so the
+    /// stale bits from an earlier, longer batch (see [BatchMatchMerger#merge]), so the
     /// partial tail word is masked rather than counted whole.
     private static int countMatches(long[] words, int limit) {
         int fullWords = limit >>> 6;
@@ -988,39 +930,6 @@ public final class FlatRowReader implements FileAwareRowReader {
             count += Long.bitCount(words[fullWords] & (~0L >>> (64 - tailBits)));
         }
         return count;
-    }
-
-    /// Collects the projected column indices referenced by `plan`, so
-    /// [#intersectMatches] can reseat only those entries of [#perColumnMatches]
-    /// instead of all `columnCount` columns each batch.
-    private static int[] referencedColumns(MergePlan plan, int columnCount) {
-        boolean[] seen = new boolean[columnCount];
-        markReferenced(plan, seen);
-        int count = 0;
-        for (int i = 0; i < columnCount; i++) {
-            if (seen[i]) {
-                count++;
-            }
-        }
-        int[] result = new int[count];
-        int idx = 0;
-        for (int i = 0; i < columnCount; i++) {
-            if (seen[i]) {
-                result[idx++] = i;
-            }
-        }
-        return result;
-    }
-
-    private static void markReferenced(MergePlan node, boolean[] seen) {
-        switch (node) {
-            case MergePlan.Column c -> seen[c.projectedIndex()] = true;
-            case MergePlan.Compound compound -> {
-                for (MergePlan child : compound.children()) {
-                    markReferenced(child, seen);
-                }
-            }
-        }
     }
 
     // ==================== Close ====================

--- a/core/src/main/java/dev/hardwood/reader/SelectionEngine.java
+++ b/core/src/main/java/dev/hardwood/reader/SelectionEngine.java
@@ -22,13 +22,12 @@ import java.util.UUID;
 
 import dev.hardwood.Validity;
 import dev.hardwood.internal.predicate.BatchFilterCompiler;
-import dev.hardwood.internal.predicate.ColumnBatchMatcher;
 import dev.hardwood.internal.predicate.CompiledBatchFilter;
-import dev.hardwood.internal.predicate.MergePlan;
-import dev.hardwood.internal.predicate.MergePlanEvaluator;
 import dev.hardwood.internal.predicate.RecordFilterCompiler;
 import dev.hardwood.internal.predicate.ResolvedPredicate;
 import dev.hardwood.internal.predicate.RowMatcher;
+import dev.hardwood.internal.reader.BatchExchange;
+import dev.hardwood.internal.reader.BatchMatchMerger;
 import dev.hardwood.internal.reader.BinaryBatchValues;
 import dev.hardwood.internal.reader.NestedBatch;
 import dev.hardwood.internal.reader.NestedBatchDataView;
@@ -52,31 +51,30 @@ import dev.hardwood.schema.FileSchema;
 /// Two backends, chosen once at construction:
 ///
 /// - **Drain-side** — when [BatchFilterCompiler] accepts the predicate (flat,
-///   top-level, supported `(type, op)`), the per-column [ColumnBatchMatcher]
-///   fragments run directly on the flat batches and are merged via the
-///   [MergePlan]. This reuses the row reader's drain-side machinery without
-///   the worker threads.
+///   top-level, supported `(type, op)`), a [BatchMatchMerger] runs the
+///   per-column matcher fragments over the flat batches and combines them into
+///   one survivor bitmap. This is the row reader's drain-side merge, in the
+///   mode where the merger runs the matchers itself because there are no
+///   worker threads to have run them already.
 /// - **Record matcher** — otherwise (nested paths, binary/string, unsupported
 ///   operators) the compiled [RowMatcher] is evaluated per record over a
 ///   batch-backed [StructAccessor] view of the predicate columns, giving full
 ///   parity with the row reader's filtered result.
 final class SelectionEngine {
 
-    private final int wordsLen;
-
     // Drain-side backend (null when the record-matcher backend is used).
-    private final ColumnBatchMatcher[] columnMatchers;
-    private final MergePlan mergePlan;
-    private final MergePlanEvaluator mergeEvaluator;
-    private final long[][] perColumn;
-    private final long[] combined;
+    private final BatchMatchMerger merger;
+    /// The batches [#merger] reads, indexed by projected column index. Staged
+    /// here rather than passed straight through because the merger takes the
+    /// batches, and this engine holds readers. `null` on the record-matcher
+    /// backend.
+    private final BatchExchange.Batch[] stagedBatches;
+    /// The projected indices [#merger] reads — its own set, read once at
+    /// construction, so nothing here re-derives which columns the plan touches.
+    /// `null` on the record-matcher backend.
+    private final int[] stagedColumns;
+
     private final ColumnReader[] readersByProjectedIndex;
-    /// Projected indices the multi-column [#mergePlan] actually reads, computed
-    /// once at construction so [#computeDrainSide] touches only the predicate
-    /// columns each batch rather than scanning all `schema.getColumnCount()`
-    /// matcher slots. `null` on the single-column fast path and the
-    /// record-matcher backend.
-    private final int[] referencedColumns;
 
     // Record-matcher backend (null when the drain-side backend is used).
     private final RowMatcher rowMatcher;
@@ -88,42 +86,16 @@ final class SelectionEngine {
     /// before the next [#computeSelection]. Sized to the batch capacity.
     private final int[] selection;
 
-    private SelectionEngine(int wordsLen,
-                            ColumnBatchMatcher[] columnMatchers, MergePlan mergePlan,
-                            MergePlanEvaluator mergeEvaluator, long[][] perColumn, long[] combined,
+    private SelectionEngine(BatchMatchMerger merger, int columnCount,
                             ColumnReader[] readersByProjectedIndex,
                             RowMatcher rowMatcher, PredicateRowView predicateView, int[] selection) {
-        this.wordsLen = wordsLen;
-        this.columnMatchers = columnMatchers;
-        this.mergePlan = mergePlan;
-        this.mergeEvaluator = mergeEvaluator;
-        this.perColumn = perColumn;
-        this.combined = combined;
+        this.merger = merger;
+        this.stagedBatches = merger != null ? new BatchExchange.Batch[columnCount] : null;
+        this.stagedColumns = merger != null ? merger.referencedColumns() : null;
         this.readersByProjectedIndex = readersByProjectedIndex;
         this.rowMatcher = rowMatcher;
         this.predicateView = predicateView;
         this.selection = selection;
-        this.referencedColumns = mergeEvaluator != null ? referencedColumns(columnMatchers) : null;
-    }
-
-    /// Collects the projected indices with an installed matcher — exactly the
-    /// columns the cross-column [MergePlan] references — so the per-batch merge
-    /// loop iterates only those.
-    private static int[] referencedColumns(ColumnBatchMatcher[] matchers) {
-        int count = 0;
-        for (ColumnBatchMatcher matcher : matchers) {
-            if (matcher != null) {
-                count++;
-            }
-        }
-        int[] referenced = new int[count];
-        int idx = 0;
-        for (int p = 0; p < matchers.length; p++) {
-            if (matchers[p] != null) {
-                referenced[idx++] = p;
-            }
-        }
-        return referenced;
     }
 
     /// Builds an engine for `resolved` over the augmented projection, reading
@@ -138,13 +110,11 @@ final class SelectionEngine {
                 resolved, schema, augProjected::toProjectedIndex);
 
         if (compiled != null) {
-            ColumnBatchMatcher[] matchers = compiled.columnMatchers();
-            MergePlan plan = compiled.mergePlan();
-            boolean single = plan instanceof MergePlan.Column;
-            MergePlanEvaluator evaluator = single ? null : new MergePlanEvaluator(wordsLen);
-            long[][] perColumn = new long[matchers.length][];
-            long[] combined = single ? null : new long[wordsLen];
-            return new SelectionEngine(wordsLen, matchers, plan, evaluator, perColumn, combined,
+            // Owning mode: no column workers ran the matchers, so the merger runs
+            // them itself into buffers it allocates.
+            BatchMatchMerger merger = BatchMatchMerger.owning(
+                    compiled, readersByProjectedIndex.length, wordsLen);
+            return new SelectionEngine(merger, readersByProjectedIndex.length,
                     readersByProjectedIndex, null, null, selection);
         }
 
@@ -154,7 +124,7 @@ final class SelectionEngine {
         RowMatcher matcher = RecordFilterCompiler.compile(resolved, schema);
         PredicateRowView view = PredicateRowView.create(
                 schema, augProjected, resolved, readersByProjectedIndex);
-        return new SelectionEngine(wordsLen, null, null, null, null, null,
+        return new SelectionEngine(null, readersByProjectedIndex.length,
                 readersByProjectedIndex, matcher, view, selection);
     }
 
@@ -163,7 +133,7 @@ final class SelectionEngine {
     /// matches (the no-compaction fast path). The indices live in
     /// `selection()[0, count)` until the next call.
     int computeSelection(int recordCount) {
-        return columnMatchers != null
+        return merger != null
                 ? computeDrainSide(recordCount)
                 : computeRecordMatcher(recordCount);
     }
@@ -175,31 +145,11 @@ final class SelectionEngine {
     }
 
     private int computeDrainSide(int recordCount) {
-        long[] result;
-        if (mergePlan instanceof MergePlan.Column c) {
-            int p = c.projectedIndex();
-            result = ensureWords(p);
-            columnMatchers[p].test(readersByProjectedIndex[p].currentFlatBatch(), result);
+        for (int i = 0; i < stagedColumns.length; i++) {
+            int p = stagedColumns[i];
+            stagedBatches[p] = readersByProjectedIndex[p].currentFlatBatch();
         }
-        else {
-            for (int p : referencedColumns) {
-                long[] words = ensureWords(p);
-                columnMatchers[p].test(readersByProjectedIndex[p].currentFlatBatch(), words);
-            }
-            int activeWords = (recordCount + 63) >>> 6;
-            mergeEvaluator.eval(mergePlan, combined, activeWords, perColumn);
-            result = combined;
-        }
-        return collectSetBits(result, recordCount);
-    }
-
-    private long[] ensureWords(int projectedIndex) {
-        long[] words = perColumn[projectedIndex];
-        if (words == null) {
-            words = new long[wordsLen];
-            perColumn[projectedIndex] = words;
-        }
-        return words;
+        return collectSetBits(merger.merge(stagedBatches, recordCount), recordCount);
     }
 
     private int computeRecordMatcher(int recordCount) {

--- a/core/src/test/java/dev/hardwood/ColumnReaderExactFilterTest.java
+++ b/core/src/test/java/dev/hardwood/ColumnReaderExactFilterTest.java
@@ -45,6 +45,7 @@ class ColumnReaderExactFilterTest {
     private static final Path INT_FILE = Paths.get("src/test/resources/filter_pushdown_int.parquet");
     private static final Path LIST_FILE = Paths.get("src/test/resources/filter_pushdown_list.parquet");
     private static final Path NESTED_FILE = Paths.get("src/test/resources/filter_pushdown_nested.parquet");
+    private static final Path MIXED_FILE = Paths.get("src/test/resources/filter_pushdown_mixed.parquet");
 
     // ==================== Flat, drain-side-eligible predicate ====================
 
@@ -284,6 +285,44 @@ class ColumnReaderExactFilterTest {
             }
             assertThat(count).isEqualTo(99); // 151..249
         }
+    }
+
+    @Test
+    void nestedCompoundAgreesWithRowReader() throws Exception {
+        // Or[Column(rating), And[Column(id), Column(price)]] — a compound with a
+        // compound child, so the merger's plan walk has to recurse to find every
+        // referenced column. The engine's merger runs the matchers itself (no
+        // workers ran them), which the one-level cases above also do; what is new
+        // here is the depth.
+        FilterPredicate filter = FilterPredicate.or(
+                FilterPredicate.and(
+                        FilterPredicate.gt("id", 5),
+                        FilterPredicate.lt("price", 100.0)),
+                FilterPredicate.gt("rating", 5.0f));
+
+        List<Integer> oracleIds = new ArrayList<>();
+        try (ParquetFileReader reader = ParquetFileReader.open(InputFile.of(MIXED_FILE));
+             RowReader rows = reader.buildRowReader().filter(filter).build()) {
+            while (rows.hasNext()) {
+                rows.next();
+                oracleIds.add(rows.getInt("id"));
+            }
+        }
+
+        List<Integer> groupedIds = new ArrayList<>();
+        try (ParquetFileReader reader = ParquetFileReader.open(InputFile.of(MIXED_FILE));
+             ColumnReaders columns = reader.buildColumnReaders(ColumnProjection.columns("id"))
+                     .filter(filter).build()) {
+            while (columns.nextBatch()) {
+                int[] ids = columns.getColumnReader("id").getInts();
+                for (int i = 0; i < columns.getRecordCount(); i++) {
+                    groupedIds.add(ids[i]);
+                }
+            }
+        }
+
+        assertThat(oracleIds).containsExactly(6, 7, 8, 9, 10, 15);
+        assertThat(groupedIds).containsExactlyElementsOf(oracleIds);
     }
 
     // ==================== Nulls: payload compaction and three-valued logic ====================

--- a/core/src/test/java/dev/hardwood/internal/predicate/DrainSideRowReaderTest.java
+++ b/core/src/test/java/dev/hardwood/internal/predicate/DrainSideRowReaderTest.java
@@ -25,9 +25,10 @@ import static org.assertj.core.api.Assertions.assertThat;
 /// End-to-end coverage for the drain-side path in `FlatRowReader`: reads a real
 /// Parquet file via the public API with a drain-eligible predicate and asserts
 /// the surviving rows match what the predicate semantically demands. Exercises
-/// `intersectMatches` (multi-column AND-merge and single-column alias), the
-/// `nextSetBit` / `scanRunEnd` helpers, and the `combinedWords` lifecycle across
-/// `loadNextBatch` — none of which the in-memory `DrainSideOracleTest` touches.
+/// `BatchMatchMerger` in its aliasing mode (compound merge and single-column
+/// alias), the `nextSetBit` / `scanRunEnd` helpers, and the `combinedWords`
+/// lifecycle across `loadNextBatch` — none of which the in-memory
+/// `DrainSideOracleTest` touches, since it merges the bitmaps itself.
 class DrainSideRowReaderTest {
 
     /// 3 row groups × 5 rows. Columns: id (INT32, 1..15), price (FLOAT64, sorted
@@ -52,7 +53,7 @@ class DrainSideRowReaderTest {
     @Test
     void singleColumnDrainEligible_aliasesBatchMatches_returnsExpectedRows() throws Exception {
         // Single-leaf drain-eligible — exercises the `combinedWords` aliasing branch
-        // in intersectMatches where no AND-merge is required.
+        // in BatchMatchMerger where there is no merge to do.
         FilterPredicate filter = FilterPredicate.gt("id", 10);
 
         List<Integer> expected = idsMatching(row -> row.id > 10);
@@ -74,6 +75,27 @@ class DrainSideRowReaderTest {
         List<Integer> actual = idsWithFilter(filter);
 
         assertThat(actual).containsExactlyElementsOf(expected);
+    }
+
+    @Test
+    void nestedCompound_drainSidePath_returnsExpectedRows() throws Exception {
+        // A compound whose child is itself a compound: the plan is
+        // Or[Column(rating), And[Column(id), Column(price)]]. Every other case here
+        // is one level deep, so this is the only one where BatchMatchMerger's plan
+        // walk has to recurse to find a referenced column — a column it missed
+        // would leave that bitmap slot unseated for the evaluator.
+        FilterPredicate filter = FilterPredicate.or(
+                FilterPredicate.and(
+                        FilterPredicate.gt("id", 5),
+                        FilterPredicate.lt("price", 100.0)),
+                FilterPredicate.gt("rating", 5.0f));
+
+        List<Integer> expected = idsMatching(
+                row -> (row.id > 5 && row.price < 100.0) || row.rating > 5.0f);
+        List<Integer> actual = idsWithFilter(filter);
+
+        assertThat(actual).containsExactlyElementsOf(expected);
+        assertThat(actual).containsExactly(6, 7, 8, 9, 10, 15);
     }
 
     @Test
@@ -103,7 +125,7 @@ class DrainSideRowReaderTest {
         assertThat(actual).containsExactlyElementsOf(expected);
     }
 
-    private record Row(int id, double price) {}
+    private record Row(int id, double price, float rating) {}
 
     private static List<Integer> idsMatching(Predicate<Row> p) throws Exception {
         List<Integer> out = new ArrayList<>();
@@ -111,7 +133,7 @@ class DrainSideRowReaderTest {
              RowReader rows = reader.buildRowReader().build()) {
             while (rows.hasNext()) {
                 rows.next();
-                Row r = new Row(rows.getInt("id"), rows.getDouble("price"));
+                Row r = new Row(rows.getInt("id"), rows.getDouble("price"), rows.getFloat("rating"));
                 if (p.test(r)) {
                     out.add(r.id);
                 }

--- a/performance-testing/micro-benchmarks/src/main/java/dev/hardwood/benchmarks/AlwaysMatchReadBenchmark.java
+++ b/performance-testing/micro-benchmarks/src/main/java/dev/hardwood/benchmarks/AlwaysMatchReadBenchmark.java
@@ -52,12 +52,15 @@ import dev.hardwood.reader.RowReader;
 /// cutoff satisfies the boundary group's min as well, which would leave every
 /// surviving group fully matching and collapse the scenario back onto `full`.
 ///
-/// Each selectivity runs on two read paths: `rowReaderString` filters on the
-/// string column through the record-matcher path (where per-row evaluation is
-/// most expensive), `columnReaderLong` filters on `id` while draining `value`.
-/// The latter reads through `SelectionEngine`, which does not yet consume the
-/// always-match proof (a #795 follow-up), so it stands as a control rather than
-/// a scenario expected to improve.
+/// Each selectivity runs on three read paths, one per way a filter reaches the
+/// rows: `rowReaderLong` filters on `id`, which the batch compiler accepts, so
+/// the row reader iterates the drain-side survivor bitmap; `rowReaderString`
+/// filters on the string column, which it does not, so the row reader falls back
+/// to the record-matcher path (where per-row evaluation is most expensive);
+/// `columnReaderLong` filters on `id` while draining `value`. The last reads
+/// through `SelectionEngine`, which does not yet consume the always-match proof
+/// (a #795 follow-up), so it stands as a control rather than a scenario expected
+/// to improve.
 ///
 /// Run:
 /// ```shell
@@ -115,6 +118,32 @@ public class AlwaysMatchReadBenchmark {
         }
     }
 
+    /// The drain-side path: `id` is a long compared with `>=`, which the batch
+    /// filter compiler accepts, so the workers mark matches per batch and the
+    /// reader walks the merged bitmap.
+    @Benchmark
+    public void rowReaderLong(Blackhole blackhole) throws IOException {
+        try (ParquetFileReader reader = ParquetFileReader.open(InputFile.of(path))) {
+            ParquetFileReader.RowReaderBuilder builder = reader.buildRowReader();
+            if (longFilter != null) {
+                builder.filter(longFilter);
+            }
+            try (RowReader rows = builder.build()) {
+                long idSum = 0;
+                int labelLengthSum = 0;
+                while (rows.hasNext()) {
+                    rows.next();
+                    idSum += rows.getLong("id");
+                    labelLengthSum += rows.getString("label").length();
+                }
+                blackhole.consume(idSum);
+                blackhole.consume(labelLengthSum);
+            }
+        }
+    }
+
+    /// The record-matcher path: a string comparison the batch filter compiler
+    /// rejects, so the reader evaluates the predicate a record at a time.
     @Benchmark
     public void rowReaderString(Blackhole blackhole) throws IOException {
         try (ParquetFileReader reader = ParquetFileReader.open(InputFile.of(path))) {


### PR DESCRIPTION
Closes #1109.

`BatchMatchMerger` owns the plan, the `MergePlanEvaluator` and its scratch pool, the per-column bitmap slots and the combined buffer. It resolves the plan shape once in its constructor into an `aliasedColumn` index, so the single-column case — yield that one column's bitmap, no buffer and no evaluator — is a local concern there instead of four correlated ternaries on `needsOwnedBuffer` in the reader's constructor.

Both consumers use it. They differ on one axis, who fills the per-column bitmaps: the row reader's column workers already did, so the merge reseats pointers (`aliasing`); `SelectionEngine` has no workers, so the merger runs the matcher fragments itself into buffers it allocates (`owning`). Everything else is shared, including the single derivation of the referenced columns — the engine reads that set from the merger instead of rederiving it by scanning the matcher array, which only agreed with the plan walk because `BatchFilterCompiler` commits a matcher for every `MergePlan.Column` node and no others, something nothing stated and no test pinned.

`FlatRowReader` keeps two fields where it held six. `combinedWords` stays: `nextSetBit` and the `runEndExclusive` run walk read it on every row, so it is cached from `merge()` when a batch loads rather than reached through the collaborator.

Two invariants that were implicit are now enforced. `CompiledBatchFilter` requires a non-null merge plan, which retires the dead branch that turned drain-side off for a compiled filter without one. `MergePlan.Column` rejects a negative index, because the merger's single-column dispatch turns on the sign where the previous type test did not care — `BatchFilterCompiler` already bails on an unprojected column before building the node, so this guards a state that is unreachable rather than changing behaviour.

`AlwaysMatchReadBenchmark` did not measure the path it is named for. `rowReaderString` filters on a binary column the batch compiler rejects, so it lands on the record matcher; `columnReaderLong` reads through `SelectionEngine`. A regression in the merge would have left both flat. `rowReaderLong` is the same read with the predicate on the long column the compiler accepts, so the three methods now cover the three ways a filter reaches rows, one each.

## Verification

`./mvnw verify` green across all modules. New coverage for the merger's recursive plan walk on a compound-of-compound plan — `Or[Column, And[Column, Column]]` — on both consumers, in `DrainSideRowReaderTest` (aliasing) and `ColumnReaderExactFilterTest` (owning), each checked against the row reader as oracle.

Benchmarked on an Intel N300 pinned at 1.50 GHz (the all-core clock sustainable at the 7 W PL1; held 1.50 GHz on every sample, no throttling), baseline = `main` plus the `rowReaderLong` commit so the two jars differ only by this PR's substance. Two runs over the selectivities that exercise the merge.

| benchmark | selectivity | before (ms/op) | after (ms/op) | Δ |
|---|---|---|---|---|
| `columnReaderLong` | full | 145.02 ± 26.17 | 144.40 ± 4.47 | −0.4% |
| `columnReaderLong` | mixed | 79.74 ± 8.31 | 76.88 ± 7.83 | −3.6% |
| `rowReaderLong` | full | 723.94 ± 9.18 | 745.69 ± 29.52 | +3.0% |
| `rowReaderLong` | mixed | 355.08 ± 14.08 | 363.79 ± 5.70 | +2.5% |
| `rowReaderString` | full | 733.95 ± 10.66 | 764.70 ± 41.31 | +4.2% |
| `rowReaderString` | mixed | 396.31 ± 8.03 | 382.25 ± 5.95 | −3.5% |

**Read these as "no regression above ~4%", not as clean numbers.** Two things bound the resolution. `rowReaderString` is the record-matcher path, which this PR does not touch, yet it moves +4.2% and −3.5% in the same pair of runs — so ~4% is the floor of what this harness can distinguish, and the touched paths move no more than the untouched control. And the two jars ran in a fixed order, `after` then `before`, on a box that warms over a run, which biases every cell toward "after slower"; the three positive deltas are all within that bias. `rowReaderString`/mixed measured +8.2% in the first run and −3.5% in the second, which is what settled that these swings are noise.

A cleaner verdict would want alternating jar order across more forks. Worth doing if the merge path is ever tuned for speed rather than shape; for a refactor that adds one field load and one null test per batch, this is enough to say nothing moved.
