### PR TITLE
#1139 Tell a file that contradicts itself apart from a caller that asked for the wrong type

### DIFF
--- a/_designs/EXCEPTION_MODEL.md
+++ b/_designs/EXCEPTION_MODEL.md
@@ -13,6 +13,38 @@ without reading the message.
 > **Trying again will not:** `ParquetReadException`, `ParquetWriteException`,
 > `UnsupportedOperationException`
 
+## The second question: whose fault
+
+Retry-or-stop does not separate a file that is wrong from a call that is wrong, since both
+mean stop. A second question runs across the first: whose fault is it? The answer tells the
+caller whether to change their code or stop trusting the file.
+
+| | Means | Type |
+|---|---|---|
+| **The file's fault** | the bytes, or the footer, are not what they claim | `ParquetReadException` |
+| **The caller's fault** | the reader was asked for something it never held | `IllegalArgumentException`, `NullPointerException`, `NoSuchElementException`, `IllegalStateException` — except wrong-type access, which is unspecified |
+
+Most of the caller's side is stated and can be relied on — a column outside the projection,
+an accessor on a null field, `next()` past the end, a `ColumnReader` used before its first
+batch. One case is not: asking an accessor for a type the column does not hold. Validating
+that cost 4% per accessor and 7–8% end-to-end, above the 3% bar, so the guards were dropped
+and the call surfaces as whatever the storage array's cast raises. Leaving that one type
+unstated keeps the freedom to put a better error back on a path where it turns out to be
+free.
+
+Every message names the file the reader was on. Exceptions raised for an invalid file add
+the read position — the row group and page the read stopped at — because that varies between
+failures and is what someone chasing one needs. Exceptions raised for a mistake in the
+calling code do not, because the fix is the same wherever in the file the reader had got to.
+
+That describes the messages the reader composes. Wrong-type access is the exception: a
+`ClassCastException` raised by the JVM's own cast names neither the file nor the column.
+#971 covers closing that gap.
+
+The file name is worth carrying on both. A process reading many files with a reader each has
+no other way to tell which one a failure came from, and no public accessor to recover it
+from afterwards.
+
 ## The categories
 
 | Category | Means | Type |
@@ -109,6 +141,43 @@ work again on the calling thread and reports to a caller that is waiting. DEBUG
 rather than WARN because that report is coming, and a backend outage would otherwise
 emit one warning per speculative chunk.
 
+## An annotation the reader cannot use is dropped, not raised
+
+A schema can be invalid on its own terms in two ways, and they are handled differently.
+
+A `FIXED_LEN_BYTE_ARRAY` that declares no width cannot be decoded at all — the width sizes
+the buffer and spaces the offsets, so without it there are no value boundaries to find.
+`FixedWidthValidator` refuses it when the reader is built, over the columns the read
+touches, as a `SchemaIncompatibleException`.
+
+An annotation its physical type cannot carry is different. A `FLOAT16` column twelve bytes
+wide is invalid, but its twelve-byte values are readable; only the annotation is unusable.
+The format says to read past it: the
+"Unsupported Logical Types" section of `LogicalTypes.md`, adopted in parquet-format PR 606,
+has readers "ignore both the logical type annotation and column order for that column. Only
+the physical type information should be used to process the column's data."
+
+So `FileSchema` drops the annotation as the schema is built, and the column is reported and
+read as its physical type. No check is needed anywhere downstream: the physical accessors
+work, `getValue` yields the physical value, a logical accessor fails as it does on any
+unannotated column of that type, and the statistics are compared under the physical type's
+ordering. Column order needs no separate handling —
+the only thing it decides is whether a float predicate compares under IEEE 754 total order,
+and a column that has lost its `FLOAT16` annotation is rejected by `FilterPredicateResolver`
+before that flag is consulted.
+
+An annotation this version does not recognize at all is dropped where it is parsed, in
+`LogicalTypeReader`. The handling is the same, but the warnings differ, because the causes
+do: an unrecognized arm means the file was written against a newer format version, while an
+annotation its physical type cannot carry means the writer produced something no version of
+the format defines. Only the second can be shown to be wrong, and so only the second could
+ever be a candidate for refusing the read. Refusing the first would break the forward
+compatibility this rule exists to provide.
+
+A footer that omits `type_length` states no width for the annotation to contradict, so
+there is nothing to show is wrong. The annotation is kept, and the column is refused for the
+missing width instead, by the validator whose message describes that defect.
+
 ## Which failures are which
 
 | | |
@@ -167,7 +236,9 @@ Accessing a column outside the projection, calling a primitive accessor on a nul
 field, calling `next()` past the end, using a `ColumnReader` accessor before
 `nextBatch()`, and the writer's own misuse types — an unknown column, a value
 outside its annotation's range, a `REQUIRED` field left unset. The caller's code is
-wrong and no file is involved. `ThriftEnumLookup.indexOf` is on this side too: it
+wrong, and the message names the file and the column but no read position, since that
+would be the same wherever the reader had got to. `ThriftEnumLookup.indexOf` is on this
+side too: it
 maps an enum to a Thrift value on the write path, where a value with no encoding is
 a mistake in the calling code.
 

--- a/core/src/main/java/dev/hardwood/internal/conversion/LogicalTypeConverter.java
+++ b/core/src/main/java/dev/hardwood/internal/conversion/LogicalTypeConverter.java
@@ -26,6 +26,93 @@ import dev.hardwood.row.PqInterval;
 /// Converts physical values to their logical type representations.
 public class LogicalTypeConverter {
 
+    /// Why `logicalType` cannot be read from a column of this physical type and width, or
+    /// `null` when it can.
+    ///
+    /// A property of the column, not of any value in it, so it is asked once — where the
+    /// schema is built, by [dev.hardwood.schema.FileSchema], which drops an annotation this
+    /// answers for. Nothing consults it per value, and by the time a conversion below runs
+    /// the column has either a sound annotation or none.
+    ///
+    /// This mirrors what the conversions accept and nothing more. [LogicalTypeValidator]
+    /// states the *writer's* rule, which is stricter — it pins `TIME(MILLIS)` to `INT32`
+    /// where reading accepts either width — and applying it here would refuse files that
+    /// read today.
+    ///
+    /// @param physicalType the column's physical type
+    /// @param typeLength its `FIXED_LEN_BYTE_ARRAY` byte length, `null` for any other type
+    /// @param logicalType its annotation, `null` for an unannotated column
+    /// @return the reason, or `null` if the annotation can be read from the column
+    public static String conversionFault(PhysicalType physicalType, Integer typeLength,
+                                         LogicalType logicalType) {
+        if (logicalType == null) {
+            return null;
+        }
+        return switch (logicalType) {
+            case LogicalType.StringType ignored -> requires(physicalType, "STRING", PhysicalType.BYTE_ARRAY);
+            case LogicalType.JsonType ignored -> requires(physicalType, "JSON", PhysicalType.BYTE_ARRAY);
+            case LogicalType.EnumType ignored -> requires(physicalType, "ENUM", PhysicalType.BYTE_ARRAY);
+            case LogicalType.BsonType ignored -> requires(physicalType, "BSON", PhysicalType.BYTE_ARRAY);
+            case LogicalType.DateType ignored -> requires(physicalType, "DATE", PhysicalType.INT32);
+            case LogicalType.TimestampType ignored -> requires(physicalType, "TIMESTAMP", PhysicalType.INT64);
+            case LogicalType.TimeType ignored -> requires(physicalType, "TIME",
+                    PhysicalType.INT32, PhysicalType.INT64);
+            case LogicalType.IntType ignored -> requires(physicalType, "INT",
+                    PhysicalType.INT32, PhysicalType.INT64);
+            case LogicalType.DecimalType ignored -> requires(physicalType, "DECIMAL",
+                    PhysicalType.INT32, PhysicalType.INT64, PhysicalType.BYTE_ARRAY,
+                    PhysicalType.FIXED_LEN_BYTE_ARRAY);
+            case LogicalType.UuidType ignored -> requiresFixed(physicalType, typeLength, "UUID", 16);
+            case LogicalType.IntervalType ignored -> requiresFixed(physicalType, typeLength, "INTERVAL", 12);
+            case LogicalType.Float16Type ignored -> requiresFixed(physicalType, typeLength, "FLOAT16", 2);
+            // Carried through as opaque payloads, so no physical type is imposed.
+            case LogicalType.GeometryType ignored -> null;
+            case LogicalType.GeographyType ignored -> null;
+            // LIST, MAP and VARIANT annotate a group. On a primitive leaf the pairing is
+            // one no version of the format defines, so it is dropped like any other.
+            case LogicalType.ListType ignored -> structural("LIST");
+            case LogicalType.MapType ignored -> structural("MAP");
+            case LogicalType.VariantType ignored -> structural("VARIANT");
+            // NULL is legal over any physical type — it says every value is null. Only the
+            // values can contradict it, and this answers from the schema alone.
+            case LogicalType.NullType ignored -> null;
+        };
+    }
+
+    private static String structural(String annotation) {
+        return annotation + " annotates a group, but the column is a primitive";
+    }
+
+    private static String requires(PhysicalType actual, String annotation, PhysicalType... allowed) {
+        for (PhysicalType candidate : allowed) {
+            if (actual == candidate) {
+                return null;
+            }
+        }
+        StringBuilder sb = new StringBuilder();
+        for (int i = 0; i < allowed.length; i++) {
+            sb.append(i == 0 ? "" : i == allowed.length - 1 ? " or " : ", ").append(allowed[i]);
+        }
+        return annotation + " is read from " + sb + ", but the column is " + actual;
+    }
+
+    private static String requiresFixed(PhysicalType actual, Integer typeLength, String annotation,
+                                        int width) {
+        String wrongType = requires(actual, annotation, PhysicalType.FIXED_LEN_BYTE_ARRAY);
+        if (wrongType != null) {
+            return wrongType;
+        }
+        // A footer that omits type_length states no width to contradict the annotation, so
+        // there is nothing here that can be proven wrong. That column cannot be decoded at
+        // all and FixedWidthValidator refuses it by name; reporting it as a bad annotation
+        // would drop a sound annotation and describe the wrong defect.
+        if (typeLength != null && typeLength != width) {
+            return annotation + " is exactly " + width + " bytes, but the column declares "
+                    + typeLength;
+        }
+        return null;
+    }
+
     /// Convert a physical value to its logical type representation.
     /// Returns the original value if no conversion is needed.
     ///

--- a/core/src/main/java/dev/hardwood/internal/reader/FlatRowReader.java
+++ b/core/src/main/java/dev/hardwood/internal/reader/FlatRowReader.java
@@ -165,6 +165,26 @@ public final class FlatRowReader implements FileAwareRowReader {
         }
     }
 
+    /// Fails when the caller has asked a column for a float it does not hold.
+    ///
+    /// Reached only once the `FLOAT` fast path has been ruled out, so the whole question is
+    /// whether the column is the other thing `getFloat` reads. It says what the column
+    /// actually is, rather than the width `FLOAT16` would have needed — which is not what
+    /// the caller asked about when the column is not annotated `FLOAT16` at all. A column
+    /// whose annotation its width cannot carry arrives unannotated, the annotation having
+    /// been dropped where the schema was built, so it is simply not a float column.
+    private void requireFloatAccess(int columnIndex) {
+        LogicalType logicalType = columnSchemas[columnIndex].logicalType();
+        if (logicalType instanceof LogicalType.Float16Type) {
+            return;
+        }
+        throw new IllegalArgumentException(prefix() + "Column '"
+                + columnSchemas[columnIndex].fieldPath() + "' is "
+                + physicalTypes[columnIndex]
+                + (logicalType == null ? "" : " annotated " + logicalType)
+                + ", which cannot be read as a float");
+    }
+
     /// Decode strategy for [#getValue(int)], selected by a column's physical and
     /// logical type. Matches the original branch order: a `UTF8` / `JSON` leaf is
     /// served interned, an `INT96` leaf is the conventional timestamp, an
@@ -511,8 +531,9 @@ public final class FlatRowReader implements FileAwareRowReader {
         if (physicalTypes[columnIndex] == PhysicalType.FLOAT) {
             return ((float[]) flatValueArrays[columnIndex])[rowIndex];
         }
-        // FLOAT16 surfaces as FIXED_LEN_BYTE_ARRAY(2) annotated Float16Type;
-        // convertToFloat16 owns the physical-type and 2-byte-width validation.
+        // FLOAT16 surfaces as FIXED_LEN_BYTE_ARRAY(2) annotated Float16Type; any other
+        // column is one the caller has asked for a float it does not hold.
+        requireFloatAccess(columnIndex);
         try {
             return LogicalTypeConverter.convertToFloat16(
                     ((BinaryBatchValues) flatValueArrays[columnIndex]).byteArrayAt(rowIndex),

--- a/core/src/main/java/dev/hardwood/internal/reader/NestedBatchDataView.java
+++ b/core/src/main/java/dev/hardwood/internal/reader/NestedBatchDataView.java
@@ -217,6 +217,7 @@ public final class NestedBatchDataView {
         // FLOAT16 path: primitive convertToFloat16 keeps the value unboxed;
         // readLogicalType isn't reused because LogicalTypeConverter.convert
         // returns Object and would box.
+        batchIndex.requireFloatAccess(p.schema());
         try {
             return LogicalTypeConverter.convertToFloat16(
                     ((BinaryBatchValues) batchIndex.valueArrays[projCol]).byteArrayAt(valueIdx),
@@ -277,6 +278,7 @@ public final class NestedBatchDataView {
         if (p.schema().type() == PhysicalType.FLOAT) {
             return ((float[]) fieldValueArrays[projectedIndex])[valueIdx];
         }
+        batchIndex.requireFloatAccess(p.schema());
         try {
             return LogicalTypeConverter.convertToFloat16(
                     ((BinaryBatchValues) fieldValueArrays[projectedIndex]).byteArrayAt(valueIdx),

--- a/core/src/main/java/dev/hardwood/internal/reader/NestedBatchIndex.java
+++ b/core/src/main/java/dev/hardwood/internal/reader/NestedBatchIndex.java
@@ -7,7 +7,9 @@
  */
 package dev.hardwood.internal.reader;
 
+import dev.hardwood.internal.ExceptionContext;
 import dev.hardwood.internal.schema.ProjectedSchema;
+import dev.hardwood.metadata.LogicalType;
 import dev.hardwood.schema.ColumnSchema;
 import dev.hardwood.schema.FileSchema;
 import dev.hardwood.schema.SchemaNode;
@@ -35,12 +37,16 @@ final class NestedBatchIndex {
     final int[][][] multiOffsets;
     final long[][] elementValidity; // [projectedCol] -> leaf validity bitmap (set bit = present)
     final ProjectedSchema projectedSchema;
+    /// The file these batches came from, for the failures that name one. Batches never
+    /// straddle files.
+    final String fileName;
 
     private NestedBatchIndex(Object[] valueArrays, int[][] defLevels,
                              ColumnSchema[] columnSchemas, int[] valueCounts,
                              int[] recordCounts, int[][] offsets,
                              int[][][] multiOffsets,
-                             long[][] elementValidity, ProjectedSchema projectedSchema) {
+                             long[][] elementValidity, ProjectedSchema projectedSchema,
+                             String fileName) {
         this.valueArrays = valueArrays;
         this.defLevels = defLevels;
         this.columnSchemas = columnSchemas;
@@ -50,6 +56,26 @@ final class NestedBatchIndex {
         this.multiOffsets = multiOffsets;
         this.elementValidity = elementValidity;
         this.projectedSchema = projectedSchema;
+        this.fileName = fileName;
+    }
+
+    /// Fails when the caller has asked a column for a float it does not hold.
+    ///
+    /// Reached only once the `FLOAT` fast path has been ruled out, so a column that holds
+    /// floats never arrives here. Shared by every nested accessor that reads a `FLOAT16`,
+    /// so all of them answer a caller the same way. The column is named by its leaf name,
+    /// as every other message this reader composes names it. A column whose annotation its
+    /// width cannot carry arrives unannotated, so it reaches here as what it physically is
+    /// rather than as a broken `FLOAT16`.
+    void requireFloatAccess(SchemaNode.PrimitiveNode column) {
+        LogicalType logicalType = column.logicalType();
+        if (logicalType instanceof LogicalType.Float16Type) {
+            return;
+        }
+        throw new IllegalArgumentException(ExceptionContext.filePrefix(fileName)
+                + "Column '" + column.name() + "' is " + column.type()
+                + (logicalType == null ? "" : " annotated " + logicalType)
+                + ", which cannot be read as a float");
     }
 
     /// Build the batch index from [NestedBatch] objects whose index fields
@@ -79,7 +105,8 @@ final class NestedBatchIndex {
 
         return new NestedBatchIndex(valueArrays, defLevels, columnSchemas,
                 valueCounts, recordCounts, offsets, multiOffsets,
-                elementValidity, projectedSchema);
+                elementValidity, projectedSchema,
+                colCount > 0 ? batches[0].fileName : null);
     }
 
     /// Compact a layer-indexed offsets array (length `layerCount`, with

--- a/core/src/main/java/dev/hardwood/internal/reader/PqListImpl.java
+++ b/core/src/main/java/dev/hardwood/internal/reader/PqListImpl.java
@@ -21,7 +21,6 @@ import java.util.function.IntFunction;
 
 import dev.hardwood.internal.reader.TopLevelFieldMap.FieldDesc.ListOf;
 import dev.hardwood.internal.variant.PqVariantImpl;
-import dev.hardwood.metadata.LogicalType;
 import dev.hardwood.metadata.PhysicalType;
 import dev.hardwood.row.PqDoubleList;
 import dev.hardwood.row.PqIntList;
@@ -192,11 +191,13 @@ final class PqListImpl implements PqList {
 
     @Override
     public List<Float> floats() {
-        // FLOAT16 (FLBA(2) + Float16Type) decodes per element via the typed
-        // converter; plain FLOAT is a direct cast.
+        // FLOAT16 (FLBA(2) + Float16Type) decodes per element via the typed converter;
+        // plain FLOAT is a direct cast. Ruling out FLOAT first lets the shared guard name
+        // an element that is neither, rather than leaving it to the cast below — and it
+        // decides once per view, as the element's annotation is decided once.
         if (elementSchema instanceof SchemaNode.PrimitiveNode prim
-                && prim.type() == PhysicalType.FIXED_LEN_BYTE_ARRAY
-                && prim.logicalType() instanceof LogicalType.Float16Type) {
+                && prim.type() != PhysicalType.FLOAT) {
+            batch.requireFloatAccess(prim);
             return new LeafList<>(raw -> ValueConverter.convertLogicalType(raw, elementSchema, Float.class));
         }
         return new LeafList<>(raw -> (Float) raw);

--- a/core/src/main/java/dev/hardwood/internal/reader/PqMapImpl.java
+++ b/core/src/main/java/dev/hardwood/internal/reader/PqMapImpl.java
@@ -21,7 +21,6 @@ import java.util.UUID;
 
 import dev.hardwood.internal.conversion.LogicalTypeConverter;
 import dev.hardwood.internal.variant.PqVariantImpl;
-import dev.hardwood.metadata.LogicalType;
 import dev.hardwood.metadata.PhysicalType;
 import dev.hardwood.row.PqInterval;
 import dev.hardwood.row.PqList;
@@ -530,10 +529,12 @@ final class PqMapImpl implements PqMap {
                 throw new NullPointerException("Value is null");
             }
             if (valueSchema instanceof SchemaNode.PrimitiveNode primitive
-                    && primitive.type() == PhysicalType.FIXED_LEN_BYTE_ARRAY
-                    && primitive.logicalType() instanceof LogicalType.Float16Type) {
-                // FLOAT16 path: FLBA(2) payload decoded to a single-precision
-                // float, matching PqStructImpl.getFloat and FlatRowReader.getFloat.
+                    && primitive.type() != PhysicalType.FLOAT) {
+                // FLOAT16 path: FLBA(2) payload decoded to a single-precision float,
+                // matching PqStructImpl.readFloat and FlatRowReader.getFloat. Ruling out
+                // FLOAT first lets the shared guard name a value that is neither, rather
+                // than leaving it to the cast below.
+                batch.requireFloatAccess(primitive);
                 return LogicalTypeConverter.convertToFloat16(
                         ((BinaryBatchValues) batch.valueArrays[valueProjCol]).byteArrayAt(valueIdx),
                         primitive.type());

--- a/core/src/main/java/dev/hardwood/internal/reader/PqStructImpl.java
+++ b/core/src/main/java/dev/hardwood/internal/reader/PqStructImpl.java
@@ -340,6 +340,7 @@ final class PqStructImpl implements PqStruct {
         // FLOAT16 path: convertToFloat16 returns primitive float so the value
         // flows through without per-row autoboxing. readLogicalType isn't reused
         // here because its `LogicalTypeConverter.convert` step boxes via Object.
+        batch.requireFloatAccess(child.schema());
         return LogicalTypeConverter.convertToFloat16(
                 ((BinaryBatchValues) batch.valueArrays[projCol]).byteArrayAt(idx),
                 child.schema().type());

--- a/core/src/main/java/dev/hardwood/internal/reader/ValueConverter.java
+++ b/core/src/main/java/dev/hardwood/internal/reader/ValueConverter.java
@@ -43,20 +43,6 @@ public final class ValueConverter {
         return (Long) rawValue;
     }
 
-    public static Float convertToFloat(Object rawValue, SchemaNode schema) {
-        if (rawValue == null) {
-            return null;
-        }
-        // FLBA(2) annotated FLOAT16 decodes the half-precision payload to a
-        // single-precision Float so callers don't need to know the on-disk encoding.
-        if (schema instanceof SchemaNode.PrimitiveNode primitive
-                && primitive.type() == PhysicalType.FIXED_LEN_BYTE_ARRAY
-                && primitive.logicalType() instanceof LogicalType.Float16Type) {
-            return convertLogicalType(rawValue, schema, Float.class);
-        }
-        return (Float) rawValue;
-    }
-
     public static Double convertToDouble(Object rawValue, SchemaNode schema) {
         if (rawValue == null) {
             return null;

--- a/core/src/main/java/dev/hardwood/internal/thrift/LogicalTypeReader.java
+++ b/core/src/main/java/dev/hardwood/internal/thrift/LogicalTypeReader.java
@@ -17,6 +17,9 @@ import dev.hardwood.reader.ParquetReadException;
 /// LogicalType is a union with different variants for each type.
 public class LogicalTypeReader {
 
+    private static final System.Logger LOG =
+            System.getLogger(LogicalTypeReader.class.getName());
+
     public static LogicalType read(ThriftCompactReader reader) {
         int saved = reader.pushFieldIdContext(ThriftStruct.LOGICAL_TYPE);
         try {
@@ -90,7 +93,16 @@ public class LogicalTypeReader {
                     case 16 -> readVariantType(reader);
                     case 17 -> readGeometryType(reader);
                     case 18 -> readGeographyType(reader);
+                    // An arm this version does not know. The format treats a new logical
+                    // type as forward-compatible: read the physical values and lose the
+                    // semantics, rather than refuse a file a newer writer produced.
                     default -> {
+                        LOG.log(System.Logger.Level.WARNING,
+                                "Ignoring unrecognized LogicalType union field {0};"
+                                + " the column will be read as its physical type."
+                                + " The file may have been written against a newer"
+                                + " version of the format.",
+                                ThriftCompactReader.fieldId(header));
                         reader.skipField(ThriftCompactReader.fieldType(header));
                         yield null;
                     }

--- a/core/src/main/java/dev/hardwood/schema/FileSchema.java
+++ b/core/src/main/java/dev/hardwood/schema/FileSchema.java
@@ -12,6 +12,7 @@ import java.util.List;
 import java.util.Locale;
 import java.util.function.Consumer;
 
+import dev.hardwood.internal.conversion.LogicalTypeConverter;
 import dev.hardwood.internal.schema.LogicalTypeAnnotations;
 import dev.hardwood.internal.schema.LogicalTypeValidator;
 import dev.hardwood.internal.util.StringToIntMap;
@@ -28,6 +29,9 @@ import dev.hardwood.metadata.SchemaElement;
 /// @see <a href="https://parquet.apache.org/docs/file-format/">File Format</a>
 /// @see <a href="https://github.com/apache/parquet-format/blob/master/src/main/thrift/parquet.thrift">parquet.thrift</a>
 public class FileSchema {
+
+    private static final System.Logger LOG =
+            System.getLogger(FileSchema.class.getName());
 
     private final String name;
     private final List<ColumnSchema> columns;
@@ -187,7 +191,16 @@ public class FileSchema {
 
         // Shared read position into the flat element list; start past the root at index 0.
         int[] cursor = { 1 };
-        List<SchemaNode> rootChildren = buildChildren(elements, cursor, root.numChildren() != null ? root.numChildren() : 0, 0, 0, List.of(), columns, columnIndex);
+        // One line per file rather than one per column: a file written against a newer
+        // format version can carry many, and they say the same thing about all of them.
+        List<String> dropped = new ArrayList<>();
+        List<SchemaNode> rootChildren = buildChildren(elements, cursor, root.numChildren() != null ? root.numChildren() : 0, 0, 0, List.of(), columns, columnIndex, dropped);
+        if (!dropped.isEmpty()) {
+            LOG.log(System.Logger.Level.WARNING,
+                    "Ignoring {0} logical type annotation(s) the column''s physical type"
+                    + " cannot carry; those columns are read as their physical type: {1}",
+                    dropped.size(), String.join("; ", dropped));
+        }
 
         SchemaNode.GroupNode rootNode = new SchemaNode.GroupNode(
                 root.name(),
@@ -211,7 +224,8 @@ public class FileSchema {
                                                   int parentRepLevel,
                                                   List<String> parentPath,
                                                   List<ColumnSchema> columns,
-                                                  int[] columnIndex) {
+                                                  int[] columnIndex,
+                                                  List<String> dropped) {
 
         List<SchemaNode> children = new ArrayList<>();
 
@@ -231,7 +245,7 @@ public class FileSchema {
             if (element.isPrimitive()) {
                 // Primitive node - represents an actual column
                 int colIdx = columnIndex[0]++;
-                LogicalType effectiveLogicalType = effectiveLogicalType(element);
+                LogicalType effectiveLogicalType = readableLogicalType(element, currentPath, dropped);
                 columns.add(new ColumnSchema(
                         new FieldPath(List.copyOf(currentPath)),
                         element.type(),
@@ -266,7 +280,8 @@ public class FileSchema {
                         repLevel,
                         currentPath,
                         columns,
-                        columnIndex);
+                        columnIndex,
+                        dropped);
 
                 SchemaNode.GroupNode groupNode = new SchemaNode.GroupNode(
                         element.name(),
@@ -284,6 +299,72 @@ public class FileSchema {
         }
 
         return children;
+    }
+
+    /// The column's annotation, or `null` where its physical type cannot carry it.
+    ///
+    /// `FLOAT16` is defined as a two-byte payload, so a column annotated `FLOAT16` that
+    /// declares twelve bytes is invalid, and no reading of it produces the value the
+    /// annotation promises. The format says to read past the annotation rather than refuse
+    /// the file: see the "Unsupported Logical Types" section of `LogicalTypes.md`, adopted in
+    /// parquet-format PR 606, which has readers "ignore both the logical type annotation and
+    /// column order for that column. Only the physical type information should be used to
+    /// process the column's data."
+    ///
+    /// So the column is reported and read as though the footer had not annotated it. Every
+    /// consequence follows from the annotation's absence rather than from a check: the
+    /// physical accessors work, `getValue` yields the physical value, a logical accessor
+    /// fails exactly as it would on any unannotated column of that type, and the column's
+    /// statistics are compared under its physical type's ordering.
+    ///
+    /// The sibling case — an annotation this version does not recognize at all — is dropped
+    /// where it is parsed, in `LogicalTypeReader`. Both end here as an unannotated column;
+    /// they differ only in what the warning can tell the reader, because one is a file from
+    /// a newer writer and the other is a file from a broken one.
+    ///
+    /// Column order needs no separate handling: the only thing it decides is whether a float
+    /// predicate compares under IEEE 754 total order, and a column that has lost its
+    /// `FLOAT16` annotation is rejected by `FilterPredicateResolver` before that flag is
+    /// consulted.
+    private static LogicalType readableLogicalType(SchemaElement element, List<String> path,
+                                                   List<String> dropped) {
+        LogicalType annotation = effectiveLogicalType(element);
+        if (annotation == null) {
+            return null;
+        }
+        String fault = LogicalTypeConverter.conversionFault(
+                element.type(), element.typeLength(), annotation);
+        if (fault == null) {
+            return annotation;
+        }
+        dropped.add(String.join(".", path) + " (" + fault + ")");
+        return null;
+    }
+
+    /// Guards the read-side leniency against a schema the caller declared.
+    ///
+    /// [#readableLogicalType] drops an annotation the column's physical type cannot carry,
+    /// which is right for a file already on disk and wrong for a schema being declared here:
+    /// the caller would get a file written without the annotation they asked for, and only a
+    /// warning to say so. [LogicalTypeValidator] already refuses every such pairing when the
+    /// leaf is declared, so reaching this means the writer's rule and the reader's have
+    /// drifted apart rather than that the caller did anything wrong.
+    private static void requireNoAnnotationDropped(List<SchemaElement> elements) {
+        for (SchemaElement element : elements) {
+            if (!element.isPrimitive()) {
+                continue;
+            }
+            LogicalType annotation = effectiveLogicalType(element);
+            if (annotation == null) {
+                continue;
+            }
+            String fault = LogicalTypeConverter.conversionFault(
+                    element.type(), element.typeLength(), annotation);
+            if (fault != null) {
+                throw new IllegalStateException("Column '" + element.name() + "': " + fault
+                        + ". A declared schema must not carry an annotation the reader drops.");
+            }
+        }
     }
 
     /// Resolve the effective logical type of a primitive element, falling back
@@ -597,6 +678,7 @@ public class FileSchema {
             List<SchemaElement> elements = new ArrayList<>();
             elements.add(SchemaElement.group(name, RepetitionType.REQUIRED, content.children.size()));
             flatten(content.children, elements);
+            requireNoAnnotationDropped(elements);
             return fromSchemaElements(elements);
         }
     }

--- a/core/src/test/java/dev/hardwood/Float16LogicalTypeTest.java
+++ b/core/src/test/java/dev/hardwood/Float16LogicalTypeTest.java
@@ -8,14 +8,20 @@
 package dev.hardwood;
 
 import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.stream.Stream;
 
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 
 import dev.hardwood.internal.conversion.LogicalTypeConverter;
 import dev.hardwood.metadata.LogicalType;
@@ -32,6 +38,9 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 class Float16LogicalTypeTest {
 
     private static final Path FILE = Paths.get("src/test/resources/float16_logical_type_test.parquet");
+
+    /// Offset of `duration`'s `LogicalType` union variant in `interval_logical_type_test.parquet`.
+    private static final int LOGICAL_TYPE_VARIANT_BYTE = 187;
 
     // Row 0: 0.0
     // Row 1: 1.0
@@ -118,9 +127,10 @@ class Float16LogicalTypeTest {
     }
 
     /// `getFloat` on a non-FLOAT column whose physical type is FLBA but is not
-    /// a half-precision payload (here: FLBA(12) annotated INTERVAL) routes
-    /// through `convertToFloat16`, whose 2-byte width check rejects the call
-    /// with `IllegalArgumentException` enriched with the source file name.
+    /// a half-precision payload (here: FLBA(12) annotated INTERVAL) is the caller
+    /// asking a column for a type it does not hold, so it keeps
+    /// `IllegalArgumentException` and names no file — the file is not at fault — and
+    /// says what the column actually is rather than the width FLOAT16 would need.
     @Test
     void testGetFloatOnNonFloat16FlbaColumnRaisesIllegalArgumentException() throws IOException {
         Path intervalFile = Paths.get("src/test/resources/interval_logical_type_test.parquet");
@@ -129,8 +139,9 @@ class Float16LogicalTypeTest {
             rowReader.next();
             assertThatThrownBy(() -> rowReader.getFloat("duration"))
                     .isInstanceOf(IllegalArgumentException.class)
-                    .hasMessageContaining("2 bytes")
-                    .hasMessageContaining("interval_logical_type_test.parquet");
+                    .hasMessage("[interval_logical_type_test.parquet] Column 'duration' is"
+                            + " FIXED_LEN_BYTE_ARRAY annotated INTERVAL,"
+                            + " which cannot be read as a float");
         }
     }
 
@@ -182,5 +193,110 @@ class Float16LogicalTypeTest {
         assertThat(filtered.get(2)).isNotNull();
         assertThat(Float.isNaN(filtered.get(2))).isTrue();
         assertThat(filtered.get(3)).isNull();
+    }
+
+    /// Byte 187 is the `LogicalType` union variant on `duration`, a `FIXED_LEN_BYTE_ARRAY(12)`
+    /// column the file annotates `INTERVAL` (variant 9). Relabelling it `FLOAT16` (variant 15)
+    /// leaves the values untouched and the annotation contradicting the width.
+    ///
+    /// The offset is a property of the checked-in bytes, so regenerating the fixture moves
+    /// it. The test then fails and reports the bytes it did produce, which is what a new
+    /// offset is derived from.
+    ///
+    /// `FLOAT16` is defined as a two-byte payload, so a column annotated `FLOAT16` that
+    /// declares twelve bytes is invalid. The format says to read past the annotation rather
+    /// than refuse the file, so the column is reported and read as the
+    /// `FIXED_LEN_BYTE_ARRAY` it physically is.
+    @Test
+    void testAnAnnotationTheWidthContradictsIsDropped() throws IOException {
+        try (ParquetFileReader fileReader = ParquetFileReader.open(
+                     InputFile.of(ByteBuffer.wrap(relabelled(0xFC))));
+             RowReader rowReader = fileReader.rowReader()) {
+
+            ColumnSchema duration = fileReader.getFileSchema().getColumn("duration");
+            assertThat(duration.logicalType()).isNull();
+            assertThat(duration.type()).isEqualTo(PhysicalType.FIXED_LEN_BYTE_ARRAY);
+            assertThat(duration.typeLength()).isEqualTo(12);
+
+            rowReader.next();
+            // The bytes were never in question, and now nothing claims to decode them.
+            assertThat(rowReader.getBinary("duration")).hasSize(12);
+            assertThat(rowReader.getValue("duration")).isInstanceOf(byte[].class);
+
+            // Asking an unannotated FIXED_LEN_BYTE_ARRAY for a float is the caller's
+            // mistake, and says so without mentioning FLOAT16 — which no longer applies.
+            assertThatThrownBy(() -> rowReader.getFloat("duration"))
+                    .isInstanceOf(IllegalArgumentException.class)
+                    .hasMessage("[<memory>] Column 'duration' is FIXED_LEN_BYTE_ARRAY,"
+                            + " which cannot be read as a float");
+        }
+    }
+
+    /// The same relabelling, aimed at the annotations the other conversions read.
+    /// `duration` is `FIXED_LEN_BYTE_ARRAY(12)`, so none of `DATE`, `TIME` or `TIMESTAMP`
+    /// can be read from it whatever the values say, and each is dropped the same way. The
+    /// accessor that would have converted then fails as it does on any unannotated column,
+    /// rather than reporting the file.
+    ///
+    /// @param variantByte the `LogicalType` union variant to relabel `duration` to
+    @ParameterizedTest
+    @MethodSource("contradictedAnnotations")
+    void testEveryContradictedAnnotationIsDropped(int variantByte) throws IOException {
+        try (ParquetFileReader fileReader = ParquetFileReader.open(
+                     InputFile.of(ByteBuffer.wrap(relabelled(variantByte))));
+             RowReader rowReader = fileReader.rowReader()) {
+
+            assertThat(fileReader.getFileSchema().getColumn("duration").logicalType()).isNull();
+            rowReader.next();
+            assertThat(rowReader.getBinary("duration")).hasSize(12);
+        }
+    }
+
+    /// Union variant bytes: the low nibble is the STRUCT wire type, the high nibble the
+    /// field-id delta from zero — so `0x6C` is `DATE` (6), `0x7C` `TIME` (7), `0x8C`
+    /// `TIMESTAMP` (8) and `0xEC` `UUID` (14). The first three cannot be read from a
+    /// `FIXED_LEN_BYTE_ARRAY` at all; `UUID` can, but only at sixteen bytes.
+    static Stream<Arguments> contradictedAnnotations() {
+        return Stream.of(Arguments.of(0x6C), Arguments.of(0x7C), Arguments.of(0x8C),
+                Arguments.of(0xEC));
+    }
+
+    /// `interval_logical_type_test.parquet` with `duration`'s `LogicalType` union variant
+    /// byte overwritten, leaving the values and the declared width untouched.
+    private static byte[] relabelled(int variantByte) throws IOException {
+        byte[] bytes = Files.readAllBytes(
+                Paths.get("src/test/resources/interval_logical_type_test.parquet"));
+        bytes[LOGICAL_TYPE_VARIANT_BYTE] = (byte) variantByte;
+        return bytes;
+    }
+
+    /// The nested reader answers a caller the same way the flat one does. The two decide it
+    /// from the same facts by different routes — the flat reader per projected column, the
+    /// nested view per primitive — so a test that only exercised one would not notice them
+    /// drifting apart.
+    @Test
+    void testNestedReaderRejectsAFloatReadTheSameWay() throws IOException {
+        Path nested = Paths.get("src/test/resources/nested_struct_test.parquet");
+        try (ParquetFileReader fileReader = ParquetFileReader.open(InputFile.of(nested));
+             RowReader rowReader = fileReader.rowReader()) {
+            rowReader.next();
+            assertThatThrownBy(() -> rowReader.getFloat("id"))
+                    .isInstanceOf(IllegalArgumentException.class)
+                    .hasMessage("[nested_struct_test.parquet] Column 'id' is INT32,"
+                            + " which cannot be read as a float");
+
+            // The by-index half of the same method, which reaches the column by a
+            // different route and used to answer with a rewrapped ClassCastException.
+            assertThatThrownBy(() -> rowReader.getFloat(0))
+                    .isInstanceOf(IllegalArgumentException.class)
+                    .hasMessage("[nested_struct_test.parquet] Column 'id' is INT32,"
+                            + " which cannot be read as a float");
+
+            // And a field one level down, read through the struct flyweight.
+            assertThatThrownBy(() -> rowReader.getStruct("address").getFloat("city"))
+                    .isInstanceOf(IllegalArgumentException.class)
+                    .hasMessage("[nested_struct_test.parquet] Column 'city' is BYTE_ARRAY"
+                            + " annotated STRING, which cannot be read as a float");
+        }
     }
 }

--- a/core/src/test/java/dev/hardwood/internal/conversion/ConversionFaultTest.java
+++ b/core/src/test/java/dev/hardwood/internal/conversion/ConversionFaultTest.java
@@ -1,0 +1,160 @@
+/*
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Copyright The original authors
+ *
+ *  Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package dev.hardwood.internal.conversion;
+
+import org.junit.jupiter.api.Test;
+
+import dev.hardwood.metadata.LogicalType;
+import dev.hardwood.metadata.PhysicalType;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/// Which annotations a column can carry, as [LogicalTypeConverter#conversionFault] answers it.
+///
+/// The answer must match what the conversions themselves accept: too lenient and a column
+/// reaches a conversion that cannot decode it, too strict and a file that reads today stops
+/// opening. `LogicalTypeValidator` states the writer's rule, which is deliberately stricter,
+/// and the cases below pin the two apart where they differ.
+class ConversionFaultTest {
+
+    @Test
+    void anAnnotationItsPhysicalTypeCarriesHasNoFault() {
+        assertThat(fault(PhysicalType.BYTE_ARRAY, null, new LogicalType.StringType())).isNull();
+        assertThat(fault(PhysicalType.INT32, null, new LogicalType.DateType())).isNull();
+        assertThat(fault(PhysicalType.INT64, null, timestamp())).isNull();
+        assertThat(fault(PhysicalType.FIXED_LEN_BYTE_ARRAY, 2, new LogicalType.Float16Type())).isNull();
+        assertThat(fault(PhysicalType.FIXED_LEN_BYTE_ARRAY, 16, new LogicalType.UuidType())).isNull();
+        assertThat(fault(PhysicalType.FIXED_LEN_BYTE_ARRAY, 12, new LogicalType.IntervalType())).isNull();
+    }
+
+    @Test
+    void anUnannotatedColumnHasNoFault() {
+        assertThat(fault(PhysicalType.INT64, null, null)).isNull();
+    }
+
+    @Test
+    void anAnnotationItsPhysicalTypeCannotCarryIsFaulted() {
+        assertThat(fault(PhysicalType.INT64, null, new LogicalType.DateType()))
+                .isEqualTo("DATE is read from INT32, but the column is INT64");
+        assertThat(fault(PhysicalType.INT32, null, new LogicalType.StringType()))
+                .isEqualTo("STRING is read from BYTE_ARRAY, but the column is INT32");
+    }
+
+    @Test
+    void aFixedWidthAnnotationOnTheWrongWidthIsFaulted() {
+        assertThat(fault(PhysicalType.FIXED_LEN_BYTE_ARRAY, 3, new LogicalType.Float16Type()))
+                .isEqualTo("FLOAT16 is exactly 2 bytes, but the column declares 3");
+        assertThat(fault(PhysicalType.FIXED_LEN_BYTE_ARRAY, 8, new LogicalType.UuidType()))
+                .isEqualTo("UUID is exactly 16 bytes, but the column declares 8");
+    }
+
+    /// The wrong physical type is reported before the width, because a column that is not
+    /// fixed-width has no width to be wrong about.
+    @Test
+    void theWrongPhysicalTypeIsReportedAheadOfTheWidth() {
+        assertThat(fault(PhysicalType.INT64, null, new LogicalType.Float16Type()))
+                .isEqualTo("FLOAT16 is read from FIXED_LEN_BYTE_ARRAY, but the column is INT64");
+    }
+
+    /// Reading accepts either width for `TIME` and `INT` whatever the unit or bit width,
+    /// where the writer pins `TIME(MILLIS)` to `INT32`. Applying the writer's rule here
+    /// would refuse files that read today.
+    @Test
+    void readingIsLenientWhereWritingIsStrict() {
+        assertThat(fault(PhysicalType.INT64, null,
+                new LogicalType.TimeType(true, LogicalType.TimeUnit.MILLIS))).isNull();
+        assertThat(fault(PhysicalType.INT64, null, new LogicalType.IntType(8, true))).isNull();
+    }
+
+    /// Geometry and geography payloads are carried through untouched, so no physical type
+    /// is imposed on them.
+    @Test
+    void anOpaquePayloadImposesNoPhysicalType() {
+        assertThat(fault(PhysicalType.INT32, null, new LogicalType.GeometryType(null))).isNull();
+    }
+
+    /// `JSON`, `BSON` and `ENUM` all carry a `BYTE_ARRAY` payload, so each is faulted on
+    /// any other physical type even though only `STRING` is decoded to a `String`.
+    @Test
+    void aByteArrayPayloadAnnotationIsFaultedOnAnyOtherPhysicalType() {
+        assertThat(fault(PhysicalType.BYTE_ARRAY, null, new LogicalType.JsonType())).isNull();
+        assertThat(fault(PhysicalType.BYTE_ARRAY, null, new LogicalType.BsonType())).isNull();
+        assertThat(fault(PhysicalType.BYTE_ARRAY, null, new LogicalType.EnumType())).isNull();
+        assertThat(fault(PhysicalType.INT64, null, new LogicalType.JsonType()))
+                .isEqualTo("JSON is read from BYTE_ARRAY, but the column is INT64");
+        assertThat(fault(PhysicalType.INT32, null, new LogicalType.BsonType()))
+                .isEqualTo("BSON is read from BYTE_ARRAY, but the column is INT32");
+        assertThat(fault(PhysicalType.DOUBLE, null, new LogicalType.EnumType()))
+                .isEqualTo("ENUM is read from BYTE_ARRAY, but the column is DOUBLE");
+    }
+
+    /// `DECIMAL` is the one annotation four physical types can carry, and the message
+    /// lists them in the order the conversion accepts them.
+    @Test
+    void decimalIsCarriedByFourPhysicalTypes() {
+        assertThat(fault(PhysicalType.INT32, null, decimal())).isNull();
+        assertThat(fault(PhysicalType.INT64, null, decimal())).isNull();
+        assertThat(fault(PhysicalType.BYTE_ARRAY, null, decimal())).isNull();
+        assertThat(fault(PhysicalType.FIXED_LEN_BYTE_ARRAY, 8, decimal())).isNull();
+        assertThat(fault(PhysicalType.BOOLEAN, null, decimal()))
+                .isEqualTo("DECIMAL is read from INT32, INT64, BYTE_ARRAY or"
+                        + " FIXED_LEN_BYTE_ARRAY, but the column is BOOLEAN");
+    }
+
+    /// A `DECIMAL` on a `FIXED_LEN_BYTE_ARRAY` imposes no particular width: the precision
+    /// decides how many bytes the unscaled value needs, and the conversion reads whatever
+    /// the column declares.
+    @Test
+    void aFixedLenDecimalImposesNoWidth() {
+        assertThat(fault(PhysicalType.FIXED_LEN_BYTE_ARRAY, 3, decimal())).isNull();
+        assertThat(fault(PhysicalType.FIXED_LEN_BYTE_ARRAY, 32, decimal())).isNull();
+    }
+
+    /// `LIST`, `MAP` and `VARIANT` annotate a group. Reaching a primitive leaf, they name a
+    /// pairing no version of the format defines, so they are dropped like any other — which
+    /// is what keeps them out of `convert`, whose structural arms throw.
+    @Test
+    void aStructuralAnnotationOnAPrimitiveIsFaulted() {
+        assertThat(fault(PhysicalType.BYTE_ARRAY, null, new LogicalType.ListType()))
+                .isEqualTo("LIST annotates a group, but the column is a primitive");
+        assertThat(fault(PhysicalType.BYTE_ARRAY, null, new LogicalType.MapType()))
+                .isEqualTo("MAP annotates a group, but the column is a primitive");
+        assertThat(fault(PhysicalType.BYTE_ARRAY, null, new LogicalType.VariantType(1)))
+                .isEqualTo("VARIANT annotates a group, but the column is a primitive");
+    }
+
+    /// `NULL` is legal over any physical type — it says every value in the column is null.
+    /// Only the values can contradict it, and this answers from the schema alone.
+    @Test
+    void nullIsLegalOverAnyPhysicalType() {
+        assertThat(fault(PhysicalType.INT32, null, new LogicalType.NullType())).isNull();
+        assertThat(fault(PhysicalType.BYTE_ARRAY, null, new LogicalType.NullType())).isNull();
+    }
+
+    /// A footer that omits `type_length` states no width for the annotation to contradict,
+    /// so nothing here is provably wrong and the annotation is kept. Such a column cannot be
+    /// decoded at all, and `FixedWidthValidator` refuses it by name — reporting it as a bad
+    /// annotation would drop a sound one and describe the wrong defect.
+    @Test
+    void anUndeclaredWidthIsNotTheAnnotationsFault() {
+        assertThat(fault(PhysicalType.FIXED_LEN_BYTE_ARRAY, null, new LogicalType.Float16Type()))
+                .isNull();
+    }
+
+    private static String fault(PhysicalType type, Integer typeLength, LogicalType logicalType) {
+        return LogicalTypeConverter.conversionFault(type, typeLength, logicalType);
+    }
+
+    private static LogicalType.DecimalType decimal() {
+        return new LogicalType.DecimalType(4, 10);
+    }
+
+    private static LogicalType.TimestampType timestamp() {
+        return new LogicalType.TimestampType(true, LogicalType.TimeUnit.MILLIS);
+    }
+}

--- a/core/src/test/java/dev/hardwood/schema/FileSchemaConvertedTypeTest.java
+++ b/core/src/test/java/dev/hardwood/schema/FileSchemaConvertedTypeTest.java
@@ -32,6 +32,16 @@ class FileSchemaConvertedTypeTest {
 
     /// Build a one-column schema whose single leaf carries only the given
     /// `convertedType` (no modern logical type), and return the resolved column.
+    /// A legacy `converted_type` is promoted to its modern annotation first, so the same
+    /// rule drops it when the column's physical type cannot carry it — a writer that put
+    /// `UTF8` on an `INT32` produced a file no version of the format defines, whichever of
+    /// the two annotations it used to say so.
+    @Test
+    void aPromotedConvertedTypeItsPhysicalTypeCannotCarryIsDropped() {
+        assertThat(resolveColumn(PhysicalType.INT32, ConvertedType.UTF8).logicalType()).isNull();
+        assertThat(resolveColumn(PhysicalType.BYTE_ARRAY, ConvertedType.DATE).logicalType()).isNull();
+    }
+
     private static ColumnSchema resolveColumn(PhysicalType type, ConvertedType convertedType) {
         return resolveColumn(type, convertedType, null, null);
     }

--- a/docs/content/reference/accessors.md
+++ b/docs/content/reference/accessors.md
@@ -65,6 +65,17 @@ normal control flow. If the column type isn't known statically, check it up fron
 `reader.getFileSchema().getColumn(name)` and inspect the returned `ColumnSchema`'s `type()` /
 `logicalType()` — see [Inspect File Metadata](../how-to/metadata.md).
 
+A column whose annotation its physical type cannot carry is not an error. `FLOAT16` is defined as
+a two-byte payload, so a `FLOAT16` column that declares three bytes is invalid. The format tells
+readers to ignore such an annotation rather than reject the file, so Hardwood drops it — and drops
+one it does not recognize at all — logging a warning in each case. The column is then reported and
+read as its physical type.
+
+`getFileSchema()` reports no logical type for it, `getValue` returns the physical value, and the
+physical accessors work. A logical accessor fails as it would on any unannotated column of that
+type. Statistics are compared under the physical type's ordering, and a logical-type predicate on
+the column is rejected at reader creation.
+
 The `getTimestamp` / `getLocalTimestamp` pair is split along the column's `isAdjustedToUTC` flag:
 `getTimestamp` requires `isAdjustedToUTC = true` and returns `Instant`; `getLocalTimestamp`
 requires `isAdjustedToUTC = false` and returns `LocalDateTime`. Calling the wrong one for a column

--- a/docs/content/reference/error-handling.md
+++ b/docs/content/reference/error-handling.md
@@ -26,19 +26,33 @@ changes on a second attempt, so parsing and decoding raise `ParquetReadException
 instead — including for a page that will not decompress and a dictionary that will
 not decode.
 
+Every message names the file the reader was on. Exceptions raised for an invalid file add
+more detail, such as the file region, row group or column the read stopped at.
+
+### The read failed
+
 | Exception | When |
 |-----------|------|
 | `IOException` | Reading the file failed: a local-disk read error, an S3 transport failure (after retry exhaustion — see [Read from S3](../how-to/s3.md)), a file that cannot be opened. Checked, and declared by every method that reaches the file: `ParquetFileReader.open`/`openAll`; the reader factories and their builders' `build()` — `rowReader`, `columnReader`, `columnReaders`; `RowReader.hasNext`/`next`/`close`; `ColumnReader.nextBatch`/`close`; `ColumnReaders.nextBatch`/`close` |
 | `ParquetReadException` | The file was read and is not valid Parquet: a bad magic number, a corrupt footer, a malformed page index, a dictionary page the metadata places outside its column chunk, a page whose checksum fails, values that do not decode. Unchecked |
 | `SchemaIncompatibleException` | A `ParquetReadException`. In a multi-file read, a file whose schema cannot be reconciled with the first file's; or one file's footer disagreeing with itself about which leaf a column chunk holds |
 | `UnsupportedOperationException` | The file is correct and Hardwood cannot read it: Parquet Modular Encryption, an encoding not implemented, a compression codec whose library is absent — the message names the dependency to add — a column chunk stored in a separate file (the legacy split-file layout), a row group whose page-index region exceeds 2 GB, or a file over 2 GB opened with the mmap-backed range cache |
-| `IllegalArgumentException` | Accessing a column not in the projection, or an invalid column name |
+
+### The call was wrong
+
+These are mistakes in the calling code rather than read failures. The message names the file
+and the column, and nothing about where in the file the read had got to.
+
+| Exception | When |
+|-----------|------|
+| `IllegalArgumentException` | Accessing a column not in the projection, an invalid column name, or asking a column for a type it does not hold — `getFloat` on a column that is neither `FLOAT` nor `FLOAT16` |
 | `NullPointerException` | Calling a primitive accessor (`getInt`, `getLong`, etc.) on a null field without checking `isNull()` first |
 | `NoSuchElementException` | Calling `next()` on a `RowReader` when `hasNext()` returns `false` |
 | `IllegalStateException` | Calling `ColumnReader` accessors before `nextBatch()`, or calling nested-column methods on a flat column |
 
-The last four are mistakes in the calling code rather than read failures, and no
-file is involved.
+Requesting the wrong type for a column — `getLong` on an `INT32` column — is a programming
+error whose exception type is deliberately unspecified, and is covered in
+[Type mismatches](accessors.md#type-mismatches).
 
 Reading a `RowReader` inside a `Stream` or an `Iterator` means adapting a checked
 exception to an interface that cannot declare one. Wrap it in

--- a/docs/content/release-notes.md
+++ b/docs/content/release-notes.md
@@ -15,6 +15,8 @@ See [GitHub Releases](https://github.com/hardwood-hq/hardwood/releases) for down
 
 ## 1.1.0-SNAPSHOT
 
+- A logical type annotation that a column's physical type cannot carry is now dropped, and the column is read as its physical type. Previously it surfaced as an `IllegalArgumentException` from whichever accessor first reached the column ([#1139](https://github.com/hardwood-hq/hardwood/issues/1139)). `FLOAT16` is defined as a two-byte payload, so a column annotated `FLOAT16` that declares three bytes is invalid; [parquet-format PR 606](https://github.com/apache/parquet-format/pull/606) specifies that readers ignore the annotation and use only the physical type. An annotation this version does not recognize is dropped the same way, so a file written against a newer format version can still be read. Both cases log a warning, naming the column and the reason, or the union field that was not recognized. **What changes for you:** `getFileSchema()` reports no logical type for such a column, `getValue` returns its physical value where it used to throw, and a logical accessor on it fails as it does on any unannotated column.
+
 - A multi-file read opens each file as it reaches it, rather than opening every file when the reader is built, so the time to the first row no longer grows with the number of files ([#1107](https://github.com/hardwood-hq/hardwood/issues/1107)).
     - A later file's I/O errors, and any `SchemaIncompatibleException` its schema raises, now surface from the reading loop rather than from `ParquetFileReader.openAll(...)` or `build()` — always before any row of that file is returned. Code that catches those around reader construction alone should catch them around iteration too.
 

--- a/parquet-testing-runner/src/test/java/dev/hardwood/testing/IncompatibleLogicalTypeReadTest.java
+++ b/parquet-testing-runner/src/test/java/dev/hardwood/testing/IncompatibleLogicalTypeReadTest.java
@@ -17,7 +17,6 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 
 import dev.hardwood.InputFile;
-import dev.hardwood.metadata.LogicalType;
 import dev.hardwood.metadata.PhysicalType;
 import dev.hardwood.reader.ParquetFileReader;
 import dev.hardwood.reader.RowReader;
@@ -29,13 +28,16 @@ import static org.assertj.core.api.Assertions.assertThat;
 /// `int32_with_uuid_logical_type.parquet` fixture from apache/parquet-testing: a `UUID`, which
 /// the format defines over `FIXED_LEN_BYTE_ARRAY(16)`, annotating an `INT32`.
 ///
-/// The annotation is not a value: the column's data is ten `INT32`s and reads back as such. So
-/// the file opens, the footer is reported as it stands — annotation included, because dropping it
-/// would misreport what the file says — and the physical values are readable.
+/// The annotation is not a value: the column's data is ten `INT32`s and reads back as such. The
+/// "Unsupported Logical Types" section of `LogicalTypes.md` — adopted in parquet-format PR 606 —
+/// has readers "ignore both the logical type annotation and column order for that column. Only
+/// the physical type information should be used to process the column's data", so the file opens
+/// and the column is reported and read as the plain `INT32` it physically is.
 ///
 /// [ParquetComparisonTest] skips the fixture: parquet-java rejects the pairing while parsing the
 /// footer ("UUID can only annotate FIXED_LEN_BYTE_ARRAY(16)") and so never opens the file, which
-/// leaves no reference reader to compare against. This test is the coverage that replaces it.
+/// leaves no reference reader to compare against. Its PR 3711 implements the same drop, so once
+/// that ships the comparison can be turned back on and this test becomes the narrower coverage.
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 class IncompatibleLogicalTypeReadTest {
 
@@ -58,10 +60,13 @@ class IncompatibleLogicalTypeReadTest {
         }
     }
 
+    /// The annotation is dropped rather than reported, so nothing downstream of the schema has
+    /// to know it was ever there — and a caller reading `logicalType()` is not told the column
+    /// holds UUIDs when it holds `INT32`s.
     @Test
-    void theSchemaIsReportedAsTheFooterStatesIt() {
+    void theUnreadableAnnotationIsDropped() {
         assertThat(schema.getColumn(COLUMN).type()).isEqualTo(PhysicalType.INT32);
-        assertThat(schema.getColumn(COLUMN).logicalType()).isInstanceOf(LogicalType.UuidType.class);
+        assertThat(schema.getColumn(COLUMN).logicalType()).isNull();
     }
 
     @Test


### PR DESCRIPTION
Closes #1139.

A column annotated `FLOAT16` but three bytes wide reached the caller as `IllegalArgumentException: FLOAT16 requires exactly 2 bytes, got 3`. That is the type [_designs/EXCEPTION_MODEL.md](_designs/EXCEPTION_MODEL.md) gives to the caller's own mistake, for a call that made none.

Raising a better exception is not the answer either. The "Unsupported Logical Types" section of `LogicalTypes.md`, adopted in [parquet-format PR 606](https://github.com/apache/parquet-format/pull/606) on 3 September, tells readers to "ignore both the logical type annotation and column order for that column. Only the physical type information should be used to process the column's data." The twelve bytes are readable; only the annotation is unusable. `apache/parquet-testing` already ships a file that depends on this: `int32_with_uuid_logical_type.parquet` annotates an `INT32` column `UUID`, and its ten values read back fine. The same rule is in flight for parquet-java ([#3711](https://github.com/apache/parquet-java/pull/3711)) and arrow C++ ([#50909](https://github.com/apache/arrow/pull/50909)).

## What it does

`FileSchema` drops the annotation as the schema is built, and the column is reported and read as its physical type. No check is needed anywhere downstream: the physical accessors work, `getValue` yields the physical value, a logical accessor fails as it does on any unannotated column, and the statistics compare under the physical type's ordering. Column order needs no handling either — the only thing it decides is whether a float predicate compares under IEEE 754 total order, and a column that has lost its `FLOAT16` annotation is rejected by `FilterPredicateResolver` before that flag is read.

`LIST`, `MAP` and `VARIANT` reaching a primitive leaf are dropped by the same rule, which keeps them out of the structural arms of `convert` that raise `IllegalStateException` for a file fault. `NULL` is not dropped: it is legal over any physical type, and only the values can contradict it.

An annotation this version does not recognize is dropped where it is parsed. The handling is the same, but the warnings differ, because the causes do: one file is written against a newer format version, the other by a broken writer. Only the second can be shown to be wrong, so only the second could ever be a candidate for refusing the read.

A footer that omits `type_length` states no width for the annotation to contradict, so the annotation is kept and the column is refused for the missing width instead, by the validator whose message describes that defect.

The drop is a read-side leniency, so `Builder.build()` refuses a declared schema that would lose an annotation to it. `LogicalTypeValidator` already rejects every such pairing when the leaf is declared, which makes this unreachable; nothing stated that before.

## What a caller sees

For a `FIXED_LEN_BYTE_ARRAY(12)` column annotated `FLOAT16`:

| | Before | After |
|---|---|---|
| `getFileSchema()…logicalType()` | `Float16Type` | `null`, plus one warning per file naming the columns |
| `getBinary` | 12 bytes | unchanged |
| `getValue` | `IllegalArgumentException: FLOAT16 requires exactly 2 bytes, got 12` | the 12 bytes |
| `getFloat` | same `IllegalArgumentException` | `[f.parquet] Column 'duration' is FIXED_LEN_BYTE_ARRAY, which cannot be read as a float` |

The exception type for asking a column for a type it does not hold stays unspecified, as [Accessors](docs/content/reference/accessors.md) has always said.

## Also here

`getFloat` is the one typed accessor that has to branch on the physical type, taking both `FLOAT` and a `FLOAT16` that needs decoding, so it can name a column that is neither for free where the others would need a check #460 measured and rejected. Its five routes disagreed: two tested for `FLOAT16` positively and fell past it into a raw cast. They now share one guard. `ValueConverter.convertToFloat`, which carried the same old shape and has no callers, is deleted.

Out of scope: #1150 (surfacing dropped annotations in `inspect` and dive) and #971 (the bare `ClassCastException` on a wrong-type call).

## Testing

`ConversionFaultTest` covers each arm, including the structural ones, `NULL`, and the two where reading is deliberately more lenient than writing — `LogicalTypeValidator` is the writer's rule and pins `TIME(MILLIS)` to `INT32` where reading takes either width.

`Float16LogicalTypeTest` relabels one byte of `interval_logical_type_test.parquet` — the `LogicalType` union variant on a `FIXED_LEN_BYTE_ARRAY(12)` column — leaving the values untouched and the annotation contradicting the column, for `FLOAT16`, `DATE`, `TIME`, `TIMESTAMP` and `UUID`. An arm no version defines is covered where it is parsed, in `LogicalTypeReaderTest`. `FileSchemaConvertedTypeTest` covers a legacy `converted_type` promoted into the same rule.

`IncompatibleLogicalTypeReadTest` reads the parquet-testing fixture end to end. Its schema assertion flips: the annotation is dropped rather than reported, matching parquet-java #3711 — after which `ParquetComparisonTest` can stop skipping the fixture for want of a reference reader.
