### PR TITLE
#1092 Keep the dive session when a screen cannot read what it is showing

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -516,6 +516,8 @@ TUI for exploring Parquet file structure. See `_designs/INTERACTIVE_DIVE_TUI.md`
 - [x] Phase 2: Pages + page-header modal / Column index / Offset index / Footer / Column-across-row-groups / Chunk-detail drill menu (#324)
 - [x] Phase 3: Dictionary / Data preview (#324)
 - [x] Phase 4: Schema tree expansion, Dictionary inline search, docs expanded (#324)
+- [x] Phase 5: a read failure anywhere becomes an error overlay rather than ending the session,
+      reporting the file, row group and column (#1092). See `_designs/DIVE_READ_FAILURE_HANDLING.md`
 - [ ] Follow-ups: async I/O (profiling-dependent); "jump to chunk" from Footer; screenshots in docs
 
 ## Testing

--- a/_designs/DIVE_READ_FAILURE_HANDLING.md
+++ b/_designs/DIVE_READ_FAILURE_HANDLING.md
@@ -1,0 +1,83 @@
+# Design: read-failure handling in dive
+
+**Status: Implemented.** Tracking issue: #1092. Supersedes #342.
+
+## Goal
+
+A reader who opens a damaged file in `hardwood dive` should be told what failed
+and where in the file it failed, and should still have a session afterwards.
+
+Every dive screen that reads from the file does so inside the render callback or
+the key handler, and neither is guarded. An unreadable region anywhere ends the
+session: the exception escapes, TamboUI paints its crash screen over a buffer it
+does not clear, and `Esc` exits the process because there is no longer a loop to
+press it in. Which screen dies depends only on which region is damaged.
+
+## Why the guard is central and not per screen
+
+Six screens reach the file from a render or keybar path: `PagesScreen`,
+`ColumnIndexScreen`, `OffsetIndexScreen`, `ColumnAcrossRowGroupsScreen`,
+`DictionaryScreen` and `DataPreviewScreen`. A per-screen error state solves one
+of them and leaves the shape of the bug in the other five, and every future
+screen has to remember to opt in. A guard in `DiveApp` covers all of them and
+cannot be forgotten.
+
+No screen gains an error state. `ScreenState` stays a description of what a
+screen is showing and the handlers stay pure functions of
+`(event, model, stack)`, which is what makes them testable without a terminal.
+
+## The model
+
+`DiveApp` holds a nullable read failure — the message, and the scroll offset
+into it.
+
+- **Key dispatch** is guarded. A read failure while handling a key records the
+  failure; the navigation stack is left as it was.
+- **Render** is guarded, around both `keybarForActive()` and `renderBody()`. A
+  failure records itself and paints the overlay in the same frame, over a body
+  cleared first: a half-drawn screen under the overlay is what makes a reported
+  error look like a corrupted display.
+- **While a failure is showing**, keys still reach the screen underneath. This
+  is what lets a reader move away from a damaged region rather than only back
+  out of it: the stack still holds the last state that rendered, so `PgUp` from
+  a failed Data preview page loads an earlier window and clears the failure. A
+  key that fails again replaces the failure with the new one.
+- **`Esc` is taken from the screen** while a failure shows. A screen normally
+  gets first refusal on it so it can claim it for something of its own, but a
+  screen that cannot read cannot honour that, and its handler reads too.
+- **The overlay** is a `ScrollPane` modal, per the navigation model: the
+  navigation keys scroll it while there is more message than box.
+
+## What the message says
+
+The overlay adds no wording of its own. It shows the exception's message, which
+the reader has already placed — `[data.parquet: row group 0, column 'id']` — per
+[EXCEPTION_MODEL.md](EXCEPTION_MODEL.md).
+
+The four regions a dive screen parses for itself (column index, offset index,
+page headers, dictionary page) bypass the read pipeline and go at the bytes
+directly, so `ParquetModel` places those failures itself. The Thrift structure
+that would not parse names itself in the message the reader raises.
+
+## What it does not do
+
+TamboUI's own crash screen paints over an un-cleared buffer. That is upstream of
+this project; this design stops dive reaching that screen, it does not fix it.
+
+Only failures the reader **detects** are reported, which is a much smaller set
+than "corrupt files". `PLAIN` has no redundancy to check, and an RLE run header
+is a varint whose every bit pattern is a syntactically valid header, so most
+corruption of page data decodes to wrong values rather than to an error.
+Per-page CRCs would catch it and the reader validates them, but only where the
+writer emitted one. That gap is #1095.
+
+How the non-interactive commands report a failure is #1094.
+
+## Validation
+
+`DiveReadFailureTest` clobbers a page header, a column index, an offset index, a
+dictionary page header and a dictionary page *body* in turn, each at an offset
+derived from the file's own metadata, and drives the screen that reads it:
+the session survives, the overlay names the file and the structure, and `Esc`
+leaves. Which screen a damaged file takes down depends on which region is
+damaged, so one region proves nothing about the rest.

--- a/cli/src/main/java/dev/hardwood/cli/command/InspectPagesCommand.java
+++ b/cli/src/main/java/dev/hardwood/cli/command/InspectPagesCommand.java
@@ -25,6 +25,7 @@ import dev.hardwood.cli.internal.IndexValueFormatter;
 import dev.hardwood.cli.internal.Sizes;
 import dev.hardwood.cli.internal.Strings;
 import dev.hardwood.cli.internal.table.RowTable;
+import dev.hardwood.internal.ExceptionContext;
 import dev.hardwood.internal.metadata.DataPageHeader;
 import dev.hardwood.internal.metadata.DataPageHeaderV2;
 import dev.hardwood.internal.metadata.PageHeader;
@@ -160,7 +161,8 @@ public class InspectPagesCommand implements Command<CommandInvocation> {
             }
 
             boolean trackRowIndex = chunk.metaData().numValues() == rg.numRows();
-            List<PageInfo> pages = collectPageHeaders(chunk, inputFile, trackRowIndex);
+            List<PageInfo> pages = collectPageHeaders(chunk, inputFile, trackRowIndex,
+                    rgIdx, col.fieldPath().toString());
 
             boolean rgHasIndex = columnIndex != null && offsetIndex != null;
             boolean rgHasInline = !noStats && hasInlineStats(pages);
@@ -418,7 +420,21 @@ public class InspectPagesCommand implements Command<CommandInvocation> {
             boolean isDictionary, Long firstRowIndex, Statistics inlineStats) {
     }
 
-    private List<PageInfo> collectPageHeaders(ColumnChunk chunk, InputFile inputFile, boolean trackRowIndex) throws IOException {
+    /// Walks a chunk's page headers, naming the file, row group and column on
+    /// anything the parser raises. A read through `ColumnReader` gets that from
+    /// the read pipeline; this command reaches the parser directly, so without
+    /// it a corrupt header reports only "Unknown field type: 15".
+    private List<PageInfo> collectPageHeaders(ColumnChunk chunk, InputFile inputFile,
+            boolean trackRowIndex, int rowGroupIndex, String columnPath) throws IOException {
+        try {
+            return walkPageHeaders(chunk, inputFile, trackRowIndex);
+        }
+        catch (RuntimeException e) {
+            throw ExceptionContext.addReadContext(inputFile.name(), rowGroupIndex, columnPath, e);
+        }
+    }
+
+    private List<PageInfo> walkPageHeaders(ColumnChunk chunk, InputFile inputFile, boolean trackRowIndex) throws IOException {
         // Under the split-file layout the offsets below address a different file, so scanning
         // this one at them would print page headers decoded from unrelated bytes.
         chunk.requireSameFile();

--- a/cli/src/main/java/dev/hardwood/cli/dive/DiveApp.java
+++ b/cli/src/main/java/dev/hardwood/cli/dive/DiveApp.java
@@ -7,6 +7,7 @@
  */
 package dev.hardwood.cli.dive;
 
+import java.io.UncheckedIOException;
 import java.time.Duration;
 
 import dev.hardwood.cli.dive.internal.Chrome;
@@ -23,12 +24,14 @@ import dev.hardwood.cli.dive.internal.Keys;
 import dev.hardwood.cli.dive.internal.OffsetIndexScreen;
 import dev.hardwood.cli.dive.internal.OverviewScreen;
 import dev.hardwood.cli.dive.internal.PagesScreen;
+import dev.hardwood.cli.dive.internal.ReadFailureOverlay;
 import dev.hardwood.cli.dive.internal.RowGroupDetailScreen;
 import dev.hardwood.cli.dive.internal.RowGroupIndexesScreen;
 import dev.hardwood.cli.dive.internal.RowGroupsScreen;
 import dev.hardwood.cli.dive.internal.SchemaScreen;
 import dev.hardwood.cli.dive.internal.ScrollPane;
 import dev.hardwood.cli.dive.internal.Theme;
+import dev.hardwood.reader.ParquetReadException;
 import dev.tamboui.buffer.Buffer;
 import dev.tamboui.layout.Rect;
 import dev.tamboui.terminal.Frame;
@@ -37,6 +40,7 @@ import dev.tamboui.tui.TuiRunner;
 import dev.tamboui.tui.event.Event;
 import dev.tamboui.tui.event.KeyCode;
 import dev.tamboui.tui.event.KeyEvent;
+import dev.tamboui.widgets.Clear;
 
 /// Dispatches events to the active screen's handler and renders the chrome plus
 /// active screen body each frame. Owns the [NavigationStack] and the help-overlay
@@ -53,6 +57,17 @@ public final class DiveApp {
     private int helpScroll;
 
     private int helpLineCount;
+
+    /// The read failure the screen is showing instead of itself, and how far
+    /// into its message the reader has scrolled; `null` when the screen is
+    /// rendering normally.
+    ///
+    /// App state rather than screen state: every screen that reads from the
+    /// file can fail this way, and putting it on [ScreenState] would make each
+    /// of them carry a field for something none of them handles.
+    private String readFailure;
+
+    private int readFailureScroll;
 
     public DiveApp(ParquetModel model) {
         this.model = model;
@@ -128,16 +143,69 @@ public final class DiveApp {
             stack.clearToRoot();
             return Action.HANDLED;
         }
+        // A failure that is longer than its box owns the navigation keys while
+        // there is more of it to read; the hint row advertises exactly those.
+        if (readFailure != null) {
+            int next = ScrollPane.scroll(ke, readFailureScroll,
+                    ReadFailureOverlay.lineCount(readFailure), Keys.viewportStride());
+            if (next != ScrollPane.UNHANDLED && next != readFailureScroll) {
+                readFailureScroll = next;
+                return Action.HANDLED;
+            }
+        }
+        // Back-navigation is taken from the screen while a failure is showing.
+        // A screen normally gets first refusal on Esc so it can claim it for
+        // something of its own, but one that cannot read cannot honour that,
+        // and its handler reads too — leaving Esc to it means the only key out
+        // of the overlay fails on its way to the door.
+        if (readFailure != null && ke.isCancel() && stack.depth() > 1) {
+            clearReadFailure();
+            stack.pop();
+            return Action.HANDLED;
+        }
         // Screen gets first crack at the event so it can claim keys like Esc (filter-cancel)
         // before the global back-navigation intercept kicks in.
-        if (dispatchToScreen(ke)) {
+        //
+        // Keys still reach a screen that is showing a failure. That is what
+        // lets a reader move off a damaged region rather than only back out of
+        // it: the stack holds the last state that rendered, so paging from it
+        // loads a different window, and a key that fails again simply replaces
+        // one failure with the next.
+        // IndexOutOfBounds is in the list because a corrupt file produces it:
+        // a dictionary reference past the end of its dictionary is an array
+        // index, and reading a damaged page is how you get one. A programming
+        // error can raise it too, and that is the cost of not ending the
+        // session over a file that is merely broken.
+        try {
+            if (dispatchToScreen(ke)) {
+                clearReadFailure();
+                return Action.HANDLED;
+            }
+        }
+        catch (UncheckedIOException | ParquetReadException | IllegalStateException
+                | IllegalArgumentException | IndexOutOfBoundsException e) {
+            recordReadFailure(e);
             return Action.HANDLED;
         }
         if (ke.isCancel() && stack.depth() > 1) {
+            clearReadFailure();
             stack.pop();
             return Action.HANDLED;
         }
         return Action.IGNORED;
+    }
+
+    /// Records a read failure for the next frame to show. The scroll offset
+    /// resets: a new failure is a new message, and carrying an offset into it
+    /// would open it part way down.
+    private void recordReadFailure(RuntimeException e) {
+        readFailure = ReadFailureOverlay.messageOf(e);
+        readFailureScroll = 0;
+    }
+
+    private void clearReadFailure() {
+        readFailure = null;
+        readFailureScroll = 0;
     }
 
     private boolean isTopInInputMode() {
@@ -183,19 +251,44 @@ public final class DiveApp {
         // first so it needs the seed.
         Keys.observeViewport(Math.max(1, area.height() - 5));
         Keys.observeViewportWidth(area.width());
-        String screenKeys = keybarForActive();
+        String screenKeys;
+        try {
+            screenKeys = keybarForActive();
+        }
+        catch (UncheckedIOException | ParquetReadException | IllegalStateException
+                | IllegalArgumentException | IndexOutOfBoundsException e) {
+            // The keybar reads from the file too — a screen that reports how
+            // many pages a chunk has had to go and count them.
+            recordReadFailure(e);
+            screenKeys = " [Esc] back";
+        }
         String globalKeys = " [?] help   [q] quit";
         int kbHeight = Chrome.keybarHeight(screenKeys, globalKeys, area.width());
         Chrome.Regions regions = Chrome.split(area, kbHeight);
 
-        // Data preview loads exactly the rows its body can paint, so the
-        // page has to be fitted before the body is rendered rather than
-        // after — otherwise the frame the screen is entered on is short.
-        DataPreviewScreen.fitToViewport(model, stack, regions.body());
-
         Chrome.renderTopBar(buffer, regions.topBar(), model);
         Chrome.renderBreadcrumb(buffer, regions.breadcrumb(), stack, model);
-        renderBody(buffer, regions.body());
+        if (readFailure == null) {
+            try {
+                // Data preview loads exactly the rows its body can paint, so the
+                // page has to be fitted before the body is rendered rather than
+                // after — otherwise the frame the screen is entered on is short.
+                DataPreviewScreen.fitToViewport(model, stack, regions.body());
+                renderBody(buffer, regions.body());
+            }
+            catch (UncheckedIOException | ParquetReadException | IllegalStateException
+                    | IllegalArgumentException | IndexOutOfBoundsException e) {
+                recordReadFailure(e);
+            }
+        }
+        if (readFailure != null) {
+            // A body that failed part way through has left some of itself
+            // behind; clear it rather than paint the overlay over a half-drawn
+            // screen, which is what makes an escaped exception look like a
+            // corrupted display rather than a reported error.
+            Clear.INSTANCE.render(regions.body(), buffer);
+            ReadFailureOverlay.render(buffer, regions.body(), readFailure, readFailureScroll);
+        }
         Chrome.renderKeybar(buffer, regions.keybar(), screenKeys, globalKeys);
 
         if (helpOpen) {

--- a/cli/src/main/java/dev/hardwood/cli/dive/ParquetModel.java
+++ b/cli/src/main/java/dev/hardwood/cli/dive/ParquetModel.java
@@ -19,6 +19,7 @@ import java.util.Set;
 
 import dev.hardwood.InputFile;
 import dev.hardwood.cli.internal.Encodings;
+import dev.hardwood.internal.ExceptionContext;
 import dev.hardwood.internal.metadata.PageHeader;
 import dev.hardwood.internal.reader.ColumnIndexBuffers;
 import dev.hardwood.internal.reader.Dictionary;
@@ -190,7 +191,12 @@ public final class ParquetModel implements AutoCloseable {
         ColumnIndexBuffers buffers = indexBuffersFor(rowGroupIndex).forColumn(columnIndex);
         ColumnIndex result = null;
         if (buffers != null && buffers.columnIndex() != null) {
-            result = ColumnIndexReader.read(new ThriftCompactReader(buffers.columnIndex()));
+            try {
+                result = ColumnIndexReader.read(new ThriftCompactReader(buffers.columnIndex()));
+            }
+            catch (RuntimeException e) {
+                throw placed(e, rowGroupIndex, columnIndex);
+            }
         }
         columnIndexCache.put(key, result);
         return result;
@@ -206,7 +212,12 @@ public final class ParquetModel implements AutoCloseable {
         ColumnIndexBuffers buffers = indexBuffersFor(rowGroupIndex).forColumn(columnIndex);
         OffsetIndex result = null;
         if (buffers != null && buffers.offsetIndex() != null) {
-            result = OffsetIndexReader.read(new ThriftCompactReader(buffers.offsetIndex()));
+            try {
+                result = OffsetIndexReader.read(new ThriftCompactReader(buffers.offsetIndex()));
+            }
+            catch (RuntimeException e) {
+                throw placed(e, rowGroupIndex, columnIndex);
+            }
         }
         offsetIndexCache.put(key, result);
         return result;
@@ -272,6 +283,9 @@ public final class ParquetModel implements AutoCloseable {
         catch (IOException e) {
             throw new UncheckedIOException(e);
         }
+        catch (RuntimeException e) {
+            throw placed(e, rowGroupIndex, columnIndex);
+        }
         List<PageHeader> result = List.copyOf(headers);
         pageHeaderCache.put(key, result);
         return result;
@@ -335,6 +349,18 @@ public final class ParquetModel implements AutoCloseable {
         catch (IOException e) {
             throw new UncheckedIOException(e);
         }
+        catch (RuntimeException e) {
+            throw placed(e, rowGroupIndex, columnIndex);
+        }
+    }
+
+    /// Names the file, row group and column on a failure raised while parsing
+    /// what a screen asked for. The reader pipeline places its own failures;
+    /// these reads bypass it and go at the bytes directly, so nothing else
+    /// would say which chunk the screen was looking at.
+    private RuntimeException placed(RuntimeException e, int rowGroupIndex, int columnIndex) {
+        return ExceptionContext.addReadContext(displayPath, rowGroupIndex,
+                schema.getColumn(columnIndex).fieldPath().toString(), e);
     }
 
     public InputFile inputFile() {

--- a/cli/src/main/java/dev/hardwood/cli/dive/internal/ReadFailureOverlay.java
+++ b/cli/src/main/java/dev/hardwood/cli/dive/internal/ReadFailureOverlay.java
@@ -1,0 +1,76 @@
+/*
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Copyright The original authors
+ *
+ *  Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package dev.hardwood.cli.dive.internal;
+
+import java.io.UncheckedIOException;
+import java.util.ArrayList;
+import java.util.List;
+
+import dev.hardwood.cli.internal.Strings;
+import dev.tamboui.buffer.Buffer;
+import dev.tamboui.layout.Rect;
+import dev.tamboui.text.Line;
+import dev.tamboui.text.Span;
+
+/// What a screen shows instead of itself when the file will not give up what it
+/// was asked for.
+///
+/// The message is the reader's, which by the time it reaches here names the
+/// file, the row group, the column and the page. This adds no wording of its own
+/// beyond the hint: a sentence invented here would be a second, vaguer account
+/// of something already described precisely.
+public final class ReadFailureOverlay {
+
+    private static final int WIDTH = 60;
+
+    private ReadFailureOverlay() {
+    }
+
+    /// The text for `e`, or its simple class name when it has none so the box
+    /// is never blank.
+    ///
+    /// `new UncheckedIOException(cause)` reports the cause's `toString()` as its
+    /// own message, which would put a fully qualified class name in front of the
+    /// reader; that bare form is unwrapped. A wrapper built with a message of
+    /// its own is kept — that is the one carrying the read context.
+    public static String messageOf(Throwable e) {
+        Throwable reported = e;
+        if (e instanceof UncheckedIOException && e.getCause() != null
+                && e.getCause().toString().equals(e.getMessage())) {
+            reported = e.getCause();
+        }
+        String message = reported.getMessage();
+        return message == null || message.isBlank()
+                ? reported.getClass().getSimpleName()
+                : message;
+    }
+
+    /// Lines the overlay would show at the width the last frame wrapped to, so
+    /// the key handler and the renderer agree on how far it can scroll.
+    public static int lineCount(String message) {
+        return lines(message, Keys.modalWidth()).size();
+    }
+
+    public static void render(Buffer buffer, Rect screenArea, String message, int scroll) {
+        Rect widthProbe = ScrollPane.modalArea(screenArea, WIDTH, screenArea.height());
+        List<Line> lines = lines(message, ScrollPane.modalWidth(widthProbe));
+        Rect area = ScrollPane.modalArea(screenArea, WIDTH, lines.size() + 4);
+        ScrollPane.renderModal(buffer, area, "Read failed", lines, scroll, "[Esc] back");
+    }
+
+    private static List<Line> lines(String message, int width) {
+        List<Line> lines = new ArrayList<>();
+        // One column narrower than the box allows, so the inset matches on both
+        // sides — wrapping to the full width insets the left and lets the text
+        // touch the right border.
+        for (String chunk : Strings.wordWrap(message, Math.max(1, width - 1))) {
+            lines.add(Line.from(Span.raw(" " + chunk)));
+        }
+        return lines;
+    }
+}

--- a/cli/src/test/java/dev/hardwood/cli/dive/DiveReadFailureTest.java
+++ b/cli/src/test/java/dev/hardwood/cli/dive/DiveReadFailureTest.java
@@ -1,0 +1,201 @@
+/*
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Copyright The original authors
+ *
+ *  Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package dev.hardwood.cli.dive;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.function.ToLongFunction;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import dev.hardwood.InputFile;
+import dev.hardwood.cli.dive.internal.Keys;
+import dev.hardwood.metadata.ColumnMetaData;
+import dev.tamboui.buffer.Buffer;
+import dev.tamboui.buffer.Cell;
+import dev.tamboui.layout.Rect;
+import dev.tamboui.tui.event.KeyCode;
+import dev.tamboui.tui.event.KeyEvent;
+import dev.tamboui.tui.event.KeyModifiers;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+
+/// A file that will not give up what a screen asked for must not take the
+/// session with it.
+///
+/// Every dive screen that reads does so inside the render callback or the key
+/// handler, so an escaping exception leaves no event loop to press `Esc` in —
+/// the terminal is left showing a stack trace over whatever was on screen.
+class DiveReadFailureTest {
+
+    @TempDir
+    private Path tempDir;
+
+    private ParquetModel model;
+    private DiveApp app;
+
+    @BeforeEach
+    void resetGeometry() {
+        Keys.resetObservedGeometry();
+    }
+
+    /// Opens a copy of the fixture with `count` bytes overwritten at the offset
+    /// `region` picks out of the file's own metadata.
+    ///
+    /// Derived rather than hardcoded: an offset written into the test is right
+    /// only for the fixture it was read off, and stops being checked the moment
+    /// either changes.
+    private void damage(ToLongFunction<ParquetModel> region, int count) throws Exception {
+        Path source = Path.of(getClass().getResource("/column_index_pushdown.parquet").getPath());
+        byte[] bytes = Files.readAllBytes(source);
+
+        long at;
+        try (ParquetModel intact = ParquetModel.open(InputFile.of(source), source.toString())) {
+            at = region.applyAsLong(intact);
+        }
+        for (int i = 0; i < count; i++) {
+            bytes[(int) at + i] = (byte) 0xff;
+        }
+
+        Path damaged = tempDir.resolve("damaged.parquet");
+        Files.write(damaged, bytes);
+        model = ParquetModel.open(InputFile.of(damaged), "damaged.parquet");
+        app = new DiveApp(model);
+    }
+
+    private void damageFirstDataPageHeader() throws Exception {
+        damage(m -> m.chunk(0, 0).metaData().dataPageOffset(), 24);
+    }
+
+    @AfterEach
+    void closeModel() throws Exception {
+        model.close();
+    }
+
+    @Test
+    void aScreenThatCannotReadRendersAnOverlayInsteadOfEndingTheSession() throws Exception {
+        damageFirstDataPageHeader();
+        toPagesScreen();
+
+        assertThatCode(() -> app.renderOnce(buffer())).doesNotThrowAnyException();
+
+        String frame = frameText();
+        assertThat(frame).contains("Read failed");
+        // The reader's own message, which by now names where in the file to look.
+        assertThat(frame).contains("damaged.parquet");
+        assertThat(frame).contains("PageHeader");
+    }
+
+    /// The overlay is not a dead end: the keys still reach the screen under it,
+    /// so `Esc` leaves the way it always did.
+    @Test
+    void escapeLeavesTheFailedScreen() throws Exception {
+        damageFirstDataPageHeader();
+        toPagesScreen();
+        app.renderOnce(buffer());
+
+        DiveApp.Action back = app.dispatchKey(new KeyEvent(KeyCode.ESCAPE, KeyModifiers.NONE, '\0'));
+
+        assertThat(back).isEqualTo(DiveApp.Action.HANDLED);
+        assertThatCode(() -> app.renderOnce(buffer())).doesNotThrowAnyException();
+        assertThat(frameText()).doesNotContain("Read failed");
+    }
+
+    /// Pages is the screen that has to walk page headers, so it is the one the
+    /// damaged header stops. Pushed rather than navigated to: how a reader gets
+    /// there is the navigation tests' subject, not this one's.
+    private void toPagesScreen() {
+        app.stack().push(new ScreenState.Pages(0, 0, 0, false, true, 0));
+    }
+
+    private Buffer lastBuffer;
+
+    private Buffer buffer() {
+        lastBuffer = Buffer.empty(new Rect(0, 0, 90, 24));
+        return lastBuffer;
+    }
+
+    private String frameText() {
+        Rect area = new Rect(0, 0, 90, 24);
+        StringBuilder sb = new StringBuilder();
+        for (int y = 0; y < area.height(); y++) {
+            for (int x = 0; x < area.width(); x++) {
+                Cell c = lastBuffer.get(x, y);
+                String sym = c.symbol();
+                sb.append(sym == null || sym.isEmpty() ? " " : sym);
+            }
+            sb.append('\n');
+        }
+        return sb.toString();
+    }
+
+    /// Every region a screen reads for itself, not just the one the first
+    /// version happened to break. Which screen dies depends on which region is
+    /// damaged, so covering one proves nothing about the rest.
+    @Test
+    void aDamagedColumnIndexIsReportedRatherThanFatal() throws Exception {
+        damage(m -> m.chunk(0, 0).columnIndexOffset(), 24);
+        app.stack().push(new ScreenState.ColumnIndexView(0, 0, 0, "", false, true, false));
+
+        assertThatCode(() -> app.renderOnce(buffer())).doesNotThrowAnyException();
+        assertThat(frameText()).contains("Read failed", "damaged.parquet", "ColumnIndex");
+    }
+
+    @Test
+    void aDamagedOffsetIndexIsReportedRatherThanFatal() throws Exception {
+        damage(m -> m.chunk(0, 0).offsetIndexOffset(), 24);
+        app.stack().push(new ScreenState.OffsetIndexView(0, 0, 0));
+
+        assertThatCode(() -> app.renderOnce(buffer())).doesNotThrowAnyException();
+        assertThat(frameText()).contains("Read failed", "damaged.parquet", "OffsetIndex");
+    }
+
+    @Test
+    void aDamagedDictionaryPageIsReportedRatherThanFatal() throws Exception {
+        damage(m -> {
+            Long dict = m.chunk(0, 0).metaData().dictionaryPageOffset();
+            return dict != null && dict > 0 ? dict : m.chunk(0, 0).metaData().dataPageOffset();
+        }, 24);
+        app.stack().push(new ScreenState.DictionaryView(0, 0, 0, false, "", false, true, true));
+
+        assertThatCode(() -> app.renderOnce(buffer())).doesNotThrowAnyException();
+        assertThat(frameText()).contains("Read failed");
+    }
+
+    /// A decode failure in a page *body* rather than a header. The failure comes
+    /// out of the decoders as an array index or a state check rather than as a
+    /// parse error, which is a different set of types for the guard to hold.
+    @Test
+    void aDamagedPageBodyIsReportedRatherThanFatal() throws Exception {
+        Path source = Path.of(getClass().getResource("/column_index_pushdown_dict.parquet").getPath());
+        byte[] bytes = Files.readAllBytes(source);
+        long bodyStart;
+        try (ParquetModel intact = ParquetModel.open(InputFile.of(source), source.toString())) {
+            ColumnMetaData meta = intact.chunk(0, 1).metaData();
+            Long dict = meta.dictionaryPageOffset();
+            // Past the header, into the body it describes.
+            bodyStart = (dict != null && dict > 0 ? dict : meta.dataPageOffset()) + 40;
+        }
+        for (int i = 0; i < 24; i++) {
+            bytes[(int) bodyStart + i] = (byte) 0xff;
+        }
+        Path damaged = tempDir.resolve("body.parquet");
+        Files.write(damaged, bytes);
+
+        model = ParquetModel.open(InputFile.of(damaged), "body.parquet");
+        app = new DiveApp(model);
+        app.stack().push(new ScreenState.DictionaryView(0, 1, 0, false, "", false, true, true));
+
+        assertThatCode(() -> app.renderOnce(buffer())).doesNotThrowAnyException();
+        assertThat(frameText()).contains("Read failed");
+    }
+}

--- a/docs/content/reference/cli.md
+++ b/docs/content/reference/cli.md
@@ -326,6 +326,25 @@ Available screens:
 - **Dictionary** — full-value modal on Enter and `/` inline search
 - **Data preview** — row values via `RowReader`; `←/→` scrolls the visible column window, `PgDn/PgUp` flips pages
 
+### When a file will not read
+
+Any screen that reads from the file shows a **Read failed** overlay in place of
+itself when the read does not come back. The session stays up: `Esc` leaves the
+screen, and the keys that move between pages, chunks or rows still work, so a
+damaged region can be stepped over rather than backed out of.
+
+The overlay carries the reader's own message, which names the file, the row
+group and the column the screen was reading:
+
+```
+╭ Read failed ─────────────────────────────────────────────╮
+│ [data.parquet: row group 0, column 'id'] PageHeader      │
+│ field 15 — Unknown field type: 15                        │
+│                                                          │
+│ [Esc] back                                               │
+╰──────────────────────────────────────────────────────────╯
+```
+
 A tour through the main screens (click any shot to open it full size):
 
 <figure markdown="span">[![Overview screen](../assets/cli/01-landing-overview.svg){ width="720" }](../assets/cli/01-landing-overview.svg)<figcaption>Overview</figcaption></figure>


### PR DESCRIPTION
Closes #1092. Supersedes #342 and its PR #1078, and replaces #1098, which was stacked on the abandoned #1097 and could not be retargeted.

Every `hardwood dive` screen that reads from the file did so inside the render callback or the key handler, and neither was guarded. An unreadable region anywhere ended the session: the exception escaped, TamboUI painted its crash screen over a buffer it does not clear — so the stack trace interleaved with the previous screen's labels — and `Esc` exited the process, because there was no longer a loop to press it in. Which screen died depended only on which region was damaged.

```
╭ Read failed ─────────────────────────────────────────────╮
│ [damaged.parquet: row group 0, column 'id'] PageHeader   │
│ field 15 — Unknown field type: 15                        │
│                                                          │
│ [Esc] back                                               │
╰──────────────────────────────────────────────────────────╯
```

## Why it is in `DiveApp` and not in the screens

Six screens reach the file from a render or keybar path — `PagesScreen`, `ColumnIndexScreen`, `OffsetIndexScreen`, `ColumnAcrossRowGroupsScreen`, `DictionaryScreen`, `DataPreviewScreen`. A per-screen error state solves one and leaves the shape of the bug in the other five, and every screen added later has to remember to opt in. **No screen changes in this PR.** `ScreenState` stays a description of what a screen is showing, and the handlers stay pure functions of `(event, model, stack)`.

Keys still reach the screen underneath a failure, which is what lets a reader move off a damaged region rather than only back out of it: the stack holds the last state that rendered, so paging from it loads a different window.

`Esc` is the exception, and a test found it. A screen normally gets first refusal on `Esc` so it can claim it for something of its own, but a screen that cannot read cannot honour that — and its handler reads too, so the one key out of the overlay was failing on its way to the door.

## The message

The overlay adds no wording of its own. #1093 has shipped, so the reader's message already names the file, the row group, the column and the page, and a sentence invented here would be a second, vaguer account of something already described precisely.

Dive is not the only place that parses the file directly. `ParquetModel` reads the page index, the page-header walk and the dictionary page outside the read pipeline, and so does `InspectPagesCommand` — so nothing was placing those failures, and `hardwood inspect pages` on a clobbered header reported a bare `PageHeader field 15 — Unknown field type: 15`. Both now place their own, which is what puts the prefix into the box above and into the command's output.

## What changed against #1098

That PR was 2,660 additions across 55 files; this is 528 across 8, all in `cli` plus docs. The difference is the byte offset. #1098 carried one on the exception so the overlay could show a hex window at it, and that needed `ContextualUncheckedIOException`, a `ReadContext` through `ExceptionContext`, per-Thrift-reader byte accounting and a `HexDump`. #1093 shipped without a byte offset — it is known only deep inside a parse, with no boundary to hand it to — so there is nothing to centre a window on, and the whole hex apparatus goes with it. What remains is the part that was the bug: the session no longer dies.

## Tests

`DiveReadFailureTest` covers a damaged page header, column index, offset index, dictionary page header and dictionary page *body*, each deriving its offset from the file's own metadata rather than hardcoding one that stops being checked the moment the fixture changes. The body case matters separately: it fails out of the decoders as an array index or a state check rather than as a parse error, which is a different set of types for the guard to hold.

`./mvnw verify` green, including the parquet-testing corpus.

## Not closed by this

- #1094 (a mid-read failure in the non-interactive commands) is narrower than when it was filed — every command in its table now catches `ParquetReadException` and reports cleanly, and the `inspect pages` message gap is fixed here. What is left is `UncheckedIOException`, which only ten of the eleven commands still miss, and the open question of what `convert` should do with output it has already written.
- #1095 (corrupt page data accepted silently) is untouched. No overlay can show what was never detected.

Design: [_designs/DIVE_READ_FAILURE_HANDLING.md](_designs/DIVE_READ_FAILURE_HANDLING.md)
