### PR TITLE
#1131 Tell the consumer the stream has ended

### DIFF
--- a/core/src/main/java/dev/hardwood/internal/reader/BatchExchange.java
+++ b/core/src/main/java/dev/hardwood/internal/reader/BatchExchange.java
@@ -71,7 +71,12 @@ public class BatchExchange<B> {
         public boolean filterAlwaysMatches;
     }
 
-    private final ArrayBlockingQueue<B> readyQueue;
+    /// Handed to the consumer by [#finish()] so that a poll already waiting on the queue learns
+    /// of the end of the stream from the queue itself, rather than from the next expiry of its
+    /// timed poll. See [#finish()] for why offering it can be left to succeed or not.
+    private static final Object END_OF_STREAM = new Object();
+
+    private final ArrayBlockingQueue<Object> readyQueue;
     private final ArrayBlockingQueue<B> freeQueue;
     private final Supplier<B> batchFactory;
     private final String columnName;
@@ -79,7 +84,7 @@ public class BatchExchange<B> {
     private volatile Throwable error;
     private volatile boolean finished;
 
-    private BatchExchange(String columnName, ArrayBlockingQueue<B> readyQueue,
+    private BatchExchange(String columnName, ArrayBlockingQueue<Object> readyQueue,
                           ArrayBlockingQueue<B> freeQueue, Supplier<B> batchFactory) {
         this.columnName = columnName;
         this.readyQueue = readyQueue;
@@ -97,7 +102,7 @@ public class BatchExchange<B> {
     /// @param <B> the batch type
     /// @return a recycling [BatchExchange]
     public static <B> BatchExchange<B> recycling(String columnName, Supplier<B> batchFactory) {
-        ArrayBlockingQueue<B> readyQueue = new ArrayBlockingQueue<>(READY_QUEUE_CAPACITY);
+        ArrayBlockingQueue<Object> readyQueue = new ArrayBlockingQueue<>(READY_QUEUE_CAPACITY);
         ArrayBlockingQueue<B> freeQueue = new ArrayBlockingQueue<>(READY_QUEUE_CAPACITY + 1);
 
         for (int i = 0; i < READY_QUEUE_CAPACITY + 1; i++) {
@@ -118,7 +123,7 @@ public class BatchExchange<B> {
     /// @param <B> the batch type
     /// @return a detaching [BatchExchange]
     public static <B> BatchExchange<B> detaching(String columnName, Supplier<B> batchFactory) {
-        ArrayBlockingQueue<B> readyQueue = new ArrayBlockingQueue<>(READY_QUEUE_CAPACITY);
+        ArrayBlockingQueue<Object> readyQueue = new ArrayBlockingQueue<>(READY_QUEUE_CAPACITY);
         return new BatchExchange<>(columnName, readyQueue, null, batchFactory);
     }
 
@@ -162,17 +167,36 @@ public class BatchExchange<B> {
         return true;
     }
 
+    /// Marks the stream ended, and hands a waiting consumer the sentinel that says so.
+    ///
+    /// The flag alone is not enough. A consumer inside [#poll()]'s timed loop is waiting on the
+    /// queue, not on the flag, and reads the flag only when its 10 ms poll expires — the same
+    /// shape #1027 found on the teardown side, where a drain waiting inside the exchange could
+    /// not see `finished` until its own window elapsed.
+    ///
+    /// The offer is deliberately non-blocking and its result deliberately ignored. A consumer is
+    /// only ever left waiting when it found the queue empty, and in that state the offer has room
+    /// and succeeds. It fails only when the queue is full, and a consumer with batches still to
+    /// take is not waiting for anything: by the time it has taken them, `finished` is set and
+    /// [#poll()] returns without waiting at all. So the sentinel removes a delay where there is
+    /// one, and where it cannot be delivered there was none to remove.
+    ///
+    /// Nothing rests on it arriving. The timed poll remains the liveness guarantee.
     public void finish() {
         finished = true;
+        readyQueue.offer(END_OF_STREAM);
     }
 
     public boolean isFinished() {
         return finished;
     }
 
+    /// Ends the stream with a failure. Goes through [#finish()] so that a waiting consumer is
+    /// released as promptly as a clean end releases it, and raises the error on its way out
+    /// rather than after the next poll expires.
     public void signalError(Throwable t) {
         error = t;
-        finished = true;
+        finish();
     }
 
     // ==================== Consumer Side ====================
@@ -185,13 +209,24 @@ public class BatchExchange<B> {
     /// empty the method falls through to a timed poll loop. The `finished` flag
     /// is only checked **after** a timed poll returns null, guaranteeing that any
     /// batch published before `finish()` is visible.
+    ///
+    /// The end of the stream arrives twice over, and the ordering above is why that is safe. It
+    /// arrives as [#END_OF_STREAM] through the queue, which is what releases a poll already
+    /// waiting, and it arrives as the `finished` flag, which is what a poll entering later reads
+    /// before it waits at all. Both are behind every batch: the sentinel by queue order, the flag
+    /// because it is only read once a poll has come back empty.
+    @SuppressWarnings("unchecked")
     public B poll() throws InterruptedException, IOException {
-        B batch = readyQueue.poll();
+        Object batch = readyQueue.poll();
+        if (batch == END_OF_STREAM) {
+            checkError();
+            return null;
+        }
         if (batch != null) {
-            return batch;
+            return (B) batch;
         }
         if (finished) {
-            return readyQueue.poll();
+            return (B) drop(readyQueue.poll());
         }
         // Past this point the consumer is stalled on the pipeline: the ready
         // queue is empty and the drain has not finished. The event's duration
@@ -201,16 +236,25 @@ public class BatchExchange<B> {
         try {
             while ((batch = readyQueue.poll(10, TimeUnit.MILLISECONDS)) == null) {
                 if (finished) {
-                    return readyQueue.poll();
+                    return (B) drop(readyQueue.poll());
                 }
                 checkError();
             }
-            return batch;
+            if (batch == END_OF_STREAM) {
+                checkError();
+                return null;
+            }
+            return (B) batch;
         }
         finally {
             event.column = columnName;
             event.commit();
         }
+    }
+
+    /// The sentinel read as nothing, so that a queue holding only it reads as an empty one.
+    private static Object drop(Object element) {
+        return element == END_OF_STREAM ? null : element;
     }
 
     /// Returns a consumed batch to the free pool so it can be refilled by the drain.
@@ -230,9 +274,13 @@ public class BatchExchange<B> {
         if (freeQueue == null) {
             return;
         }
-        B leftover;
+        Object leftover;
         while ((leftover = readyQueue.poll()) != null) {
-            freeQueue.offer(leftover);
+            if (leftover != END_OF_STREAM) {
+                @SuppressWarnings("unchecked")
+                B batch = (B) leftover;
+                freeQueue.offer(batch);
+            }
         }
     }
 

--- a/core/src/test/java/dev/hardwood/ReaderEofLatencyTest.java
+++ b/core/src/test/java/dev/hardwood/ReaderEofLatencyTest.java
@@ -1,0 +1,154 @@
+/*
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Copyright The original authors
+ *
+ *  Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package dev.hardwood;
+
+import java.nio.ByteBuffer;
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+
+import dev.hardwood.internal.writer.ByteBufferOutputFile;
+import dev.hardwood.metadata.PhysicalType;
+import dev.hardwood.metadata.RepetitionType;
+import dev.hardwood.reader.ColumnReader;
+import dev.hardwood.reader.ParquetFileReader;
+import dev.hardwood.schema.FileSchema;
+import dev.hardwood.writer.ParquetFileWriter;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/// What reading a small file to the end costs, as a function of how many columns are read.
+///
+/// This is the read-path counterpart of [ReaderCloseLatencyTest], and the same defect one step
+/// earlier. That test covers teardown: a drain blocked inside its exchange could not see the
+/// `finished` flag until its own timed queue operation expired, so `close()` inherited the wait
+/// once per column. This covers the read itself: the *consumer* waiting inside
+/// [dev.hardwood.internal.reader.BatchExchange#poll()] cannot see the flag either, so the last
+/// `nextBatch()` — the one that reports the end — waited out the same window.
+///
+/// The two are mirrored. Teardown strands a producer whose consumer has stopped consuming; this
+/// strands a consumer whose producer has stopped producing. Teardown was also the abnormal path,
+/// reached only by abandoning a read with data outstanding. This is the ordinary one: every
+/// reader that reads to completion asks once more than there is data for, and that ask is the
+/// one that waited.
+///
+/// The property under test is that a full read costs the same whether one column is read or
+/// sixteen. Each column is opened through its own [ParquetFileReader#columnReader(String)] and
+/// drained before the next is opened, because that is what makes the delays add rather than
+/// overlap — a projection read through one [dev.hardwood.reader.ColumnReaders] runs its columns
+/// concurrently, so the later ones find their streams already ended and pay nothing.
+///
+/// On the bound: see [ReaderCloseLatencyTest]'s note, which applies unchanged. Sub-millisecond
+/// reads are typical here, the distribution has a heavy tail under CPU oversubscription, and the
+/// bound is set to keep a real gap on both sides rather than to sit just under the regression.
+class ReaderEofLatencyTest {
+
+    /// Wide enough that one stall per column is unmistakable against the bound.
+    private static final int COLUMNS = 16;
+
+    /// Few enough rows that a column is one batch, which is the state this is about: the
+    /// consumer takes that batch, asks again, and arrives at the exchange before the drain has
+    /// finished itself. A file large enough to need many batches gives the drain time to end the
+    /// stream while the consumer is still working through them, and the last ask finds the flag
+    /// already set — the same read, none of the wait.
+    private static final int ROWS = 1_000;
+
+    /// What a read that waits out the poll interval once per column settles at. The exchange
+    /// polls on a 10 ms window, so that is what one column costs.
+    private static final Duration PER_COLUMN_STALL_DURATION = Duration.ofMillis(10L);
+
+    /// Passes comfortably when no read stalls, and cannot pass when they all do: stalling costs
+    /// about `COLUMNS * 10 ms` = 160 ms, against measurements of a few milliseconds for the
+    /// whole loop when the end of the stream is signalled.
+    private static final Duration BOUND = Duration.ofMillis(60L);
+
+    @Test
+    @Timeout(value = 60, unit = TimeUnit.SECONDS)
+    void readingToTheEndDoesNotScaleWithColumnCount() throws Exception {
+        byte[] file = writeSyntheticFile();
+
+        try (Hardwood hardwood = Hardwood.create()) {
+            // A first pass pays the one-off costs — class loading, the executor's threads, the
+            // footer parse — so they are not attributed to the reads being measured.
+            timeFullReadOfEveryColumn(hardwood, file);
+
+            Duration elapsed = timeFullReadOfEveryColumn(hardwood, file);
+
+            assertThat(elapsed)
+                    .as("reading %d columns of %d rows to the end, one column at a time; "
+                            + "a %d ms stall per column would be about %d ms",
+                            COLUMNS, ROWS, PER_COLUMN_STALL_DURATION.toMillis(),
+                            stallAcrossColumns().toMillis())
+                    .isLessThan(BOUND);
+        }
+    }
+
+    /// Opens each column in turn, drains it to the end, and returns how long all of them took.
+    ///
+    /// The `nextBatch()` that returns `false` is what is being measured, so every column is read
+    /// past its last batch rather than stopped at it.
+    private static Duration timeFullReadOfEveryColumn(Hardwood hardwood, byte[] file)
+            throws Exception {
+
+        try (ParquetFileReader parquet = hardwood.open(InputFile.of(ByteBuffer.wrap(file)))) {
+            long start = System.nanoTime();
+            for (String column : columnNames()) {
+                int batches = 0;
+                try (ColumnReader reader = parquet.columnReader(column)) {
+                    while (reader.nextBatch()) {
+                        batches++;
+                    }
+                }
+                assertThat(batches).as("batches read from %s", column).isPositive();
+            }
+            return Duration.ofNanos(System.nanoTime() - start);
+        }
+    }
+
+    /// What a read that stalls once per column would cost in total, for the assertion message.
+    /// Every column is opened and drained in turn, so none of the stalls overlap.
+    private static Duration stallAcrossColumns() {
+        return PER_COLUMN_STALL_DURATION.multipliedBy(COLUMNS);
+    }
+
+    private static List<String> columnNames() {
+        List<String> names = new ArrayList<>(COLUMNS);
+        for (int i = 0; i < COLUMNS; i++) {
+            names.add("c" + i);
+        }
+        return names;
+    }
+
+    /// A synthetic file of `COLUMNS` required `INT64` columns and `ROWS` rows. Nothing about the
+    /// values matters, only that every column has a chunk to decode.
+    private static byte[] writeSyntheticFile() throws Exception {
+        FileSchema.Builder schema = FileSchema.builder("eof_scaling");
+        for (String name : columnNames()) {
+            schema.addColumn(name, PhysicalType.INT64, RepetitionType.REQUIRED);
+        }
+
+        long[] values = new long[ROWS];
+        for (int i = 0; i < ROWS; i++) {
+            values[i] = i;
+        }
+
+        ByteBufferOutputFile out = new ByteBufferOutputFile();
+        try (ParquetFileWriter writer = ParquetFileWriter.create(out, schema.build())) {
+            writer.columnWriter().writeBatch(batch -> {
+                for (String name : columnNames()) {
+                    batch.longs(name, values);
+                }
+            });
+        }
+        return out.toByteArray();
+    }
+}

--- a/core/src/test/java/dev/hardwood/internal/reader/BatchExchangeTest.java
+++ b/core/src/test/java/dev/hardwood/internal/reader/BatchExchangeTest.java
@@ -1,0 +1,118 @@
+/*
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Copyright The original authors
+ *
+ *  Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package dev.hardwood.internal.reader;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/// What [BatchExchange#finish()] may and may not do to the batches already in flight.
+///
+/// `finish()` hands the consumer an end-of-stream sentinel through the ready queue, so that a
+/// poll already waiting learns of the end from the queue rather than from the next expiry of its
+/// timed poll. That puts a non-batch into the same queue the batches travel through, and these
+/// are the three ways that could go wrong: the sentinel overtaking a batch, the sentinel being
+/// recycled as if it were one, and the queue reading as ended only once.
+///
+/// The latency the sentinel exists for is asserted separately, in
+/// [dev.hardwood.ReaderEofLatencyTest].
+class BatchExchangeTest {
+
+    @Test
+    void deliversEveryQueuedBatchBeforeTheEnd() throws Exception {
+        BatchExchange<Object> exchange = BatchExchange.detaching("c", Object::new);
+        Object first = new Object();
+        Object second = new Object();
+
+        exchange.publish(first);
+        exchange.publish(second);
+        exchange.finish();
+
+        assertThat(exchange.poll()).as("first batch").isSameAs(first);
+        assertThat(exchange.poll()).as("second batch").isSameAs(second);
+        assertThat(exchange.poll()).as("end of stream").isNull();
+    }
+
+    /// The case above fills the queue to capacity, so `finish()` cannot offer its sentinel at
+    /// all and the consumer reaches the end through the `finished` flag. This is the other side:
+    /// room to spare, the sentinel queued behind the batch, and the batch still delivered first.
+    @Test
+    void queuesTheSentinelBehindABatchRatherThanAheadOfIt() throws Exception {
+        BatchExchange<Object> exchange = BatchExchange.detaching("c", Object::new);
+        Object only = new Object();
+
+        exchange.publish(only);
+        exchange.finish();
+
+        assertThat(exchange.poll()).as("the batch").isSameAs(only);
+        assertThat(exchange.poll()).as("end of stream").isNull();
+    }
+
+    /// A consumer that keeps asking past the end keeps being told the same thing. The sentinel
+    /// is consumed by the poll that reports it, so every later poll has to reach the same
+    /// conclusion from the `finished` flag instead.
+    @Test
+    void staysEndedOnceItHasEnded() throws Exception {
+        BatchExchange<Object> exchange = BatchExchange.detaching("c", Object::new);
+        exchange.finish();
+
+        assertThat(exchange.poll()).as("first poll past the end").isNull();
+        assertThat(exchange.poll()).as("second poll past the end").isNull();
+        assertThat(exchange.poll()).as("third poll past the end").isNull();
+    }
+
+    /// In recycling mode the consumer's leftovers go back to the free pool for the drain to
+    /// refill. The sentinel is not one of them: a pool holding it would hand the drain something
+    /// to write a batch of values into that is not a batch.
+    @Test
+    void doesNotRecycleTheSentinelIntoTheFreePool() throws Exception {
+        List<Object> holders = new ArrayList<>();
+        BatchExchange<Object> exchange = BatchExchange.recycling("c", () -> {
+            Object holder = new Object();
+            holders.add(holder);
+            return holder;
+        });
+
+        Object taken = exchange.takeBatch();
+        exchange.publish(taken);
+        exchange.finish();
+        exchange.drainReady();
+
+        List<Object> pooled = new ArrayList<>();
+        Object holder;
+        while ((holder = exchange.takeBatch()) != null) {
+            pooled.add(holder);
+        }
+
+        assertThat(pooled)
+                .as("everything the free pool holds was made by the batch factory")
+                .isSubsetOf(holders);
+        assertThat(pooled)
+                .as("the published batch came back and nothing was lost with it")
+                .containsExactlyInAnyOrderElementsOf(holders);
+    }
+
+    /// An error ends the stream too, and has to reach the consumer rather than sit behind a
+    /// poll that has already returned. [BatchExchange#signalError] goes through `finish()` for
+    /// that reason, which puts the sentinel in the queue ahead of the throw.
+    @Test
+    void raisesAnErrorThroughTheEndOfStreamPath() {
+        BatchExchange<Object> exchange = BatchExchange.detaching("c", Object::new);
+        exchange.signalError(new IllegalStateException("decode failed"));
+
+        assertThat(exchange.isFinished()).as("an error ends the stream").isTrue();
+        assertThatThrownBy(exchange::poll)
+                .as("the error reaches the consumer rather than a silent null")
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessage("decode failed");
+    }
+}


### PR DESCRIPTION
Fixes #1131.

`BatchExchange.finish()` set a `volatile boolean` and nothing else. A consumer inside `poll()`'s timed loop is waiting on the ready queue, not on that flag, so the terminal `nextBatch()` — the one every read that runs to completion makes — waited out the full 10 ms window before re-reading it. `ColumnWorker.finishDrain()` unparks the retriever; nothing woke the consumer.

This is the read-path half of #1027, which found the same defect on teardown and fixed it by having `close()` interrupt the drain. That remedy does not transfer — `close()` could interrupt because it owns the drain thread and because the drain does no I/O, and neither holds for a consumer thread — and a bare `unpark` is ruled out for the reason `close()` already documents, that `ArrayBlockingQueue`'s timed waits treat it as spurious. So the end of the stream now travels through the queue, as an `END_OF_STREAM` sentinel.

The offer is non-blocking and its result ignored, which is the part worth reviewing. A consumer is only ever left waiting when it found the queue empty, and in that state the offer has room and succeeds. It fails only when the queue is full — and a consumer with batches still to take is not waiting for anything, because by the time it has taken them `finished` is set and `poll()` returns without waiting at all. Queue capacity and back-pressure are therefore untouched, and the 10 ms poll remains the liveness guarantee rather than being replaced by the signal.

## Measured

`alltypes_plain.parquet` — 671 bytes, 8 rows, 11 leaf columns. 40 iterations after 20 warmup, three runs, medians.

| Read | before | after | |
| --- | --- | --- | --- |
| `RowReader`, full read | 1.96 ms | 1.55 ms | 1.3x |
| `ColumnReaders`, every column in one pass | 6.84 ms | 1.24 ms | **5.5x** |
| `ColumnReader`, one column at a time | 117.2 ms | 3.57 ms | **33x** |
| ... per column | 10.65 ms | 0.32 ms | |

The cost was a fixed floor per read rather than anything to do with how much data moved, which is what made it 119 ms to read 671 bytes.

## Tests

`ReaderEofLatencyTest` is the read-path counterpart of `ReaderCloseLatencyTest` and asserts the same shape of property — that a full read costs the same whether one column is read or sixteen. It fails on `main` and passes here; each column is opened and drained in turn, because a projection read through one `ColumnReaders` runs its columns concurrently and the later ones find their streams already ended.

`BatchExchangeTest` covers what putting a non-batch into the batch queue could break, deterministically rather than by timing: that a queued batch is never overtaken by the sentinel (in both the queue-full case, where the sentinel cannot be offered at all, and the case where it is queued behind), that the sentinel is not recycled into the free pool as if it were a batch holder, that the exchange stays ended once ended, and that an error still reaches the consumer.

Full `./mvnw verify` is green.
