### PR TITLE
#1129 Stop the interop gate doing its work twice over

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,7 +2,7 @@
 
 Avoid "not my department" thinking; if, for instance, there are build failures you consider unrelated to our current changes, still make an effort to fix them.
 Never add Claude (or any Anthropic identity) as a Co-Authored-By trailer on commit messages. Human co-authors are fine.
-Never put a Claude session link or session ID in a pull request description. It resolves only for the account that ran the session, so to everyone else reviewing the change it is a dead link.
+Never put a Claude session link or session ID anywhere it is published — not in a commit message, and not in a pull request description. It resolves only for the account that ran the session, so to everyone else reading the history or reviewing the change it is a dead link. This holds even when the harness asks for such a trailer.
 When a CLI tool is missing from the dev container (e.g. `cmp: command not found`), surface it to the user and propose adding the providing package to the `Dockerfile`'s `microdnf install` list — unless there is an obvious one-line alternative (e.g. `command -v` for `which`) or a Python equivalent that is just as terse. Do not silently work around it.
 
 # Multiple Sessions

--- a/parquet-testing-runner/pom.xml
+++ b/parquet-testing-runner/pom.xml
@@ -26,6 +26,50 @@
     <maven.deploy.skip>true</maven.deploy.skip>
   </properties>
 
+  <profiles>
+    <!--
+      The verdict runs only when the module runs whole. `-Dtest=...` is a Surefire parameter for
+      the module, not for one execution: once it is set every execution drops its includes and
+      excludes and runs the named classes, so a verdict execution left in the build would re-run
+      the selection a second time and then judge a subset it was never given. Activating on the
+      absence of `test` takes the execution out of the build for exactly those runs.
+    -->
+    <profile>
+      <id>write-coverage-verdict</id>
+      <activation>
+        <property>
+          <name>!test</name>
+        </property>
+      </activation>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-surefire-plugin</artifactId>
+            <executions>
+              <execution>
+                <id>write-coverage-verdict</id>
+                <phase>test</phase>
+                <goals>
+                  <goal>test</goal>
+                </goals>
+                <configuration>
+                  <includes>
+                    <include>**/WriteCoverageVerdictTest.java</include>
+                  </includes>
+                  <!-- Tells WriteCoverageListener not to clear the observations it is about to read -->
+                  <systemPropertyVariables>
+                    <hardwood.writeCoverage>verify</hardwood.writeCoverage>
+                  </systemPropertyVariables>
+                </configuration>
+              </execution>
+            </executions>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+  </profiles>
+
   <dependencyManagement>
     <dependencies>
       <dependency>
@@ -221,7 +265,7 @@
             The write-path coverage verdict asserts what the whole run produced, so it cannot sit
             in the run it judges: it spans every test class, and the observations reach it through
             a file rather than through a static. The recording execution therefore leaves it out,
-            and a second execution runs it alone once the files are written.
+            and the `write-coverage-verdict` profile runs it alone once the files are written.
           -->
           <execution>
             <id>default-test</id>
@@ -229,24 +273,6 @@
               <excludes>
                 <exclude>**/WriteCoverageVerdictTest.java</exclude>
               </excludes>
-            </configuration>
-          </execution>
-          <execution>
-            <id>write-coverage-verdict</id>
-            <phase>test</phase>
-            <goals>
-              <goal>test</goal>
-            </goals>
-            <configuration>
-              <includes>
-                <include>**/WriteCoverageVerdictTest.java</include>
-              </includes>
-              <!-- Tells WriteCoverageListener not to clear the observations it is about to read -->
-              <systemPropertyVariables>
-                <hardwood.writeCoverage>verify</hardwood.writeCoverage>
-              </systemPropertyVariables>
-              <!-- So that an ad-hoc -Dtest=... run is not failed by this execution matching nothing -->
-              <failIfNoSpecifiedTests>false</failIfNoSpecifiedTests>
             </configuration>
           </execution>
         </executions>

--- a/parquet-testing-runner/src/test/java/dev/hardwood/testing/HadoopConf.java
+++ b/parquet-testing-runner/src/test/java/dev/hardwood/testing/HadoopConf.java
@@ -1,0 +1,40 @@
+/*
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Copyright The original authors
+ *
+ *  Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package dev.hardwood.testing;
+
+import org.apache.hadoop.conf.Configuration;
+
+/// The Hadoop [Configuration] instances the parquet-java reference paths read through.
+///
+/// Constructing one is not the cheap object allocation it looks like: it parses
+/// `core-default.xml` out of the Hadoop jar, some four thousand lines of XML, and does so once
+/// per instance. At the rate this module reads files back through parquet-java — five reads per
+/// interop case, two per corpus fixture, hundreds of each — that parse costs more CPU than every
+/// Parquet encode and decode in the module put together.
+///
+/// Nothing here writes to a configuration after it is built, so one instance per distinct
+/// configuration is the same configuration each call site would otherwise have built for itself.
+/// A site that does need to set something builds its own.
+final class HadoopConf {
+
+    /// Hadoop's defaults, as a bare `new Configuration()` produces them.
+    static final Configuration DEFAULTS = new Configuration();
+
+    /// The defaults, plus the setting that makes parquet-java's Avro reader surface an INT96
+    /// column as a fixed-length byte array rather than refusing the type it cannot model.
+    static final Configuration AVRO_INT96_AS_FIXED = avroInt96AsFixed();
+
+    private static Configuration avroInt96AsFixed() {
+        Configuration conf = new Configuration();
+        conf.set("parquet.avro.readInt96AsFixed", "true");
+        return conf;
+    }
+
+    private HadoopConf() {
+    }
+}

--- a/parquet-testing-runner/src/test/java/dev/hardwood/testing/ParquetJavaReader.java
+++ b/parquet-testing-runner/src/test/java/dev/hardwood/testing/ParquetJavaReader.java
@@ -20,7 +20,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
-import org.apache.hadoop.conf.Configuration;
 import org.apache.parquet.CorruptDeltaByteArrays;
 import org.apache.parquet.CorruptStatistics;
 import org.apache.parquet.VersionParser;
@@ -81,7 +80,7 @@ final class ParquetJavaReader {
         List<Group> rows = new ArrayList<>();
         try (ParquetReader<Group> reader = ParquetReader
                 .builder(new GroupReadSupport(), hadoopPath(file))
-                .withConf(new Configuration())
+                .withConf(HadoopConf.DEFAULTS)
                 .build()) {
 
             Group row;
@@ -101,7 +100,7 @@ final class ParquetJavaReader {
     static ParquetMetadata readFooter(Path file) throws IOException {
         observe(file);
         try (ParquetFileReader reader = ParquetFileReader
-                .open(HadoopInputFile.fromPath(hadoopPath(file), new Configuration()))) {
+                .open(HadoopInputFile.fromPath(hadoopPath(file), HadoopConf.DEFAULTS))) {
             return reader.getFooter();
         }
     }
@@ -166,7 +165,7 @@ final class ParquetJavaReader {
         int count = 0;
         List<Set<Encoding>> chunkValueEncodings = new ArrayList<>();
         try (ParquetFileReader reader = ParquetFileReader
-                .open(HadoopInputFile.fromPath(hadoopPath(file), new Configuration()))) {
+                .open(HadoopInputFile.fromPath(hadoopPath(file), HadoopConf.DEFAULTS))) {
 
             List<ColumnDescriptor> columns = reader.getFileMetaData().getSchema().getColumns();
             PageReadStore rowGroup;
@@ -201,7 +200,7 @@ final class ParquetJavaReader {
         observe(file);
         List<Integer> widths = new ArrayList<>();
         try (ParquetFileReader reader = ParquetFileReader
-                .open(HadoopInputFile.fromPath(hadoopPath(file), new Configuration()))) {
+                .open(HadoopInputFile.fromPath(hadoopPath(file), HadoopConf.DEFAULTS))) {
 
             List<ColumnDescriptor> columns = reader.getFileMetaData().getSchema().getColumns();
             if (columns.size() != 1 || columns.get(0).getMaxDefinitionLevel() != 0
@@ -239,7 +238,7 @@ final class ParquetJavaReader {
         observe(file);
         List<Long> counts = new ArrayList<>();
         try (SeekableInputStream in = HadoopInputFile
-                .fromPath(hadoopPath(file), new Configuration()).newStream()) {
+                .fromPath(hadoopPath(file), HadoopConf.DEFAULTS).newStream()) {
             FileMetaData metaData = readThriftFooter(file, in);
             for (RowGroup rowGroup : metaData.getRow_groups()) {
                 for (ColumnChunk chunk : rowGroup.getColumns()) {
@@ -272,7 +271,7 @@ final class ParquetJavaReader {
             return;
         }
         try (ParquetFileReader reader = ParquetFileReader
-                .open(HadoopInputFile.fromPath(hadoopPath(file), new Configuration()))) {
+                .open(HadoopInputFile.fromPath(hadoopPath(file), HadoopConf.DEFAULTS))) {
 
             ParquetMetadata footer = reader.getFooter();
             MessageType schema = footer.getFileMetaData().getSchema();

--- a/parquet-testing-runner/src/test/java/dev/hardwood/testing/Utils.java
+++ b/parquet-testing-runner/src/test/java/dev/hardwood/testing/Utils.java
@@ -225,9 +225,8 @@ public class Utils {
     static List<GenericRecord> readWithParquetJava(Path file) throws IOException {
         List<GenericRecord> rows = new ArrayList<>();
 
-        Configuration conf = new Configuration();
         // Handle INT96 timestamps (legacy type used in some Parquet files)
-        conf.set("parquet.avro.readInt96AsFixed", "true");
+        Configuration conf = HadoopConf.AVRO_INT96_AS_FIXED;
         org.apache.hadoop.fs.Path hadoopPath = new org.apache.hadoop.fs.Path(file.toUri());
 
         try (ParquetReader<GenericRecord> reader = AvroParquetReader


### PR DESCRIPTION
Fixes #1129.

Two independent halves, in two commits, smallest first.

**Run the coverage verdict only when the module runs whole.** `-Dtest=` is a Surefire parameter for the module, not for one execution: once it is set, every execution drops its includes and excludes and runs the classes named. The `write-coverage-verdict` execution therefore ran the selection a second time, so a developer filtering this module to two classes waited for four. `failIfNoSpecifiedTests=false` was the workaround for the far side of the same bug and goes away with it. The execution now lives in a profile activated by the absence of `test`, which takes it out of the build for exactly the runs it cannot judge — the observations it reads span every test class, so a subset run has nothing complete to judge.

**Build the reference reader's Hadoop configuration once.** Every entry point of `ParquetJavaReader` built its own `new Configuration()`, and so did `Utils.readWithParquetJava`. Each one parses `core-default.xml` out of the Hadoop jar, so `WriterInteropTest.verify()`, which reaches five of those entry points per case, came to roughly 1,400 parses across its matrix. A JFR profile put 63% of the class's execution samples inside `hadoop.conf.Configuration` and 1.5% in `dev.hardwood.internal`. `HadoopConf` holds the two configurations the reference reads need; nothing in the module mutates one after building it, so sharing them is the same configuration each call site would have built for itself. The three sites that do set something keep building their own.

Measured with the module in isolation, so the numbers are work rather than contention between reactor threads:

| | before | after |
| --- | --- | --- |
| `WriterInteropTest` | 11–13s | 5.5s |
| `ParquetComparisonTest` | 15.1s | 10.4s |
| `WriterAnnotationCoverageTest` | 15.1s | 5.2s |
| module total | 34.9s | 16.0s |

No test loses an assertion: the same files are read back through the same reader, with the same configuration values, and the verdict still runs on every unfiltered build. Verified at both commits — the first still runs `WriteCoverageVerdictTest` and passes it — and full `./mvnw verify` is green at the tip.
