### PR TITLE
#1160 Make the logical-type converters primitive-first

### DIFF
--- a/_designs/LOCAL_TIMESTAMP_ACCESSOR.md
+++ b/_designs/LOCAL_TIMESTAMP_ACCESSOR.md
@@ -51,10 +51,10 @@ LocalDateTime asLocalTimestamp();   // TIMESTAMP_NTZ / TIMESTAMP_NTZ_NANOS tags
 
 ## Errors
 
-`IllegalStateException` thrown by the accessor with a message of the form:
+`IllegalStateException` thrown by the accessor, naming the column and the kind it turned out to be:
 
 ```
-Column 'tpep_pickup_datetime' is a local-wall-clock TIMESTAMP (isAdjustedToUTC=false); use getLocalTimestamp instead
+Column 'tpep_pickup_datetime' is a local-wall-clock TIMESTAMP (isAdjustedToUTC=false)
 ```
 
 The exception type, message shape, and the column-name + flag-value content are part of the documented contract — `docs/content/how-to/row-reader.md` directs callers to inspect `LogicalType.TimestampType.isAdjustedToUTC()` ahead of time when the kind isn't statically known.

--- a/_designs/LOCAL_TIMESTAMP_ACCESSOR.md
+++ b/_designs/LOCAL_TIMESTAMP_ACCESSOR.md
@@ -69,16 +69,16 @@ INT96 TIMESTAMP columns have no `isAdjustedToUTC` field. The reader treats them 
 
 ## Internal converters
 
-`LogicalTypeConverter` exposes two split helpers:
+`LogicalTypeConverter` exposes two split entry points, each taking the stored int64 and the unit:
 
 ```java
-Instant       convertToTimestamp(Object value, PhysicalType pt, LogicalType.TimestampType tt);
-LocalDateTime convertToLocalTimestamp(Object value, PhysicalType pt, LogicalType.TimestampType tt);
+Instant       longToTimestamp(long rawValue, LogicalType.TimeUnit unit);
+LocalDateTime longToLocalTimestamp(long rawValue, LogicalType.TimeUnit unit);
 ```
 
-Each enforces the `isAdjustedToUTC` precondition (throws `IllegalStateException` if called for the wrong kind) as defense in depth; accessor sites do the user-facing check earlier so the rejection message names the column.
+Neither checks the kind — a primitive signature carries no annotation to check it against. `TimestampAccessorKind` is the single statement of that rule and runs at the accessor site, where the rejection can name the column.
 
-The generic `LogicalTypeConverter.convert` switch dispatches the `TimestampType` arm on `isAdjustedToUTC` so `ValueConverter.convertValue` (which backs `getValue` and the `PqList.values()` / `PqMap.Entry.getValue()` fallback path) automatically returns the right Java type.
+`longToTemporal(long, LogicalType.TimestampType)` states the routing between the two, for a caller that decodes whatever the column holds rather than asking for one kind. The generic `LogicalTypeConverter.convert` switch dispatches the `TimestampType` arm through it, so `ValueConverter.convertValue` (which backs `getValue` and the `PqList.values()` / `PqMap.Entry.getValue()` fallback path) returns the right Java type.
 
 `VariantValueDecoder` splits along the same line:
 

--- a/cli/src/main/java/dev/hardwood/cli/internal/IndexValueFormatter.java
+++ b/cli/src/main/java/dev/hardwood/cli/internal/IndexValueFormatter.java
@@ -65,10 +65,7 @@ public final class IndexValueFormatter {
             }).toPlainString();
         }
         if (lt instanceof LogicalType.TimestampType ts) {
-            long raw = decodeIntegral(bytes, col);
-            return (ts.isAdjustedToUTC()
-                    ? LogicalTypeConverter.longToTimestamp(raw, ts.unit())
-                    : LogicalTypeConverter.longToLocalTimestamp(raw, ts.unit())).toString();
+            return LogicalTypeConverter.longToTemporal(decodeIntegral(bytes, col), ts).toString();
         }
         if (lt instanceof LogicalType.DateType) {
             return LogicalTypeConverter.intToDate(StatisticsDecoder.decodeInt(bytes)).toString();

--- a/cli/src/main/java/dev/hardwood/cli/internal/IndexValueFormatter.java
+++ b/cli/src/main/java/dev/hardwood/cli/internal/IndexValueFormatter.java
@@ -7,14 +7,8 @@
  */
 package dev.hardwood.cli.internal;
 
-import java.math.BigDecimal;
-import java.math.BigInteger;
-import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
-import java.time.LocalDate;
-import java.time.LocalTime;
 import java.util.HexFormat;
-import java.util.UUID;
 
 import dev.hardwood.internal.conversion.LogicalTypeConverter;
 import dev.hardwood.internal.predicate.StatisticsDecoder;
@@ -64,34 +58,23 @@ public final class IndexValueFormatter {
         LogicalType lt = useLogicalType ? col.logicalType() : null;
 
         if (lt instanceof LogicalType.DecimalType dt) {
-            BigInteger unscaled = switch (col.type()) {
-                case INT32 -> BigInteger.valueOf(StatisticsDecoder.decodeInt(bytes));
-                case INT64 -> BigInteger.valueOf(StatisticsDecoder.decodeLong(bytes));
-                default -> new BigInteger(bytes);
-            };
-            return new BigDecimal(unscaled, dt.scale()).toPlainString();
+            return (switch (col.type()) {
+                case INT32 -> LogicalTypeConverter.longToDecimal(StatisticsDecoder.decodeInt(bytes), dt.scale());
+                case INT64 -> LogicalTypeConverter.longToDecimal(StatisticsDecoder.decodeLong(bytes), dt.scale());
+                default -> LogicalTypeConverter.bytesToDecimal(bytes, dt.scale());
+            }).toPlainString();
         }
         if (lt instanceof LogicalType.TimestampType ts) {
-            long raw = col.type() == PhysicalType.INT32
-                    ? StatisticsDecoder.decodeInt(bytes)
-                    : StatisticsDecoder.decodeLong(bytes);
+            long raw = decodeIntegral(bytes, col);
             return (ts.isAdjustedToUTC()
-                    ? LogicalTypeConverter.convertToTimestamp(raw, PhysicalType.INT64, ts)
-                    : LogicalTypeConverter.convertToLocalTimestamp(raw, PhysicalType.INT64, ts)).toString();
+                    ? LogicalTypeConverter.longToTimestamp(raw, ts.unit())
+                    : LogicalTypeConverter.longToLocalTimestamp(raw, ts.unit())).toString();
         }
         if (lt instanceof LogicalType.DateType) {
-            return LocalDate.ofEpochDay(StatisticsDecoder.decodeInt(bytes)).toString();
+            return LogicalTypeConverter.intToDate(StatisticsDecoder.decodeInt(bytes)).toString();
         }
         if (lt instanceof LogicalType.TimeType t) {
-            long raw = col.type() == PhysicalType.INT32
-                    ? StatisticsDecoder.decodeInt(bytes)
-                    : StatisticsDecoder.decodeLong(bytes);
-            long nanosOfDay = switch (t.unit()) {
-                case MILLIS -> raw * 1_000_000L;
-                case MICROS -> raw * 1_000L;
-                case NANOS -> raw;
-            };
-            return LocalTime.ofNanoOfDay(nanosOfDay).toString();
+            return LogicalTypeConverter.longToTime(decodeIntegral(bytes, col), t.unit()).toString();
         }
 
         return switch (col.type()) {
@@ -151,6 +134,14 @@ public final class IndexValueFormatter {
         return format(value, col);
     }
 
+    /// A statistic on an `INT32` or `INT64` column, widened to the `long` the
+    /// converters take. The date, time and timestamp annotations all read one.
+    private static long decodeIntegral(byte[] bytes, ColumnSchema col) {
+        return col.type() == PhysicalType.INT32
+                ? StatisticsDecoder.decodeInt(bytes)
+                : StatisticsDecoder.decodeLong(bytes);
+    }
+
     private static String formatInt32(byte[] bytes, LogicalType lt) {
         return formatInt32Value(StatisticsDecoder.decodeInt(bytes), lt);
     }
@@ -183,15 +174,13 @@ public final class IndexValueFormatter {
             return formatString(bytes);
         }
         if (lt instanceof LogicalType.UuidType && bytes.length == 16) {
-            ByteBuffer bb = ByteBuffer.wrap(bytes);
-            return new UUID(bb.getLong(), bb.getLong()).toString();
+            return LogicalTypeConverter.bytesToUuid(bytes).toString();
         }
         if (lt instanceof LogicalType.IntervalType && bytes.length == 12) {
             return RowValueFormatter.formatIntervalBytes(bytes);
         }
         if (lt instanceof LogicalType.Float16Type && bytes.length == 2) {
-            return Float.toString(
-                    LogicalTypeConverter.convertToFloat16(bytes, PhysicalType.FIXED_LEN_BYTE_ARRAY));
+            return Float.toString(LogicalTypeConverter.bytesToFloat16(bytes));
         }
         return BinaryValues.render(bytes, maxChars);
     }

--- a/cli/src/main/java/dev/hardwood/cli/internal/RowValueFormatter.java
+++ b/cli/src/main/java/dev/hardwood/cli/internal/RowValueFormatter.java
@@ -393,9 +393,7 @@ public final class RowValueFormatter {
     private static String formatLong(long raw, LogicalType lt) {
         return switch (lt) {
             case null -> Long.toString(raw);
-            case LogicalType.TimestampType ts -> (ts.isAdjustedToUTC()
-                    ? LogicalTypeConverter.longToTimestamp(raw, ts.unit())
-                    : LogicalTypeConverter.longToLocalTimestamp(raw, ts.unit())).toString();
+            case LogicalType.TimestampType ts -> LogicalTypeConverter.longToTemporal(raw, ts).toString();
             case LogicalType.TimeType t -> formatTime(raw, t.unit());
             case LogicalType.IntType it when !it.isSigned() -> Long.toUnsignedString(raw);
             case LogicalType.IntType it -> Long.toString(raw);

--- a/cli/src/main/java/dev/hardwood/cli/internal/RowValueFormatter.java
+++ b/cli/src/main/java/dev/hardwood/cli/internal/RowValueFormatter.java
@@ -8,18 +8,12 @@
 package dev.hardwood.cli.internal;
 
 import java.math.BigDecimal;
-import java.math.BigInteger;
-import java.nio.ByteBuffer;
-import java.nio.charset.StandardCharsets;
 import java.time.Instant;
-import java.time.LocalDate;
 import java.time.LocalDateTime;
-import java.time.LocalTime;
 import java.util.UUID;
 
 import dev.hardwood.internal.conversion.LogicalTypeConverter;
 import dev.hardwood.metadata.LogicalType;
-import dev.hardwood.metadata.PhysicalType;
 import dev.hardwood.reader.RowReader;
 import dev.hardwood.row.PqInterval;
 import dev.hardwood.row.PqList;
@@ -384,11 +378,11 @@ public final class RowValueFormatter {
     private static String formatInt(int raw, LogicalType lt) {
         return switch (lt) {
             case null -> Integer.toString(raw);
-            case LogicalType.DateType d -> LocalDate.ofEpochDay(raw).toString();
+            case LogicalType.DateType d -> LogicalTypeConverter.intToDate(raw).toString();
             case LogicalType.TimeType t -> formatTime(raw, t.unit());
             case LogicalType.IntType it when !it.isSigned() -> Long.toString(Integer.toUnsignedLong(raw));
             case LogicalType.IntType it -> Integer.toString(raw);
-            case LogicalType.DecimalType d -> new BigDecimal(BigInteger.valueOf(raw), d.scale()).toPlainString();
+            case LogicalType.DecimalType d -> LogicalTypeConverter.longToDecimal(raw, d.scale()).toPlainString();
             default -> throw notBackedBy(lt, "INT32");
         };
     }
@@ -400,12 +394,12 @@ public final class RowValueFormatter {
         return switch (lt) {
             case null -> Long.toString(raw);
             case LogicalType.TimestampType ts -> (ts.isAdjustedToUTC()
-                    ? LogicalTypeConverter.convertToTimestamp(raw, PhysicalType.INT64, ts)
-                    : LogicalTypeConverter.convertToLocalTimestamp(raw, PhysicalType.INT64, ts)).toString();
+                    ? LogicalTypeConverter.longToTimestamp(raw, ts.unit())
+                    : LogicalTypeConverter.longToLocalTimestamp(raw, ts.unit())).toString();
             case LogicalType.TimeType t -> formatTime(raw, t.unit());
             case LogicalType.IntType it when !it.isSigned() -> Long.toUnsignedString(raw);
             case LogicalType.IntType it -> Long.toString(raw);
-            case LogicalType.DecimalType d -> new BigDecimal(BigInteger.valueOf(raw), d.scale()).toPlainString();
+            case LogicalType.DecimalType d -> LogicalTypeConverter.longToDecimal(raw, d.scale()).toPlainString();
             default -> throw notBackedBy(lt, "INT64");
         };
     }
@@ -417,20 +411,17 @@ public final class RowValueFormatter {
     private static String formatBytes(byte[] raw, LogicalType lt, int maxChars) {
         return switch (lt) {
             case null -> formatRawBytes(raw, maxChars);
-            case LogicalType.StringType s -> new String(raw, StandardCharsets.UTF_8);
-            case LogicalType.EnumType e -> new String(raw, StandardCharsets.UTF_8);
-            case LogicalType.JsonType j -> new String(raw, StandardCharsets.UTF_8);
-            case LogicalType.BsonType b -> new String(raw, StandardCharsets.UTF_8);
-            case LogicalType.DecimalType d -> new BigDecimal(new BigInteger(raw), d.scale()).toPlainString();
-            case LogicalType.UuidType u when raw.length == 16 -> {
-                ByteBuffer bb = ByteBuffer.wrap(raw);
-                yield new UUID(bb.getLong(), bb.getLong()).toString();
-            }
+            case LogicalType.StringType s -> LogicalTypeConverter.bytesToString(raw);
+            case LogicalType.EnumType e -> LogicalTypeConverter.bytesToString(raw);
+            case LogicalType.JsonType j -> LogicalTypeConverter.bytesToString(raw);
+            case LogicalType.BsonType b -> LogicalTypeConverter.bytesToString(raw);
+            case LogicalType.DecimalType d -> LogicalTypeConverter.bytesToDecimal(raw, d.scale()).toPlainString();
+            case LogicalType.UuidType u when raw.length == 16 -> LogicalTypeConverter.bytesToUuid(raw).toString();
             case LogicalType.UuidType u -> formatRawBytes(raw, maxChars);
             case LogicalType.IntervalType i when raw.length == 12 -> formatIntervalBytes(raw);
             case LogicalType.IntervalType i -> formatRawBytes(raw, maxChars);
             case LogicalType.Float16Type f when raw.length == 2 ->
-                    Float.toString(LogicalTypeConverter.convertToFloat16(raw, PhysicalType.FIXED_LEN_BYTE_ARRAY));
+                    Float.toString(LogicalTypeConverter.bytesToFloat16(raw));
             case LogicalType.Float16Type f -> formatRawBytes(raw, maxChars);
             case LogicalType.GeometryType g -> formatRawBytes(raw, maxChars);
             case LogicalType.GeographyType g -> formatRawBytes(raw, maxChars);
@@ -447,7 +438,7 @@ public final class RowValueFormatter {
     /// Decode a 12-byte FIXED_LEN_BYTE_ARRAY INTERVAL payload (as used in
     /// page/dictionary stats) and render it via [#formatInterval(PqInterval)].
     public static String formatIntervalBytes(byte[] bytes) {
-        return formatInterval(LogicalTypeConverter.convertToInterval(bytes, PhysicalType.FIXED_LEN_BYTE_ARRAY));
+        return formatInterval(LogicalTypeConverter.bytesToInterval(bytes));
     }
 
     public static String formatInterval(PqInterval interval) {
@@ -676,11 +667,6 @@ public final class RowValueFormatter {
     }
 
     private static String formatTime(long raw, LogicalType.TimeUnit unit) {
-        long nanosOfDay = switch (unit) {
-            case MILLIS -> raw * 1_000_000L;
-            case MICROS -> raw * 1_000L;
-            case NANOS -> raw;
-        };
-        return LocalTime.ofNanoOfDay(nanosOfDay).toString();
+        return LogicalTypeConverter.longToTime(raw, unit).toString();
     }
 }

--- a/core/src/main/java/dev/hardwood/internal/conversion/LogicalTypeConverter.java
+++ b/core/src/main/java/dev/hardwood/internal/conversion/LogicalTypeConverter.java
@@ -284,12 +284,18 @@ public final class LogicalTypeConverter {
 
     /// The single-precision value a 2-byte `FLOAT16` payload stands for.
     public static float bytesToFloat16(byte[] bytes) {
-        if (bytes.length != FLOAT16_BYTES) {
+        return bytesToFloat16(bytes, 0, bytes.length);
+    }
+
+    /// The single-precision value the 2-byte `FLOAT16` payload at `offset` stands for, for
+    /// a caller holding the payload inside a larger buffer.
+    public static float bytesToFloat16(byte[] bytes, int offset, int length) {
+        if (length != FLOAT16_BYTES) {
             throw new IllegalArgumentException(
-                    "FLOAT16 requires exactly " + FLOAT16_BYTES + " bytes, got " + bytes.length);
+                    "FLOAT16 requires exactly " + FLOAT16_BYTES + " bytes, got " + length);
         }
         // LE 2-byte short; `& 0xFF` blocks sign extension on the byte→int promotion.
-        short raw = (short) ((bytes[0] & 0xFF) | ((bytes[1] & 0xFF) << 8));
+        short raw = (short) ((bytes[offset] & 0xFF) | ((bytes[offset + 1] & 0xFF) << 8));
         return Float.float16ToFloat(raw);
     }
 

--- a/core/src/main/java/dev/hardwood/internal/conversion/LogicalTypeConverter.java
+++ b/core/src/main/java/dev/hardwood/internal/conversion/LogicalTypeConverter.java
@@ -26,6 +26,16 @@ import dev.hardwood.row.PqInterval;
 /// Converts physical values to their logical type representations.
 public final class LogicalTypeConverter {
 
+    /// Bytes of the `FIXED_LEN_BYTE_ARRAY` payloads whose width the format fixes, and of
+    /// the legacy `INT96` timestamp.
+    private static final int UUID_BYTES = 16;
+    private static final int INTERVAL_BYTES = 12;
+    private static final int FLOAT16_BYTES = 2;
+    private static final int INT96_BYTES = 12;
+
+    /// Julian day number of the Unix epoch (1970-01-01).
+    private static final long JULIAN_EPOCH_OFFSET_DAYS = 2440588L;
+
     private LogicalTypeConverter() {
     }
 
@@ -129,22 +139,27 @@ public final class LogicalTypeConverter {
         }
 
         return switch (logicalType) {
-            case LogicalType.StringType t -> convertToString(physicalValue, physicalType);
-            case LogicalType.DateType t -> convertToDate(physicalValue, physicalType);
+            case LogicalType.StringType t -> bytesToString((byte[]) physicalValue);
+            case LogicalType.DateType t -> intToDate((Integer) physicalValue);
             case LogicalType.TimestampType tt -> tt.isAdjustedToUTC()
-                    ? convertToTimestamp(physicalValue, physicalType, tt)
-                    : convertToLocalTimestamp(physicalValue, physicalType, tt);
+                    ? longToTimestamp((Long) physicalValue, tt.unit())
+                    : longToLocalTimestamp((Long) physicalValue, tt.unit());
+            // TIME, DECIMAL and INT are the arms whose unboxing depends on the physical
+            // type, so they keep a helper that takes it; the rest decode from one
+            // representation and go straight to the primitive entry point.
             case LogicalType.TimeType tt -> convertToTime(physicalValue, physicalType, tt);
             case LogicalType.DecimalType dt -> convertToDecimal(physicalValue, physicalType, dt);
             case LogicalType.IntType it -> convertToInt(physicalValue, physicalType, it);
-            case LogicalType.UuidType t -> convertToUuid(physicalValue, physicalType);
-            case LogicalType.JsonType t -> convertToString(physicalValue, physicalType);
-            case LogicalType.BsonType t -> convertToBson(physicalValue, physicalType);
-            case LogicalType.IntervalType t -> convertToInterval(physicalValue, physicalType);
-            case LogicalType.Float16Type t -> convertToFloat16(physicalValue, physicalType);
+            case LogicalType.UuidType t -> bytesToUuid((byte[]) physicalValue);
+            case LogicalType.JsonType t -> bytesToString((byte[]) physicalValue);
+            // BSON is a binary format; expose the raw bytes rather than attempting a
+            // UTF-8 decode.
+            case LogicalType.BsonType t -> physicalValue;
+            case LogicalType.IntervalType t -> bytesToInterval((byte[]) physicalValue);
+            case LogicalType.Float16Type t -> bytesToFloat16((byte[]) physicalValue);
             // Enum stores a UTF-8 payload and the spec tells readers without a
             // native enum type to interpret it as a string, so it decodes like UTF8.
-            case LogicalType.EnumType e -> convertToString(physicalValue, physicalType);
+            case LogicalType.EnumType e -> bytesToString((byte[]) physicalValue);
             // Geometry / Geography carry opaque WKB / WKT binary payloads with no
             // decoder yet — pass each through unchanged.
             case LogicalType.GeometryType g -> physicalValue;
@@ -169,59 +184,48 @@ public final class LogicalTypeConverter {
                         + " reached primitive-value conversion");
     }
 
-    private static String convertToString(Object value, PhysicalType physicalType) {
-        if (physicalType != PhysicalType.BYTE_ARRAY) {
-            throw new IllegalArgumentException("STRING logical type requires BYTE_ARRAY physical type, got " + physicalType);
-        }
-        return new String((byte[]) value, StandardCharsets.UTF_8);
-    }
+    // ==================== Primitive entry points ====================
+    //
+    // A caller that has already resolved the column's physical type reads its value
+    // straight out of the storage array and decodes it here, with no box and no second
+    // dispatch on a type it knows. `convert` above is the one path that starts from an
+    // `Object` and has to dispatch.
 
-    /// BSON is a binary format; expose the raw bytes rather than attempting a UTF-8 decode.
-    public static byte[] convertToBson(Object value, PhysicalType physicalType) {
-        if (physicalType != PhysicalType.BYTE_ARRAY) {
-            throw new IllegalArgumentException("BSON logical type requires BYTE_ARRAY physical type, got " + physicalType);
-        }
-        return (byte[]) value;
-    }
-
-    public static LocalDate convertToDate(Object value, PhysicalType physicalType) {
-        if (physicalType != PhysicalType.INT32) {
-            throw new IllegalArgumentException("DATE logical type requires INT32 physical type, got " + physicalType);
-        }
-        // DATE is days since Unix epoch
-        int daysSinceEpoch = (Integer) value;
+    /// The [LocalDate] a `DATE` column's day count stands for.
+    public static LocalDate intToDate(int daysSinceEpoch) {
         return LocalDate.ofEpochDay(daysSinceEpoch);
     }
 
-    /// Decodes a UTC-adjusted `TIMESTAMP`. Which of the two timestamp kinds an accessor
-    /// accepts is stated once, in `TimestampAccessorKind`, which names the column and the
-    /// accessor that fits it; this method decodes whatever unit it is handed.
-    public static Instant convertToTimestamp(Object value, PhysicalType physicalType,
-                                             LogicalType.TimestampType timestampType) {
-        if (physicalType != PhysicalType.INT64) {
-            throw new IllegalArgumentException("TIMESTAMP logical type requires INT64 physical type, got " + physicalType);
-        }
-        long rawValue = (Long) value;
-        return switch (timestampType.unit()) {
+    /// The time of day a `TIME` column's value in `unit` stands for.
+    public static LocalTime longToTime(long rawValue, LogicalType.TimeUnit unit) {
+        return LocalTime.ofNanoOfDay(switch (unit) {
+            case MILLIS -> rawValue * 1_000_000L;
+            case MICROS -> rawValue * 1_000L;
+            case NANOS -> rawValue;
+        });
+    }
+
+    /// The instant a UTC-adjusted `TIMESTAMP` column's offset in `unit` stands for.
+    ///
+    /// Which of the two timestamp kinds an accessor accepts is stated once, in
+    /// `TimestampAccessorKind`, which names the column and the accessor that fits it.
+    /// This decodes whatever unit it is handed.
+    public static Instant longToTimestamp(long rawValue, LogicalType.TimeUnit unit) {
+        return switch (unit) {
             case MILLIS -> Instant.ofEpochMilli(rawValue);
             case MICROS -> Instant.ofEpochSecond(rawValue / 1_000_000, (rawValue % 1_000_000) * 1000);
             case NANOS -> Instant.ofEpochSecond(rawValue / 1_000_000_000, rawValue % 1_000_000_000);
         };
     }
 
-    /// Decodes a local-wall-clock `TIMESTAMP`. See [#convertToTimestamp] on where the
-    /// kind itself is checked.
-    public static LocalDateTime convertToLocalTimestamp(Object value, PhysicalType physicalType,
-                                                        LogicalType.TimestampType timestampType) {
-        if (physicalType != PhysicalType.INT64) {
-            throw new IllegalArgumentException("TIMESTAMP logical type requires INT64 physical type, got " + physicalType);
-        }
-        // For a local-wall-clock TIMESTAMP the stored int64 is the offset from the
-        // epoch *of the wall clock itself*, so the same epoch arithmetic that
-        // produces an Instant gives the right LocalDateTime when read at UTC —
-        // the bits never change, only the type label.
-        long rawValue = (Long) value;
-        return switch (timestampType.unit()) {
+    /// The wall-clock date and time a local `TIMESTAMP` column's offset in `unit` stands
+    /// for. The stored int64 is the offset from the epoch *of the wall clock itself*, so
+    /// the same epoch arithmetic that produces an [Instant] gives the right
+    /// [LocalDateTime] when read at UTC — the bits never change, only the type label.
+    ///
+    /// See [#longToTimestamp] on where the kind itself is checked.
+    public static LocalDateTime longToLocalTimestamp(long rawValue, LogicalType.TimeUnit unit) {
+        return switch (unit) {
             case MILLIS -> LocalDateTime.ofEpochSecond(
                     Math.floorDiv(rawValue, 1_000L),
                     (int) (Math.floorMod(rawValue, 1_000L) * 1_000_000L),
@@ -237,49 +241,63 @@ public final class LogicalTypeConverter {
         };
     }
 
-    public static PqInterval convertToInterval(Object value, PhysicalType physicalType) {
-        if (physicalType != PhysicalType.FIXED_LEN_BYTE_ARRAY) {
-            throw new IllegalArgumentException(
-                    "INTERVAL logical type requires FIXED_LEN_BYTE_ARRAY physical type, got " + physicalType);
-        }
+    /// The decimal an `INT32` or `INT64` `DECIMAL` column's unscaled value stands for.
+    public static BigDecimal longToDecimal(long unscaled, int scale) {
+        return BigDecimal.valueOf(unscaled, scale);
+    }
 
-        byte[] bytes = (byte[]) value;
-        if (bytes.length != 12) {
+    /// The decimal a `BYTE_ARRAY` or `FIXED_LEN_BYTE_ARRAY` `DECIMAL` column's payload
+    /// stands for. Parquet stores it big-endian two's complement.
+    public static BigDecimal bytesToDecimal(byte[] bytes, int scale) {
+        return new BigDecimal(new BigInteger(bytes), scale);
+    }
+
+    /// The UTF-8 text of a `STRING`, `ENUM` or `JSON` payload.
+    public static String bytesToString(byte[] bytes) {
+        return new String(bytes, StandardCharsets.UTF_8);
+    }
+
+    /// The [UUID] a 16-byte `UUID` payload stands for, most significant half first.
+    public static UUID bytesToUuid(byte[] bytes) {
+        if (bytes.length != UUID_BYTES) {
+            throw new IllegalArgumentException("UUID requires exactly " + UUID_BYTES + " bytes, got " + bytes.length);
+        }
+        ByteBuffer bb = ByteBuffer.wrap(bytes);
+        long mostSigBits = bb.getLong();
+        long leastSigBits = bb.getLong();
+        return new UUID(mostSigBits, leastSigBits);
+    }
+
+    /// The [PqInterval] a 12-byte `INTERVAL` payload stands for: months, days and millis
+    /// as little-endian unsigned 4-byte fields.
+    public static PqInterval bytesToInterval(byte[] bytes) {
+        if (bytes.length != INTERVAL_BYTES) {
             throw new IllegalArgumentException(
-                    "INTERVAL requires exactly 12 bytes, got " + bytes.length);
+                    "INTERVAL requires exactly " + INTERVAL_BYTES + " bytes, got " + bytes.length);
         }
         ByteBuffer buffer = ByteBuffer.wrap(bytes).order(ByteOrder.LITTLE_ENDIAN);
         long months = Integer.toUnsignedLong(buffer.getInt(0));
         long days = Integer.toUnsignedLong(buffer.getInt(4));
         long millis = Integer.toUnsignedLong(buffer.getInt(8));
-
         return new PqInterval(months, days, millis);
     }
 
-    public static float convertToFloat16(Object value, PhysicalType physicalType) {
-        if (physicalType != PhysicalType.FIXED_LEN_BYTE_ARRAY) {
+    /// The single-precision value a 2-byte `FLOAT16` payload stands for.
+    public static float bytesToFloat16(byte[] bytes) {
+        if (bytes.length != FLOAT16_BYTES) {
             throw new IllegalArgumentException(
-                    "FLOAT16 logical type requires FIXED_LEN_BYTE_ARRAY physical type, got " + physicalType);
-        }
-
-        byte[] bytes = (byte[]) value;
-        if (bytes.length != 2) {
-            throw new IllegalArgumentException(
-                    "FLOAT16 requires exactly 2 bytes, got " + bytes.length);
+                    "FLOAT16 requires exactly " + FLOAT16_BYTES + " bytes, got " + bytes.length);
         }
         // LE 2-byte short; `& 0xFF` blocks sign extension on the byte→int promotion.
         short raw = (short) ((bytes[0] & 0xFF) | ((bytes[1] & 0xFF) << 8));
         return Float.float16ToFloat(raw);
     }
 
-    /// Julian day number of the Unix epoch (1970-01-01).
-    private static final long JULIAN_EPOCH_OFFSET_DAYS = 2440588L;
-
     /// Convert a legacy INT96 timestamp (12 bytes, little-endian: 8 bytes nanos-of-day,
     /// 4 bytes Julian day) to an [Instant]. Used by Apache Spark and Hive.
     public static Instant int96ToInstant(byte[] bytes) {
-        if (bytes.length != 12) {
-            throw new IllegalArgumentException("INT96 requires exactly 12 bytes, got " + bytes.length);
+        if (bytes.length != INT96_BYTES) {
+            throw new IllegalArgumentException("INT96 requires exactly " + INT96_BYTES + " bytes, got " + bytes.length);
         }
         ByteBuffer bb = ByteBuffer.wrap(bytes).order(ByteOrder.LITTLE_ENDIAN);
         long nanosOfDay = bb.getLong(0);
@@ -290,41 +308,70 @@ public final class LogicalTypeConverter {
         return Instant.ofEpochSecond(epochSecond, nanoAdjustment);
     }
 
+    // ==================== Boxed forms ====================
+
+    public static LocalDate convertToDate(Object value, PhysicalType physicalType) {
+        if (physicalType != PhysicalType.INT32) {
+            throw new IllegalArgumentException("DATE logical type requires INT32 physical type, got " + physicalType);
+        }
+        return intToDate((Integer) value);
+    }
+
+    public static Instant convertToTimestamp(Object value, PhysicalType physicalType,
+                                             LogicalType.TimestampType timestampType) {
+        if (physicalType != PhysicalType.INT64) {
+            throw new IllegalArgumentException("TIMESTAMP logical type requires INT64 physical type, got " + physicalType);
+        }
+        return longToTimestamp((Long) value, timestampType.unit());
+    }
+
+    public static LocalDateTime convertToLocalTimestamp(Object value, PhysicalType physicalType,
+                                                        LogicalType.TimestampType timestampType) {
+        if (physicalType != PhysicalType.INT64) {
+            throw new IllegalArgumentException("TIMESTAMP logical type requires INT64 physical type, got " + physicalType);
+        }
+        return longToLocalTimestamp((Long) value, timestampType.unit());
+    }
+
+    public static PqInterval convertToInterval(Object value, PhysicalType physicalType) {
+        if (physicalType != PhysicalType.FIXED_LEN_BYTE_ARRAY) {
+            throw new IllegalArgumentException(
+                    "INTERVAL logical type requires FIXED_LEN_BYTE_ARRAY physical type, got " + physicalType);
+        }
+        return bytesToInterval((byte[]) value);
+    }
+
+    public static float convertToFloat16(Object value, PhysicalType physicalType) {
+        if (physicalType != PhysicalType.FIXED_LEN_BYTE_ARRAY) {
+            throw new IllegalArgumentException(
+                    "FLOAT16 logical type requires FIXED_LEN_BYTE_ARRAY physical type, got " + physicalType);
+        }
+        return bytesToFloat16((byte[]) value);
+    }
+
     public static LocalTime convertToTime(Object value, PhysicalType physicalType,
                                           LogicalType.TimeType timeType) {
         if (physicalType != PhysicalType.INT32 && physicalType != PhysicalType.INT64) {
             throw new IllegalArgumentException(
                     "TIME logical type requires INT32 or INT64 physical type, got " + physicalType);
         }
-
         long rawValue = physicalType == PhysicalType.INT32 ? (Integer) value : (Long) value;
-
-        return switch (timeType.unit()) {
-            case MILLIS -> LocalTime.ofNanoOfDay(rawValue * 1_000_000);
-            case MICROS -> LocalTime.ofNanoOfDay(rawValue * 1000);
-            case NANOS -> LocalTime.ofNanoOfDay(rawValue);
-        };
+        return longToTime(rawValue, timeType.unit());
     }
 
     public static BigDecimal convertToDecimal(Object value, PhysicalType physicalType,
                                               LogicalType.DecimalType decimalType) {
-        BigInteger unscaled = switch (physicalType) {
-            case INT32 -> BigInteger.valueOf((Integer) value);
-            case INT64 -> BigInteger.valueOf((Long) value);
-            case BYTE_ARRAY, FIXED_LEN_BYTE_ARRAY -> {
-                byte[] bytes = (byte[]) value;
-                // Parquet uses big-endian two's complement for decimal
-                yield new BigInteger(bytes);
-            }
+        return switch (physicalType) {
+            case INT32 -> longToDecimal((Integer) value, decimalType.scale());
+            case INT64 -> longToDecimal((Long) value, decimalType.scale());
+            case BYTE_ARRAY, FIXED_LEN_BYTE_ARRAY -> bytesToDecimal((byte[]) value, decimalType.scale());
             default -> throw new IllegalArgumentException(
                     "DECIMAL requires INT32, INT64, BYTE_ARRAY, or FIXED_LEN_BYTE_ARRAY, got " + physicalType);
         };
-
-        return new BigDecimal(unscaled, decimalType.scale());
     }
 
     private static Object convertToInt(Object value, PhysicalType physicalType,
-                                      LogicalType.IntType intType) {
+                                       LogicalType.IntType intType) {
         if (physicalType != PhysicalType.INT32 && physicalType != PhysicalType.INT64) {
             throw new IllegalArgumentException("INT logical type requires INT32 or INT64 physical type, got " + physicalType);
         }
@@ -348,15 +395,6 @@ public final class LogicalTypeConverter {
         if (physicalType != PhysicalType.FIXED_LEN_BYTE_ARRAY) {
             throw new IllegalArgumentException("UUID logical type requires FIXED_LEN_BYTE_ARRAY physical type, got " + physicalType);
         }
-
-        byte[] bytes = (byte[]) value;
-        if (bytes.length != 16) {
-            throw new IllegalArgumentException("UUID requires exactly 16 bytes, got " + bytes.length);
-        }
-
-        ByteBuffer bb = ByteBuffer.wrap(bytes);
-        long mostSigBits = bb.getLong();
-        long leastSigBits = bb.getLong();
-        return new UUID(mostSigBits, leastSigBits);
+        return bytesToUuid((byte[]) value);
     }
 }

--- a/core/src/main/java/dev/hardwood/internal/conversion/LogicalTypeConverter.java
+++ b/core/src/main/java/dev/hardwood/internal/conversion/LogicalTypeConverter.java
@@ -314,59 +314,20 @@ public final class LogicalTypeConverter {
         return Instant.ofEpochSecond(epochSecond, nanoAdjustment);
     }
 
-    // ==================== Boxed forms ====================
+    // ==================== Boxed unboxing helpers ====================
+    //
+    // The three arms of `convert` whose unboxing genuinely depends on the physical type,
+    // because the same annotation is stored over more than one of them. Every other arm
+    // decodes from a single representation and calls its primitive entry point directly.
 
-    public static LocalDate convertToDate(Object value, PhysicalType physicalType) {
-        if (physicalType != PhysicalType.INT32) {
-            throw new IllegalArgumentException("DATE logical type requires INT32 physical type, got " + physicalType);
-        }
-        return intToDate((Integer) value);
-    }
-
-    public static Instant convertToTimestamp(Object value, PhysicalType physicalType,
-                                             LogicalType.TimestampType timestampType) {
-        if (physicalType != PhysicalType.INT64) {
-            throw new IllegalArgumentException("TIMESTAMP logical type requires INT64 physical type, got " + physicalType);
-        }
-        return longToTimestamp((Long) value, timestampType.unit());
-    }
-
-    public static LocalDateTime convertToLocalTimestamp(Object value, PhysicalType physicalType,
-                                                        LogicalType.TimestampType timestampType) {
-        if (physicalType != PhysicalType.INT64) {
-            throw new IllegalArgumentException("TIMESTAMP logical type requires INT64 physical type, got " + physicalType);
-        }
-        return longToLocalTimestamp((Long) value, timestampType.unit());
-    }
-
-    public static PqInterval convertToInterval(Object value, PhysicalType physicalType) {
-        if (physicalType != PhysicalType.FIXED_LEN_BYTE_ARRAY) {
-            throw new IllegalArgumentException(
-                    "INTERVAL logical type requires FIXED_LEN_BYTE_ARRAY physical type, got " + physicalType);
-        }
-        return bytesToInterval((byte[]) value);
-    }
-
-    public static float convertToFloat16(Object value, PhysicalType physicalType) {
-        if (physicalType != PhysicalType.FIXED_LEN_BYTE_ARRAY) {
-            throw new IllegalArgumentException(
-                    "FLOAT16 logical type requires FIXED_LEN_BYTE_ARRAY physical type, got " + physicalType);
-        }
-        return bytesToFloat16((byte[]) value);
-    }
-
-    public static LocalTime convertToTime(Object value, PhysicalType physicalType,
-                                          LogicalType.TimeType timeType) {
-        if (physicalType != PhysicalType.INT32 && physicalType != PhysicalType.INT64) {
-            throw new IllegalArgumentException(
-                    "TIME logical type requires INT32 or INT64 physical type, got " + physicalType);
-        }
+    private static LocalTime convertToTime(Object value, PhysicalType physicalType,
+                                           LogicalType.TimeType timeType) {
         long rawValue = physicalType == PhysicalType.INT32 ? (Integer) value : (Long) value;
         return longToTime(rawValue, timeType.unit());
     }
 
-    public static BigDecimal convertToDecimal(Object value, PhysicalType physicalType,
-                                              LogicalType.DecimalType decimalType) {
+    private static BigDecimal convertToDecimal(Object value, PhysicalType physicalType,
+                                               LogicalType.DecimalType decimalType) {
         return switch (physicalType) {
             case INT32 -> longToDecimal((Integer) value, decimalType.scale());
             case INT64 -> longToDecimal((Long) value, decimalType.scale());
@@ -376,31 +337,20 @@ public final class LogicalTypeConverter {
         };
     }
 
+    /// Narrows an `INT(8)` or `INT(16)` value to the box its bit width states. Java has no
+    /// native unsigned types, so an unsigned annotation passes its value through unchanged
+    /// and the caller reads the magnitude with `Integer.toUnsignedLong` or
+    /// `Long.toUnsignedString`.
     private static Object convertToInt(Object value, PhysicalType physicalType,
                                        LogicalType.IntType intType) {
-        if (physicalType != PhysicalType.INT32 && physicalType != PhysicalType.INT64) {
-            throw new IllegalArgumentException("INT logical type requires INT32 or INT64 physical type, got " + physicalType);
-        }
-
-        // For signed integers with narrowing
-        if (intType.isSigned()) {
-            if (intType.bitWidth() == 8 && physicalType == PhysicalType.INT32) {
+        if (intType.isSigned() && physicalType == PhysicalType.INT32) {
+            if (intType.bitWidth() == 8) {
                 return ((Integer) value).byteValue();
             }
-            else if (intType.bitWidth() == 16 && physicalType == PhysicalType.INT32) {
+            if (intType.bitWidth() == 16) {
                 return ((Integer) value).shortValue();
             }
         }
-
-        // For 32 or 64 bit, or unsigned types, pass through
-        // Note: Java doesn't have native unsigned types, so we return the same value
         return value;
-    }
-
-    public static UUID convertToUuid(Object value, PhysicalType physicalType) {
-        if (physicalType != PhysicalType.FIXED_LEN_BYTE_ARRAY) {
-            throw new IllegalArgumentException("UUID logical type requires FIXED_LEN_BYTE_ARRAY physical type, got " + physicalType);
-        }
-        return bytesToUuid((byte[]) value);
     }
 }

--- a/core/src/main/java/dev/hardwood/internal/conversion/LogicalTypeConverter.java
+++ b/core/src/main/java/dev/hardwood/internal/conversion/LogicalTypeConverter.java
@@ -24,7 +24,10 @@ import dev.hardwood.metadata.PhysicalType;
 import dev.hardwood.row.PqInterval;
 
 /// Converts physical values to their logical type representations.
-public class LogicalTypeConverter {
+public final class LogicalTypeConverter {
+
+    private LogicalTypeConverter() {
+    }
 
     /// Why `logicalType` cannot be read from a column of this physical type and width, or
     /// `null` when it can.
@@ -166,7 +169,7 @@ public class LogicalTypeConverter {
                         + " reached primitive-value conversion");
     }
 
-    public static String convertToString(Object value, PhysicalType physicalType) {
+    private static String convertToString(Object value, PhysicalType physicalType) {
         if (physicalType != PhysicalType.BYTE_ARRAY) {
             throw new IllegalArgumentException("STRING logical type requires BYTE_ARRAY physical type, got " + physicalType);
         }
@@ -320,7 +323,7 @@ public class LogicalTypeConverter {
         return new BigDecimal(unscaled, decimalType.scale());
     }
 
-    public static Object convertToInt(Object value, PhysicalType physicalType,
+    private static Object convertToInt(Object value, PhysicalType physicalType,
                                       LogicalType.IntType intType) {
         if (physicalType != PhysicalType.INT32 && physicalType != PhysicalType.INT64) {
             throw new IllegalArgumentException("INT logical type requires INT32 or INT64 physical type, got " + physicalType);

--- a/core/src/main/java/dev/hardwood/internal/conversion/LogicalTypeConverter.java
+++ b/core/src/main/java/dev/hardwood/internal/conversion/LogicalTypeConverter.java
@@ -17,6 +17,7 @@ import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
 import java.time.ZoneOffset;
+import java.time.temporal.Temporal;
 import java.util.UUID;
 
 import dev.hardwood.metadata.LogicalType;
@@ -141,9 +142,7 @@ public final class LogicalTypeConverter {
         return switch (logicalType) {
             case LogicalType.StringType t -> bytesToString((byte[]) physicalValue);
             case LogicalType.DateType t -> intToDate((Integer) physicalValue);
-            case LogicalType.TimestampType tt -> tt.isAdjustedToUTC()
-                    ? longToTimestamp((Long) physicalValue, tt.unit())
-                    : longToLocalTimestamp((Long) physicalValue, tt.unit());
+            case LogicalType.TimestampType tt -> longToTemporal((Long) physicalValue, tt);
             // TIME, DECIMAL and INT are the arms whose unboxing depends on the physical
             // type, so they keep a helper that takes it; the rest decode from one
             // representation and go straight to the primitive entry point.
@@ -216,6 +215,21 @@ public final class LogicalTypeConverter {
             case MICROS -> Instant.ofEpochSecond(rawValue / 1_000_000, (rawValue % 1_000_000) * 1000);
             case NANOS -> Instant.ofEpochSecond(rawValue / 1_000_000_000, rawValue % 1_000_000_000);
         };
+    }
+
+    /// The value a `TIMESTAMP` column's offset stands for, as the annotation's own
+    /// `isAdjustedToUTC` flag decides it: an [Instant] for a UTC-adjusted column, a
+    /// [LocalDateTime] for a local one.
+    ///
+    /// The one statement of that routing, for a caller decoding whatever the column holds
+    /// rather than asking for one kind. A caller that has asked — a typed accessor — names
+    /// the kind it wants in its return type and calls [#longToTimestamp] or
+    /// [#longToLocalTimestamp] directly, having checked the column is that kind through
+    /// `TimestampAccessorKind`.
+    public static Temporal longToTemporal(long rawValue, LogicalType.TimestampType type) {
+        return type.isAdjustedToUTC()
+                ? longToTimestamp(rawValue, type.unit())
+                : longToLocalTimestamp(rawValue, type.unit());
     }
 
     /// The wall-clock date and time a local `TIMESTAMP` column's offset in `unit` stands

--- a/core/src/main/java/dev/hardwood/internal/conversion/LogicalTypeConverter.java
+++ b/core/src/main/java/dev/hardwood/internal/conversion/LogicalTypeConverter.java
@@ -207,7 +207,7 @@ public final class LogicalTypeConverter {
     /// The instant a UTC-adjusted `TIMESTAMP` column's offset in `unit` stands for.
     ///
     /// Which of the two timestamp kinds an accessor accepts is stated once, in
-    /// `TimestampAccessorKind`, which names the column and the accessor that fits it.
+    /// `TimestampAccessorKind`, which names the column and the kind it turned out to be.
     /// This decodes whatever unit it is handed.
     public static Instant longToTimestamp(long rawValue, LogicalType.TimeUnit unit) {
         return switch (unit) {

--- a/core/src/main/java/dev/hardwood/internal/conversion/LogicalTypeConverter.java
+++ b/core/src/main/java/dev/hardwood/internal/conversion/LogicalTypeConverter.java
@@ -190,17 +190,14 @@ public class LogicalTypeConverter {
         return LocalDate.ofEpochDay(daysSinceEpoch);
     }
 
+    /// Decodes a UTC-adjusted `TIMESTAMP`. Which of the two timestamp kinds an accessor
+    /// accepts is stated once, in `TimestampAccessorKind`, which names the column and the
+    /// accessor that fits it; this method decodes whatever unit it is handed.
     public static Instant convertToTimestamp(Object value, PhysicalType physicalType,
                                              LogicalType.TimestampType timestampType) {
         if (physicalType != PhysicalType.INT64) {
             throw new IllegalArgumentException("TIMESTAMP logical type requires INT64 physical type, got " + physicalType);
         }
-        if (!timestampType.isAdjustedToUTC()) {
-            throw new IllegalStateException(
-                    "TIMESTAMP value is local-wall-clock (isAdjustedToUTC=false); "
-                            + "decode via convertToLocalTimestamp instead");
-        }
-
         long rawValue = (Long) value;
         return switch (timestampType.unit()) {
             case MILLIS -> Instant.ofEpochMilli(rawValue);
@@ -209,17 +206,13 @@ public class LogicalTypeConverter {
         };
     }
 
+    /// Decodes a local-wall-clock `TIMESTAMP`. See [#convertToTimestamp] on where the
+    /// kind itself is checked.
     public static LocalDateTime convertToLocalTimestamp(Object value, PhysicalType physicalType,
                                                         LogicalType.TimestampType timestampType) {
         if (physicalType != PhysicalType.INT64) {
             throw new IllegalArgumentException("TIMESTAMP logical type requires INT64 physical type, got " + physicalType);
         }
-        if (timestampType.isAdjustedToUTC()) {
-            throw new IllegalStateException(
-                    "TIMESTAMP value is UTC-adjusted (isAdjustedToUTC=true); "
-                            + "decode via convertToTimestamp instead");
-        }
-
         // For a local-wall-clock TIMESTAMP the stored int64 is the offset from the
         // epoch *of the wall clock itself*, so the same epoch arithmetic that
         // produces an Instant gives the right LocalDateTime when read at UTC —

--- a/core/src/main/java/dev/hardwood/internal/conversion/PhysicalValueConverter.java
+++ b/core/src/main/java/dev/hardwood/internal/conversion/PhysicalValueConverter.java
@@ -231,7 +231,7 @@ public final class PhysicalValueConverter {
     }
 
     /// The 12 bytes of an `INTERVAL`: months, days and millis as little-endian unsigned
-    /// 4-byte fields, the layout [LogicalTypeConverter#convertToInterval] reads back.
+    /// 4-byte fields, the layout [LogicalTypeConverter#bytesToInterval] reads back.
     public static byte[] intervalToBytes(String field, PqInterval value) {
         byte[] bytes = new byte[INTERVAL_BYTES];
         writeUnsignedIntLittleEndian(field, bytes, 0, value.months(), "months");

--- a/core/src/main/java/dev/hardwood/internal/reader/BinaryBatchValues.java
+++ b/core/src/main/java/dev/hardwood/internal/reader/BinaryBatchValues.java
@@ -10,6 +10,8 @@ package dev.hardwood.internal.reader;
 import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 
+import dev.hardwood.internal.conversion.LogicalTypeConverter;
+
 /// Per-batch values slot for a varlength leaf (`BYTE_ARRAY` / `FIXED_LEN_BYTE_ARRAY`
 /// / `INT96`).
 ///
@@ -60,6 +62,16 @@ public final class BinaryBatchValues {
         byte[] result = new byte[len];
         System.arraycopy(bytes, start, result, 0, len);
         return result;
+    }
+
+    /// Decode value `idx` as the single-precision value its `FLOAT16` payload stands for,
+    /// reading the two bytes where they sit rather than materialising a `byte[]` for them.
+    ///
+    /// The float accessors decode here rather than through the generic value conversion
+    /// because that path returns `Object` and would box the value they promised unboxed.
+    public float float16At(int idx) {
+        int start = offsets[idx];
+        return LogicalTypeConverter.bytesToFloat16(bytes, start, offsets[idx + 1] - start);
     }
 
     /// Materialise value `idx` as a UTF-8 decoded `String`. A dictionary-encoded

--- a/core/src/main/java/dev/hardwood/internal/reader/FlatRowReader.java
+++ b/core/src/main/java/dev/hardwood/internal/reader/FlatRowReader.java
@@ -538,9 +538,8 @@ public final class FlatRowReader implements FileAwareRowReader {
         // column is one the caller has asked for a float it does not hold.
         requireFloatAccess(columnIndex);
         try {
-            return LogicalTypeConverter.convertToFloat16(
-                    ((BinaryBatchValues) flatValueArrays[columnIndex]).byteArrayAt(rowIndex),
-                    physicalTypes[columnIndex]);
+            return LogicalTypeConverter.bytesToFloat16(
+                    ((BinaryBatchValues) flatValueArrays[columnIndex]).byteArrayAt(rowIndex));
         }
         catch (RuntimeException e) {
             throw ExceptionContext.addFileContext(currentFileName, e);
@@ -625,13 +624,7 @@ public final class FlatRowReader implements FileAwareRowReader {
         if (isNull(columnIndex)) {
             return null;
         }
-        int rawValue = ((int[]) flatValueArrays[columnIndex])[rowIndex];
-        try {
-            return LogicalTypeConverter.convertToDate(rawValue, physicalTypes[columnIndex]);
-        }
-        catch (RuntimeException e) {
-            throw ExceptionContext.addFileContext(currentFileName, e);
-        }
+        return LogicalTypeConverter.intToDate(((int[]) flatValueArrays[columnIndex])[rowIndex]);
     }
 
     @Override
@@ -645,16 +638,11 @@ public final class FlatRowReader implements FileAwareRowReader {
             return null;
         }
         ColumnSchema col = columnSchemas[columnIndex];
-        Object rawValue;
-        if (col.type() == PhysicalType.INT32) {
-            rawValue = ((int[]) flatValueArrays[columnIndex])[rowIndex];
-        }
-        else {
-            rawValue = ((long[]) flatValueArrays[columnIndex])[rowIndex];
-        }
+        long rawValue = col.type() == PhysicalType.INT32
+                ? ((int[]) flatValueArrays[columnIndex])[rowIndex]
+                : ((long[]) flatValueArrays[columnIndex])[rowIndex];
         try {
-            return LogicalTypeConverter.convertToTime(rawValue, col.type(),
-                    (LogicalType.TimeType) col.logicalType());
+            return LogicalTypeConverter.longToTime(rawValue, ((LogicalType.TimeType) col.logicalType()).unit());
         }
         catch (RuntimeException e) {
             throw ExceptionContext.addFileContext(currentFileName, e);
@@ -679,8 +667,8 @@ public final class FlatRowReader implements FileAwareRowReader {
             }
             TimestampAccessorKind.require(col.name(), col.logicalType(), true);
             long rawValue = ((long[]) flatValueArrays[columnIndex])[rowIndex];
-            return LogicalTypeConverter.convertToTimestamp(rawValue, col.type(),
-                    (LogicalType.TimestampType) col.logicalType());
+            return LogicalTypeConverter.longToTimestamp(rawValue,
+                    ((LogicalType.TimestampType) col.logicalType()).unit());
         }
         catch (RuntimeException e) {
             throw ExceptionContext.addFileContext(currentFileName, e);
@@ -701,8 +689,8 @@ public final class FlatRowReader implements FileAwareRowReader {
         try {
             TimestampAccessorKind.require(col.name(), col.logicalType(), false);
             long rawValue = ((long[]) flatValueArrays[columnIndex])[rowIndex];
-            return LogicalTypeConverter.convertToLocalTimestamp(rawValue, col.type(),
-                    (LogicalType.TimestampType) col.logicalType());
+            return LogicalTypeConverter.longToLocalTimestamp(rawValue,
+                    ((LogicalType.TimestampType) col.logicalType()).unit());
         }
         catch (RuntimeException e) {
             throw ExceptionContext.addFileContext(currentFileName, e);
@@ -720,17 +708,18 @@ public final class FlatRowReader implements FileAwareRowReader {
             return null;
         }
         ColumnSchema col = columnSchemas[columnIndex];
-        Object rawValue = switch (col.type()) {
-            case INT32 -> ((int[]) flatValueArrays[columnIndex])[rowIndex];
-            case INT64 -> ((long[]) flatValueArrays[columnIndex])[rowIndex];
-            case BYTE_ARRAY, FIXED_LEN_BYTE_ARRAY ->
-                    ((BinaryBatchValues) flatValueArrays[columnIndex]).byteArrayAt(rowIndex);
-            default -> throw new IllegalArgumentException(prefix()
-                    + "Unexpected physical type for DECIMAL: " + col.type());
-        };
+        int scale = ((LogicalType.DecimalType) col.logicalType()).scale();
         try {
-            return LogicalTypeConverter.convertToDecimal(rawValue, col.type(),
-                    (LogicalType.DecimalType) col.logicalType());
+            return switch (col.type()) {
+                case INT32 -> LogicalTypeConverter.longToDecimal(
+                        ((int[]) flatValueArrays[columnIndex])[rowIndex], scale);
+                case INT64 -> LogicalTypeConverter.longToDecimal(
+                        ((long[]) flatValueArrays[columnIndex])[rowIndex], scale);
+                case BYTE_ARRAY, FIXED_LEN_BYTE_ARRAY -> LogicalTypeConverter.bytesToDecimal(
+                        ((BinaryBatchValues) flatValueArrays[columnIndex]).byteArrayAt(rowIndex), scale);
+                default -> throw new IllegalArgumentException(prefix()
+                        + "Unexpected physical type for DECIMAL: " + col.type());
+            };
         }
         catch (RuntimeException e) {
             throw ExceptionContext.addFileContext(currentFileName, e);
@@ -748,9 +737,8 @@ public final class FlatRowReader implements FileAwareRowReader {
             return null;
         }
         try {
-            return LogicalTypeConverter.convertToUuid(
-                    ((BinaryBatchValues) flatValueArrays[columnIndex]).byteArrayAt(rowIndex),
-                    physicalTypes[columnIndex]);
+            return LogicalTypeConverter.bytesToUuid(
+                    ((BinaryBatchValues) flatValueArrays[columnIndex]).byteArrayAt(rowIndex));
         }
         catch (RuntimeException e) {
             throw ExceptionContext.addFileContext(currentFileName, e);
@@ -773,9 +761,8 @@ public final class FlatRowReader implements FileAwareRowReader {
             return null;
         }
         try {
-            return LogicalTypeConverter.convertToInterval(
-                    ((BinaryBatchValues) flatValueArrays[columnIndex]).byteArrayAt(rowIndex),
-                    physicalTypes[columnIndex]);
+            return LogicalTypeConverter.bytesToInterval(
+                    ((BinaryBatchValues) flatValueArrays[columnIndex]).byteArrayAt(rowIndex));
         }
         catch (RuntimeException e) {
             throw ExceptionContext.addFileContext(currentFileName, e);

--- a/core/src/main/java/dev/hardwood/internal/reader/FlatRowReader.java
+++ b/core/src/main/java/dev/hardwood/internal/reader/FlatRowReader.java
@@ -538,8 +538,7 @@ public final class FlatRowReader implements FileAwareRowReader {
         // column is one the caller has asked for a float it does not hold.
         requireFloatAccess(columnIndex);
         try {
-            return LogicalTypeConverter.bytesToFloat16(
-                    ((BinaryBatchValues) flatValueArrays[columnIndex]).byteArrayAt(rowIndex));
+            return ((BinaryBatchValues) flatValueArrays[columnIndex]).float16At(rowIndex);
         }
         catch (RuntimeException e) {
             throw ExceptionContext.addFileContext(currentFileName, e);

--- a/core/src/main/java/dev/hardwood/internal/reader/NestedBatchDataView.java
+++ b/core/src/main/java/dev/hardwood/internal/reader/NestedBatchDataView.java
@@ -15,7 +15,6 @@ import java.time.LocalTime;
 import java.util.UUID;
 
 import dev.hardwood.internal.ExceptionContext;
-import dev.hardwood.internal.conversion.LogicalTypeConverter;
 import dev.hardwood.internal.schema.ProjectedSchema;
 import dev.hardwood.internal.variant.PqVariantImpl;
 import dev.hardwood.internal.variant.VariantMetadata;
@@ -213,14 +212,9 @@ public final class NestedBatchDataView {
         if (p.schema().type() == PhysicalType.FLOAT) {
             return ((float[]) batchIndex.valueArrays[projCol])[valueIdx];
         }
-        // FLOAT16 path: primitive convertToFloat16 keeps the value unboxed;
-        // readLogicalType isn't reused because LogicalTypeConverter.convert
-        // returns Object and would box.
         batchIndex.requireFloatAccess(p.schema());
         try {
-            return LogicalTypeConverter.convertToFloat16(
-                    ((BinaryBatchValues) batchIndex.valueArrays[projCol]).byteArrayAt(valueIdx),
-                    p.schema().type());
+            return ((BinaryBatchValues) batchIndex.valueArrays[projCol]).float16At(valueIdx);
         }
         catch (RuntimeException e) {
             throw ExceptionContext.addFileContext(currentFileName, e);
@@ -279,9 +273,7 @@ public final class NestedBatchDataView {
         }
         batchIndex.requireFloatAccess(p.schema());
         try {
-            return LogicalTypeConverter.convertToFloat16(
-                    ((BinaryBatchValues) fieldValueArrays[projectedIndex]).byteArrayAt(valueIdx),
-                    p.schema().type());
+            return ((BinaryBatchValues) fieldValueArrays[projectedIndex]).float16At(valueIdx);
         }
         catch (RuntimeException e) {
             throw ExceptionContext.addFileContext(currentFileName, e);

--- a/core/src/main/java/dev/hardwood/internal/reader/NestedBatchDataView.java
+++ b/core/src/main/java/dev/hardwood/internal/reader/NestedBatchDataView.java
@@ -318,13 +318,13 @@ public final class NestedBatchDataView {
 
     public Instant getTimestamp(String name) {
         TopLevelFieldMap.FieldDesc.Primitive p = lookupPrimitive(name);
-        TimestampAccessorKind.require(p.name(), p.schema().logicalType(), true);
+        TimestampAccessorKind.require(p.schema(), true);
         return readLogicalType(p, Instant.class);
     }
 
     public LocalDateTime getLocalTimestamp(String name) {
         TopLevelFieldMap.FieldDesc.Primitive p = lookupPrimitive(name);
-        TimestampAccessorKind.require(p.name(), p.schema().logicalType(), false);
+        TimestampAccessorKind.require(p.schema(), false);
         return readLogicalType(p, LocalDateTime.class);
     }
 
@@ -370,13 +370,13 @@ public final class NestedBatchDataView {
 
     public Instant getTimestamp(int projectedIndex) {
         TopLevelFieldMap.FieldDesc.Primitive p = lookupPrimitiveByIndex(projectedIndex);
-        TimestampAccessorKind.require(p.name(), p.schema().logicalType(), true);
+        TimestampAccessorKind.require(p.schema(), true);
         return readLogicalType(p, Instant.class);
     }
 
     public LocalDateTime getLocalTimestamp(int projectedIndex) {
         TopLevelFieldMap.FieldDesc.Primitive p = lookupPrimitiveByIndex(projectedIndex);
-        TimestampAccessorKind.require(p.name(), p.schema().logicalType(), false);
+        TimestampAccessorKind.require(p.schema(), false);
         return readLogicalType(p, LocalDateTime.class);
     }
 

--- a/core/src/main/java/dev/hardwood/internal/reader/PqListImpl.java
+++ b/core/src/main/java/dev/hardwood/internal/reader/PqListImpl.java
@@ -237,20 +237,14 @@ final class PqListImpl implements PqList {
 
     @Override
     public List<Instant> timestamps() {
-        requireElementTimestampKind(true);
+        TimestampAccessorKind.require(elementSchema, true);
         return new LeafList<>(raw -> ValueConverter.convertLogicalType(raw, elementSchema, Instant.class));
     }
 
     @Override
     public List<LocalDateTime> localTimestamps() {
-        requireElementTimestampKind(false);
+        TimestampAccessorKind.require(elementSchema, false);
         return new LeafList<>(raw -> ValueConverter.convertLogicalType(raw, elementSchema, LocalDateTime.class));
-    }
-
-    private void requireElementTimestampKind(boolean wantUtcAdjusted) {
-        if (elementSchema instanceof SchemaNode.PrimitiveNode prim) {
-            TimestampAccessorKind.require(elementSchema.name(), prim.logicalType(), wantUtcAdjusted);
-        }
     }
 
     @Override

--- a/core/src/main/java/dev/hardwood/internal/reader/PqMapImpl.java
+++ b/core/src/main/java/dev/hardwood/internal/reader/PqMapImpl.java
@@ -19,7 +19,6 @@ import java.util.List;
 import java.util.Objects;
 import java.util.UUID;
 
-import dev.hardwood.internal.conversion.LogicalTypeConverter;
 import dev.hardwood.internal.variant.PqVariantImpl;
 import dev.hardwood.metadata.PhysicalType;
 import dev.hardwood.row.PqInterval;
@@ -530,14 +529,10 @@ final class PqMapImpl implements PqMap {
             }
             if (valueSchema instanceof SchemaNode.PrimitiveNode primitive
                     && primitive.type() != PhysicalType.FLOAT) {
-                // FLOAT16 path: FLBA(2) payload decoded to a single-precision float,
-                // matching PqStructImpl.readFloat and FlatRowReader.getFloat. Ruling out
-                // FLOAT first lets the shared guard name a value that is neither, rather
-                // than leaving it to the cast below.
+                // Ruling out FLOAT first lets the shared guard name a value that is
+                // neither, rather than leaving it to the cast below.
                 batch.requireFloatAccess(primitive);
-                return LogicalTypeConverter.convertToFloat16(
-                        ((BinaryBatchValues) batch.valueArrays[valueProjCol]).byteArrayAt(valueIdx),
-                        primitive.type());
+                return ((BinaryBatchValues) batch.valueArrays[valueProjCol]).float16At(valueIdx);
             }
             return ((float[]) batch.valueArrays[valueProjCol])[valueIdx];
         }

--- a/core/src/main/java/dev/hardwood/internal/reader/PqMapImpl.java
+++ b/core/src/main/java/dev/hardwood/internal/reader/PqMapImpl.java
@@ -587,22 +587,16 @@ final class PqMapImpl implements PqMap {
 
         @Override
         public Instant getTimestampValue() {
-            requireValueTimestampKind(true);
+            TimestampAccessorKind.require(valueSchema, true);
             Object raw = readValueAt(valueIdx);
             return ValueConverter.convertLogicalType(raw, valueSchema, Instant.class);
         }
 
         @Override
         public LocalDateTime getLocalTimestampValue() {
-            requireValueTimestampKind(false);
+            TimestampAccessorKind.require(valueSchema, false);
             Object raw = readValueAt(valueIdx);
             return ValueConverter.convertLogicalType(raw, valueSchema, LocalDateTime.class);
-        }
-
-        private void requireValueTimestampKind(boolean wantUtcAdjusted) {
-            if (valueSchema instanceof SchemaNode.PrimitiveNode primitive) {
-                TimestampAccessorKind.require(valueSchema.name(), primitive.logicalType(), wantUtcAdjusted);
-            }
         }
 
         @Override

--- a/core/src/main/java/dev/hardwood/internal/reader/PqStructImpl.java
+++ b/core/src/main/java/dev/hardwood/internal/reader/PqStructImpl.java
@@ -14,7 +14,6 @@ import java.time.LocalDateTime;
 import java.time.LocalTime;
 import java.util.UUID;
 
-import dev.hardwood.internal.conversion.LogicalTypeConverter;
 import dev.hardwood.internal.variant.PqVariantImpl;
 import dev.hardwood.internal.variant.VariantMetadata;
 import dev.hardwood.metadata.PhysicalType;
@@ -336,13 +335,8 @@ final class PqStructImpl implements PqStruct {
         if (child.schema().type() == PhysicalType.FLOAT) {
             return ((float[]) batch.valueArrays[projCol])[idx];
         }
-        // FLOAT16 path: convertToFloat16 returns primitive float so the value
-        // flows through without per-row autoboxing. readLogicalType isn't reused
-        // here because its `LogicalTypeConverter.convert` step boxes via Object.
         batch.requireFloatAccess(child.schema());
-        return LogicalTypeConverter.convertToFloat16(
-                ((BinaryBatchValues) batch.valueArrays[projCol]).byteArrayAt(idx),
-                child.schema().type());
+        return ((BinaryBatchValues) batch.valueArrays[projCol]).float16At(idx);
     }
 
     private double readDouble(TopLevelFieldMap.FieldDesc.Primitive child) {

--- a/core/src/main/java/dev/hardwood/internal/reader/PqStructImpl.java
+++ b/core/src/main/java/dev/hardwood/internal/reader/PqStructImpl.java
@@ -161,28 +161,28 @@ final class PqStructImpl implements PqStruct {
     @Override
     public Instant getTimestamp(String name) {
         TopLevelFieldMap.FieldDesc.Primitive child = lookupPrimitive(name);
-        TimestampAccessorKind.require(child.name(), child.schema().logicalType(), true);
+        TimestampAccessorKind.require(child.schema(), true);
         return readLogicalType(child, Instant.class);
     }
 
     @Override
     public Instant getTimestamp(int fieldIndex) {
         TopLevelFieldMap.FieldDesc.Primitive child = primitiveAt(fieldIndex);
-        TimestampAccessorKind.require(child.name(), child.schema().logicalType(), true);
+        TimestampAccessorKind.require(child.schema(), true);
         return readLogicalType(child, Instant.class);
     }
 
     @Override
     public LocalDateTime getLocalTimestamp(String name) {
         TopLevelFieldMap.FieldDesc.Primitive child = lookupPrimitive(name);
-        TimestampAccessorKind.require(child.name(), child.schema().logicalType(), false);
+        TimestampAccessorKind.require(child.schema(), false);
         return readLogicalType(child, LocalDateTime.class);
     }
 
     @Override
     public LocalDateTime getLocalTimestamp(int fieldIndex) {
         TopLevelFieldMap.FieldDesc.Primitive child = primitiveAt(fieldIndex);
-        TimestampAccessorKind.require(child.name(), child.schema().logicalType(), false);
+        TimestampAccessorKind.require(child.schema(), false);
         return readLogicalType(child, LocalDateTime.class);
     }
 

--- a/core/src/main/java/dev/hardwood/internal/reader/TimestampAccessorKind.java
+++ b/core/src/main/java/dev/hardwood/internal/reader/TimestampAccessorKind.java
@@ -33,47 +33,31 @@ final class TimestampAccessorKind {
         }
     }
 
-    /// Verify that a column is the right TIMESTAMP kind for the accessor being
-    /// called. A `null` logical type means a legacy INT96 column (no
-    /// `isAdjustedToUTC` field); the convention is to treat it as UTC-adjusted,
-    /// so it is accepted by [#requireUtcAdjusted] and rejected by [#requireLocal].
-    /// Non-TIMESTAMP logical types pass through without action — the caller's
-    /// subsequent typed read will fail with its own type-mismatch exception.
+    /// Verify that a column is the kind of TIMESTAMP the accessor being called reads.
     ///
-    /// @throws IllegalStateException if the column's kind doesn't match the request
+    /// A `null` annotation is a legacy INT96 column, which carries no `isAdjustedToUTC`
+    /// field and is conventionally UTC-adjusted. A non-TIMESTAMP annotation passes through
+    /// without action: the caller's subsequent typed read fails with its own type-mismatch
+    /// exception.
+    ///
+    /// @throws IllegalStateException if the column is the other kind
     static void require(String columnName, LogicalType lt, boolean wantUtcAdjusted) {
-        if (lt == null) {
-            // INT96: only the UTC-adjusted accessor accepts it.
-            if (!wantUtcAdjusted) {
-                throw new IllegalStateException("Column '" + columnName
-                        + "' is a legacy INT96 TIMESTAMP (no isAdjustedToUTC field); "
-                        + "use getTimestamp instead");
-            }
+        if (lt != null && !(lt instanceof LogicalType.TimestampType)) {
             return;
         }
-        if (lt instanceof LogicalType.TimestampType tt) {
-            if (wantUtcAdjusted) {
-                requireUtcAdjusted(columnName, tt);
-            }
-            else {
-                requireLocal(columnName, tt);
-            }
+        boolean utcAdjusted = lt == null || ((LogicalType.TimestampType) lt).isAdjustedToUTC();
+        if (utcAdjusted != wantUtcAdjusted) {
+            throw new IllegalStateException(
+                    "Column '" + columnName + "' is " + describe(lt, utcAdjusted));
         }
     }
 
-    private static void requireUtcAdjusted(String columnName, LogicalType.TimestampType tt) {
-        if (!tt.isAdjustedToUTC()) {
-            throw new IllegalStateException("Column '" + columnName
-                    + "' is a local-wall-clock TIMESTAMP (isAdjustedToUTC=false); "
-                    + "use getLocalTimestamp instead");
+    private static String describe(LogicalType lt, boolean utcAdjusted) {
+        if (lt == null) {
+            return "a legacy INT96 TIMESTAMP (no isAdjustedToUTC field)";
         }
-    }
-
-    private static void requireLocal(String columnName, LogicalType.TimestampType tt) {
-        if (tt.isAdjustedToUTC()) {
-            throw new IllegalStateException("Column '" + columnName
-                    + "' is a UTC-adjusted TIMESTAMP (isAdjustedToUTC=true); "
-                    + "use getTimestamp instead");
-        }
+        return utcAdjusted
+                ? "a UTC-adjusted TIMESTAMP (isAdjustedToUTC=true)"
+                : "a local-wall-clock TIMESTAMP (isAdjustedToUTC=false)";
     }
 }

--- a/core/src/main/java/dev/hardwood/internal/reader/TimestampAccessorKind.java
+++ b/core/src/main/java/dev/hardwood/internal/reader/TimestampAccessorKind.java
@@ -51,7 +51,7 @@ final class TimestampAccessorKind {
         }
     }
 
-    static void requireUtcAdjusted(String columnName, LogicalType.TimestampType tt) {
+    private static void requireUtcAdjusted(String columnName, LogicalType.TimestampType tt) {
         if (!tt.isAdjustedToUTC()) {
             throw new IllegalStateException("Column '" + columnName
                     + "' is a local-wall-clock TIMESTAMP (isAdjustedToUTC=false); "
@@ -59,7 +59,7 @@ final class TimestampAccessorKind {
         }
     }
 
-    static void requireLocal(String columnName, LogicalType.TimestampType tt) {
+    private static void requireLocal(String columnName, LogicalType.TimestampType tt) {
         if (tt.isAdjustedToUTC()) {
             throw new IllegalStateException("Column '" + columnName
                     + "' is a UTC-adjusted TIMESTAMP (isAdjustedToUTC=true); "

--- a/core/src/main/java/dev/hardwood/internal/reader/TimestampAccessorKind.java
+++ b/core/src/main/java/dev/hardwood/internal/reader/TimestampAccessorKind.java
@@ -8,6 +8,7 @@
 package dev.hardwood.internal.reader;
 
 import dev.hardwood.metadata.LogicalType;
+import dev.hardwood.schema.SchemaNode;
 
 /// Shared dispatch guards for the TIMESTAMP accessor pair (#568).
 ///
@@ -21,6 +22,15 @@ import dev.hardwood.metadata.LogicalType;
 final class TimestampAccessorKind {
 
     private TimestampAccessorKind() {
+    }
+
+    /// Verify that a leaf is the right TIMESTAMP kind for the accessor being called, for
+    /// a caller holding the leaf's schema node. A group node is not a timestamp leaf and
+    /// passes through, as a non-TIMESTAMP annotation does.
+    static void require(SchemaNode schema, boolean wantUtcAdjusted) {
+        if (schema instanceof SchemaNode.PrimitiveNode primitive) {
+            require(schema.name(), primitive.logicalType(), wantUtcAdjusted);
+        }
     }
 
     /// Verify that a column is the right TIMESTAMP kind for the accessor being

--- a/core/src/test/java/dev/hardwood/Float16LogicalTypeTest.java
+++ b/core/src/test/java/dev/hardwood/Float16LogicalTypeTest.java
@@ -111,17 +111,9 @@ class Float16LogicalTypeTest {
     }
 
     @Test
-    void testConvertToFloat16RejectsWrongPhysicalType() {
+    void testFloat16RejectsWrongByteLength() {
         assertThatThrownBy(() ->
-                LogicalTypeConverter.convertToFloat16(0L, PhysicalType.INT64))
-                .isInstanceOf(IllegalArgumentException.class)
-                .hasMessage("FLOAT16 logical type requires FIXED_LEN_BYTE_ARRAY physical type, got INT64");
-    }
-
-    @Test
-    void testConvertToFloat16RejectsWrongByteLength() {
-        assertThatThrownBy(() ->
-                LogicalTypeConverter.convertToFloat16(new byte[4], PhysicalType.FIXED_LEN_BYTE_ARRAY))
+                LogicalTypeConverter.bytesToFloat16(new byte[4]))
                 .isInstanceOf(IllegalArgumentException.class)
                 .hasMessage("FLOAT16 requires exactly 2 bytes, got 4");
     }

--- a/core/src/test/java/dev/hardwood/IntervalLogicalTypeTest.java
+++ b/core/src/test/java/dev/hardwood/IntervalLogicalTypeTest.java
@@ -99,24 +99,16 @@ class IntervalLogicalTypeTest {
         buf.putInt((int) maxUint32);
         buf.putInt((int) maxUint32);
         buf.putInt((int) maxUint32);
-        PqInterval interval = LogicalTypeConverter.convertToInterval(buf.array(), PhysicalType.FIXED_LEN_BYTE_ARRAY);
+        PqInterval interval = LogicalTypeConverter.bytesToInterval(buf.array());
         assertThat(interval.months()).isEqualTo(maxUint32);
         assertThat(interval.days()).isEqualTo(maxUint32);
         assertThat(interval.milliseconds()).isEqualTo(maxUint32);
     }
 
     @Test
-    void testConvertToIntervalRejectsWrongPhysicalType() {
+    void testIntervalRejectsWrongByteLength() {
         assertThatThrownBy(() ->
-                LogicalTypeConverter.convertToInterval(0L, PhysicalType.INT64))
-                .isInstanceOf(IllegalArgumentException.class)
-                .hasMessage("INTERVAL logical type requires FIXED_LEN_BYTE_ARRAY physical type, got INT64");
-    }
-
-    @Test
-    void testConvertToIntervalRejectsWrongByteLength() {
-        assertThatThrownBy(() ->
-                LogicalTypeConverter.convertToInterval(new byte[8], PhysicalType.FIXED_LEN_BYTE_ARRAY))
+                LogicalTypeConverter.bytesToInterval(new byte[8]))
                 .isInstanceOf(IllegalArgumentException.class)
                 .hasMessage("INTERVAL requires exactly 12 bytes, got 8");
     }

--- a/core/src/test/java/dev/hardwood/LocalTimestampTest.java
+++ b/core/src/test/java/dev/hardwood/LocalTimestampTest.java
@@ -74,7 +74,7 @@ class LocalTimestampTest {
             assertThatThrownBy(() -> rows.getTimestamp("local_micros"))
                     .isInstanceOf(IllegalStateException.class)
                     .hasMessage("Column 'local_micros' is a local-wall-clock TIMESTAMP "
-                             + "(isAdjustedToUTC=false); use getLocalTimestamp instead")
+                             + "(isAdjustedToUTC=false)")
                     ;
         }
     }
@@ -86,8 +86,7 @@ class LocalTimestampTest {
             rows.next();
             assertThatThrownBy(() -> rows.getLocalTimestamp("utc_micros"))
                     .isInstanceOf(IllegalStateException.class)
-                    .hasMessage("Column 'utc_micros' is a UTC-adjusted TIMESTAMP (isAdjustedToUTC=true); "
-                             + "use getTimestamp instead")
+                    .hasMessage("Column 'utc_micros' is a UTC-adjusted TIMESTAMP (isAdjustedToUTC=true)")
                     ;
         }
     }
@@ -129,12 +128,11 @@ class LocalTimestampTest {
             assertThatThrownBy(() -> nested.getTimestamp("local_ts"))
                     .isInstanceOf(IllegalStateException.class)
                     .hasMessage("Column 'local_ts' is a local-wall-clock TIMESTAMP "
-                             + "(isAdjustedToUTC=false); use getLocalTimestamp instead")
+                             + "(isAdjustedToUTC=false)")
                     ;
             assertThatThrownBy(() -> nested.getLocalTimestamp("utc_ts"))
                     .isInstanceOf(IllegalStateException.class)
-                    .hasMessage("Column 'utc_ts' is a UTC-adjusted TIMESTAMP (isAdjustedToUTC=true); use "
-                             + "getTimestamp instead")
+                    .hasMessage("Column 'utc_ts' is a UTC-adjusted TIMESTAMP (isAdjustedToUTC=true)")
                     ;
         }
     }
@@ -150,8 +148,7 @@ class LocalTimestampTest {
             // wrong-kind rejection through PqListImpl
             assertThatThrownBy(list::timestamps)
                     .isInstanceOf(IllegalStateException.class)
-                    .hasMessage("Column 'element' is a local-wall-clock TIMESTAMP (isAdjustedToUTC=false); "
-                             + "use getLocalTimestamp instead");
+                    .hasMessage("Column 'element' is a local-wall-clock TIMESTAMP (isAdjustedToUTC=false)");
         }
     }
 
@@ -171,8 +168,7 @@ class LocalTimestampTest {
             // wrong-kind rejection through PqMapImpl
             assertThatThrownBy(first::getTimestampValue)
                     .isInstanceOf(IllegalStateException.class)
-                    .hasMessage("Column 'value' is a local-wall-clock TIMESTAMP (isAdjustedToUTC=false); "
-                             + "use getLocalTimestamp instead");
+                    .hasMessage("Column 'value' is a local-wall-clock TIMESTAMP (isAdjustedToUTC=false)");
         }
     }
 
@@ -192,7 +188,7 @@ class LocalTimestampTest {
             assertThatThrownBy(() -> rows.getLocalTimestamp("ts"))
                     .isInstanceOf(IllegalStateException.class)
                     .hasMessage("[int96_timestamp_test.parquet] Column 'ts' is a legacy INT96 TIMESTAMP "
-                             + "(no isAdjustedToUTC field); use getTimestamp instead")
+                             + "(no isAdjustedToUTC field)")
                     ;
         }
     }

--- a/core/src/test/java/dev/hardwood/internal/conversion/ConversionFaultTest.java
+++ b/core/src/test/java/dev/hardwood/internal/conversion/ConversionFaultTest.java
@@ -43,6 +43,8 @@ class ConversionFaultTest {
                 .isEqualTo("DATE is read from INT32, but the column is INT64");
         assertThat(fault(PhysicalType.INT32, null, new LogicalType.StringType()))
                 .isEqualTo("STRING is read from BYTE_ARRAY, but the column is INT32");
+        assertThat(fault(PhysicalType.INT32, null, timestamp()))
+                .isEqualTo("TIMESTAMP is read from INT64, but the column is INT32");
     }
 
     @Test
@@ -51,6 +53,8 @@ class ConversionFaultTest {
                 .isEqualTo("FLOAT16 is exactly 2 bytes, but the column declares 3");
         assertThat(fault(PhysicalType.FIXED_LEN_BYTE_ARRAY, 8, new LogicalType.UuidType()))
                 .isEqualTo("UUID is exactly 16 bytes, but the column declares 8");
+        assertThat(fault(PhysicalType.FIXED_LEN_BYTE_ARRAY, 8, new LogicalType.IntervalType()))
+                .isEqualTo("INTERVAL is exactly 12 bytes, but the column declares 8");
     }
 
     /// The wrong physical type is reported before the width, because a column that is not
@@ -59,6 +63,10 @@ class ConversionFaultTest {
     void theWrongPhysicalTypeIsReportedAheadOfTheWidth() {
         assertThat(fault(PhysicalType.INT64, null, new LogicalType.Float16Type()))
                 .isEqualTo("FLOAT16 is read from FIXED_LEN_BYTE_ARRAY, but the column is INT64");
+        assertThat(fault(PhysicalType.INT64, null, new LogicalType.IntervalType()))
+                .isEqualTo("INTERVAL is read from FIXED_LEN_BYTE_ARRAY, but the column is INT64");
+        assertThat(fault(PhysicalType.BYTE_ARRAY, null, new LogicalType.UuidType()))
+                .isEqualTo("UUID is read from FIXED_LEN_BYTE_ARRAY, but the column is BYTE_ARRAY");
     }
 
     /// Reading accepts either width for `TIME` and `INT` whatever the unit or bit width,

--- a/core/src/test/java/dev/hardwood/internal/conversion/LogicalTypeConverterTest.java
+++ b/core/src/test/java/dev/hardwood/internal/conversion/LogicalTypeConverterTest.java
@@ -80,14 +80,6 @@ class LogicalTypeConverterTest {
     }
 
     @Test
-    void bsonRejectsNonByteArrayPhysicalType() {
-        assertThatThrownBy(() -> LogicalTypeConverter.convertToBson(new byte[0], PhysicalType.FIXED_LEN_BYTE_ARRAY))
-                .isInstanceOf(IllegalArgumentException.class)
-                .hasMessage("BSON logical type requires BYTE_ARRAY physical type, got FIXED_LEN_BYTE_ARRAY")
-                ;
-    }
-
-    @Test
     void jsonDispatchesToString() {
         byte[] jsonBytes = "{\"k\":1}".getBytes(StandardCharsets.UTF_8);
 


### PR DESCRIPTION
Closes #1160.

`LogicalTypeConverter` was shaped as `(Object value, PhysicalType, LogicalType) -> Object`, so an accessor that already knew the column's physical type still boxed the primitive it read, passed the physical type along, and let the converter branch on it a second time and cast back down. Around that, the rule about which physical type an annotation is legal over ended up stated several times, and the decodes themselves were re-implemented wherever the `Object` signature was inconvenient.

The converters now have primitive entry points named after their write-side inverses in `PhysicalValueConverter` — `dateToInt` reads back as `intToDate` — and `convert(Object, PhysicalType, LogicalType)` is left as the one path that starts from an `Object` and has to dispatch.

One commit per item from the issue, in dependency order rather than issue order, since the primitive entry points are what the rest is built on:

| Commit | Issue item |
| --- | --- |
| Check the timestamp kind in one place | 5 |
| Expose only what is reached from outside the converters | 6 |
| Decode a leaf without boxing it first | 2 |
| Decode a FLOAT16 leaf in one place | 3 |
| Render a value through the converter that already decodes it | 4 |
| Stop re-asserting what the schema already settled | 1 |

Two things beyond the issue, both falling out of the same call sites:

`BinaryBatchValues.float16At` reads the two bytes where they sit, so the FLOAT16 accessors no longer allocate a two-byte array per value just to hand it to the decoder — `byteArrayAt` copies before the decode looks at it.

`FlatRowReader.getTime` and `getDecimal` keep the file-context wrapper they had, because `LocalTime.ofNanoOfDay` and `new BigInteger(byte[])` both reject a corrupt file's payload. `getDate` no longer has one: `LocalDate.ofEpochDay` is total over `int`, so nothing under it can throw.

Nothing user-facing changes. `dev.hardwood.internal.conversion` is an internal package, no public accessor changes shape, and the messages a typed accessor gives on a physical-type mismatch are #971, not this.

`./mvnw verify` green.
