### PR TITLE
#1147 Let a file be written to memory without reaching into an internal class

### DIFF
--- a/core/src/main/java/dev/hardwood/BufferOutputFile.java
+++ b/core/src/main/java/dev/hardwood/BufferOutputFile.java
@@ -1,0 +1,43 @@
+/*
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Copyright The original authors
+ *
+ *  Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package dev.hardwood;
+
+import java.nio.ByteBuffer;
+
+/// An [OutputFile] that keeps the file in memory and hands it back.
+///
+/// Use it to produce Parquet bytes without a filesystem: a file to upload to an object store,
+/// a payload to send over a network, or one written and read back in the same process. It is
+/// created with [OutputFile#inMemory()], and the buffer [#buffer()] returns can be passed
+/// straight to [InputFile#of(ByteBuffer)]:
+///
+/// ```java
+/// BufferOutputFile out = OutputFile.inMemory();
+/// try (ParquetFileWriter writer = ParquetFileWriter.create(out, schema)) {
+///     // write the file
+/// }
+/// try (ParquetFileReader reader = ParquetFileReader.open(InputFile.of(out.buffer()))) {
+///     // read it back
+/// }
+/// ```
+///
+/// The whole file is held on the heap, which costs the size of the finished file in addition
+/// to the memory the writer uses for the row group it has open.
+public interface BufferOutputFile extends OutputFile {
+
+    /// The file that was written.
+    ///
+    /// The returned buffer contains the whole file and nothing else: its position is `0` and
+    /// its limit and capacity are the number of bytes written, so it can be passed to
+    /// [InputFile#of(ByteBuffer)] unchanged. It is a view of the written bytes rather than a
+    /// copy, and each call returns a new view, so reading one buffer does not affect another.
+    ///
+    /// @return the bytes of the finished file
+    /// @throws IllegalStateException if the file has not been closed, or was discarded
+    ByteBuffer buffer();
+}

--- a/core/src/main/java/dev/hardwood/OutputFile.java
+++ b/core/src/main/java/dev/hardwood/OutputFile.java
@@ -12,6 +12,7 @@ import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.nio.file.Path;
 
+import dev.hardwood.internal.writer.ByteBufferOutputFile;
 import dev.hardwood.internal.writer.ChannelOutputFile;
 
 /// Abstraction for writing Parquet file data.
@@ -67,5 +68,16 @@ public interface OutputFile extends Closeable {
     /// @return a new uncreated OutputFile
     static OutputFile of(Path path) {
         return new ChannelOutputFile(path);
+    }
+
+    /// Creates an uncreated [OutputFile] that keeps the file in memory. The finished file is
+    /// retrieved from [BufferOutputFile#buffer()] after the writer is closed.
+    ///
+    /// The buffer grows with the file, so no size has to be given up front; the length of a
+    /// Parquet file is only known once it has been written.
+    ///
+    /// @return a new uncreated in-memory OutputFile
+    static BufferOutputFile inMemory() {
+        return new ByteBufferOutputFile();
     }
 }

--- a/core/src/main/java/dev/hardwood/internal/writer/ByteBufferOutputFile.java
+++ b/core/src/main/java/dev/hardwood/internal/writer/ByteBufferOutputFile.java
@@ -10,16 +10,28 @@ package dev.hardwood.internal.writer;
 import java.io.ByteArrayOutputStream;
 import java.nio.ByteBuffer;
 
+import dev.hardwood.BufferOutputFile;
 import dev.hardwood.OutputFile;
 
-/// [OutputFile] backed by a growable in-memory buffer.
+/// [OutputFile] backed by a growable in-memory buffer, behind [OutputFile#inMemory()].
 ///
-/// The write-side counterpart to `ByteBufferInputFile`, used for round-trip tests
-/// and for producing Parquet bytes without touching the filesystem. The accumulated
-/// bytes are retrieved with [#toByteArray()] after [#close()].
-public final class ByteBufferOutputFile implements OutputFile {
+/// The write-side counterpart to `ByteBufferInputFile`: the file is accumulated on the heap
+/// and the buffer grows with it, so no size has to be given up front. The accumulated bytes
+/// are retrieved after [#close()], either as a view with [#buffer()] or as a copy with
+/// [#toByteArray()].
+public final class ByteBufferOutputFile implements BufferOutputFile {
 
-    private final ByteArrayOutputStream sink = new ByteArrayOutputStream();
+    /// The accumulated bytes. `ByteArrayOutputStream` only hands them out as a copy, which
+    /// would copy the whole file for every caller of [#buffer()]; the subclass exposes a
+    /// buffer over the array instead.
+    private static final class Sink extends ByteArrayOutputStream {
+
+        ByteBuffer view() {
+            return ByteBuffer.wrap(buf, 0, count).slice();
+        }
+    }
+
+    private final Sink sink = new Sink();
     private boolean created;
     private boolean closed;
     private boolean discarded;
@@ -70,15 +82,25 @@ public final class ByteBufferOutputFile implements OutputFile {
         sink.reset();
     }
 
+    @Override
+    public ByteBuffer buffer() {
+        requireFinished();
+        return sink.view();
+    }
+
     /// Returns a copy of the bytes written so far.
     public byte[] toByteArray() {
+        requireFinished();
+        return sink.toByteArray();
+    }
+
+    private void requireFinished() {
         if (discarded) {
             throw new IllegalStateException("OutputFile was discarded");
         }
         if (!closed) {
             throw new IllegalStateException("OutputFile not closed");
         }
-        return sink.toByteArray();
     }
 
     private void requireCreated() {

--- a/core/src/test/java/dev/hardwood/BufferOutputFileTest.java
+++ b/core/src/test/java/dev/hardwood/BufferOutputFileTest.java
@@ -1,0 +1,119 @@
+/*
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Copyright The original authors
+ *
+ *  Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package dev.hardwood;
+
+import java.nio.ByteBuffer;
+
+import org.junit.jupiter.api.Test;
+
+import dev.hardwood.metadata.PhysicalType;
+import dev.hardwood.metadata.RepetitionType;
+import dev.hardwood.reader.ParquetFileReader;
+import dev.hardwood.reader.RowReader;
+import dev.hardwood.schema.FileSchema;
+import dev.hardwood.writer.ParquetFileWriter;
+import dev.hardwood.writer.RowWriter;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/// Tests for [OutputFile#inMemory()] and the [BufferOutputFile] it returns.
+///
+/// What these assert is the pairing the destination exists for: the buffer
+/// [BufferOutputFile#buffer()] returns can be passed to [InputFile#of(ByteBuffer)], so a file
+/// can be written and read back without a filesystem.
+class BufferOutputFileTest {
+
+    private static FileSchema schema() {
+        return FileSchema.builder("schema")
+                .addColumn("id", PhysicalType.INT64, RepetitionType.REQUIRED)
+                .build();
+    }
+
+    private static BufferOutputFile writeThreeRows() throws Exception {
+        BufferOutputFile out = OutputFile.inMemory();
+        try (ParquetFileWriter writer = ParquetFileWriter.create(out, schema())) {
+            RowWriter rows = writer.rowWriter();
+            for (long id = 1; id <= 3; id++) {
+                long value = id;
+                rows.writeRow(row -> row.setLong("id", value));
+            }
+        }
+        return out;
+    }
+
+    @Test
+    void writesAFileThatIsReadBackFromTheBuffer() throws Exception {
+        BufferOutputFile out = writeThreeRows();
+
+        try (ParquetFileReader reader = ParquetFileReader.open(InputFile.of(out.buffer()));
+                RowReader rows = reader.rowReader()) {
+            for (long id = 1; id <= 3; id++) {
+                rows.next();
+                assertThat(rows.getLong("id")).isEqualTo(id);
+            }
+            assertThat(rows.hasNext()).isFalse();
+        }
+    }
+
+    /// The buffer contains the file and nothing else. Unused space behind the footer would
+    /// break the read back, because [InputFile#of(ByteBuffer)] takes the buffer's capacity as
+    /// the file's length and looks for the footer at its end.
+    @Test
+    void theBufferHoldsExactlyTheFileThatWasWritten() throws Exception {
+        BufferOutputFile out = writeThreeRows();
+        ByteBuffer buffer = out.buffer();
+
+        assertThat(buffer.position()).isZero();
+        assertThat(buffer.limit()).isEqualTo(buffer.capacity());
+        assertThat(buffer.remaining()).isEqualTo(out.position());
+        assertThat(InputFile.of(buffer).length()).isEqualTo(out.position());
+    }
+
+    /// Reading a returned buffer does not consume anything, so a second caller still gets the
+    /// complete file.
+    @Test
+    void everyCallReturnsAFreshViewOfTheSameBytes() throws Exception {
+        BufferOutputFile out = writeThreeRows();
+
+        ByteBuffer first = out.buffer();
+        first.position(first.limit());
+
+        ByteBuffer second = out.buffer();
+        assertThat(second.position()).isZero();
+        assertThat(second.remaining()).isEqualTo(first.capacity());
+    }
+
+    /// A file is valid only once it is closed. Before that no footer has been written, so what
+    /// the buffer holds is not a Parquet file and is not handed out.
+    @Test
+    void refusesToHandOutAFileThatIsNotFinished() throws Exception {
+        BufferOutputFile out = OutputFile.inMemory();
+        try (ParquetFileWriter writer = ParquetFileWriter.create(out, schema())) {
+            writer.rowWriter().writeRow(row -> row.setLong("id", 1L));
+
+            assertThatThrownBy(out::buffer)
+                    .isInstanceOf(IllegalStateException.class)
+                    .hasMessageContaining("not closed");
+        }
+    }
+
+    /// A destination is discarded when the writer could not finish a valid file at it, and is
+    /// then left as if nothing had been written.
+    @Test
+    void refusesToHandOutADiscardedFile() throws Exception {
+        BufferOutputFile out = OutputFile.inMemory();
+        out.create();
+        out.write(ByteBuffer.wrap(new byte[] { 'P', 'A', 'R', '1' }));
+        out.discard();
+
+        assertThatThrownBy(out::buffer)
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessageContaining("discarded");
+    }
+}

--- a/docs/content/index.md
+++ b/docs/content/index.md
@@ -90,7 +90,7 @@ Support for writing Parquet files is under active development as of Hardwood 1.1
 
 The Hardwood library supports reading arbitrarily large Parquet files, provided individual column chunks are not larger than 2 GB (see [Parquet file layout](concepts/parquet-layout.md)).
 The interactive `dive` TUI currently caps S3 files at 2 GB.
-Writing targets local files through `OutputFile.of(Path)`; output to object storage is coming soon.
+Writing targets local files through `OutputFile.of(Path)` and the heap through `OutputFile.inMemory()`; output to object storage is coming soon.
 
 ## Roadmap
 

--- a/docs/content/reference/error-handling.md
+++ b/docs/content/reference/error-handling.md
@@ -54,6 +54,6 @@ consumed; Hardwood itself raises `UncheckedIOException` from no public method.
 | `UnsupportedOperationException` | A schema column of an unsupported physical type (`INT96`); a refused compression codec (`LZ4`, `LZO`), one whose library is not on the classpath, or one whose native library will not load; a schema shape the writer cannot produce — repetition no `LIST` or `MAP` annotation accounts for |
 | `IllegalArgumentException` | An unknown column name or path, a setter that does not fit the column's type, a column set twice, a batch that leaves a column unset or whose arrays disagree in length, a null mask on a `REQUIRED` column, list offsets that do not describe the elements given, a value outside the range its annotation declares, or a `REQUIRED` field a record leaves unset |
 | `IndexOutOfBoundsException` | A leaf-column index outside `[0, leaf column count)` on a `ColumnBatch` setter, or a field index outside `[0, getFieldCount())` on a `StructBuilder` setter |
-| `IllegalStateException` | Writing after `close()`, using both write APIs on one file, or using a `ColumnBatch` or nested builder after its scope has ended |
+| `IllegalStateException` | Writing after `close()`, using both write APIs on one file, using a `ColumnBatch` or nested builder after its scope has ended, or taking `BufferOutputFile.buffer()` before the writer has closed |
 
 For what each of these means in context, see the [Writer Reference](writer.md#what-the-writer-rejects).

--- a/docs/content/reference/writer.md
+++ b/docs/content/reference/writer.md
@@ -11,7 +11,36 @@
 -->
 # Writer Reference
 
-Facts about the write path: how a schema is declared, the configuration options, the encodings and codecs the writer produces, the setters each column type accepts, and what it rejects. For task-oriented instructions see [Write Row by Row](../how-to/write-row-by-row.md) and [Write Column by Column](../how-to/write-column-by-column.md).
+Facts about the write path: where a file can be written, how a schema is declared, the configuration options, the encodings and codecs the writer produces, the setters each column type accepts, and what it rejects. For task-oriented instructions see [Write Row by Row](../how-to/write-row-by-row.md) and [Write Column by Column](../how-to/write-column-by-column.md).
+
+## Destination
+
+The `OutputFile` a writer is created with decides where the file is written.
+
+| Factory | Destination |
+|---|---|
+| `OutputFile.of(Path)` | A local file. The bytes are streamed to a temporary sibling of the target path and renamed onto it when the writer closes, so a write that fails or is abandoned leaves nothing at the path |
+| `OutputFile.inMemory()` | The heap. Returns a `BufferOutputFile`, whose `buffer()` returns the finished file |
+
+An in-memory file can be written and read back without a filesystem: `buffer()` returns the whole file as a `ByteBuffer` positioned at its first byte, which is what `InputFile.of(ByteBuffer)` expects.
+
+```java
+BufferOutputFile out = OutputFile.inMemory();
+try (ParquetFileWriter writer = ParquetFileWriter.create(out, schema)) {
+    RowWriter rows = writer.rowWriter();
+    rows.writeRow(row -> row.setLong("id", 1L));
+}
+
+try (ParquetFileReader reader = ParquetFileReader.open(InputFile.of(out.buffer()))) {
+    // ...
+}
+```
+
+The buffer grows with the file, so no size has to be given up front; the length of a Parquet file is only known once it has been written. The whole file is held on the heap, which costs the size of the finished file in addition to the memory the writer uses for the open row group. `buffer()` returns a view of those bytes rather than a copy, and each call returns a new view, so reading the file back leaves it intact.
+
+The file is complete only after the writer is closed, and `buffer()` throws `IllegalStateException` before that, or if the destination was discarded.
+
+To write anywhere else — an object store, a network connection — implement `OutputFile`.
 
 ## Schema
 
@@ -238,7 +267,7 @@ hardwood version <version> (build <commit>)
 | `UnsupportedOperationException` | A schema column of an unsupported physical type (`INT96`); a refused codec (`LZ4`, `LZO`) or one whose library is missing; a [schema shape](#schema-shapes) the writer cannot produce |
 | `IllegalArgumentException` | A `null` metadata key, metadata map or `created_by`; an unknown column name or path; a setter that does not fit the column's type; a `null` value array, or a `null` value at a present row of a binary column; a column set twice in one batch or record; a batch that leaves a column unset, or whose arrays disagree in length; a null mask on a `REQUIRED` column; a `boolean[]` mask whose length does not match the values; list offsets that do not start at `0`, are not non-decreasing, or disagree with the element count; a value outside the range its annotation declares; a `REQUIRED` field left unset by a record |
 | `IndexOutOfBoundsException` | A leaf-column index outside `[0, leaf column count)` on a `ColumnBatch` setter, or a field index outside `[0, getFieldCount())` on a `StructBuilder` setter |
-| `IllegalStateException` | Writing, or setting key-value metadata or `created_by`, after `close()`; using both write APIs on one file; using a `ColumnBatch` after it has been submitted, or a nested builder after its filler has returned |
+| `IllegalStateException` | Writing, or setting key-value metadata or `created_by`, after `close()`; using both write APIs on one file; using a `ColumnBatch` after it has been submitted, or a nested builder after its filler has returned; taking `BufferOutputFile.buffer()` before the writer has closed, or from a destination that was discarded |
 | `IOException` | The destination cannot be created, written, or finalized |
 
 ### Schema Shapes


### PR DESCRIPTION
Fixes #1147.

Reading has `InputFile.of(ByteBuffer)`; writing had only `OutputFile.of(Path)`, so a caller producing Parquet bytes without a filesystem had to use `dev.hardwood.internal.writer.ByteBufferOutputFile` — the internal class whose JavaDoc calls it a round-trip test helper — which is what the reporter of #1146 was doing.

```java
BufferOutputFile out = OutputFile.inMemory();
try (ParquetFileWriter writer = ParquetFileWriter.create(out, schema)) {
    RowWriter rows = writer.rowWriter();
    rows.writeRow(row -> row.setLong("id", 1L));
}

try (ParquetFileReader reader = ParquetFileReader.open(InputFile.of(out.buffer()))) {
    // ...
}
```

`OutputFile.inMemory()` returns a `BufferOutputFile`: an `OutputFile` with `buffer()` added, which is the whole public surface this adds. The implementation is the existing internal `ByteBufferOutputFile`, which now also exposes its bytes as a view rather than only as a copy — for a destination whose purpose is to give the file back, `toByteArray()` alone would copy the whole file for every caller.

**The destination allocates the buffer instead of taking one to fill.** The symmetric signature would be `OutputFile.of(ByteBuffer)`, but the length of a Parquet file is only known once it has been written, so a caller asked to size the destination up front has nothing to base that size on, and a file larger than the guess fails on a full buffer. Allocating removes the question, and it is what lets the round trip above work as written: the buffer that comes back spans the file exactly — position `0`, limit and capacity both the file's length — so `InputFile.of(ByteBuffer)`, which reads a buffer's whole capacity, finds the footer where it expects it. A buffer the caller had trimmed to `position`–`limit` would not, since that method ignores both. That is worth its own look, and is not needed here.
