### PR TITLE
#1092 Hold a read failure whatever type it arrives as

### DIFF
--- a/_designs/DIVE_READ_FAILURE_HANDLING.md
+++ b/_designs/DIVE_READ_FAILURE_HANDLING.md
@@ -33,6 +33,16 @@ into it.
 
 - **Key dispatch** is guarded. A read failure while handling a key records the
   failure; the navigation stack is left as it was.
+- **The guard catches `RuntimeException`**, not a list of types. Which one a
+  damaged file raises is decided by the decoder that trips over it — a
+  dictionary index past its dictionary is an `ArrayIndexOutOfBoundsException`,
+  an impossible RLE run header an `IllegalStateException`, a length that will
+  not fit an `ArithmeticException` — and the four regions below are parsed
+  outside the read pipeline, so nothing narrows that set to
+  `ParquetReadException` on the way here. An enumeration would have to be
+  revisited every time a decoder learns a new way to fail, and the promise this
+  guard exists to make is that no file ends the session. The price is that a
+  defect of ours in a render path is reported as a read failure.
 - **Render** is guarded, around both `keybarForActive()` and `renderBody()`. A
   failure records itself and paints the overlay in the same frame, over a body
   cleared first: a half-drawn screen under the overlay is what makes a reported
@@ -44,7 +54,13 @@ into it.
   key that fails again replaces the failure with the new one.
 - **`Esc` is taken from the screen** while a failure shows. A screen normally
   gets first refusal on it so it can claim it for something of its own, but a
-  screen that cannot read cannot honour that, and its handler reads too.
+  screen that cannot read cannot honour that, and its handler reads too. At the
+  root there is nothing to pop and `Esc` dismisses the failure alone; `o`, which
+  collapses to the root, clears it on the way. Neither leaves an overlay
+  standing over a screen that reads.
+- **The overlay scrolls before the screen moves.** While there is more message
+  than box the navigation keys address the overlay, and reach the screen again
+  once it is at its end.
 - **The overlay** is a `ScrollPane` modal, per the navigation model: the
   navigation keys scroll it while there is more message than box.
 
@@ -58,6 +74,12 @@ The four regions a dive screen parses for itself (column index, offset index,
 page headers, dictionary page) bypass the read pipeline and go at the bytes
 directly, so `ParquetModel` places those failures itself. The Thrift structure
 that would not parse names itself in the message the reader raises.
+
+Placing a failure restates it, and restating it must not change what it is. A
+`ParquetReadException` leaves `ExceptionContext` as one, through the subclass's
+own `(String, Throwable)` constructor where there is one and through the base
+type where there is not — otherwise the callers that catch that type to report a
+broken file cleanly, `hardwood inspect pages` among them, stop seeing it.
 
 ## What it does not do
 
@@ -76,8 +98,13 @@ How the non-interactive commands report a failure is #1094.
 ## Validation
 
 `DiveReadFailureTest` clobbers a page header, a column index, an offset index, a
-dictionary page header and a dictionary page *body* in turn, each at an offset
-derived from the file's own metadata, and drives the screen that reads it:
-the session survives, the overlay names the file and the structure, and `Esc`
-leaves. Which screen a damaged file takes down depends on which region is
+dictionary page header, a dictionary page *body* and a row of data in turn, each
+at an offset derived from the file's own metadata, and drives the screen that
+reads it: the session survives, the overlay names the file and the structure, and
+`Esc` leaves. Which screen a damaged file takes down depends on which region is
 damaged, so one region proves nothing about the rest.
+
+Truncation is covered separately from malformation. Overwriting bytes in place
+tends to raise `ParquetReadException`; a field declaring more bytes than its
+buffer holds raises `ThriftTruncatedException`, which is the shape that tells
+whether restating a failure has kept its type.

--- a/cli/src/main/java/dev/hardwood/cli/command/InspectPagesCommand.java
+++ b/cli/src/main/java/dev/hardwood/cli/command/InspectPagesCommand.java
@@ -443,7 +443,7 @@ public class InspectPagesCommand implements Command<CommandInvocation> {
         long chunkStart = (dictOffset != null && dictOffset > 0) ? dictOffset : cmd.dataPageOffset();
         long chunkSize = cmd.totalCompressedSize();
 
-        ByteBuffer buffer = inputFile.readRange(chunkStart, (int) chunkSize);
+        ByteBuffer buffer = inputFile.readRange(chunkStart, Math.toIntExact(chunkSize));
 
         List<PageInfo> rows = new ArrayList<>();
         int pageIndex = 0;

--- a/cli/src/main/java/dev/hardwood/cli/dive/DiveApp.java
+++ b/cli/src/main/java/dev/hardwood/cli/dive/DiveApp.java
@@ -7,7 +7,6 @@
  */
 package dev.hardwood.cli.dive;
 
-import java.io.UncheckedIOException;
 import java.time.Duration;
 
 import dev.hardwood.cli.dive.internal.Chrome;
@@ -31,7 +30,6 @@ import dev.hardwood.cli.dive.internal.RowGroupsScreen;
 import dev.hardwood.cli.dive.internal.SchemaScreen;
 import dev.hardwood.cli.dive.internal.ScrollPane;
 import dev.hardwood.cli.dive.internal.Theme;
-import dev.hardwood.reader.ParquetReadException;
 import dev.tamboui.buffer.Buffer;
 import dev.tamboui.layout.Rect;
 import dev.tamboui.terminal.Frame;
@@ -140,6 +138,7 @@ public final class DiveApp {
             return Action.IGNORED;
         }
         if (!textInput && ke.code() == KeyCode.CHAR && ke.character() == 'o' && !ke.hasCtrl() && !ke.hasAlt()) {
+            clearReadFailure();
             stack.clearToRoot();
             return Action.HANDLED;
         }
@@ -158,9 +157,15 @@ public final class DiveApp {
         // something of its own, but one that cannot read cannot honour that,
         // and its handler reads too — leaving Esc to it means the only key out
         // of the overlay fails on its way to the door.
-        if (readFailure != null && ke.isCancel() && stack.depth() > 1) {
+        //
+        // At the root there is nothing to pop, and Esc still has to dismiss the
+        // overlay: a failure carried up to Overview by another key outlives the
+        // screen it came from, and Overview reads nothing that could clear it.
+        if (readFailure != null && ke.isCancel()) {
             clearReadFailure();
-            stack.pop();
+            if (stack.depth() > 1) {
+                stack.pop();
+            }
             return Action.HANDLED;
         }
         // Screen gets first crack at the event so it can claim keys like Esc (filter-cancel)
@@ -171,19 +176,24 @@ public final class DiveApp {
         // it: the stack holds the last state that rendered, so paging from it
         // loads a different window, and a key that fails again simply replaces
         // one failure with the next.
-        // IndexOutOfBounds is in the list because a corrupt file produces it:
-        // a dictionary reference past the end of its dictionary is an array
-        // index, and reading a damaged page is how you get one. A programming
-        // error can raise it too, and that is the cost of not ending the
-        // session over a file that is merely broken.
+        //
+        // The guard takes RuntimeException whole rather than a list of types.
+        // What a damaged file raises is decided by the decoder that trips over
+        // it — a dictionary index past its dictionary is an ArrayIndexOutOfBounds,
+        // an impossible RLE run header an IllegalStateException, a length that
+        // will not fit an ArithmeticException — and these screens parse outside
+        // the read pipeline, so nothing narrows that set to ParquetReadException
+        // first. A list has to be revisited every time a decoder learns a new
+        // way to fail, and the one thing this guard exists to promise is that
+        // no file ends the session. A programming error is reported as a read
+        // failure instead of a stack trace, which is the price.
         try {
             if (dispatchToScreen(ke)) {
                 clearReadFailure();
                 return Action.HANDLED;
             }
         }
-        catch (UncheckedIOException | ParquetReadException | IllegalStateException
-                | IllegalArgumentException | IndexOutOfBoundsException e) {
+        catch (RuntimeException e) {
             recordReadFailure(e);
             return Action.HANDLED;
         }
@@ -255,8 +265,7 @@ public final class DiveApp {
         try {
             screenKeys = keybarForActive();
         }
-        catch (UncheckedIOException | ParquetReadException | IllegalStateException
-                | IllegalArgumentException | IndexOutOfBoundsException e) {
+        catch (RuntimeException e) {
             // The keybar reads from the file too — a screen that reports how
             // many pages a chunk has had to go and count them.
             recordReadFailure(e);
@@ -276,8 +285,7 @@ public final class DiveApp {
                 DataPreviewScreen.fitToViewport(model, stack, regions.body());
                 renderBody(buffer, regions.body());
             }
-            catch (UncheckedIOException | ParquetReadException | IllegalStateException
-                    | IllegalArgumentException | IndexOutOfBoundsException e) {
+            catch (RuntimeException e) {
                 recordReadFailure(e);
             }
         }

--- a/cli/src/test/java/dev/hardwood/cli/dive/DiveReadFailureTest.java
+++ b/cli/src/test/java/dev/hardwood/cli/dive/DiveReadFailureTest.java
@@ -150,6 +150,78 @@ class DiveReadFailureTest {
         assertThat(frameText()).contains("Read failed", "damaged.parquet", "ColumnIndex");
     }
 
+    /// The screen that reads a column's offset index once per row group, so the
+    /// failure comes out of a loop rather than out of a single read.
+    @Test
+    void aDamagedOffsetIndexAcrossRowGroupsIsReportedRatherThanFatal() throws Exception {
+        damage(m -> m.chunk(0, 0).offsetIndexOffset(), 24);
+        app.stack().push(new ScreenState.ColumnAcrossRowGroups(0, 0, false));
+
+        assertThatCode(() -> app.renderOnce(buffer())).doesNotThrowAnyException();
+        assertThat(frameText()).contains("Read failed", "damaged.parquet");
+    }
+
+    /// Data preview reads through the row pipeline rather than at the bytes, and
+    /// it is entered by a key rather than by a render — so this is the guard on
+    /// the dispatch side, on the one screen whose page is fitted inside the
+    /// render guard as well.
+    @Test
+    void aDamagedDataPageIsReportedRatherThanFatalOnDataPreview() throws Exception {
+        damageFirstDataPageHeader();
+        app.renderOnce(buffer());
+        for (int i = 0; i < MENU_ROWS_TO_DATA_PREVIEW; i++) {
+            app.dispatchKey(new KeyEvent(KeyCode.DOWN, KeyModifiers.NONE, '\0'));
+        }
+
+        DiveApp.Action enter = app.dispatchKey(new KeyEvent(KeyCode.ENTER, KeyModifiers.NONE, '\0'));
+
+        assertThat(enter).isEqualTo(DiveApp.Action.HANDLED);
+        assertThatCode(() -> app.renderOnce(buffer())).doesNotThrowAnyException();
+        assertThat(frameText()).contains("Read failed", "damaged.parquet");
+    }
+
+    /// `o` collapses to Overview, which reads nothing that could fail — so it
+    /// has to take the failure with it. Left behind, it paints an error box over
+    /// a screen that reads, and `Esc` at the root has no frame to pop.
+    @Test
+    void collapsingToTheRootLeavesNoFailureBehind() throws Exception {
+        damageFirstDataPageHeader();
+        toPagesScreen();
+        app.renderOnce(buffer());
+        assertThat(frameText()).contains("Read failed");
+
+        app.dispatchKey(new KeyEvent(KeyCode.CHAR, KeyModifiers.NONE, 'o'));
+
+        app.renderOnce(buffer());
+        assertThat(frameText()).doesNotContain("Read failed");
+    }
+
+    /// A failure the root screen is left holding still has to be dismissable.
+    /// Esc dismisses the overlay with no frame to pop.
+    @Test
+    void escapeDismissesAFailureAtTheRoot() throws Exception {
+        damageFirstDataPageHeader();
+        toPagesScreen();
+        app.renderOnce(buffer());
+        app.dispatchKey(new KeyEvent(KeyCode.ESCAPE, KeyModifiers.NONE, '\0'));
+        assertThat(app.stack().depth()).isEqualTo(1);
+
+        // Put the root back into a failure the way a carried-over one would look.
+        app.stack().push(new ScreenState.Pages(0, 0, 0, false, true, 0));
+        app.renderOnce(buffer());
+        app.stack().pop();
+        assertThat(frameText()).contains("Read failed");
+
+        DiveApp.Action esc = app.dispatchKey(new KeyEvent(KeyCode.ESCAPE, KeyModifiers.NONE, '\0'));
+
+        assertThat(esc).isEqualTo(DiveApp.Action.HANDLED);
+        app.renderOnce(buffer());
+        assertThat(frameText()).doesNotContain("Read failed");
+    }
+
+    /// Overview's menu cursor starts on the first entry; Data preview is the last.
+    private static final int MENU_ROWS_TO_DATA_PREVIEW = 3;
+
     @Test
     void aDamagedOffsetIndexIsReportedRatherThanFatal() throws Exception {
         damage(m -> m.chunk(0, 0).offsetIndexOffset(), 24);

--- a/core/src/main/java/dev/hardwood/internal/ExceptionContext.java
+++ b/core/src/main/java/dev/hardwood/internal/ExceptionContext.java
@@ -214,6 +214,14 @@ public final class ExceptionContext {
         catch (ReflectiveOperationException ignored) {
             // Type cannot be preserved
         }
+        // A ParquetReadException subclass without that constructor still has to leave as
+        // one. What callers catch is the base type, so degrading it to RuntimeException
+        // silently takes the failure out of every `catch (ParquetReadException)` between
+        // here and the top — the file is still what is wrong, and it stops being reported
+        // that way.
+        if (e instanceof ParquetReadException) {
+            return new ParquetReadException(newMessage, e);
+        }
         return new RuntimeException(newMessage, e);
     }
 

--- a/core/src/main/java/dev/hardwood/internal/thrift/ThriftTruncatedException.java
+++ b/core/src/main/java/dev/hardwood/internal/thrift/ThriftTruncatedException.java
@@ -34,4 +34,15 @@ public class ThriftTruncatedException extends ParquetReadException {
     public ThriftTruncatedException(String message) {
         super(message);
     }
+
+    /// The same, keeping `cause`.
+    ///
+    /// Needed by [dev.hardwood.internal.ExceptionContext#addReadContext], which restates a
+    /// failure with the file and chunk in front of its message and reconstructs it through
+    /// this constructor. Without one the type it hands back is a plain [RuntimeException],
+    /// and a caller that catches [ParquetReadException] to report a broken file cleanly
+    /// stops seeing it.
+    public ThriftTruncatedException(String message, Throwable cause) {
+        super(message, cause);
+    }
 }

--- a/core/src/test/java/dev/hardwood/internal/ExceptionContextTest.java
+++ b/core/src/test/java/dev/hardwood/internal/ExceptionContextTest.java
@@ -9,6 +9,9 @@ package dev.hardwood.internal;
 
 import org.junit.jupiter.api.Test;
 
+import dev.hardwood.internal.thrift.ThriftTruncatedException;
+import dev.hardwood.reader.ParquetReadException;
+
 import static org.assertj.core.api.Assertions.assertThat;
 
 /// Unit tests for [ExceptionContext].
@@ -145,9 +148,46 @@ class ExceptionContextTest {
         assertThat(wrapped.getCause()).isSameAs(original);
     }
 
+    /// A truncation carries the file's name like any other failure and stays a
+    /// [ThriftTruncatedException] doing it. The page-header peek widens its guess on
+    /// this type and gives up on any other, so a restated one that came back as
+    /// something else would turn a header with long statistics into a read error.
+    @Test
+    void preservesThriftTruncatedException() {
+        RuntimeException original = new ThriftTruncatedException("Unexpected EOF while reading varint");
+        RuntimeException wrapped = ExceptionContext.addReadContext("f.parquet", 0, "id", original);
+
+        assertThat(wrapped).isInstanceOf(ThriftTruncatedException.class);
+        assertThat(wrapped.getMessage())
+                .isEqualTo("[f.parquet: row group 0, column 'id'] Unexpected EOF while reading varint");
+        assertThat(wrapped.getCause()).isSameAs(original);
+    }
+
+    /// What callers catch is the base type. A subclass that cannot be reconstructed still
+    /// has to leave as a [ParquetReadException], or restating it takes the failure out of
+    /// every `catch (ParquetReadException)` above and the file stops being reported as
+    /// what is wrong.
+    @Test
+    void keepsAnUnreconstructableReadFailureAReadFailure() {
+        RuntimeException original = new UnreconstructableReadException();
+        RuntimeException wrapped = ExceptionContext.addFileContext("f.parquet", original);
+
+        assertThat(wrapped).isInstanceOf(ParquetReadException.class);
+        assertThat(wrapped.getMessage()).isEqualTo("[f.parquet] cannot be rebuilt");
+        assertThat(wrapped.getCause()).isSameAs(original);
+    }
+
     private static class CustomException extends RuntimeException {
         CustomException() {
             super("custom error");
+        }
+    }
+
+    private static class UnreconstructableReadException extends ParquetReadException {
+        private static final long serialVersionUID = 1L;
+
+        UnreconstructableReadException() {
+            super("cannot be rebuilt");
         }
     }
 }

--- a/docs/content/reference/cli.md
+++ b/docs/content/reference/cli.md
@@ -333,6 +333,11 @@ itself when the read does not come back. The session stays up: `Esc` leaves the
 screen, and the keys that move between pages, chunks or rows still work, so a
 damaged region can be stepped over rather than backed out of.
 
+A message longer than the box scrolls first: while there is more of it below,
+`↑/↓`, `PgUp/PgDn` and `g/G` move the message rather than the screen under it,
+and reach the screen again once it is at its end. The hint row along the bottom
+of the box says which of them are doing that.
+
 The overlay carries the reader's own message, which names the file, the row
 group and the column the screen was reading:
 


### PR DESCRIPTION
Follow-up to #1092, from a review of #1162 that landed after it merged. Two defects in the guard that PR added, plus the doc claim they contradict.

## A restated failure stopped being a read failure

`ExceptionContext.addReadContext` rebuilds an exception through its `(String, Throwable)` constructor and falls back to a plain `RuntimeException` when there is none. `ThriftTruncatedException` has only a `(String)` one, so the moment `ParquetModel` and `InspectPagesCommand` started placing their own failures, a truncation came back as something no caller was watching for:

```
ThriftTruncatedException  ->  java.lang.RuntimeException
ParquetReadException      ->  dev.hardwood.reader.ParquetReadException
```

That is a gap in dive — a truncated column index, offset index, page header or dictionary page still ended the session, which is the bug #1092 exists to fix — and a regression in `hardwood inspect pages`, which caught `IOException | ParquetReadException` and printed a clean line before, and printed a stack trace after. `ThriftCompactReader` raises the type from eight sites, and neither `ParquetModel.pageHeaders` nor `InspectPagesCommand.walkPageHeaders` has the peek-and-retry that converts it in the read pipeline, so it reaches the placing code raw.

`ThriftTruncatedException` gains the constructor. The fallback also keeps a `ParquetReadException` subclass a `ParquetReadException` when it cannot be reconstructed at all — what callers catch is the base type, and the next subclass should not have to rediscover this.

## The guard caught five named types

Which exception a damaged file raises is decided by the decoder that trips over it. `ColumnWorker`'s own JavaDoc names three — `ArrayIndexOutOfBoundsException` from a dictionary index past its dictionary, `IllegalStateException` from an impossible RLE run header, `ArithmeticException` from a length that will not fit — `DeltaBinaryPackedDecoder` and `ThriftCompactReader` name `NegativeArraySizeException`, and only the first of those survives placement with a type the list held. These four regions are parsed outside the read pipeline, so nothing narrows the set to `ParquetReadException` before the guard sees it.

The guard now takes `RuntimeException`. The list would have to be revisited every time a decoder learns a new way to fail, and the one thing this guard exists to promise is that no file ends the session. A defect of ours in a render path is reported as a read failure instead of a stack trace, which is the price — the same one #1162 already accepted for `IllegalStateException`.

## Two keys outlived their screen

`o` collapses to Overview without clearing the failure, so the overlay stayed painted over a screen that reads perfectly well. `Esc` could not dismiss it there either: both back-navigation arms want a frame to pop, and `OverviewScreen` ignores `Esc` itself. A reader who pressed `o` on a damaged region was left with an error box and no key but `q`. Both new tests fail on the merged code.

## Docs

`docs/content/reference/cli.md` said the keys that move between pages, chunks and rows still work under a failure. They do until the message is longer than its box, at which point `dispatchKey` gives the navigation keys to the overlay's `ScrollPane` first and only lets them through once the offset stops changing. Documented as it behaves.

## Also

`inspect pages` narrowed a column chunk's `total_compressed_size` with a cast, which turns a corrupt length into a wrong read rather than a raised one.

## Tests

`ExceptionContextTest` gains the two type-preservation cases; `DiveReadFailureTest` gains `ColumnAcrossRowGroups` and `DataPreview` — the two of the six screens the design doc names that had no case, the second entered by a key so the dispatch-side guard is covered too — and the two navigation cases above.

`./mvnw verify` green, integration tests included.
