### PR TITLE
#1170 Release a read's iterator when the reader consuming it closes

### DIFF
--- a/core/src/main/java/dev/hardwood/internal/reader/FlatRowReader.java
+++ b/core/src/main/java/dev/hardwood/internal/reader/FlatRowReader.java
@@ -133,10 +133,17 @@ public final class FlatRowReader implements FileAwareRowReader {
     /// filter and nothing evaluates records.
     private final RecordFilterTally tally;
 
+    /// The iterator this reader consumes. No column reader owns it — they all
+    /// draw from the one iterator — so this reader releases it, which is also
+    /// what stops the owning [dev.hardwood.reader.ParquetFileReader] tracking it.
+    private final RowGroupIterator rowGroupIterator;
+
     private FlatRowReader(BatchExchange<BatchExchange.Batch>[] exchanges, FlatColumnWorker[] columnWorkers,
                          FileSchema fileSchema, ProjectedSchema projectedSchema,
                          BatchMatchMerger matchMerger, long maxMatchedRows,
-                         RowMatcher recordMatcher, RecordFilterTally tally) {
+                         RowMatcher recordMatcher, RecordFilterTally tally,
+                         RowGroupIterator rowGroupIterator) {
+        this.rowGroupIterator = rowGroupIterator;
         this.maxMatchedRows = maxMatchedRows;
         this.recordMatcher = recordMatcher;
         this.tally = tally;
@@ -296,7 +303,7 @@ public final class FlatRowReader implements FileAwareRowReader {
         // boundaries as it loads batches.
         RecordFilterTally tally = filter != null ? new RecordFilterTally() : null;
         FlatRowReader reader = new FlatRowReader(buffers, workers, schema, projectedSchema,
-                matchMerger, readerMatchLimit, recordMatcher, tally);
+                matchMerger, readerMatchLimit, recordMatcher, tally, rowGroupIterator);
         reader.initialize();
         return reader;
     }
@@ -941,20 +948,26 @@ public final class FlatRowReader implements FileAwareRowReader {
             return;
         }
         closed = true;
-        if (tally != null) {
-            tally.close();
-        }
-        if (columnWorkers != null) {
-            for (FlatColumnWorker worker : columnWorkers) {
-                worker.close();
+        // The iterator is released even when tearing the pipeline down fails: this
+        // reader will not run its close body again, so skipping the release would
+        // leave the work list reachable for the parent reader's whole lifetime. A
+        // failure to release is suppressed beneath the original.
+        try (rowGroupIterator) {
+            if (tally != null) {
+                tally.close();
             }
-        }
-        for (int i = 0; i < columnCount; i++) {
-            if (previousBatches[i] != null) {
-                exchanges[i].recycle(previousBatches[i]);
-                previousBatches[i] = null;
+            if (columnWorkers != null) {
+                for (FlatColumnWorker worker : columnWorkers) {
+                    worker.close();
+                }
             }
-            exchanges[i].drainReady();
+            for (int i = 0; i < columnCount; i++) {
+                if (previousBatches[i] != null) {
+                    exchanges[i].recycle(previousBatches[i]);
+                    previousBatches[i] = null;
+                }
+                exchanges[i].drainReady();
+            }
         }
     }
 

--- a/core/src/main/java/dev/hardwood/internal/reader/NestedRowReader.java
+++ b/core/src/main/java/dev/hardwood/internal/reader/NestedRowReader.java
@@ -54,6 +54,11 @@ public final class NestedRowReader implements FileAwareRowReader {
     /// filter and nothing evaluates records.
     private final RecordFilterTally tally;
 
+    /// The iterator this reader consumes. No column reader owns it — they all
+    /// draw from the one iterator — so this reader releases it, which is also
+    /// what stops the owning [dev.hardwood.reader.ParquetFileReader] tracking it.
+    private final RowGroupIterator rowGroupIterator;
+
     // Iteration state
     private NestedBatch[] previousBatches;
     /// File name from the current batch — used for exception enrichment
@@ -84,7 +89,9 @@ public final class NestedRowReader implements FileAwareRowReader {
 
     NestedRowReader(BatchExchange<NestedBatch>[] exchanges, NestedColumnWorker[] columnWorkers,
                     FileSchema fileSchema, ProjectedSchema projectedSchema,
-                    long maxMatchedRows, RowMatcher recordMatcher, RecordFilterTally tally) {
+                    long maxMatchedRows, RowMatcher recordMatcher, RecordFilterTally tally,
+                    RowGroupIterator rowGroupIterator) {
+        this.rowGroupIterator = rowGroupIterator;
         this.maxMatchedRows = maxMatchedRows;
         this.recordMatcher = recordMatcher;
         this.tally = tally;
@@ -191,7 +198,7 @@ public final class NestedRowReader implements FileAwareRowReader {
         }
         long readerMatchLimit = filter != null ? maxRows : ColumnWorker.UNLIMITED;
         NestedRowReader reader = new NestedRowReader(buffers, workers, schema, projectedSchema,
-                readerMatchLimit, recordMatcher, tally);
+                readerMatchLimit, recordMatcher, tally, rowGroupIterator);
         reader.initialize();
         return reader;
     }
@@ -456,20 +463,26 @@ public final class NestedRowReader implements FileAwareRowReader {
             return;
         }
         closed = true;
-        if (tally != null) {
-            tally.close();
-        }
-        if (columnWorkers != null) {
-            for (NestedColumnWorker worker : columnWorkers) {
-                worker.close();
+        // The iterator is released even when tearing the pipeline down fails: this
+        // reader will not run its close body again, so skipping the release would
+        // leave the work list reachable for the parent reader's whole lifetime. A
+        // failure to release is suppressed beneath the original.
+        try (rowGroupIterator) {
+            if (tally != null) {
+                tally.close();
             }
-        }
-        for (int i = 0; i < columnCount; i++) {
-            if (previousBatches[i] != null) {
-                exchanges[i].recycle(previousBatches[i]);
-                previousBatches[i] = null;
+            if (columnWorkers != null) {
+                for (NestedColumnWorker worker : columnWorkers) {
+                    worker.close();
+                }
             }
-            exchanges[i].drainReady();
+            for (int i = 0; i < columnCount; i++) {
+                if (previousBatches[i] != null) {
+                    exchanges[i].recycle(previousBatches[i]);
+                    previousBatches[i] = null;
+                }
+                exchanges[i].drainReady();
+            }
         }
     }
 

--- a/core/src/main/java/dev/hardwood/internal/reader/RowGroupIterator.java
+++ b/core/src/main/java/dev/hardwood/internal/reader/RowGroupIterator.java
@@ -7,6 +7,7 @@
  */
 package dev.hardwood.internal.reader;
 
+import java.io.Closeable;
 import java.io.IOException;
 import java.io.UncheckedIOException;
 import java.util.ArrayList;
@@ -61,7 +62,7 @@ import dev.hardwood.schema.FileSchema;
 /// Each [PageSource] maintains its own cursor into the work list exposed by
 /// this iterator. Shared per-row-group metadata (index buffers, matching rows)
 /// is cached for the current file and reused across columns.
-public class RowGroupIterator {
+public class RowGroupIterator implements Closeable {
 
     private static final System.Logger LOG = System.getLogger(RowGroupIterator.class.getName());
 
@@ -83,6 +84,13 @@ public class RowGroupIterator {
     private final FileMetadataCache fileMetadataCache;
     private final boolean ownsFileMetadataCache;
     private final Consumer<RowGroupIterator> closeListener;
+
+    /// Several owners can reach [#close()]: the group that consumes this iterator,
+    /// the `FilterCoordinator` that tears that group down on the filtered path, and
+    /// every reader of a no-rows group, which has neither. A read handed a single
+    /// reader out of a group it never sees reaches the iterator only through the
+    /// last two. Closing twice releases nothing twice.
+    private boolean closed;
     private final HardwoodContextImpl context;
     private final long maxRows;
     private final long physicalSkip;
@@ -1099,7 +1107,12 @@ public class RowGroupIterator {
     /// ParquetFileReader leave those shared resources to the parent and instead
     /// tell it to stop tracking this iterator, so a closed child reader's work
     /// list does not stay reachable for the parent's whole lifetime.
+    @Override
     public void close() throws IOException {
+        if (closed) {
+            return;
+        }
+        closed = true;
         metadataCache.clear();
         fetchPlanCache.clear();
 

--- a/core/src/main/java/dev/hardwood/reader/ColumnReader.java
+++ b/core/src/main/java/dev/hardwood/reader/ColumnReader.java
@@ -138,13 +138,21 @@ public class ColumnReader implements Closeable {
     /// A reader that yields no batches, for when row-group pruning has dropped
     /// every row group so nothing can match. Allocates no batch buffer and
     /// starts no worker thread — [#nextBatch()] reports exhausted immediately.
-    static ColumnReader exhausted(FileSchema schema, ColumnSchema column) {
+    ///
+    /// Every reader of such a group holds `rowGroupIterator`, because a no-rows
+    /// group has no [FilterCoordinator] and no per-column state, so each reader is
+    /// independent and closing any one of them must release the iterator: the
+    /// filtered single-column entry point is handed one reader out of the group and
+    /// never sees the group itself. [RowGroupIterator#close()] is idempotent, so the
+    /// group and its readers releasing the same iterator releases it once.
+    static ColumnReader exhausted(FileSchema schema, ColumnSchema column,
+                                  RowGroupIterator rowGroupIterator) {
         NestedLevelComputer.Layers layers = NestedLevelComputer.computeLayers(
                 schema.getRootNode(), column.columnIndex());
         boolean nested = layers.count() > 0 || column.maxRepetitionLevel() > 0;
         ColumnReader reader = nested
-                ? forNested(column, layers, null, null, null)
-                : forFlat(column, null, null, null);
+                ? forNested(column, layers, null, null, rowGroupIterator)
+                : forFlat(column, null, null, rowGroupIterator);
         reader.exhausted = true;
         return reader;
     }

--- a/core/src/main/java/dev/hardwood/reader/ColumnReaders.java
+++ b/core/src/main/java/dev/hardwood/reader/ColumnReaders.java
@@ -54,6 +54,11 @@ public class ColumnReaders implements Closeable {
     /// lockstep and compacts each to the matching records per batch. `null` on
     /// the plain projection path.
     private final FilterCoordinator coordinator;
+    /// The iterator every column in this group decodes through. No individual
+    /// column reader owns it, so this group releases it, which is also what stops
+    /// the owning [ParquetFileReader] tracking it. Never `null`: every group is
+    /// built around an iterator, [#noRows] included.
+    private final RowGroupIterator rowGroupIterator;
     private int recordCount;
     private boolean batchAvailable;
 
@@ -67,6 +72,7 @@ public class ColumnReaders implements Closeable {
         this.readersByName = new LinkedHashMap<>(projectedColumnCount);
         this.readersByIndex = new ColumnReader[projectedColumnCount];
         this.coordinator = null;
+        this.rowGroupIterator = rowGroupIterator;
 
         for (int i = 0; i < projectedColumnCount; i++) {
             int originalIndex = projectedSchema.toOriginalIndex(i);
@@ -83,10 +89,12 @@ public class ColumnReaders implements Closeable {
 
     private ColumnReaders(Map<String, ColumnReader> readersByName,
                           ColumnReader[] readersByIndex,
-                          FilterCoordinator coordinator) {
+                          FilterCoordinator coordinator,
+                          RowGroupIterator rowGroupIterator) {
         this.readersByName = readersByName;
         this.readersByIndex = readersByIndex;
         this.coordinator = coordinator;
+        this.rowGroupIterator = rowGroupIterator;
     }
 
     /// Builds a filtered [ColumnReaders] that returns only the records matching
@@ -126,32 +134,34 @@ public class ColumnReaders implements Closeable {
         }
 
         SelectionEngine engine = SelectionEngine.create(schema, augProjected, resolved, allReaders, batchSize);
-        FilterCoordinator coordinator = new FilterCoordinator(allReaders, payloadReaders, engine);
+        FilterCoordinator coordinator = new FilterCoordinator(allReaders, payloadReaders, engine, rowGroupIterator);
         for (ColumnReader reader : allReaders) {
             reader.setCoordinator(coordinator);
         }
-        return new ColumnReaders(readersByName, payloadReaders, coordinator);
+        return new ColumnReaders(readersByName, payloadReaders, coordinator, rowGroupIterator);
     }
 
     /// Builds a [ColumnReaders] for the case where row-group pruning
     /// (statistics/bloom) dropped every row group, so no record can match.
     /// Exposes the `payloadProjected` columns as immediately-exhausted no-op
     /// readers — no worker threads, no batch buffers, no [SelectionEngine] or
-    /// [FilterCoordinator]. The shared [RowGroupIterator] is owned and closed by
-    /// the [ParquetFileReader]; these readers hold no reference to it. Used by
-    /// [ParquetFileReader#buildColumnReaders] to skip the whole per-column decode
-    /// setup when there is nothing to decode.
-    static ColumnReaders noRows(FileSchema schema, ProjectedSchema payloadProjected) {
+    /// [FilterCoordinator]. The group and every reader in it release
+    /// `rowGroupIterator`: with no coordinator to tear the projection down, a
+    /// caller handed a single reader out of this group has nothing else to reach
+    /// it through. Used by [ParquetFileReader#buildColumnReaders] to skip the
+    /// whole per-column decode setup when there is nothing to decode.
+    static ColumnReaders noRows(FileSchema schema, ProjectedSchema payloadProjected,
+                                RowGroupIterator rowGroupIterator) {
         int payloadCount = payloadProjected.getProjectedColumnCount();
         Map<String, ColumnReader> readersByName = new LinkedHashMap<>(payloadCount);
         ColumnReader[] payloadReaders = new ColumnReader[payloadCount];
         for (int p = 0; p < payloadCount; p++) {
             ColumnSchema columnSchema = schema.getColumn(payloadProjected.toOriginalIndex(p));
-            ColumnReader reader = ColumnReader.exhausted(schema, columnSchema);
+            ColumnReader reader = ColumnReader.exhausted(schema, columnSchema, rowGroupIterator);
             payloadReaders[p] = reader;
             readersByName.put(columnSchema.fieldPath().toString(), reader);
         }
-        return new ColumnReaders(readersByName, payloadReaders, null);
+        return new ColumnReaders(readersByName, payloadReaders, null, rowGroupIterator);
     }
 
     /// Get the number of projected columns.
@@ -279,12 +289,17 @@ public class ColumnReaders implements Closeable {
 
     @Override
     public void close() throws IOException {
-        if (coordinator != null) {
-            coordinator.close();
-            return;
-        }
-        for (ColumnReader reader : readersByIndex) {
-            reader.close();
+        // Released even when a reader's teardown fails, so a failed close cannot
+        // leave the work list reachable for the parent reader's whole lifetime.
+        try (rowGroupIterator) {
+            if (coordinator != null) {
+                coordinator.close();
+            }
+            else {
+                for (ColumnReader reader : readersByIndex) {
+                    reader.close();
+                }
+            }
         }
     }
 

--- a/core/src/main/java/dev/hardwood/reader/FilterCoordinator.java
+++ b/core/src/main/java/dev/hardwood/reader/FilterCoordinator.java
@@ -10,6 +10,7 @@ package dev.hardwood.reader;
 import java.io.IOException;
 
 import dev.hardwood.internal.reader.RecordFilterTally;
+import dev.hardwood.internal.reader.RowGroupIterator;
 
 /// Drives the filtered column-reader path (#624). It advances every reader of
 /// the augmented projection (payload columns plus the predicate columns) in
@@ -29,6 +30,10 @@ final class FilterCoordinator {
     /// The exposed subset, compacted to the matching records each batch.
     private final ColumnReader[] payloadReaders;
     private final SelectionEngine engine;
+    /// The iterator all readers decode through. A filtered single-column read is
+    /// handed one reader out of the projection and never sees the enclosing group,
+    /// so tearing the projection down has to release the iterator too.
+    private final RowGroupIterator rowGroupIterator;
     /// Per-file record-filter counts for JFR. Every batch this path produces has
     /// passed through the selection, so the counts are complete for the read.
     private final RecordFilterTally tally = new RecordFilterTally();
@@ -38,10 +43,12 @@ final class FilterCoordinator {
     private int recordCount;
     private boolean closed;
 
-    FilterCoordinator(ColumnReader[] allReaders, ColumnReader[] payloadReaders, SelectionEngine engine) {
+    FilterCoordinator(ColumnReader[] allReaders, ColumnReader[] payloadReaders, SelectionEngine engine,
+                      RowGroupIterator rowGroupIterator) {
         this.allReaders = allReaders;
         this.payloadReaders = payloadReaders;
         this.engine = engine;
+        this.rowGroupIterator = rowGroupIterator;
     }
 
     long generation() {
@@ -113,8 +120,13 @@ final class FilterCoordinator {
         }
         closed = true;
         tally.close();
-        for (ColumnReader reader : allReaders) {
-            reader.rawClose();
+        // Released even when a reader's teardown fails: this coordinator will not
+        // run its close body again, so skipping the release would leave the work
+        // list reachable for the parent reader's whole lifetime.
+        try (rowGroupIterator) {
+            for (ColumnReader reader : allReaders) {
+                reader.rawClose();
+            }
         }
     }
 }

--- a/core/src/main/java/dev/hardwood/reader/ParquetFileReader.java
+++ b/core/src/main/java/dev/hardwood/reader/ParquetFileReader.java
@@ -626,7 +626,7 @@ public class ParquetFileReader implements Closeable {
             // them all): nothing to decode. Asked of the first work item rather than
             // the whole list, which would plan every file before the first batch.
             if (iterator.workItemAt(0) == null) {
-                return ColumnReaders.noRows(schema, projected);
+                return ColumnReaders.noRows(schema, projected, iterator);
             }
             return new ColumnReaders(context, fixedListFastPathEnabled, iterator, schema, projected,
                     resolveBatchSize(batchSize, projected, rowGroups));
@@ -644,11 +644,13 @@ public class ParquetFileReader implements Closeable {
         // Statistics/bloom pruning dropped every row group — no record can match.
         // Skip building the per-column readers (worker threads + ~batch-sized
         // buffers) and the selection engine entirely; expose exhausted no-op
-        // readers over the payload columns. The iterator is registered above and
-        // closed by close(), so its file handles/prefetch futures still release.
+        // readers over the payload columns. The group and each of its readers own
+        // the iterator — the single-column entry point below is handed one reader
+        // out of this group — so closing either releases the fetch plans and the
+        // parent's tracking entry.
         // Asked of the first work item, so a read that has one plans no further.
         if (iterator.workItemAt(0) == null) {
-            return ColumnReaders.noRows(schema, payloadProjected);
+            return ColumnReaders.noRows(schema, payloadProjected, iterator);
         }
         // Size against the augmented projection — the predicate columns allocate
         // per-batch arrays too, so they count toward the byte budget.

--- a/core/src/test/java/dev/hardwood/reader/IteratorTrackingTest.java
+++ b/core/src/test/java/dev/hardwood/reader/IteratorTrackingTest.java
@@ -28,6 +28,12 @@ import static org.assertj.core.api.Assertions.assertThat;
 class IteratorTrackingTest {
 
     private static final String FILE = "src/test/resources/page_index_test.parquet";
+    /// A nested schema, so the row path routes through `NestedRowReader` rather
+    /// than the `FlatRowReader` every other test here exercises.
+    private static final String NESTED_FILE = "src/test/resources/deep_nested_struct_test.parquet";
+    /// Higher than any `id` in [#FILE], so statistics pruning drops every row
+    /// group and the read is served by an all-exhausted group.
+    private static final long PRUNES_EVERY_ROW_GROUP = 100_000_000L;
 
     @Test
     void closingAChildReaderStopsTrackingItsIterator() throws Exception {
@@ -49,20 +55,152 @@ class IteratorTrackingTest {
             }
 
             // The row-reader and multi-column paths share one iterator across
-            // sibling readers, so no individual child owns it and closing them
-            // leaves it tracked until the parent closes. Only the single-column
-            // path hands out an iterator its reader exclusively owns.
+            // sibling readers. No individual child owns it, so the group that does
+            // — the RowReader, the ColumnReaders — closes it.
             try (RowReader rows = reader.rowReader()) {
                 while (rows.hasNext()) {
                     rows.next();
                 }
             }
+            assertThat(reader.trackedIteratorCount())
+                    .as("a closed row reader must not leave its iterator behind")
+                    .isZero();
+
             try (ColumnReaders columns = reader.columnReaders(ColumnProjection.columns("id"))) {
                 while (columns.nextBatch()) {
                     // drain
                 }
             }
-            assertThat(reader.trackedIteratorCount()).isEqualTo(2);
+            assertThat(reader.trackedIteratorCount())
+                    .as("a closed column-readers group must not leave its iterator behind")
+                    .isZero();
+        }
+    }
+
+    /// The retention this tracking can cause is unbounded rather than one-off: a
+    /// reader driving many sequential reads holds every finished read's work list,
+    /// page-index buffers and fetch plans until it is itself closed.
+    @Test
+    void sequentialReadsDoNotAccumulateIterators() throws Exception {
+        try (ParquetFileReader reader = ParquetFileReader.open(InputFile.of(Paths.get(FILE)))) {
+            for (int i = 0; i < 8; i++) {
+                try (RowReader rows = reader.rowReader()) {
+                    rows.next();
+                }
+                try (ColumnReaders columns = reader.columnReaders(ColumnProjection.columns("id"))) {
+                    columns.nextBatch();
+                }
+                try (ColumnReader column = reader.columnReader(0)) {
+                    column.nextBatch();
+                }
+                assertThat(reader.trackedIteratorCount())
+                        .as("iteration %d must not leave an iterator behind", i)
+                        .isZero();
+            }
+        }
+    }
+
+    /// The filtered paths hand their readers to a `FilterCoordinator`, which closes
+    /// the whole projection rather than one child. That must release the shared
+    /// iterator too.
+    @Test
+    void closingAFilteredChildReaderStopsTrackingItsIterator() throws Exception {
+        try (ParquetFileReader reader = ParquetFileReader.open(InputFile.of(Paths.get(FILE)))) {
+            for (int i = 0; i < 4; i++) {
+                try (RowReader rows = reader.buildRowReader()
+                        .filter(FilterPredicate.gt("id", 1L))
+                        .build()) {
+                    if (rows.hasNext()) {
+                        rows.next();
+                    }
+                }
+                try (ColumnReaders columns = reader.buildColumnReaders(ColumnProjection.columns("id"))
+                        .filter(FilterPredicate.gt("id", 1L))
+                        .build()) {
+                    columns.nextBatch();
+                }
+                assertThat(reader.trackedIteratorCount())
+                        .as("filtered iteration %d must not leave an iterator behind", i)
+                        .isZero();
+            }
+        }
+    }
+
+    /// A filtered single-column read is served by the shared filtered-projection
+    /// engine and exposes one of its readers. The enclosing group is never handed
+    /// to the caller, so closing that one reader has to release the iterator the
+    /// group was built around.
+    @Test
+    void closingAFilteredSingleColumnReaderStopsTrackingItsIterator() throws Exception {
+        try (ParquetFileReader reader = ParquetFileReader.open(InputFile.of(Paths.get(FILE)))) {
+            for (int i = 0; i < 4; i++) {
+                try (ColumnReader column = reader.buildColumnReader(0)
+                        .filter(FilterPredicate.gt("id", 1L))
+                        .build()) {
+                    column.nextBatch();
+                }
+                assertThat(reader.trackedIteratorCount())
+                        .as("filtered single-column iteration %d must not leave an iterator behind", i)
+                        .isZero();
+            }
+        }
+    }
+
+    /// The nested row path is a separate reader class with its own `close()`, so
+    /// the flat fixture every other test uses would not catch a regression there.
+    @Test
+    void closingANestedRowReaderStopsTrackingItsIterator() throws Exception {
+        try (ParquetFileReader reader = ParquetFileReader.open(InputFile.of(Paths.get(NESTED_FILE)))) {
+            for (int i = 0; i < 4; i++) {
+                try (RowReader rows = reader.rowReader()) {
+                    while (rows.hasNext()) {
+                        rows.next();
+                    }
+                }
+                assertThat(reader.trackedIteratorCount())
+                        .as("nested iteration %d must not leave an iterator behind", i)
+                        .isZero();
+            }
+        }
+    }
+
+    /// A read whose row groups are all pruned is served by a group of exhausted
+    /// readers with no coordinator. The group still holds the iterator, so closing
+    /// it releases it.
+    @Test
+    void closingAPrunedColumnReadersGroupStopsTrackingItsIterator() throws Exception {
+        try (ParquetFileReader reader = ParquetFileReader.open(InputFile.of(Paths.get(FILE)))) {
+            for (int i = 0; i < 4; i++) {
+                try (ColumnReaders columns = reader.buildColumnReaders(ColumnProjection.columns("id"))
+                        .filter(FilterPredicate.gt("id", PRUNES_EVERY_ROW_GROUP))
+                        .build()) {
+                    assertThat(columns.nextBatch()).isFalse();
+                }
+                assertThat(reader.trackedIteratorCount())
+                        .as("pruned iteration %d must not leave an iterator behind", i)
+                        .isZero();
+            }
+        }
+    }
+
+    /// The pruned counterpart of
+    /// [#closingAFilteredSingleColumnReaderStopsTrackingItsIterator]: the caller is
+    /// handed one exhausted reader out of a group it never sees, and that group has
+    /// no coordinator to route the close through, so the reader itself has to
+    /// release the iterator.
+    @Test
+    void closingAPrunedFilteredSingleColumnReaderStopsTrackingItsIterator() throws Exception {
+        try (ParquetFileReader reader = ParquetFileReader.open(InputFile.of(Paths.get(FILE)))) {
+            for (int i = 0; i < 4; i++) {
+                try (ColumnReader column = reader.buildColumnReader(0)
+                        .filter(FilterPredicate.gt("id", PRUNES_EVERY_ROW_GROUP))
+                        .build()) {
+                    assertThat(column.nextBatch()).isFalse();
+                }
+                assertThat(reader.trackedIteratorCount())
+                        .as("pruned single-column iteration %d must not leave an iterator behind", i)
+                        .isZero();
+            }
         }
     }
 

--- a/docs/content/release-notes.md
+++ b/docs/content/release-notes.md
@@ -15,6 +15,8 @@ See [GitHub Releases](https://github.com/hardwood-hq/hardwood/releases) for down
 
 ## 1.1.0-SNAPSHOT
 
+- A `ParquetFileReader` no longer retains a read's `RowGroupIterator` after the reader consuming it is closed ([#1170](https://github.com/hardwood-hq/hardwood/issues/1170)).
+
 - A logical type annotation that a column's physical type cannot carry is now dropped, and the column is read as its physical type. Previously it surfaced as an `IllegalArgumentException` from whichever accessor first reached the column ([#1139](https://github.com/hardwood-hq/hardwood/issues/1139)). `FLOAT16` is defined as a two-byte payload, so a column annotated `FLOAT16` that declares three bytes is invalid; [parquet-format PR 606](https://github.com/apache/parquet-format/pull/606) specifies that readers ignore the annotation and use only the physical type. An annotation this version does not recognize is dropped the same way, so a file written against a newer format version can still be read. Both cases log a warning, naming the column and the reason, or the union field that was not recognized. **What changes for you:** `getFileSchema()` reports no logical type for such a column, `getValue` returns its physical value where it used to throw, and a logical accessor on it fails as it does on any unannotated column.
 
 - A multi-file read opens each file as it reaches it, rather than opening every file when the reader is built, so the time to the first row no longer grows with the number of files ([#1107](https://github.com/hardwood-hq/hardwood/issues/1107)).


### PR DESCRIPTION
Fixes #1170.

A `ParquetFileReader` tracks the `RowGroupIterator` it hands to each child reader so that its own `close()` can tear down one whose child the caller never closed. Dropping back out of that list was wired only into the single-column path, because that is the one child holding an iterator it exclusively owns. The row-reader and multi-column paths share one iterator across sibling readers, so nothing released it, and a reader driving many sequential reads held every finished read's work list, page-index buffers and fetch plans until it was itself closed.

Ownership now follows the group rather than the child: the `RowReader` and the `ColumnReaders` group release the iterator they were built around. A read handed a single reader out of a group it never sees needs a second owner on that reader's own close path — on the filtered path the `FilterCoordinator` that tears the projection down, which is what its contract already claimed, and for a group whose row groups were all pruned each exhausted reader, since such a group has neither a coordinator nor any per-column state to guard. Several owners can reach the same iterator, so `RowGroupIterator.close()` is idempotent.

Each owner releases the iterator on the way out of its own `close()`, failure or not. An owner does not run its close body twice, so a teardown that throws would otherwise strand the work list for the parent reader's whole lifetime.

## Effect

One reader, N sequential reads, every child closed, against a 50-row-group file with a page index:

| Path | tracked (before → after) | heap retained at N=500 (before → after) |
|---|---|---|
| `rowReader()` | 500 → 0 | 4.0 MB → 129 KB |
| `columnReaders(...)` | 500 → 0 | 14.3 MB → 91 KB |
| `columnReader(0)` | 0 → 0 | 87 KB → 75 KB |

Retention is now flat from N=10 to N=500 on every path rather than growing with the number of reads.

## Tests

`IteratorTrackingTest` gains six tests and flips one assertion. The flipped one is `closingAChildReaderStopsTrackingItsIterator`, which pinned the unfixed paths at `isEqualTo(2)`. The new ones cover sequential reads across all three paths, the nested row path, the filtered group paths, a filtered single-column read, and the pruned counterparts of the last two, where the group is all exhausted readers.

`./mvnw verify` is green: all modules, including the integration tests.
