### PR TITLE
#1172 Rework MinMaxStats into decoded, self-validating bounds

### DIFF
--- a/.claude/skills/hardwood-review/SKILL.md
+++ b/.claude/skills/hardwood-review/SKILL.md
@@ -41,6 +41,8 @@ Parse the user's request for one of:
 
 For PR diffs, persist large output to a file and read it in chunks rather than letting it land in the conversation as one blob. The diff for a non-trivial PR can run 5k+ lines.
 
+**Don't build the branch to find out whether it compiles and passes.** CI already answers that. Check it with `gh pr checks <n>`; a green run means no worktree, no `./mvnw`, no test run. Reading the diff is the review. Build locally only when CI is red or absent and you need to know whether a failure is real, or when a specific finding turns on behaviour you cannot settle by reading — and then run the narrowest thing that settles it, not `verify`.
+
 ### 2. Read the design context
 
 If the PR touches a new design area, look in `_designs/` for a matching markdown file. Hardwood requires non-trivial changes to land a design doc; if one is expected but missing, that's a finding. If one exists, skim it before reading code so the review can flag drift between intent and implementation.

--- a/core/src/main/java/dev/hardwood/internal/predicate/LogContext.java
+++ b/core/src/main/java/dev/hardwood/internal/predicate/LogContext.java
@@ -1,0 +1,50 @@
+/*
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Copyright The original authors
+ *
+ *  Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package dev.hardwood.internal.predicate;
+
+import dev.hardwood.internal.ExceptionContext;
+import dev.hardwood.metadata.FieldPath;
+
+/// Where in a file the filter layer is reading, for anything it has to say about what it found
+/// there.
+///
+/// Built as far up as the position is known — a row group's evaluator knows the file and the
+/// row group, but not which column a leaf will test, nor which page a scan will reach — and
+/// narrowed with [#withColumn] and [#withPageIndex] as it descends. The parts still unknown are
+/// left off the rendered prefix rather than guessed at.
+///
+/// @param fileName the file, or `null` where there is none to name, in which case nothing
+///        locates the message and the whole position is left off
+/// @param rowGroupIndex the row group, or [ExceptionContext#UNKNOWN_ROW_GROUP]
+/// @param columnPath the column, or `null` before one is resolved
+/// @param pageIndex the page, or [ExceptionContext#UNKNOWN_PAGE] where the subject is a whole
+///        column chunk rather than one of its pages
+public record LogContext(String fileName, int rowGroupIndex, FieldPath columnPath, int pageIndex) {
+
+    /// A row group, before a column or page within it is known.
+    public LogContext(String fileName, int rowGroupIndex) {
+        this(fileName, rowGroupIndex, null, ExceptionContext.UNKNOWN_PAGE);
+    }
+
+    /// The same position, narrowed to one of the row group's columns.
+    public LogContext withColumn(FieldPath columnPath) {
+        return new LogContext(fileName, rowGroupIndex, columnPath, pageIndex);
+    }
+
+    /// The same position, narrowed to one of the column chunk's pages.
+    public LogContext withPageIndex(int pageIndex) {
+        return new LogContext(fileName, rowGroupIndex, columnPath, pageIndex);
+    }
+
+    /// The `[file: row group N, column 'X', page P] ` prefix for this position, dropping
+    /// whichever parts are unknown, as the read pipeline marks its failures.
+    String prefix() {
+        return ExceptionContext.readPrefix(fileName, rowGroupIndex,
+                columnPath != null ? columnPath.toString() : null, pageIndex);
+    }
+}

--- a/core/src/main/java/dev/hardwood/internal/predicate/MinMaxStats.java
+++ b/core/src/main/java/dev/hardwood/internal/predicate/MinMaxStats.java
@@ -10,64 +10,411 @@ package dev.hardwood.internal.predicate;
 import dev.hardwood.metadata.ColumnIndex;
 import dev.hardwood.metadata.Statistics;
 
-/// Abstraction over min/max statistics, used by [RowGroupFilterEvaluator] to evaluate
-/// predicates against either row-group-level [Statistics] or page-level [ColumnIndex] entries.
-interface MinMaxStats {
+/// One unit's min/max statistics, decoded — sourced from either row-group-level [Statistics]
+/// or a [ColumnIndex] entry for a single page, and asked directly what they prove about a
+/// leaf predicate.
+///
+/// The bounds are decoded once, where the unit is sourced, and held as the primitives the
+/// comparisons actually use. A leaf's physical type therefore stops mattering past that point:
+/// eleven leaf types map onto six of these, because a `FLOAT16` bound is a `float` once
+/// decoded and an `IN` predicate reads the same bounds as the comparison of the same width.
+///
+/// Bounds the filter layer cannot compare against never become one of the typed variants at
+/// all. They become [NullCountOnlyStats], which keeps the one statistic that does not depend
+/// on them and carries why the rest were dropped. It proves nothing about a value predicate:
+/// [#canDrop] is `false` and [#decideLeaf] is [FilterDecision#MIGHT_MATCH]. Deciding that
+/// where the bounds are sourced keeps every comparator free of the question, and keeps a
+/// comparator added later from having to remember it.
+sealed interface MinMaxStats {
 
-    /// @return the minimum value as raw bytes, or `null` if absent
-    byte[] minValue();
+    System.Logger LOG = System.getLogger(MinMaxStats.class.getName());
 
-    /// @return the maximum value as raw bytes, or `null` if absent
-    byte[] maxValue();
+    /// Read from the deprecated `min`/`max` Thrift fields, which compare unsigned whatever the
+    /// column's type is, so they carry the wrong order for every signed one.
+    String DEPRECATED_SORT_ORDER =
+            "they come from the deprecated min/max fields, which compare unsigned";
 
-    /// @return the number of null values in the unit, or `null` if unknown
+    /// The Parquet spec forbids writing `NaN` to statistics min/max, but older and buggy
+    /// writers have produced such bounds (#566). `NaN` sorts above every finite value in
+    /// `Double.compare`'s total order, so comparing against it would prune units holding
+    /// matching finite rows.
+    String NOT_A_NUMBER = "one of them is NaN, which sits outside the column's ordering";
+
+    /// The spec requires `min <= max`. A pair the wrong way round excludes every value it
+    /// should contain and contains every value it should exclude, so it is wrong in both
+    /// pruning directions at once (#1172).
+    String INVERTED = "the minimum sorts above the maximum";
+
+    /// The number of null values in the unit, or `null` if unknown.
     Long nullCount();
 
-    /// Wraps a [Statistics] record.
+    /// Why the file's bounds were discarded, or `null` where they were kept — or where the
+    /// file wrote none to discard.
+    default String discardReason() {
+        return null;
+    }
+
+    /// Whether these bounds prove no row can match the leaf, so the unit can be skipped.
+    boolean canDrop(ResolvedPredicate leaf);
+
+    /// Whether these bounds prove every value in the unit satisfies the leaf. Assumes the
+    /// caller has established a zero null count.
+    boolean alwaysMatches(ResolvedPredicate leaf);
+
+    /// Says at `WARNING` that these bounds were discarded, so that a read which pruned nothing
+    /// can be traced back to the file that caused it. Silent when they were kept.
     ///
-    /// When `stats.isMinMaxDeprecated()` is `true`, the min/max values were read from
-    /// deprecated Thrift fields that use unsigned byte comparison, which produces incorrect
-    /// sort order for signed types. In that case, both `minValue()` and `maxValue()` return
-    /// `null` so that callers conservatively keep the row group rather than incorrectly
-    /// dropping it.
-    static MinMaxStats of(Statistics stats) {
-        boolean deprecated = stats.isMinMaxDeprecated();
-        return new MinMaxStats() {
-            @Override
-            public byte[] minValue() {
-                return deprecated ? null : stats.minValue();
-            }
+    /// Reporting only; the discard itself already took effect when the unit was sourced, since
+    /// unusable bounds become [NullCountOnlyStats], which drops nothing.
+    ///
+    /// Every discard is reported, with no attempt to collapse repeats. Statistics that will
+    /// not compare are rare, and a reader who finds the volume unhelpful can raise the level
+    /// on this logger — neither is worth carrying state through the evaluators to pre-empt.
+    ///
+    /// @param logContext where these statistics were read from, for the message to name
+    default void reportIfDiscarded(LogContext logContext) {
+        String discardReason = discardReason();
+        if (discardReason == null) {
+            return;
+        }
+        LOG.log(System.Logger.Level.WARNING,
+                "{0}Ignoring the min/max statistics for pruning: {1}. "
+                        + "Rows they could have skipped are read and filtered instead.",
+                logContext.prefix(), discardReason);
+    }
 
-            @Override
-            public byte[] maxValue() {
-                return deprecated ? null : stats.maxValue();
-            }
+    /// Whether the unit is proven to hold no nulls.
+    default boolean nullFree() {
+        Long nullCount = nullCount();
+        return nullCount != null && nullCount == 0;
+    }
 
-            @Override
-            public Long nullCount() {
-                return stats.nullCount();
-            }
+    /// What these statistics prove about a value predicate, as a three-valued
+    /// [FilterDecision].
+    ///
+    /// [FilterDecision#ALWAYS_MATCHES] requires the whole `[min, max]` interval to satisfy
+    /// the predicate **and** a proven-zero null count — a null row satisfies no value
+    /// predicate, so without it a fully-matching range still cannot promise every row. That
+    /// conjunction is the reason to compose the two halves here rather than at each call
+    /// site: [#alwaysMatches] answers only the interval half, and dropping the null-count
+    /// half returns null rows to a caller that asked for a value.
+    ///
+    /// Truncated (inexact) bounds are safe by construction: they only widen the interval,
+    /// and a predicate satisfied by the widened interval is satisfied by the actual values.
+    ///
+    /// `IS NULL` and `IS NOT NULL` are not value predicates and do not come here.
+    /// [RowGroupFilterEvaluator] decides them from the null count against the row count,
+    /// which lets it drop a wholly-null row group — something this cannot see, holding no
+    /// row count of its own.
+    default FilterDecision decideLeaf(ResolvedPredicate leaf) {
+        if (canDrop(leaf)) {
+            return FilterDecision.CANNOT_MATCH;
+        }
+        if (!nullFree()) {
+            return FilterDecision.MIGHT_MATCH;
+        }
+        return alwaysMatches(leaf) ? FilterDecision.ALWAYS_MATCHES : FilterDecision.MIGHT_MATCH;
+    }
+
+    // ==================== Sourcing ====================
+
+    /// The statistics of a column chunk, or of a single page where they are carried inline on
+    /// the page header, decoded as the given leaf reads them.
+    static MinMaxStats of(Statistics stats, ResolvedPredicate leaf) {
+        if (stats.isMinMaxDeprecated()) {
+            return new NullCountOnlyStats(stats.nullCount(), DEPRECATED_SORT_ORDER);
+        }
+        return sourced(stats.minValue(), stats.maxValue(), stats.nullCount(), leaf);
+    }
+
+    /// The [ColumnIndex] entry for one page of a column chunk.
+    static MinMaxStats ofPage(ColumnIndex columnIndex, int pageIndex, ResolvedPredicate leaf) {
+        long[] nullCounts = columnIndex.nullCounts();
+        return sourced(columnIndex.minValues().get(pageIndex), columnIndex.maxValues().get(pageIndex),
+                nullCounts != null ? Long.valueOf(nullCounts[pageIndex]) : null, leaf);
+    }
+
+    /// Decodes the pair as the leaf reads it, yielding [NullCountOnlyStats] where the file
+    /// wrote no bounds, where the leaf reads none, or where the pair does not hold together.
+    private static MinMaxStats sourced(byte[] min, byte[] max, Long nullCount, ResolvedPredicate leaf) {
+        if (min == null || max == null) {
+            // Nothing was written, so nothing was discarded; a half-present pair prunes no
+            // more than an absent one.
+            return new NullCountOnlyStats(nullCount, null);
+        }
+        return switch (leaf) {
+            case ResolvedPredicate.IntPredicate ignored -> IntStats.of(
+                    StatisticsDecoder.decodeInt(min), StatisticsDecoder.decodeInt(max), nullCount);
+            case ResolvedPredicate.IntInPredicate ignored -> IntStats.of(
+                    StatisticsDecoder.decodeInt(min), StatisticsDecoder.decodeInt(max), nullCount);
+            case ResolvedPredicate.LongPredicate ignored -> LongStats.of(
+                    StatisticsDecoder.decodeLong(min), StatisticsDecoder.decodeLong(max), nullCount);
+            case ResolvedPredicate.LongInPredicate ignored -> LongStats.of(
+                    StatisticsDecoder.decodeLong(min), StatisticsDecoder.decodeLong(max), nullCount);
+            case ResolvedPredicate.BooleanPredicate ignored -> BooleanStats.of(
+                    StatisticsDecoder.decodeBoolean(min), StatisticsDecoder.decodeBoolean(max), nullCount);
+            case ResolvedPredicate.FloatPredicate p -> FloatStats.of(
+                    StatisticsDecoder.decodeFloat(min), StatisticsDecoder.decodeFloat(max),
+                    p.ieee754TotalOrder(), nullCount);
+            // A binary16 bound is a float once decoded, so it needs no variant of its own.
+            case ResolvedPredicate.Float16Predicate p -> FloatStats.of(
+                    StatisticsDecoder.decodeFloat16(min), StatisticsDecoder.decodeFloat16(max),
+                    p.ieee754TotalOrder(), nullCount);
+            case ResolvedPredicate.DoublePredicate p -> DoubleStats.of(
+                    StatisticsDecoder.decodeDouble(min), StatisticsDecoder.decodeDouble(max),
+                    p.ieee754TotalOrder(), nullCount);
+            case ResolvedPredicate.BinaryPredicate p -> BinaryStats.of(min, max, p.signed(), nullCount);
+            case ResolvedPredicate.BinaryInPredicate ignored -> BinaryStats.of(min, max, false, nullCount);
+            // These leaves read no bounds, so there is nothing to decode and nothing to
+            // validate. What the file wrote is not discarded; it is simply not their business.
+            case ResolvedPredicate.IsNullPredicate ignored -> new NullCountOnlyStats(nullCount, null);
+            case ResolvedPredicate.IsNotNullPredicate ignored -> new NullCountOnlyStats(nullCount, null);
+            case ResolvedPredicate.GeospatialPredicate ignored -> new NullCountOnlyStats(nullCount, null);
+            case ResolvedPredicate.And ignored -> new NullCountOnlyStats(nullCount, null);
+            case ResolvedPredicate.Or ignored -> new NullCountOnlyStats(nullCount, null);
         };
     }
 
-    /// Wraps a [ColumnIndex] entry for a specific page.
-    static MinMaxStats ofPage(ColumnIndex columnIndex, int pageIndex) {
-        return new MinMaxStats() {
-            @Override
-            public byte[] minValue() {
-                return columnIndex.minValues().get(pageIndex);
-            }
+    /// Reports a leaf reaching bounds of a width that cannot decide it. A unit is decoded for
+    /// the leaf it is then asked about, so this is a wiring mistake rather than anything a
+    /// file can cause.
+    private static IllegalArgumentException wrongWidth(String type, ResolvedPredicate leaf) {
+        return new IllegalArgumentException(
+                type + " statistics cannot decide a " + leaf.getClass().getSimpleName());
+    }
 
-            @Override
-            public byte[] maxValue() {
-                return columnIndex.maxValues().get(pageIndex);
-            }
+    /// Why a floating-point pair cannot be compared against, or `null` when it can — over
+    /// `double` for both widths, since a `float` widens exactly and both the `NaN` test and
+    /// the ordering are the same question at either.
+    private static String floatingPointReason(double min, double max, boolean ieee754TotalOrder) {
+        if (Double.isNaN(min) || Double.isNaN(max)) {
+            return NOT_A_NUMBER;
+        }
+        // The comparators widen a ±0 bound under the type-defined ordering, where the spec
+        // leaves the two zeroes interchangeable; the same widening applies here so that
+        // legitimate bounds of (+0, -0) are not read as inverted.
+        if (!ieee754TotalOrder) {
+            min = (min == 0.0) ? -0.0 : min;
+            max = (max == 0.0) ? 0.0 : max;
+        }
+        return Double.compare(min, max) > 0 ? INVERTED : null;
+    }
 
-            @Override
-            public Long nullCount() {
-                long[] nullCounts = columnIndex.nullCounts();
-                return nullCounts != null ? Long.valueOf(nullCounts[pageIndex]) : null;
+    // ==================== The typed bounds ====================
+
+    /// Everything left when there are no bounds to compare against — because the file wrote
+    /// none, because this leaf reads none, or because the pair it wrote was discarded as
+    /// unusable, which `discardReason` is what tells apart.
+    ///
+    /// The null count survives all three, and decides `IS NOT NULL` on its own.
+    record NullCountOnlyStats(Long nullCount, String discardReason) implements MinMaxStats {
+
+        @Override
+        public boolean canDrop(ResolvedPredicate leaf) {
+            return false;
+        }
+
+        @Override
+        public boolean alwaysMatches(ResolvedPredicate leaf) {
+            return false;
+        }
+    }
+
+    /// `INT32` bounds, including those of an `INT32`-backed `DECIMAL`.
+    record IntStats(int min, int max, Long nullCount) implements MinMaxStats {
+
+        static MinMaxStats of(int min, int max, Long nullCount) {
+            return min > max ? new NullCountOnlyStats(nullCount, INVERTED) : new IntStats(min, max, nullCount);
+        }
+
+        @Override
+        public boolean canDrop(ResolvedPredicate leaf) {
+            return switch (leaf) {
+                case ResolvedPredicate.IntPredicate p ->
+                        StatisticsFilterSupport.canDrop(p.op(), p.value(), min, max);
+                case ResolvedPredicate.IntInPredicate p ->
+                        StatisticsFilterSupport.canDropIntIn(p.values(), min, max);
+                default -> throw wrongWidth("INT32", leaf);
+            };
+        }
+
+        @Override
+        public boolean alwaysMatches(ResolvedPredicate leaf) {
+            return switch (leaf) {
+                case ResolvedPredicate.IntPredicate p ->
+                        StatisticsFilterSupport.alwaysMatches(p.op(), p.value(), min, max);
+                case ResolvedPredicate.IntInPredicate p ->
+                        StatisticsFilterSupport.alwaysMatchesIntIn(p.values(), min, max);
+                default -> throw wrongWidth("INT32", leaf);
+            };
+        }
+    }
+
+    /// `INT64` bounds, including those of an `INT64`-backed `DECIMAL`.
+    record LongStats(long min, long max, Long nullCount) implements MinMaxStats {
+
+        static MinMaxStats of(long min, long max, Long nullCount) {
+            return min > max ? new NullCountOnlyStats(nullCount, INVERTED) : new LongStats(min, max, nullCount);
+        }
+
+        @Override
+        public boolean canDrop(ResolvedPredicate leaf) {
+            return switch (leaf) {
+                case ResolvedPredicate.LongPredicate p ->
+                        StatisticsFilterSupport.canDrop(p.op(), p.value(), min, max);
+                case ResolvedPredicate.LongInPredicate p ->
+                        StatisticsFilterSupport.canDropLongIn(p.values(), min, max);
+                default -> throw wrongWidth("INT64", leaf);
+            };
+        }
+
+        @Override
+        public boolean alwaysMatches(ResolvedPredicate leaf) {
+            return switch (leaf) {
+                case ResolvedPredicate.LongPredicate p ->
+                        StatisticsFilterSupport.alwaysMatches(p.op(), p.value(), min, max);
+                case ResolvedPredicate.LongInPredicate p ->
+                        StatisticsFilterSupport.alwaysMatchesLongIn(p.values(), min, max);
+                default -> throw wrongWidth("INT64", leaf);
+            };
+        }
+    }
+
+    /// `BOOLEAN` bounds, compared as `0` and `1`.
+    record BooleanStats(boolean min, boolean max, Long nullCount) implements MinMaxStats {
+
+        static MinMaxStats of(boolean min, boolean max, Long nullCount) {
+            // false sorts below true, so only a true minimum with a false maximum is inverted.
+            return min && !max
+                    ? new NullCountOnlyStats(nullCount, INVERTED)
+                    : new BooleanStats(min, max, nullCount);
+        }
+
+        @Override
+        public boolean canDrop(ResolvedPredicate leaf) {
+            if (leaf instanceof ResolvedPredicate.BooleanPredicate p) {
+                return StatisticsFilterSupport.canDrop(p.op(), ordinal(p.value()), ordinal(min), ordinal(max));
             }
-        };
+            throw wrongWidth("BOOLEAN", leaf);
+        }
+
+        @Override
+        public boolean alwaysMatches(ResolvedPredicate leaf) {
+            if (leaf instanceof ResolvedPredicate.BooleanPredicate p) {
+                return StatisticsFilterSupport.alwaysMatches(p.op(), ordinal(p.value()), ordinal(min), ordinal(max));
+            }
+            throw wrongWidth("BOOLEAN", leaf);
+        }
+
+        private static long ordinal(boolean value) {
+            return value ? 1 : 0;
+        }
+    }
+
+    /// `FLOAT` bounds, and the `FLOAT16` ones that widen exactly onto them.
+    ///
+    /// `ieee754TotalOrder` is carried rather than applied here because it changes what the
+    /// comparators compare against, not whether the bounds hold together; see
+    /// [StatisticsFilterSupport#canDropFloat].
+    record FloatStats(float min, float max, boolean ieee754TotalOrder, Long nullCount)
+            implements MinMaxStats {
+
+        static MinMaxStats of(float min, float max, boolean ieee754TotalOrder, Long nullCount) {
+            String reason = floatingPointReason(min, max, ieee754TotalOrder);
+            return reason != null
+                    ? new NullCountOnlyStats(nullCount, reason)
+                    : new FloatStats(min, max, ieee754TotalOrder, nullCount);
+        }
+
+        @Override
+        public boolean canDrop(ResolvedPredicate leaf) {
+            return switch (leaf) {
+                case ResolvedPredicate.FloatPredicate p -> StatisticsFilterSupport.canDropFloat(
+                        p.op(), p.value(), min, max, ieee754TotalOrder);
+                case ResolvedPredicate.Float16Predicate p -> StatisticsFilterSupport.canDropFloat(
+                        p.op(), p.value(), min, max, ieee754TotalOrder);
+                default -> throw wrongWidth("FLOAT", leaf);
+            };
+        }
+
+        /// NaN values sit outside the min/max ordering, so a unit whose `[min, max]` fully
+        /// satisfies the predicate may still hold non-matching NaN rows. `nan_count` would
+        /// settle it — the reader parses it and Hardwood's writer emits it — but nothing here
+        /// consults it, so a floating-point column is never promised a full match (#898).
+        @Override
+        public boolean alwaysMatches(ResolvedPredicate leaf) {
+            return false;
+        }
+    }
+
+    /// `DOUBLE` bounds. See [FloatStats] for what `ieee754TotalOrder` is doing here.
+    record DoubleStats(double min, double max, boolean ieee754TotalOrder, Long nullCount)
+            implements MinMaxStats {
+
+        static MinMaxStats of(double min, double max, boolean ieee754TotalOrder, Long nullCount) {
+            String reason = floatingPointReason(min, max, ieee754TotalOrder);
+            return reason != null
+                    ? new NullCountOnlyStats(nullCount, reason)
+                    : new DoubleStats(min, max, ieee754TotalOrder, nullCount);
+        }
+
+        @Override
+        public boolean canDrop(ResolvedPredicate leaf) {
+            if (leaf instanceof ResolvedPredicate.DoublePredicate p) {
+                return StatisticsFilterSupport.canDropDouble(p.op(), p.value(), min, max, ieee754TotalOrder);
+            }
+            throw wrongWidth("DOUBLE", leaf);
+        }
+
+        /// See [FloatStats#alwaysMatches].
+        @Override
+        public boolean alwaysMatches(ResolvedPredicate leaf) {
+            return false;
+        }
+    }
+
+    /// Byte-string bounds, compared unsigned or as big-endian two's complement according to
+    /// the column's order.
+    record BinaryStats(byte[] min, byte[] max, boolean signed, Long nullCount) implements MinMaxStats {
+
+        static MinMaxStats of(byte[] min, byte[] max, boolean signed, Long nullCount) {
+            // -100 sorts below +100 as a two's complement number and above it as a byte
+            // string, so only the column's own order tells a decimal's bounds apart from an
+            // inverted pair.
+            int comparison = signed
+                    ? BinaryComparator.compareSigned(min, max)
+                    : BinaryComparator.compareUnsigned(min, max);
+            return comparison > 0
+                    ? new NullCountOnlyStats(nullCount, INVERTED)
+                    : new BinaryStats(min, max, signed, nullCount);
+        }
+
+        @Override
+        public boolean canDrop(ResolvedPredicate leaf) {
+            return switch (leaf) {
+                case ResolvedPredicate.BinaryPredicate p -> StatisticsFilterSupport.canDropCompared(
+                        p.op(), compare(p.value(), min), compare(p.value(), max), compare(min, max));
+                case ResolvedPredicate.BinaryInPredicate p ->
+                        StatisticsFilterSupport.canDropBinaryIn(p.values(), min, max);
+                default -> throw wrongWidth("BYTE_ARRAY", leaf);
+            };
+        }
+
+        @Override
+        public boolean alwaysMatches(ResolvedPredicate leaf) {
+            return switch (leaf) {
+                case ResolvedPredicate.BinaryPredicate p -> StatisticsFilterSupport.alwaysMatchesCompared(
+                        p.op(), compare(p.value(), min), compare(p.value(), max), compare(min, max));
+                case ResolvedPredicate.BinaryInPredicate p ->
+                        StatisticsFilterSupport.alwaysMatchesBinaryIn(p.values(), min, max);
+                default -> throw wrongWidth("BYTE_ARRAY", leaf);
+            };
+        }
+
+        private int compare(byte[] left, byte[] right) {
+            return signed
+                    ? BinaryComparator.compareSigned(left, right)
+                    : BinaryComparator.compareUnsigned(left, right);
+        }
     }
 }

--- a/core/src/main/java/dev/hardwood/internal/predicate/PageDropPredicates.java
+++ b/core/src/main/java/dev/hardwood/internal/predicate/PageDropPredicates.java
@@ -28,10 +28,10 @@ import dev.hardwood.metadata.Statistics;
 /// recursive descent: recurse into `And` children, skip `Or` subtrees, keep
 /// leaves.
 ///
-/// [StatisticsFilterSupport#canDropLeaf] returns `false` for `IsNullPredicate`
-/// and `IsNotNullPredicate`, so including them in the result is harmless —
-/// they will never cause a page drop. They are included anyway so callers do
-/// not have to distinguish.
+/// [MinMaxStats#canDrop] is `false` for `IsNullPredicate` and
+/// `IsNotNullPredicate`, so including them in the result is harmless — they
+/// will never cause a page drop. They are included anyway so callers do not
+/// have to distinguish.
 public final class PageDropPredicates {
 
     private PageDropPredicates() {
@@ -78,15 +78,23 @@ public final class PageDropPredicates {
     /// supplied inline page [Statistics] alone, that the page cannot match — i.e.
     /// the page can be skipped.
     ///
-    /// Returns `false` when `stats` is `null`, carries only deprecated (unsigned
-    /// sort order) min/max bytes, or when no leaf can drop.
-    public static boolean canDropPage(List<ResolvedPredicate> leaves, Statistics stats) {
-        if (leaves == null || leaves.isEmpty() || stats == null || stats.isMinMaxDeprecated()) {
+    /// Returns `false` when `stats` is `null`, when its bounds are unusable — see
+    /// [MinMaxStats] — or when no leaf can drop.
+    ///
+    /// @param leaves the AND-necessary leaves testing this page's column
+    /// @param stats the page's inline statistics, or `null` if it carries none
+    /// @param logContext the page these statistics came from, for a discard to name
+    public static boolean canDropPage(List<ResolvedPredicate> leaves, Statistics stats,
+            LogContext logContext) {
+        if (leaves == null || leaves.isEmpty() || stats == null) {
             return false;
         }
-        MinMaxStats minMax = MinMaxStats.of(stats);
         for (ResolvedPredicate leaf : leaves) {
-            if (StatisticsFilterSupport.canDropLeaf(leaf, minMax)) {
+            // Sourced per leaf: what makes bounds usable depends on the order the leaf
+            // compares them in.
+            MinMaxStats minMax = MinMaxStats.of(stats, leaf);
+            minMax.reportIfDiscarded(logContext);
+            if (minMax.canDrop(leaf)) {
                 return true;
             }
         }

--- a/core/src/main/java/dev/hardwood/internal/predicate/PageFilterEvaluator.java
+++ b/core/src/main/java/dev/hardwood/internal/predicate/PageFilterEvaluator.java
@@ -28,8 +28,8 @@ import dev.hardwood.reader.ParquetReadException;
 /// decides whether an entire row group can be skipped, this class determines which
 /// pages within a surviving row group can be skipped.
 ///
-/// Leaf predicate evaluation is delegated to [StatisticsFilterSupport#canDropLeaf],
-/// which handles all resolved predicate types against a [MinMaxStats] abstraction.
+/// Leaf predicate evaluation is delegated to [MinMaxStats#canDrop], which decodes each page's
+/// bounds once and answers for the leaf they were decoded for.
 ///
 /// When the `ColumnIndex` is absent, this evaluator returns `RowRanges.all()` — page
 /// skipping then happens per-column inside [dev.hardwood.internal.reader.SequentialFetchPlan]
@@ -45,27 +45,29 @@ public class PageFilterEvaluator {
     /// @param predicate    the resolved predicate to evaluate
     /// @param rowGroup     the row group to evaluate against
     /// @param indexBuffers pre-fetched index buffers for the row group
+    /// @param logContext  where this row group is, for the warning raised when a column's
+    ///                     page bounds turn out to be unusable
     /// @return row ranges that might contain matching rows
     public static RowRanges computeMatchingRows(ResolvedPredicate predicate, RowGroup rowGroup,
-            RowGroupIndexBuffers indexBuffers) {
+            RowGroupIndexBuffers indexBuffers, LogContext logContext) {
         long rowCount = rowGroup.numRows();
-        return evaluate(predicate, rowGroup, indexBuffers, rowCount);
+        return evaluate(predicate, rowGroup, indexBuffers, rowCount, logContext);
     }
 
     private static RowRanges evaluate(ResolvedPredicate predicate, RowGroup rowGroup,
-            RowGroupIndexBuffers indexBuffers, long rowCount) {
+            RowGroupIndexBuffers indexBuffers, long rowCount, LogContext logContext) {
         return switch (predicate) {
             case ResolvedPredicate.And a -> {
                 RowRanges result = RowRanges.all(rowCount);
                 for (ResolvedPredicate child : a.children()) {
-                    result = result.intersect(evaluate(child, rowGroup, indexBuffers, rowCount));
+                    result = result.intersect(evaluate(child, rowGroup, indexBuffers, rowCount, logContext));
                 }
                 yield result;
             }
             case ResolvedPredicate.Or o -> {
                 RowRanges result = null;
                 for (ResolvedPredicate child : o.children()) {
-                    RowRanges childRanges = evaluate(child, rowGroup, indexBuffers, rowCount);
+                    RowRanges childRanges = evaluate(child, rowGroup, indexBuffers, rowCount, logContext);
                     result = (result == null) ? childRanges : result.union(childRanges);
                 }
                 yield (result != null) ? result : RowRanges.all(rowCount);
@@ -75,16 +77,16 @@ public class PageFilterEvaluator {
             // Parquet has no per-page geospatial statistics (GeospatialStatistics lives only on
             // ColumnMetaData, applied during row-group filtering), so no page-level pruning is possible.
             case ResolvedPredicate.GeospatialPredicate ignored -> RowRanges.all(rowCount);
-            default -> evaluateLeafPages(predicate, rowGroup, indexBuffers, rowCount);
+            default -> evaluateLeafPages(predicate, rowGroup, indexBuffers, rowCount, logContext);
         };
     }
 
     /// Evaluates a leaf predicate against per-page Column Index statistics,
-    /// using [StatisticsFilterSupport#canDropLeaf] for the actual comparison.
+    /// using [MinMaxStats#canDrop] for the actual comparison.
     private static RowRanges evaluateLeafPages(ResolvedPredicate predicate, RowGroup rowGroup,
-            RowGroupIndexBuffers indexBuffers, long rowCount) {
+            RowGroupIndexBuffers indexBuffers, long rowCount, LogContext logContext) {
 
-        int columnIndex = leafColumnIndex(predicate);
+        int columnIndex = ResolvedPredicate.leafColumnIndex(predicate);
         if (columnIndex < 0 || columnIndex >= rowGroup.columns().size()) {
             return RowRanges.all(rowCount);
         }
@@ -102,11 +104,16 @@ public class PageFilterEvaluator {
         int pageCount = pages.size();
         boolean[] keep = new boolean[pageCount];
 
+        LogContext columnContext = logContext.withColumn(
+                rowGroup.columns().get(columnIndex).metaData().pathInSchema());
+
         for (int i = 0; i < pageCount; i++) {
             if (columnIdx.nullPages()[i]) {
                 continue;
             }
-            keep[i] = !StatisticsFilterSupport.canDropLeaf(predicate, MinMaxStats.ofPage(columnIdx, i));
+            MinMaxStats pageStats = MinMaxStats.ofPage(columnIdx, i, predicate);
+            pageStats.reportIfDiscarded(columnContext.withPageIndex(i));
+            keep[i] = !pageStats.canDrop(predicate);
         }
 
         return RowRanges.fromPages(pages, keep, rowCount);
@@ -162,27 +169,6 @@ public class PageFilterEvaluator {
         }
 
         return RowRanges.fromPages(pages, keep, rowCount);
-    }
-
-    /// Extracts the column index from a leaf predicate.
-    private static int leafColumnIndex(ResolvedPredicate predicate) {
-        return switch (predicate) {
-            case ResolvedPredicate.IntPredicate p -> p.columnIndex();
-            case ResolvedPredicate.LongPredicate p -> p.columnIndex();
-            case ResolvedPredicate.FloatPredicate p -> p.columnIndex();
-            case ResolvedPredicate.Float16Predicate p -> p.columnIndex();
-            case ResolvedPredicate.DoublePredicate p -> p.columnIndex();
-            case ResolvedPredicate.BooleanPredicate p -> p.columnIndex();
-            case ResolvedPredicate.BinaryPredicate p -> p.columnIndex();
-            case ResolvedPredicate.IntInPredicate p -> p.columnIndex();
-            case ResolvedPredicate.LongInPredicate p -> p.columnIndex();
-            case ResolvedPredicate.BinaryInPredicate p -> p.columnIndex();
-            case ResolvedPredicate.IsNullPredicate p -> p.columnIndex();
-            case ResolvedPredicate.IsNotNullPredicate p -> p.columnIndex();
-            case ResolvedPredicate.GeospatialPredicate p -> p.columnIndex();
-            case ResolvedPredicate.And ignored -> -1;
-            case ResolvedPredicate.Or ignored -> -1;
-        };
     }
 
     /// Evaluates a keep bitmap for pages using pre-parsed Column Index and Offset Index.

--- a/core/src/main/java/dev/hardwood/internal/predicate/RowGroupFilterEvaluator.java
+++ b/core/src/main/java/dev/hardwood/internal/predicate/RowGroupFilterEvaluator.java
@@ -54,12 +54,23 @@ public class RowGroupFilterEvaluator {
     ///        filter checks
     /// @param dictionaries source of the row group's dictionaries, or `null` to skip the dictionary
     ///        checks
+    /// @param logContext where this row group is, for the warning raised when a column's
+    ///        statistics bounds turn out to be unusable
     /// @return the statistics decision for the row group
     public static FilterDecision decideRowGroup(ResolvedPredicate predicate, RowGroup rowGroup,
-            BloomFilterSource bloomFilters, RowGroupDictionaryFilterSource dictionaries) throws IOException {
+            BloomFilterSource bloomFilters, RowGroupDictionaryFilterSource dictionaries,
+            LogContext logContext) throws IOException {
+        return decide(predicate, rowGroup, bloomFilters, dictionaries, logContext);
+    }
+
+    /// The recursive body of [#decideRowGroup], carrying where the row group is so that a
+    /// column whose bounds turn out to be unusable can be named.
+    private static FilterDecision decide(ResolvedPredicate predicate, RowGroup rowGroup,
+            BloomFilterSource bloomFilters, RowGroupDictionaryFilterSource dictionaries,
+            LogContext logContext) throws IOException {
         return switch (predicate) {
             case ResolvedPredicate.IntPredicate p -> {
-                FilterDecision decision = statisticsDecision(p, p.columnIndex(), rowGroup);
+                FilterDecision decision = statisticsDecision(p, rowGroup, logContext, p.columnIndex());
                 if (decision != FilterDecision.CANNOT_MATCH
                         && p.op() == FilterPredicate.Operator.EQ
                         && (BloomFilterSupport.valueAbsent(bloom(bloomFilters, p.columnIndex()), p.value())
@@ -69,7 +80,7 @@ public class RowGroupFilterEvaluator {
                 yield decision;
             }
             case ResolvedPredicate.LongPredicate p -> {
-                FilterDecision decision = statisticsDecision(p, p.columnIndex(), rowGroup);
+                FilterDecision decision = statisticsDecision(p, rowGroup, logContext, p.columnIndex());
                 if (decision != FilterDecision.CANNOT_MATCH
                         && p.op() == FilterPredicate.Operator.EQ
                         && (BloomFilterSupport.valueAbsent(bloom(bloomFilters, p.columnIndex()), p.value())
@@ -79,7 +90,7 @@ public class RowGroupFilterEvaluator {
                 yield decision;
             }
             case ResolvedPredicate.FloatPredicate p -> {
-                FilterDecision decision = statisticsDecision(p, p.columnIndex(), rowGroup);
+                FilterDecision decision = statisticsDecision(p, rowGroup, logContext, p.columnIndex());
                 if (decision != FilterDecision.CANNOT_MATCH
                         && p.op() == FilterPredicate.Operator.EQ
                         // The NaN case is repeated from BloomFilterSupport so the filter is not
@@ -96,7 +107,7 @@ public class RowGroupFilterEvaluator {
             // neighbouring value would prove the wrong one absent. The dictionary holds the
             // stored values, so its entries can be widened instead and compared exactly.
             case ResolvedPredicate.Float16Predicate p -> {
-                FilterDecision decision = statisticsDecision(p, p.columnIndex(), rowGroup);
+                FilterDecision decision = statisticsDecision(p, rowGroup, logContext, p.columnIndex());
                 if (decision != FilterDecision.CANNOT_MATCH
                         && p.op() == FilterPredicate.Operator.EQ
                         && DictionaryFilterSupport.valueAbsentFloat16(dictionary(dictionaries, p.columnIndex()), p.value())) {
@@ -105,7 +116,7 @@ public class RowGroupFilterEvaluator {
                 yield decision;
             }
             case ResolvedPredicate.DoublePredicate p -> {
-                FilterDecision decision = statisticsDecision(p, p.columnIndex(), rowGroup);
+                FilterDecision decision = statisticsDecision(p, rowGroup, logContext, p.columnIndex());
                 if (decision != FilterDecision.CANNOT_MATCH
                         && p.op() == FilterPredicate.Operator.EQ
                         // The NaN case is repeated from BloomFilterSupport so the filter is not
@@ -118,9 +129,9 @@ public class RowGroupFilterEvaluator {
                 yield decision;
             }
             case ResolvedPredicate.BooleanPredicate p ->
-                    statisticsDecision(p, p.columnIndex(), rowGroup);
+                    statisticsDecision(p, rowGroup, logContext, p.columnIndex());
             case ResolvedPredicate.BinaryPredicate p -> {
-                FilterDecision decision = statisticsDecision(p, p.columnIndex(), rowGroup);
+                FilterDecision decision = statisticsDecision(p, rowGroup, logContext, p.columnIndex());
                 // Bloom filters and dictionary membership answer "are these exact bytes here?",
                 // which stands in for "is this value here?" only where the value has one
                 // encoding — see BinaryPredicate#byteExact. Statistics compare in the column's
@@ -135,7 +146,7 @@ public class RowGroupFilterEvaluator {
                 yield decision;
             }
             case ResolvedPredicate.IntInPredicate p -> {
-                FilterDecision decision = statisticsDecision(p, p.columnIndex(), rowGroup);
+                FilterDecision decision = statisticsDecision(p, rowGroup, logContext, p.columnIndex());
                 if (decision != FilterDecision.CANNOT_MATCH
                         && (BloomFilterSupport.absentAll(bloom(bloomFilters, p.columnIndex()), p.values())
                                 || DictionaryFilterSupport.absentAll(dictionary(dictionaries, p.columnIndex()), p.values()))) {
@@ -144,7 +155,7 @@ public class RowGroupFilterEvaluator {
                 yield decision;
             }
             case ResolvedPredicate.LongInPredicate p -> {
-                FilterDecision decision = statisticsDecision(p, p.columnIndex(), rowGroup);
+                FilterDecision decision = statisticsDecision(p, rowGroup, logContext, p.columnIndex());
                 if (decision != FilterDecision.CANNOT_MATCH
                         && (BloomFilterSupport.absentAll(bloom(bloomFilters, p.columnIndex()), p.values())
                                 || DictionaryFilterSupport.absentAll(dictionary(dictionaries, p.columnIndex()), p.values()))) {
@@ -153,7 +164,7 @@ public class RowGroupFilterEvaluator {
                 yield decision;
             }
             case ResolvedPredicate.BinaryInPredicate p -> {
-                FilterDecision decision = statisticsDecision(p, p.columnIndex(), rowGroup);
+                FilterDecision decision = statisticsDecision(p, rowGroup, logContext, p.columnIndex());
                 if (decision != FilterDecision.CANNOT_MATCH
                         && (BloomFilterSupport.absentAll(bloom(bloomFilters, p.columnIndex()), p.values())
                                 || DictionaryFilterSupport.absentAll(dictionary(dictionaries, p.columnIndex()), p.values()))) {
@@ -162,7 +173,7 @@ public class RowGroupFilterEvaluator {
                 yield decision;
             }
             case ResolvedPredicate.IsNullPredicate p -> {
-                Statistics stats = getStatistics(p.columnIndex(), rowGroup);
+                Statistics stats = getStatistics(rowGroup, p.columnIndex());
                 // Can drop IS NULL if nullCount is known to be 0 (no nulls exist).
                 // The always-matching dual (every row null) is deliberately not derived:
                 // for nested columns the null count tallies leaf values, not rows, so
@@ -172,7 +183,7 @@ public class RowGroupFilterEvaluator {
                         : FilterDecision.MIGHT_MATCH;
             }
             case ResolvedPredicate.IsNotNullPredicate p -> {
-                Statistics stats = getStatistics(p.columnIndex(), rowGroup);
+                Statistics stats = getStatistics(rowGroup, p.columnIndex());
                 if (stats == null || stats.nullCount() == null) {
                     yield FilterDecision.MIGHT_MATCH;
                 }
@@ -190,7 +201,7 @@ public class RowGroupFilterEvaluator {
                 }
                 FilterDecision result = FilterDecision.ALWAYS_MATCHES;
                 for (ResolvedPredicate child : a.children()) {
-                    result = FilterDecision.and(result, decideRowGroup(child, rowGroup, bloomFilters, dictionaries));
+                    result = FilterDecision.and(result, decide(child, rowGroup, bloomFilters, dictionaries, logContext));
                     if (result == FilterDecision.CANNOT_MATCH) {
                         break;
                     }
@@ -203,7 +214,7 @@ public class RowGroupFilterEvaluator {
                 }
                 FilterDecision result = FilterDecision.CANNOT_MATCH;
                 for (ResolvedPredicate child : o.children()) {
-                    result = FilterDecision.or(result, decideRowGroup(child, rowGroup, bloomFilters, dictionaries));
+                    result = FilterDecision.or(result, decide(child, rowGroup, bloomFilters, dictionaries, logContext));
                     if (result == FilterDecision.ALWAYS_MATCHES) {
                         break;
                     }
@@ -227,18 +238,23 @@ public class RowGroupFilterEvaluator {
     }
 
     /// The column's min/max statistics decision for the leaf, [FilterDecision#MIGHT_MATCH]
-    /// when statistics are absent.
-    private static FilterDecision statisticsDecision(ResolvedPredicate leaf, int columnIndex,
-            RowGroup rowGroup) {
-        Statistics stats = getStatistics(columnIndex, rowGroup);
-        return stats == null
-                ? FilterDecision.MIGHT_MATCH
-                : StatisticsFilterSupport.decideLeaf(leaf, MinMaxStats.of(stats));
+    /// when statistics are absent — or when their bounds are unusable, which [MinMaxStats]
+    /// decides and this reports.
+    private static FilterDecision statisticsDecision(ResolvedPredicate leaf, RowGroup rowGroup,
+            LogContext logContext, int columnIndex) {
+        Statistics stats = getStatistics(rowGroup, columnIndex);
+        if (stats == null) {
+            return FilterDecision.MIGHT_MATCH;
+        }
+        MinMaxStats minMax = MinMaxStats.of(stats, leaf);
+        minMax.reportIfDiscarded(logContext.withColumn(
+                rowGroup.columns().get(columnIndex).metaData().pathInSchema()));
+        return minMax.decideLeaf(leaf);
     }
 
     /// Gets statistics for a column by its pre-resolved index.
     /// Returns null if the column index is out of bounds or statistics are absent.
-    private static Statistics getStatistics(int columnIndex, RowGroup rowGroup) {
+    private static Statistics getStatistics(RowGroup rowGroup, int columnIndex) {
         if (columnIndex < 0 || columnIndex >= rowGroup.columns().size()) {
             return null;
         }

--- a/core/src/main/java/dev/hardwood/internal/predicate/StatisticsFilterSupport.java
+++ b/core/src/main/java/dev/hardwood/internal/predicate/StatisticsFilterSupport.java
@@ -9,148 +9,16 @@ package dev.hardwood.internal.predicate;
 
 import dev.hardwood.reader.FilterPredicate;
 
-/// Shared utilities for evaluating filter predicates against min/max statistics.
+/// What each [dev.hardwood.reader.FilterPredicate.Operator] proves over an interval, as pure
+/// functions of a probe value and a pair of bounds.
 ///
-/// Used by both [RowGroupFilterEvaluator] (row-group-level statistics) and
-/// [PageFilterEvaluator] (page-level Column Index statistics) via the
-/// [MinMaxStats] abstraction.
+/// The bounds arrive already decoded and already established as comparable — [MinMaxStats] is
+/// where a unit's statistics are read and where a pair that cannot be compared against is
+/// turned away — so nothing here asks which column it is working for, or whether the interval
+/// it was handed makes sense.
 final class StatisticsFilterSupport {
 
     private StatisticsFilterSupport() {
-    }
-
-    // ==================== Leaf predicate evaluation ====================
-
-    /// Evaluates a resolved leaf predicate against [MinMaxStats].
-    ///
-    /// @return `true` if the predicate proves no rows can match (safe to drop)
-    static boolean canDropLeaf(ResolvedPredicate leaf, MinMaxStats stats) {
-        if (stats.minValue() == null || stats.maxValue() == null) {
-            return false;
-        }
-        return switch (leaf) {
-            case ResolvedPredicate.IntPredicate p -> canDrop(p.op(), p.value(),
-                    StatisticsDecoder.decodeInt(stats.minValue()),
-                    StatisticsDecoder.decodeInt(stats.maxValue()));
-            case ResolvedPredicate.LongPredicate p -> canDrop(p.op(), p.value(),
-                    StatisticsDecoder.decodeLong(stats.minValue()),
-                    StatisticsDecoder.decodeLong(stats.maxValue()));
-            case ResolvedPredicate.FloatPredicate p -> canDropFloat(p.op(), p.value(),
-                    StatisticsDecoder.decodeFloat(stats.minValue()),
-                    StatisticsDecoder.decodeFloat(stats.maxValue()), p.ieee754TotalOrder());
-            case ResolvedPredicate.Float16Predicate p -> canDropFloat(p.op(), p.value(),
-                    StatisticsDecoder.decodeFloat16(stats.minValue()),
-                    StatisticsDecoder.decodeFloat16(stats.maxValue()), p.ieee754TotalOrder());
-            case ResolvedPredicate.DoublePredicate p -> canDropDouble(p.op(), p.value(),
-                    StatisticsDecoder.decodeDouble(stats.minValue()),
-                    StatisticsDecoder.decodeDouble(stats.maxValue()), p.ieee754TotalOrder());
-            case ResolvedPredicate.BooleanPredicate p -> canDrop(p.op(), p.value() ? 1 : 0,
-                    StatisticsDecoder.decodeBoolean(stats.minValue()) ? 1 : 0,
-                    StatisticsDecoder.decodeBoolean(stats.maxValue()) ? 1 : 0);
-            case ResolvedPredicate.BinaryPredicate p -> {
-                if (p.signed()) {
-                    int cmpMin = BinaryComparator.compareSigned(p.value(), stats.minValue());
-                    int cmpMax = BinaryComparator.compareSigned(p.value(), stats.maxValue());
-                    yield canDropCompared(p.op(), cmpMin, cmpMax,
-                            BinaryComparator.compareSigned(stats.minValue(), stats.maxValue()));
-                }
-                else {
-                    int cmpMin = BinaryComparator.compareUnsigned(p.value(), stats.minValue());
-                    int cmpMax = BinaryComparator.compareUnsigned(p.value(), stats.maxValue());
-                    yield canDropCompared(p.op(), cmpMin, cmpMax,
-                            BinaryComparator.compareUnsigned(stats.minValue(), stats.maxValue()));
-                }
-            }
-            case ResolvedPredicate.IntInPredicate p -> canDropIntIn(p.values(),
-                    StatisticsDecoder.decodeInt(stats.minValue()),
-                    StatisticsDecoder.decodeInt(stats.maxValue()));
-            case ResolvedPredicate.LongInPredicate p -> canDropLongIn(p.values(),
-                    StatisticsDecoder.decodeLong(stats.minValue()),
-                    StatisticsDecoder.decodeLong(stats.maxValue()));
-            case ResolvedPredicate.BinaryInPredicate p -> canDropBinaryIn(p.values(),
-                    stats.minValue(), stats.maxValue());
-            case ResolvedPredicate.IsNullPredicate ignored -> false;
-            case ResolvedPredicate.IsNotNullPredicate ignored -> false;
-            case ResolvedPredicate.And ignored -> false;
-            case ResolvedPredicate.Or ignored -> false;
-            case ResolvedPredicate.GeospatialPredicate ignored -> false;
-        };
-    }
-
-    /// Evaluates a resolved leaf predicate against [MinMaxStats] as a three-valued
-    /// [FilterDecision].
-    ///
-    /// [FilterDecision#ALWAYS_MATCHES] requires the whole `[min, max]` interval to satisfy
-    /// the predicate **and** a proven-zero null count — a null row satisfies no value
-    /// predicate, so without it a fully-matching range still cannot promise every row.
-    /// Truncated (inexact) bounds are safe by construction: they only widen the interval,
-    /// and a predicate satisfied by the widened interval is satisfied by the actual values.
-    static FilterDecision decideLeaf(ResolvedPredicate leaf, MinMaxStats stats) {
-        // IS NOT NULL is decided by the null count alone; min/max are irrelevant.
-        if (leaf instanceof ResolvedPredicate.IsNotNullPredicate) {
-            return isNullFree(stats) ? FilterDecision.ALWAYS_MATCHES : FilterDecision.MIGHT_MATCH;
-        }
-        if (canDropLeaf(leaf, stats)) {
-            return FilterDecision.CANNOT_MATCH;
-        }
-        if (!isNullFree(stats) || stats.minValue() == null || stats.maxValue() == null) {
-            return FilterDecision.MIGHT_MATCH;
-        }
-        return alwaysMatchesLeaf(leaf, stats) ? FilterDecision.ALWAYS_MATCHES : FilterDecision.MIGHT_MATCH;
-    }
-
-    private static boolean isNullFree(MinMaxStats stats) {
-        Long nullCount = stats.nullCount();
-        return nullCount != null && nullCount == 0;
-    }
-
-    /// Whether the min/max statistics prove the leaf matches every row. Assumes the caller
-    /// has already established a zero null count and present bounds.
-    private static boolean alwaysMatchesLeaf(ResolvedPredicate leaf, MinMaxStats stats) {
-        return switch (leaf) {
-            case ResolvedPredicate.IntPredicate p -> alwaysMatches(p.op(), p.value(),
-                    StatisticsDecoder.decodeInt(stats.minValue()),
-                    StatisticsDecoder.decodeInt(stats.maxValue()));
-            case ResolvedPredicate.LongPredicate p -> alwaysMatches(p.op(), p.value(),
-                    StatisticsDecoder.decodeLong(stats.minValue()),
-                    StatisticsDecoder.decodeLong(stats.maxValue()));
-            case ResolvedPredicate.BooleanPredicate p -> alwaysMatches(p.op(), p.value() ? 1 : 0,
-                    StatisticsDecoder.decodeBoolean(stats.minValue()) ? 1 : 0,
-                    StatisticsDecoder.decodeBoolean(stats.maxValue()) ? 1 : 0);
-            // NaN values sit outside the min/max ordering, and nan_count is not read yet:
-            // a floating-point unit whose [min, max] fully satisfies the predicate may
-            // still hold non-matching NaN rows. Never promise a full match for FP columns.
-            case ResolvedPredicate.FloatPredicate ignored -> false;
-            case ResolvedPredicate.Float16Predicate ignored -> false;
-            case ResolvedPredicate.DoublePredicate ignored -> false;
-            case ResolvedPredicate.BinaryPredicate p -> {
-                if (p.signed()) {
-                    yield alwaysMatchesCompared(p.op(),
-                            BinaryComparator.compareSigned(p.value(), stats.minValue()),
-                            BinaryComparator.compareSigned(p.value(), stats.maxValue()),
-                            BinaryComparator.compareSigned(stats.minValue(), stats.maxValue()));
-                }
-                yield alwaysMatchesCompared(p.op(),
-                        BinaryComparator.compareUnsigned(p.value(), stats.minValue()),
-                        BinaryComparator.compareUnsigned(p.value(), stats.maxValue()),
-                        BinaryComparator.compareUnsigned(stats.minValue(), stats.maxValue()));
-            }
-            case ResolvedPredicate.IntInPredicate p ->
-                    alwaysMatchesIntIn(p.values(),
-                            StatisticsDecoder.decodeInt(stats.minValue()),
-                            StatisticsDecoder.decodeInt(stats.maxValue()));
-            case ResolvedPredicate.LongInPredicate p ->
-                    alwaysMatchesLongIn(p.values(),
-                            StatisticsDecoder.decodeLong(stats.minValue()),
-                            StatisticsDecoder.decodeLong(stats.maxValue()));
-            case ResolvedPredicate.BinaryInPredicate p ->
-                    alwaysMatchesBinaryIn(p.values(), stats.minValue(), stats.maxValue());
-            case ResolvedPredicate.IsNullPredicate ignored -> false;
-            case ResolvedPredicate.IsNotNullPredicate ignored -> false;
-            case ResolvedPredicate.And ignored -> false;
-            case ResolvedPredicate.Or ignored -> false;
-            case ResolvedPredicate.GeospatialPredicate ignored -> false;
-        };
     }
 
     // ==================== Range comparison logic ====================
@@ -168,15 +36,12 @@ final class StatisticsFilterSupport {
         };
     }
 
+    /// Determines if a range can be dropped given `FLOAT` or `FLOAT16` min/max statistics.
+    ///
+    /// The bounds are assumed usable — neither `NaN` nor inverted — which [MinMaxStats]
+    /// establishes where it sources them.
     static boolean canDropFloat(FilterPredicate.Operator op, float value, float min, float max,
             boolean ieee754TotalOrder) {
-        // The Parquet spec forbids writing NaN to statistics min/max, but older / buggy writers
-        // have produced such bounds. NaN sorts above every finite value in Float.compare's total
-        // order, so applying the range checks below would silently prune row groups / pages that
-        // hold matching finite rows. Treat NaN bounds as no-bound and never prune.
-        if (Float.isNaN(min) || Float.isNaN(max)) {
-            return false;
-        }
         // Under the type-defined ordering the spec leaves +0/-0 ambiguous: a +0 min may hide -0, a
         // -0 max may hide +0. Float.compare's total order separates them (-0 < +0), which could
         // wrongly drop the opposite zero, so widen each zero bound to its total-order extreme. The
@@ -195,11 +60,10 @@ final class StatisticsFilterSupport {
         };
     }
 
+    /// Determines if a range can be dropped given `DOUBLE` min/max statistics. See
+    /// [#canDropFloat] for what the bounds are assumed to be.
     static boolean canDropDouble(FilterPredicate.Operator op, double value, double min, double max,
             boolean ieee754TotalOrder) {
-        if (Double.isNaN(min) || Double.isNaN(max)) {
-            return false;
-        }
         // See canDropFloat: widen ±0 bounds under the type-defined ordering, leave them exact for
         // the unambiguous IEEE 754 total order.
         if (!ieee754TotalOrder) {

--- a/core/src/main/java/dev/hardwood/internal/reader/RowGroupIterator.java
+++ b/core/src/main/java/dev/hardwood/internal/reader/RowGroupIterator.java
@@ -26,6 +26,7 @@ import dev.hardwood.InputFile;
 import dev.hardwood.internal.ExceptionContext;
 import dev.hardwood.internal.FetchReason;
 import dev.hardwood.internal.predicate.FilterDecision;
+import dev.hardwood.internal.predicate.LogContext;
 import dev.hardwood.internal.predicate.PageDropPredicates;
 import dev.hardwood.internal.predicate.PageFilterEvaluator;
 import dev.hardwood.internal.predicate.ResolvedPredicate;
@@ -423,7 +424,8 @@ public class RowGroupIterator implements Closeable {
                 RowRanges matchingRows = RowRanges.ALL;
                 if (pageFiltering) {
                     matchingRows = PageFilterEvaluator.computeMatchingRows(
-                            workItem.columnOrdinals().filter(), workItem.rowGroup(), indexBuffers);
+                            workItem.columnOrdinals().filter(), workItem.rowGroup(), indexBuffers,
+                            new LogContext(workItem.inputFile().name(), workItem.rowGroupIndex()));
                 }
 
                 MaskCapability maskCapability = masksApplicableForRowGroup(
@@ -1380,7 +1382,8 @@ public class RowGroupIterator implements Closeable {
             RowGroup rg = rowGroups.get(rgIndex);
             FilterDecision decision = RowGroupFilterEvaluator.decideRowGroup(columnOrdinals.filter(), rg,
                     new RowGroupBloomFilterSource(inputFile, rg),
-                    new RowGroupDictionaryFilterSource(inputFile, rg, fileSchema, context));
+                    new RowGroupDictionaryFilterSource(inputFile, rg, fileSchema, context),
+                    new LogContext(inputFile.name(), rgIndex));
             if (decision == FilterDecision.CANNOT_MATCH) {
                 continue;
             }

--- a/core/src/main/java/dev/hardwood/internal/reader/SequentialFetchPlan.java
+++ b/core/src/main/java/dev/hardwood/internal/reader/SequentialFetchPlan.java
@@ -17,6 +17,7 @@ import dev.hardwood.internal.ExceptionContext;
 import dev.hardwood.internal.metadata.DataPageHeader;
 import dev.hardwood.internal.metadata.DataPageHeaderV2;
 import dev.hardwood.internal.metadata.PageHeader;
+import dev.hardwood.internal.predicate.LogContext;
 import dev.hardwood.internal.predicate.PageDropPredicates;
 import dev.hardwood.internal.predicate.ResolvedPredicate;
 import dev.hardwood.internal.thrift.PageHeaderReader;
@@ -303,6 +304,9 @@ public final class SequentialFetchPlan implements FetchPlan, RowGroupIterator.Co
     private class SequentialPageIterator implements PageIterator {
 
         private final ColumnMetaData metaData = columnChunk.metaData();
+        /// Where this chunk is, for a page whose statistics turn out to be unusable to name.
+        private final LogContext logContext =
+                new LogContext(fileName, rowGroupIndex).withColumn(columnSchema.fieldPath());
         private Dictionary dictionary;
         private boolean initialized;
         private boolean exhausted;
@@ -683,7 +687,8 @@ public final class SequentialFetchPlan implements FetchPlan, RowGroupIterator.Co
                 }
                 default -> null;
             };
-            return PageDropPredicates.canDropPage(dropLeaves, inline);
+            return PageDropPredicates.canDropPage(dropLeaves, inline,
+                    logContext.withPageIndex(currentPage));
         }
 
         private void emitEvent() {

--- a/core/src/main/java/dev/hardwood/internal/thrift/StatisticsReader.java
+++ b/core/src/main/java/dev/hardwood/internal/thrift/StatisticsReader.java
@@ -92,8 +92,12 @@ public class StatisticsReader {
             }
         }
 
-        // Prefer fields 5/6 over deprecated 1/2
-        boolean deprecated = (minValue == null && maxValue == null);
+        // Prefer fields 5/6 over deprecated 1/2. A struct carrying neither pair — a column
+        // that wrote a null count and no bounds — took its bounds from nowhere, so it is not
+        // reporting deprecated ones; saying otherwise labels an ordinary file's statistics
+        // deprecated for everything that reads the flag.
+        boolean deprecated = minValue == null && maxValue == null
+                && (deprecatedMin != null || deprecatedMax != null);
         byte[] resolvedMin = minValue != null ? minValue : deprecatedMin;
         byte[] resolvedMax = maxValue != null ? maxValue : deprecatedMax;
 

--- a/core/src/test/java/dev/hardwood/FilterPredicateTest.java
+++ b/core/src/test/java/dev/hardwood/FilterPredicateTest.java
@@ -25,8 +25,10 @@ import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.EnumSource;
 import org.junit.jupiter.params.provider.MethodSource;
 
+import dev.hardwood.internal.ExceptionContext;
 import dev.hardwood.internal.predicate.FilterDecision;
 import dev.hardwood.internal.predicate.FilterPredicateResolver;
+import dev.hardwood.internal.predicate.LogContext;
 import dev.hardwood.internal.predicate.ResolvedPredicate;
 import dev.hardwood.internal.predicate.RowGroupFilterEvaluator;
 import dev.hardwood.metadata.BoundingBox;
@@ -49,6 +51,11 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 class FilterPredicateTest {
+
+    /// A position with nothing to point at: these cases assert decisions, not diagnostics.
+    private static final LogContext UNNAMED =
+            new LogContext(null, ExceptionContext.UNKNOWN_ROW_GROUP);
+
 
     // ==================== Predicate Factory Tests ====================
 
@@ -1407,6 +1414,6 @@ class FilterPredicateTest {
     /// This mirrors the production code path: resolve first, then evaluate.
     private static boolean canDropRowGroup(FilterPredicate filter, RowGroup rg, FileSchema schema) throws IOException {
         ResolvedPredicate resolved = FilterPredicateResolver.resolve(filter, schema);
-        return RowGroupFilterEvaluator.decideRowGroup(resolved, rg, null, null) == FilterDecision.CANNOT_MATCH;
+        return RowGroupFilterEvaluator.decideRowGroup(resolved, rg, null, null, UNNAMED) == FilterDecision.CANNOT_MATCH;
     }
 }

--- a/core/src/test/java/dev/hardwood/internal/predicate/BinaryDecimalFilterTest.java
+++ b/core/src/test/java/dev/hardwood/internal/predicate/BinaryDecimalFilterTest.java
@@ -17,6 +17,7 @@ import java.util.List;
 import org.junit.jupiter.api.Test;
 
 import dev.hardwood.InputFile;
+import dev.hardwood.internal.ExceptionContext;
 import dev.hardwood.internal.bloomfilter.BloomFilter;
 import dev.hardwood.internal.bloomfilter.BloomFilterHeader;
 import dev.hardwood.internal.predicate.ResolvedPredicate.BinaryPredicate.Comparison;
@@ -38,6 +39,11 @@ import static org.assertj.core.api.Assertions.assertThat;
 /// `127` is `0x7F` and `128` is `0x00 0x80`. Predicates over such a column compare the
 /// represented value, not the byte string.
 class BinaryDecimalFilterTest {
+
+    /// A position with nothing to point at: these cases assert decisions, not diagnostics.
+    private static final LogContext UNNAMED =
+            new LogContext(null, ExceptionContext.UNKNOWN_ROW_GROUP);
+
 
     private static final int PADDED_ROWS = 512;
 
@@ -239,7 +245,7 @@ class BinaryDecimalFilterTest {
                 new BloomFilterHeader(BLOOM_FILTER_BYTES, BloomFilterHeader.Algorithm.BLOCK,
                         BloomFilterHeader.Hash.XXHASH, BloomFilterHeader.Compression.UNCOMPRESSED),
                 ByteBuffer.allocate(BLOOM_FILTER_BYTES).order(ByteOrder.LITTLE_ENDIAN).asReadOnlyBuffer());
-        return RowGroupFilterEvaluator.decideRowGroup(predicate, rowGroup, empty, null);
+        return RowGroupFilterEvaluator.decideRowGroup(predicate, rowGroup, empty, null, UNNAMED);
     }
 
     /// Rows alternating a padded `127` with a minimally encoded `300`.

--- a/core/src/test/java/dev/hardwood/internal/predicate/BloomFilterPushDownTest.java
+++ b/core/src/test/java/dev/hardwood/internal/predicate/BloomFilterPushDownTest.java
@@ -32,6 +32,7 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
 import dev.hardwood.InputFile;
+import dev.hardwood.internal.ExceptionContext;
 import dev.hardwood.internal.bloomfilter.BloomFilter;
 import dev.hardwood.internal.bloomfilter.XxHash64;
 import dev.hardwood.internal.reader.CountingInputFile;
@@ -55,6 +56,11 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 /// so statistics alone keep the row group — but were never written, so only the bloom filter can
 /// prove their absence.
 class BloomFilterPushDownTest {
+
+    /// A position with nothing to point at: these cases assert decisions, not diagnostics.
+    private static final LogContext UNNAMED =
+            new LogContext(null, ExceptionContext.UNKNOWN_ROW_GROUP);
+
 
     private static final Path FIXTURE = Paths.get("src/test/resources/bloom_filter_test.parquet");
 
@@ -333,12 +339,12 @@ class BloomFilterPushDownTest {
     private static boolean bloomDrop(FilterPredicate filter) throws IOException {
         ResolvedPredicate resolved = FilterPredicateResolver.resolve(filter, schema);
         return RowGroupFilterEvaluator.decideRowGroup(resolved, rowGroup,
-                new RowGroupBloomFilterSource(inputFile, rowGroup), null) == FilterDecision.CANNOT_MATCH;
+                new RowGroupBloomFilterSource(inputFile, rowGroup), null, UNNAMED) == FilterDecision.CANNOT_MATCH;
     }
 
     private static boolean statisticsDrop(FilterPredicate filter) throws IOException {
         ResolvedPredicate resolved = FilterPredicateResolver.resolve(filter, schema);
-        return RowGroupFilterEvaluator.decideRowGroup(resolved, rowGroup, null, null) == FilterDecision.CANNOT_MATCH;
+        return RowGroupFilterEvaluator.decideRowGroup(resolved, rowGroup, null, null, UNNAMED) == FilterDecision.CANNOT_MATCH;
     }
 
     /// A `BloomFilterHeader` thrift struct followed by a minimal one-block (32-byte) bitset holding

--- a/core/src/test/java/dev/hardwood/internal/predicate/BloomFilterSignedZeroPushDownTest.java
+++ b/core/src/test/java/dev/hardwood/internal/predicate/BloomFilterSignedZeroPushDownTest.java
@@ -16,6 +16,7 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
 import dev.hardwood.InputFile;
+import dev.hardwood.internal.ExceptionContext;
 import dev.hardwood.metadata.RowGroup;
 import dev.hardwood.reader.FilterPredicate;
 import dev.hardwood.reader.ParquetFileReader;
@@ -28,6 +29,11 @@ import static org.assertj.core.api.Assertions.assertThat;
 /// Statistics are disabled in the fixture so these assertions exercise bloom-filter decisions
 /// directly.
 class BloomFilterSignedZeroPushDownTest {
+
+    /// A position with nothing to point at: these cases assert decisions, not diagnostics.
+    private static final LogContext UNNAMED =
+            new LogContext(null, ExceptionContext.UNKNOWN_ROW_GROUP);
+
 
     private static final Path FIXTURE =
             Paths.get("src/test/resources/bloom_filter_signed_zero_test.parquet");
@@ -73,11 +79,11 @@ class BloomFilterSignedZeroPushDownTest {
     private static boolean bloomDrop(FilterPredicate filter) throws IOException {
         ResolvedPredicate resolved = FilterPredicateResolver.resolve(filter, schema);
         return RowGroupFilterEvaluator.decideRowGroup(resolved, rowGroup,
-                new RowGroupBloomFilterSource(inputFile, rowGroup), null) == FilterDecision.CANNOT_MATCH;
+                new RowGroupBloomFilterSource(inputFile, rowGroup), null, UNNAMED) == FilterDecision.CANNOT_MATCH;
     }
 
     private static boolean statisticsDrop(FilterPredicate filter) throws IOException {
         ResolvedPredicate resolved = FilterPredicateResolver.resolve(filter, schema);
-        return RowGroupFilterEvaluator.decideRowGroup(resolved, rowGroup, null, null) == FilterDecision.CANNOT_MATCH;
+        return RowGroupFilterEvaluator.decideRowGroup(resolved, rowGroup, null, null, UNNAMED) == FilterDecision.CANNOT_MATCH;
     }
 }

--- a/core/src/test/java/dev/hardwood/internal/predicate/CapturedWarnings.java
+++ b/core/src/test/java/dev/hardwood/internal/predicate/CapturedWarnings.java
@@ -1,0 +1,68 @@
+/*
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Copyright The original authors
+ *
+ *  Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package dev.hardwood.internal.predicate;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.apache.logging.log4j.Level;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.core.LogEvent;
+import org.apache.logging.log4j.core.LoggerContext;
+import org.apache.logging.log4j.core.appender.AbstractAppender;
+import org.apache.logging.log4j.core.config.LoggerConfig;
+import org.apache.logging.log4j.core.config.Property;
+import org.junit.jupiter.api.extension.AfterEachCallback;
+import org.junit.jupiter.api.extension.BeforeEachCallback;
+import org.junit.jupiter.api.extension.ExtensionContext;
+
+/// Collects the `WARNING` lines a test provokes, for the cases that assert what the filter
+/// layer says about a file rather than what it decides about one.
+///
+/// Register it with `@RegisterExtension`; it attaches to the root logger for the duration of
+/// each test and detaches afterwards, so the messages of one case never reach another.
+final class CapturedWarnings implements BeforeEachCallback, AfterEachCallback {
+
+    private final CapturingAppender appender = new CapturingAppender();
+
+    private LoggerConfig loggerConfig;
+
+    /// The formatted text of every warning logged since the current test started.
+    List<String> messages() {
+        return appender.messages;
+    }
+
+    @Override
+    public void beforeEach(ExtensionContext context) {
+        LoggerContext loggerContext = (LoggerContext) LogManager.getContext(false);
+        loggerConfig = loggerContext.getConfiguration().getRootLogger();
+        appender.messages.clear();
+        appender.start();
+        loggerConfig.addAppender(appender, Level.WARN, null);
+    }
+
+    @Override
+    public void afterEach(ExtensionContext context) {
+        loggerConfig.removeAppender(appender.getName());
+        appender.stop();
+    }
+
+    private static final class CapturingAppender extends AbstractAppender {
+
+        private final List<String> messages = new ArrayList<>();
+
+        CapturingAppender() {
+            super("CapturedWarnings", null, null, true, Property.EMPTY_ARRAY);
+        }
+
+        @Override
+        public void append(LogEvent event) {
+            messages.add(event.getMessage().getFormattedMessage());
+        }
+    }
+}

--- a/core/src/test/java/dev/hardwood/internal/predicate/DictionaryFixedLenByteArrayPushDownTest.java
+++ b/core/src/test/java/dev/hardwood/internal/predicate/DictionaryFixedLenByteArrayPushDownTest.java
@@ -16,6 +16,7 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
 import dev.hardwood.InputFile;
+import dev.hardwood.internal.ExceptionContext;
 import dev.hardwood.internal.predicate.dictionary.RowGroupDictionaryFilterSource;
 import dev.hardwood.internal.reader.HardwoodContextImpl;
 import dev.hardwood.metadata.PhysicalType;
@@ -34,6 +35,11 @@ import static org.assertj.core.api.Assertions.assertThat;
 /// column's statistics min/max range, so statistics alone keep the row group and only the
 /// dictionary can prove absence.
 class DictionaryFixedLenByteArrayPushDownTest {
+
+    /// A position with nothing to point at: these cases assert decisions, not diagnostics.
+    private static final LogContext UNNAMED =
+            new LogContext(null, ExceptionContext.UNKNOWN_ROW_GROUP);
+
 
     private static final Path FIXTURE = Paths.get("src/test/resources/dict_flba_pushdown.parquet");
 
@@ -86,12 +92,12 @@ class DictionaryFixedLenByteArrayPushDownTest {
 
     private static boolean dictionaryDrop(FilterPredicate filter) throws IOException {
         ResolvedPredicate resolved = FilterPredicateResolver.resolve(filter, schema);
-        return RowGroupFilterEvaluator.decideRowGroup(resolved, rowGroup, null, dictionaries())
+        return RowGroupFilterEvaluator.decideRowGroup(resolved, rowGroup, null, dictionaries(), UNNAMED)
                 == FilterDecision.CANNOT_MATCH;
     }
 
     private static boolean statisticsDrop(FilterPredicate filter) throws IOException {
         ResolvedPredicate resolved = FilterPredicateResolver.resolve(filter, schema);
-        return RowGroupFilterEvaluator.decideRowGroup(resolved, rowGroup, null, null) == FilterDecision.CANNOT_MATCH;
+        return RowGroupFilterEvaluator.decideRowGroup(resolved, rowGroup, null, null, UNNAMED) == FilterDecision.CANNOT_MATCH;
     }
 }

--- a/core/src/test/java/dev/hardwood/internal/predicate/DictionaryFloat16PushDownTest.java
+++ b/core/src/test/java/dev/hardwood/internal/predicate/DictionaryFloat16PushDownTest.java
@@ -16,6 +16,7 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
 import dev.hardwood.InputFile;
+import dev.hardwood.internal.ExceptionContext;
 import dev.hardwood.internal.predicate.dictionary.RowGroupDictionaryFilterSource;
 import dev.hardwood.internal.reader.HardwoodContextImpl;
 import dev.hardwood.metadata.LogicalType;
@@ -36,6 +37,11 @@ import static org.assertj.core.api.Assertions.assertThat;
 /// through [RowGroupFilterEvaluator]. Every probe sits inside the `[1.0, 8.0]` range statistics
 /// advertise, so statistics alone keep the row group and only the dictionary can prove absence.
 class DictionaryFloat16PushDownTest {
+
+    /// A position with nothing to point at: these cases assert decisions, not diagnostics.
+    private static final LogContext UNNAMED =
+            new LogContext(null, ExceptionContext.UNKNOWN_ROW_GROUP);
+
 
     private static final Path FIXTURE = Paths.get("src/test/resources/dict_float16_pushdown.parquet");
 
@@ -92,12 +98,12 @@ class DictionaryFloat16PushDownTest {
 
     private static boolean dictionaryDrop(FilterPredicate filter) throws IOException {
         ResolvedPredicate resolved = FilterPredicateResolver.resolve(filter, schema);
-        return RowGroupFilterEvaluator.decideRowGroup(resolved, rowGroup, null, dictionaries())
+        return RowGroupFilterEvaluator.decideRowGroup(resolved, rowGroup, null, dictionaries(), UNNAMED)
                 == FilterDecision.CANNOT_MATCH;
     }
 
     private static boolean statisticsDrop(FilterPredicate filter) throws IOException {
         ResolvedPredicate resolved = FilterPredicateResolver.resolve(filter, schema);
-        return RowGroupFilterEvaluator.decideRowGroup(resolved, rowGroup, null, null) == FilterDecision.CANNOT_MATCH;
+        return RowGroupFilterEvaluator.decideRowGroup(resolved, rowGroup, null, null, UNNAMED) == FilterDecision.CANNOT_MATCH;
     }
 }

--- a/core/src/test/java/dev/hardwood/internal/predicate/DictionaryNumericPushDownTest.java
+++ b/core/src/test/java/dev/hardwood/internal/predicate/DictionaryNumericPushDownTest.java
@@ -16,6 +16,7 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
 import dev.hardwood.InputFile;
+import dev.hardwood.internal.ExceptionContext;
 import dev.hardwood.internal.predicate.dictionary.DictionaryFilterSupport;
 import dev.hardwood.internal.predicate.dictionary.RowGroupDictionaryFilterSource;
 import dev.hardwood.internal.reader.HardwoodContextImpl;
@@ -35,6 +36,11 @@ import static org.assertj.core.api.Assertions.assertThat;
 /// column's statistics min/max range, so statistics alone keep the row group and only the
 /// dictionary can prove absence.
 class DictionaryNumericPushDownTest {
+
+    /// A position with nothing to point at: these cases assert decisions, not diagnostics.
+    private static final LogContext UNNAMED =
+            new LogContext(null, ExceptionContext.UNKNOWN_ROW_GROUP);
+
 
     private static final Path FIXTURE = Paths.get("src/test/resources/dict_numeric_pushdown.parquet");
 
@@ -133,12 +139,12 @@ class DictionaryNumericPushDownTest {
 
     private static boolean dictionaryDrop(FilterPredicate filter) throws IOException {
         ResolvedPredicate resolved = FilterPredicateResolver.resolve(filter, schema);
-        return RowGroupFilterEvaluator.decideRowGroup(resolved, rowGroup, null, dictionaries())
+        return RowGroupFilterEvaluator.decideRowGroup(resolved, rowGroup, null, dictionaries(), UNNAMED)
                 == FilterDecision.CANNOT_MATCH;
     }
 
     private static boolean statisticsDrop(FilterPredicate filter) throws IOException {
         ResolvedPredicate resolved = FilterPredicateResolver.resolve(filter, schema);
-        return RowGroupFilterEvaluator.decideRowGroup(resolved, rowGroup, null, null) == FilterDecision.CANNOT_MATCH;
+        return RowGroupFilterEvaluator.decideRowGroup(resolved, rowGroup, null, null, UNNAMED) == FilterDecision.CANNOT_MATCH;
     }
 }

--- a/core/src/test/java/dev/hardwood/internal/predicate/DictionaryPushDownTest.java
+++ b/core/src/test/java/dev/hardwood/internal/predicate/DictionaryPushDownTest.java
@@ -16,6 +16,7 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
 import dev.hardwood.InputFile;
+import dev.hardwood.internal.ExceptionContext;
 import dev.hardwood.internal.predicate.dictionary.RowGroupDictionaryFilterSource;
 import dev.hardwood.internal.reader.HardwoodContextImpl;
 import dev.hardwood.metadata.RowGroup;
@@ -35,6 +36,11 @@ import static org.assertj.core.api.Assertions.assertThat;
 /// Asserts the evaluator decision directly; [dev.hardwood.DictionaryEndToEndTest] drives the same
 /// fixture through the public reader APIs.
 class DictionaryPushDownTest {
+
+    /// A position with nothing to point at: these cases assert decisions, not diagnostics.
+    private static final LogContext UNNAMED =
+            new LogContext(null, ExceptionContext.UNKNOWN_ROW_GROUP);
+
 
     private static final Path FIXTURE = Paths.get("src/test/resources/column_index_pushdown_dict.parquet");
 
@@ -125,12 +131,12 @@ class DictionaryPushDownTest {
 
     private static boolean dictionaryDrop(FilterPredicate filter) throws IOException {
         ResolvedPredicate resolved = FilterPredicateResolver.resolve(filter, schema);
-        return RowGroupFilterEvaluator.decideRowGroup(resolved, rowGroup, null, dictionaries())
+        return RowGroupFilterEvaluator.decideRowGroup(resolved, rowGroup, null, dictionaries(), UNNAMED)
                 == FilterDecision.CANNOT_MATCH;
     }
 
     private static boolean statisticsDrop(FilterPredicate filter) throws IOException {
         ResolvedPredicate resolved = FilterPredicateResolver.resolve(filter, schema);
-        return RowGroupFilterEvaluator.decideRowGroup(resolved, rowGroup, null, null) == FilterDecision.CANNOT_MATCH;
+        return RowGroupFilterEvaluator.decideRowGroup(resolved, rowGroup, null, null, UNNAMED) == FilterDecision.CANNOT_MATCH;
     }
 }

--- a/core/src/test/java/dev/hardwood/internal/predicate/FilterDecisionTest.java
+++ b/core/src/test/java/dev/hardwood/internal/predicate/FilterDecisionTest.java
@@ -7,8 +7,6 @@
  */
 package dev.hardwood.internal.predicate;
 
-import java.nio.ByteBuffer;
-import java.nio.ByteOrder;
 import java.nio.charset.StandardCharsets;
 import java.util.Random;
 
@@ -23,7 +21,7 @@ import static dev.hardwood.internal.predicate.FilterDecision.MIGHT_MATCH;
 import static org.assertj.core.api.Assertions.assertThat;
 
 /// Unit matrix for the three-valued statistics decision: [FilterDecision] combinators and
-/// [StatisticsFilterSupport#decideLeaf] over synthetic [MinMaxStats].
+/// [MinMaxStats#decideLeaf] over synthetic bounds.
 ///
 /// The [#decisionAgreesWithBruteForceOnRandomData] property pins the decision's meaning
 /// against decoded values: [FilterDecision#ALWAYS_MATCHES] must imply zero non-matching
@@ -90,11 +88,11 @@ class FilterDecisionTest {
     @Test
     void intInDecisions() {
         ResolvedPredicate in = new ResolvedPredicate.IntInPredicate(0, new int[]{ 5, 42, 99 });
-        assertThat(StatisticsFilterSupport.decideLeaf(in, intStats(42, 42, 0L)))
+        assertThat(intStats(42, 42, 0L).decideLeaf(in))
                 .isEqualTo(ALWAYS_MATCHES);
-        assertThat(StatisticsFilterSupport.decideLeaf(in, intStats(42, 43, 0L)))
+        assertThat(intStats(42, 43, 0L).decideLeaf(in))
                 .isEqualTo(MIGHT_MATCH);
-        assertThat(StatisticsFilterSupport.decideLeaf(in, intStats(6, 41, 0L)))
+        assertThat(intStats(6, 41, 0L).decideLeaf(in))
                 .isEqualTo(CANNOT_MATCH);
     }
 
@@ -105,18 +103,18 @@ class FilterDecisionTest {
         // [10, 20] fully satisfies GT 5, but nulls (or an unknown null count) may hide
         // non-matching rows: a null row satisfies no value predicate.
         ResolvedPredicate gt = new ResolvedPredicate.IntPredicate(0, FilterPredicate.Operator.GT, 5);
-        assertThat(StatisticsFilterSupport.decideLeaf(gt, intStats(10, 20, 0L)))
+        assertThat(intStats(10, 20, 0L).decideLeaf(gt))
                 .isEqualTo(ALWAYS_MATCHES);
-        assertThat(StatisticsFilterSupport.decideLeaf(gt, intStats(10, 20, 3L)))
+        assertThat(intStats(10, 20, 3L).decideLeaf(gt))
                 .isEqualTo(MIGHT_MATCH);
-        assertThat(StatisticsFilterSupport.decideLeaf(gt, intStats(10, 20, null)))
+        assertThat(intStats(10, 20, null).decideLeaf(gt))
                 .isEqualTo(MIGHT_MATCH);
     }
 
     @Test
     void missingBoundsNeverPromiseAlwaysMatches() {
         ResolvedPredicate gt = new ResolvedPredicate.IntPredicate(0, FilterPredicate.Operator.GT, 5);
-        assertThat(StatisticsFilterSupport.decideLeaf(gt, stats(null, null, 0L)))
+        assertThat(noBounds(0L).decideLeaf(gt))
                 .isEqualTo(MIGHT_MATCH);
     }
 
@@ -128,18 +126,18 @@ class FilterDecisionTest {
         // fully-satisfying interval cannot promise every row for FP columns.
         ResolvedPredicate gtDouble =
                 new ResolvedPredicate.DoublePredicate(0, FilterPredicate.Operator.GT, 1.0);
-        assertThat(StatisticsFilterSupport.decideLeaf(gtDouble, doubleStats(10.0, 20.0, 0L)))
+        assertThat(doubleStats(10.0, 20.0, 0L).decideLeaf(gtDouble))
                 .isEqualTo(MIGHT_MATCH);
 
         ResolvedPredicate gtFloat =
                 new ResolvedPredicate.FloatPredicate(0, FilterPredicate.Operator.GT, 1.0f);
-        assertThat(StatisticsFilterSupport.decideLeaf(gtFloat, floatStats(10.0f, 20.0f, 0L)))
+        assertThat(floatStats(10.0f, 20.0f, 0L).decideLeaf(gtFloat))
                 .isEqualTo(MIGHT_MATCH);
 
         // The CANNOT_MATCH side is unaffected.
         ResolvedPredicate gtOutside =
                 new ResolvedPredicate.DoublePredicate(0, FilterPredicate.Operator.GT, 25.0);
-        assertThat(StatisticsFilterSupport.decideLeaf(gtOutside, doubleStats(10.0, 20.0, 0L)))
+        assertThat(doubleStats(10.0, 20.0, 0L).decideLeaf(gtOutside))
                 .isEqualTo(CANNOT_MATCH);
     }
 
@@ -160,19 +158,6 @@ class FilterDecisionTest {
                 .isEqualTo(ALWAYS_MATCHES);
         assertThat(decideBinary(FilterPredicate.Operator.EQ, "apple", "mango", "peach"))
                 .isEqualTo(CANNOT_MATCH);
-    }
-
-    // ==================== IS NOT NULL ====================
-
-    @Test
-    void isNotNullDecidedByNullCountAlone() {
-        ResolvedPredicate isNotNull = new ResolvedPredicate.IsNotNullPredicate(0);
-        assertThat(StatisticsFilterSupport.decideLeaf(isNotNull, stats(null, null, 0L)))
-                .isEqualTo(ALWAYS_MATCHES);
-        assertThat(StatisticsFilterSupport.decideLeaf(isNotNull, stats(null, null, 3L)))
-                .isEqualTo(MIGHT_MATCH);
-        assertThat(StatisticsFilterSupport.decideLeaf(isNotNull, stats(null, null, null)))
-                .isEqualTo(MIGHT_MATCH);
     }
 
     // ==================== Property: decision agrees with brute force ====================
@@ -198,7 +183,7 @@ class FilterDecisionTest {
 
             ResolvedPredicate leaf = new ResolvedPredicate.LongPredicate(0, op, literal);
             FilterDecision decision =
-                    StatisticsFilterSupport.decideLeaf(leaf, longStats(min, max, 0L));
+                    longStats(min, max, 0L).decideLeaf(leaf);
 
             int matching = 0;
             for (long value : values) {
@@ -234,65 +219,34 @@ class FilterDecisionTest {
 
     private static FilterDecision decideInt(FilterPredicate.Operator op, int value, int min, int max) {
         ResolvedPredicate leaf = new ResolvedPredicate.IntPredicate(0, op, value);
-        return StatisticsFilterSupport.decideLeaf(leaf, intStats(min, max, 0L));
+        return intStats(min, max, 0L).decideLeaf(leaf);
     }
 
     private static FilterDecision decideBinary(FilterPredicate.Operator op, String value,
             String min, String max) {
         ResolvedPredicate leaf = new ResolvedPredicate.BinaryPredicate(
                 0, op, value.getBytes(StandardCharsets.UTF_8), Comparison.BYTE_STRING);
-        return StatisticsFilterSupport.decideLeaf(leaf, stats(
-                min.getBytes(StandardCharsets.UTF_8), max.getBytes(StandardCharsets.UTF_8), 0L));
+        return MinMaxStats.BinaryStats.of(min.getBytes(StandardCharsets.UTF_8),
+                max.getBytes(StandardCharsets.UTF_8), false, 0L).decideLeaf(leaf);
     }
 
     private static MinMaxStats intStats(int min, int max, Long nullCount) {
-        return stats(intBytes(min), intBytes(max), nullCount);
+        return MinMaxStats.IntStats.of(min, max, nullCount);
     }
 
     private static MinMaxStats longStats(long min, long max, Long nullCount) {
-        return stats(longBytes(min), longBytes(max), nullCount);
+        return MinMaxStats.LongStats.of(min, max, nullCount);
     }
 
     private static MinMaxStats floatStats(float min, float max, Long nullCount) {
-        return stats(floatBytes(min), floatBytes(max), nullCount);
+        return MinMaxStats.FloatStats.of(min, max, false, nullCount);
     }
 
     private static MinMaxStats doubleStats(double min, double max, Long nullCount) {
-        return stats(doubleBytes(min), doubleBytes(max), nullCount);
+        return MinMaxStats.DoubleStats.of(min, max, false, nullCount);
     }
 
-    private static MinMaxStats stats(byte[] min, byte[] max, Long nullCount) {
-        return new MinMaxStats() {
-            @Override
-            public byte[] minValue() {
-                return min;
-            }
-
-            @Override
-            public byte[] maxValue() {
-                return max;
-            }
-
-            @Override
-            public Long nullCount() {
-                return nullCount;
-            }
-        };
-    }
-
-    private static byte[] intBytes(int value) {
-        return ByteBuffer.allocate(4).order(ByteOrder.LITTLE_ENDIAN).putInt(value).array();
-    }
-
-    private static byte[] longBytes(long value) {
-        return ByteBuffer.allocate(8).order(ByteOrder.LITTLE_ENDIAN).putLong(value).array();
-    }
-
-    private static byte[] floatBytes(float value) {
-        return ByteBuffer.allocate(4).order(ByteOrder.LITTLE_ENDIAN).putFloat(value).array();
-    }
-
-    private static byte[] doubleBytes(double value) {
-        return ByteBuffer.allocate(8).order(ByteOrder.LITTLE_ENDIAN).putDouble(value).array();
+    private static MinMaxStats noBounds(Long nullCount) {
+        return new MinMaxStats.NullCountOnlyStats(nullCount, null);
     }
 }

--- a/core/src/test/java/dev/hardwood/internal/predicate/InvertedStatisticsFilterTest.java
+++ b/core/src/test/java/dev/hardwood/internal/predicate/InvertedStatisticsFilterTest.java
@@ -1,0 +1,262 @@
+/*
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Copyright The original authors
+ *
+ *  Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package dev.hardwood.internal.predicate;
+
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
+import java.nio.charset.StandardCharsets;
+import java.util.function.Function;
+import java.util.stream.Stream;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import dev.hardwood.internal.predicate.ResolvedPredicate.BinaryPredicate.Comparison;
+import dev.hardwood.metadata.Statistics;
+import dev.hardwood.reader.FilterPredicate.Operator;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/// Regression tests for #1172: statistics whose `min` sorts above its `max` must not prune.
+///
+/// The Parquet spec requires `min <= max`, but writers that fill the two slots the wrong way
+/// round, or that misapply a column's sort order, have emitted pairs that violate it. Such a
+/// pair is wrong in both directions at once — it excludes the values it should contain, so a
+/// drop check skips units holding matching rows, and it contains the values it should exclude,
+/// so an always-match check promises rows that do not match. Both are silent wrong results, so
+/// the bounds are discarded where [MinMaxStats] sources them and every unit is kept.
+class InvertedStatisticsFilterTest {
+
+    /// The reason [MinMaxStats] gives for dropping bounds that are the wrong way round.
+    private static final String INVERTED = "the minimum sorts above the maximum";
+
+    // ==================== The drop side ====================
+
+    @ParameterizedTest(name = "{1} on inverted {0} bounds")
+    @MethodSource("columnsAndOperators")
+    void invertedBoundsNeverDrop(Column column, Operator op) {
+        assertThat(column.inverted().canDrop(column.leaf(op)))
+                .as("inverted bounds prove nothing and must never drop a unit")
+                .isFalse();
+    }
+
+    @ParameterizedTest(name = "{0} IN on inverted bounds")
+    @MethodSource("inColumns")
+    void invertedBoundsNeverDropForInPredicates(Column column) {
+        assertThat(column.inverted().canDrop(column.leaf(null)))
+                .isFalse();
+    }
+
+    // ==================== The always-match side ====================
+
+    @ParameterizedTest(name = "{1} on inverted {0} bounds")
+    @MethodSource("columnsAndOperators")
+    void invertedBoundsNeverPromiseAlwaysMatches(Column column, Operator op) {
+        assertThat(column.inverted().decideLeaf(column.leaf(op)))
+                .as("inverted bounds prove nothing and must never skip per-row filtering")
+                .isEqualTo(FilterDecision.MIGHT_MATCH);
+    }
+
+    @ParameterizedTest(name = "{0} IN on inverted bounds")
+    @MethodSource("inColumns")
+    void invertedBoundsNeverPromiseAlwaysMatchesForInPredicates(Column column) {
+        assertThat(column.inverted().decideLeaf(column.leaf(null)))
+                .isEqualTo(FilterDecision.MIGHT_MATCH);
+    }
+
+    // ==================== The bounds are discarded, and said to be ====================
+
+    @ParameterizedTest(name = "{0}")
+    @MethodSource({ "columns", "inColumns" })
+    void invertedBoundsAreDiscardedWithTheirReason(Column column) {
+        assertThat(column.inverted())
+                .isInstanceOf(MinMaxStats.NullCountOnlyStats.class)
+                .extracting(MinMaxStats::discardReason).isEqualTo(INVERTED);
+    }
+
+    @ParameterizedTest(name = "{0}")
+    @MethodSource({ "columns", "inColumns" })
+    void orderedBoundsAreKept(Column column) {
+        assertThat(column.ordered())
+                .as("bounds the right way round are kept and decoded")
+                .isNotInstanceOf(MinMaxStats.NullCountOnlyStats.class);
+    }
+
+    // ==================== Ordered bounds still prune ====================
+
+    /// The same columns with their bounds the right way round: a probe below the range still
+    /// drops on `GT_EQ`, so the guard has not disabled pruning wholesale.
+    @ParameterizedTest(name = "{0}")
+    @MethodSource("columns")
+    void orderedBoundsStillPrune(Column column) {
+        // Every probe sits strictly inside [low, high], so "everything is >= the probe" is
+        // false for the low end and the unit cannot match "< probe".
+        assertThat(column.ordered().decideLeaf(column.leaf(Operator.LT_EQ)))
+                .isEqualTo(FilterDecision.MIGHT_MATCH);
+        assertThat(column.ordered().canDrop(column.leaf(Operator.GT)))
+                .as("the probe is inside [low, high], so GT cannot be ruled out")
+                .isFalse();
+    }
+
+    @Test
+    void orderedIntBoundsStillDropAndPromise() {
+        Column column = intColumn();
+        ResolvedPredicate below = new ResolvedPredicate.IntPredicate(0, Operator.EQ, 5);
+        assertThat(column.ordered().decideLeaf(below))
+                .isEqualTo(FilterDecision.CANNOT_MATCH);
+
+        ResolvedPredicate everything = new ResolvedPredicate.IntPredicate(0, Operator.GT, 5);
+        assertThat(column.ordered().decideLeaf(everything))
+                .isEqualTo(FilterDecision.ALWAYS_MATCHES);
+    }
+
+    // ==================== ±0 bounds are not inverted ====================
+
+    /// Under the type-defined ordering the spec leaves `+0` and `-0` interchangeable, so
+    /// `(min = +0, max = -0)` is a legitimate pair that the comparators widen rather than
+    /// reject. The usability check applies the same widening, so it must not read the pair as
+    /// inverted.
+    @Test
+    void typeDefinedZeroBoundsAreNotInverted() {
+        MinMaxStats floatStats = MinMaxStats.of(stats(floatBytes(0.0f), floatBytes(-0.0f)),
+                new ResolvedPredicate.FloatPredicate(0, Operator.EQ, 5.0f, false));
+        assertThat(floatStats).isNotInstanceOf(MinMaxStats.NullCountOnlyStats.class);
+
+        MinMaxStats doubleStats = MinMaxStats.of(stats(doubleBytes(0.0), doubleBytes(-0.0)),
+                new ResolvedPredicate.DoublePredicate(0, Operator.EQ, 5.0, false));
+        assertThat(doubleStats).isNotInstanceOf(MinMaxStats.NullCountOnlyStats.class);
+
+        // And they still prune a value neither zero can be.
+        assertThat(doubleStats.canDrop(new ResolvedPredicate.DoublePredicate(0, Operator.EQ, 5.0, false)))
+                .isTrue();
+    }
+
+    /// The IEEE 754 total order is unambiguous — `-0` sorts below `+0` — so the same pair is
+    /// genuinely the wrong way round there.
+    @Test
+    void ieee754ZeroBoundsTheWrongWayRoundAreInverted() {
+        MinMaxStats doubleStats = MinMaxStats.of(stats(doubleBytes(0.0), doubleBytes(-0.0)),
+                new ResolvedPredicate.DoublePredicate(0, Operator.EQ, 5.0, true));
+        assertThat(doubleStats.discardReason()).isEqualTo(INVERTED);
+    }
+
+    // ==================== Fixtures ====================
+
+    /// One column's bounds and the leaf that reads them, in the order that leaf compares in.
+    ///
+    /// @param name the physical type, for the test's display name
+    /// @param leaf builds the leaf under test for an operator, ignoring it for `IN` leaves
+    /// @param low the lower of the two bounds
+    /// @param high the higher of the two bounds
+    private record Column(String name, Function<Operator, ResolvedPredicate> leaf,
+            byte[] low, byte[] high) {
+
+        /// The bounds the wrong way round, as a buggy writer emits them.
+        MinMaxStats inverted() {
+            return MinMaxStats.of(stats(high, low), leaf.apply(Operator.EQ));
+        }
+
+        /// The same bounds the right way round.
+        MinMaxStats ordered() {
+            return MinMaxStats.of(stats(low, high), leaf.apply(Operator.EQ));
+        }
+
+        ResolvedPredicate leaf(Operator op) {
+            return leaf.apply(op);
+        }
+
+        @Override
+        public String toString() {
+            return name;
+        }
+    }
+
+    static Stream<Column> columns() {
+        return Stream.of(
+                intColumn(),
+                new Column("INT64", op -> new ResolvedPredicate.LongPredicate(0, op, 15L),
+                        longBytes(10L), longBytes(20L)),
+                new Column("FLOAT", op -> new ResolvedPredicate.FloatPredicate(0, op, 15.0f, false),
+                        floatBytes(10.0f), floatBytes(20.0f)),
+                new Column("FLOAT16", op -> new ResolvedPredicate.Float16Predicate(0, op, 15.0f, false),
+                        float16Bytes(10.0f), float16Bytes(20.0f)),
+                new Column("DOUBLE", op -> new ResolvedPredicate.DoublePredicate(0, op, 15.0, false),
+                        doubleBytes(10.0), doubleBytes(20.0)),
+                new Column("BOOLEAN", op -> new ResolvedPredicate.BooleanPredicate(0, op, false),
+                        new byte[]{ 0 }, new byte[]{ 1 }),
+                new Column("BYTE_ARRAY", op -> new ResolvedPredicate.BinaryPredicate(0, op,
+                        utf8("mango"), Comparison.BYTE_STRING), utf8("apple"), utf8("peach")),
+                // Two's complement bounds: -100 sorts below +100 signed but above it unsigned,
+                // so only the column's own order tells the pair apart from an inverted one.
+                new Column("FIXED_LEN_BYTE_ARRAY DECIMAL", op -> new ResolvedPredicate.BinaryPredicate(0, op,
+                        fixedDecimalBytes(0), Comparison.FIXED_DECIMAL),
+                        fixedDecimalBytes(-100), fixedDecimalBytes(100)),
+                new Column("BYTE_ARRAY DECIMAL", op -> new ResolvedPredicate.BinaryPredicate(0, op,
+                        new byte[]{ 0 }, Comparison.VARIABLE_DECIMAL),
+                        new byte[]{ (byte) 0x9C }, new byte[]{ 0x64 }));
+    }
+
+    static Stream<Column> inColumns() {
+        return Stream.of(
+                new Column("INT32 IN", op -> new ResolvedPredicate.IntInPredicate(0, new int[]{ 15 }),
+                        intBytes(10), intBytes(20)),
+                new Column("INT64 IN", op -> new ResolvedPredicate.LongInPredicate(0, new long[]{ 15L }),
+                        longBytes(10L), longBytes(20L)),
+                new Column("BYTE_ARRAY IN", op -> new ResolvedPredicate.BinaryInPredicate(0,
+                        new byte[][]{ utf8("mango") }), utf8("apple"), utf8("peach")));
+    }
+
+    static Stream<Arguments> columnsAndOperators() {
+        return columns().flatMap(column -> Stream.of(Operator.values())
+                .map(op -> Arguments.of(column, op)));
+    }
+
+    private static Column intColumn() {
+        return new Column("INT32", op -> new ResolvedPredicate.IntPredicate(0, op, 15),
+                intBytes(10), intBytes(20));
+    }
+
+    /// Statistics with a proven-zero null count, so that [FilterDecision#ALWAYS_MATCHES] is
+    /// reachable and the always-match side of the bug is actually exercised.
+    private static Statistics stats(byte[] min, byte[] max) {
+        return new Statistics(min, max, 0L, null, false);
+    }
+
+    private static byte[] intBytes(int value) {
+        return ByteBuffer.allocate(4).order(ByteOrder.LITTLE_ENDIAN).putInt(value).array();
+    }
+
+    private static byte[] longBytes(long value) {
+        return ByteBuffer.allocate(8).order(ByteOrder.LITTLE_ENDIAN).putLong(value).array();
+    }
+
+    private static byte[] floatBytes(float value) {
+        return ByteBuffer.allocate(4).order(ByteOrder.LITTLE_ENDIAN).putFloat(value).array();
+    }
+
+    private static byte[] doubleBytes(double value) {
+        return ByteBuffer.allocate(8).order(ByteOrder.LITTLE_ENDIAN).putDouble(value).array();
+    }
+
+    private static byte[] float16Bytes(float value) {
+        short raw = Float.floatToFloat16(value);
+        return new byte[]{ (byte) (raw & 0xFF), (byte) ((raw >> 8) & 0xFF) };
+    }
+
+    /// A four-byte big-endian two's complement unscaled value, as a `FIXED_LEN_BYTE_ARRAY(4)`
+    /// `DECIMAL` column stores it.
+    private static byte[] fixedDecimalBytes(int unscaled) {
+        return ByteBuffer.allocate(4).order(ByteOrder.BIG_ENDIAN).putInt(unscaled).array();
+    }
+
+    private static byte[] utf8(String value) {
+        return value.getBytes(StandardCharsets.UTF_8);
+    }
+}

--- a/core/src/test/java/dev/hardwood/internal/predicate/MinMaxStatsTest.java
+++ b/core/src/test/java/dev/hardwood/internal/predicate/MinMaxStatsTest.java
@@ -11,12 +11,24 @@ import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
 
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
 
+import dev.hardwood.metadata.FieldPath;
 import dev.hardwood.metadata.Statistics;
+import dev.hardwood.reader.FilterPredicate.Operator;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 class MinMaxStatsTest {
+
+    /// The leaf every case here decides against, and the one the bounds are read in the order
+    /// of: `INT32`, compared signed.
+    private static final ResolvedPredicate.IntPredicate GT_MINUS_FIVE =
+            new ResolvedPredicate.IntPredicate(0, Operator.GT, -5);
+
+    @RegisterExtension
+    final CapturedWarnings warnings = new CapturedWarnings();
 
     @Test
     void testDeprecatedMinMaxStatsReturnsNull() {
@@ -28,12 +40,14 @@ class MinMaxStatsTest {
         byte[] fakeMax = intBytes(-10);
         Statistics deprecated = new Statistics(fakeMin, fakeMax, 0L, null, true);
 
-        MinMaxStats stats = MinMaxStats.of(deprecated);
+        MinMaxStats stats = MinMaxStats.of(deprecated, GT_MINUS_FIVE);
 
         // When isMinMaxDeprecated is true, minValue/maxValue must be null so that
         // canDropLeaf conservatively returns false (never drops the row group).
-        assertThat(stats.minValue()).isNull();
-        assertThat(stats.maxValue()).isNull();
+        assertThat(stats)
+                .isInstanceOf(MinMaxStats.NullCountOnlyStats.class)
+                .extracting(MinMaxStats::discardReason)
+                .isEqualTo("they come from the deprecated min/max fields, which compare unsigned");
     }
 
     @Test
@@ -42,10 +56,9 @@ class MinMaxStatsTest {
         byte[] max = intBytes(100);
         Statistics nonDeprecated = new Statistics(min, max, 0L, null, false);
 
-        MinMaxStats stats = MinMaxStats.of(nonDeprecated);
+        MinMaxStats stats = MinMaxStats.of(nonDeprecated, GT_MINUS_FIVE);
 
-        assertThat(stats.minValue()).isEqualTo(min);
-        assertThat(stats.maxValue()).isEqualTo(max);
+        assertThat(stats).isEqualTo(new MinMaxStats.IntStats(1, 100, 0L));
     }
 
     @Test
@@ -59,13 +72,90 @@ class MinMaxStatsTest {
         byte[] deprecatedMax = intBytes(-10);
         Statistics stats = new Statistics(deprecatedMin, deprecatedMax, 0L, null, true);
 
-        MinMaxStats minMaxStats = MinMaxStats.of(stats);
+        MinMaxStats minMaxStats = MinMaxStats.of(stats, GT_MINUS_FIVE);
 
         // With the fix, canDropLeaf sees null min/max and returns false (conservative)
-        ResolvedPredicate.IntPredicate predicate = new ResolvedPredicate.IntPredicate(
-                0, dev.hardwood.reader.FilterPredicate.Operator.GT, -5);
-        boolean canDrop = StatisticsFilterSupport.canDropLeaf(predicate, minMaxStats);
+        boolean canDrop = minMaxStats.canDrop(GT_MINUS_FIVE);
         assertThat(canDrop).isFalse();
+    }
+
+    @Test
+    void boundsSourcedForOneWidthRefuseALeafOfAnother() {
+        // A unit is decoded for the leaf it is then asked about, so a mismatch is a wiring
+        // mistake in the reader rather than anything a file can cause. It fails loudly rather
+        // than answering "cannot prove anything", which would silently disable pruning.
+        MinMaxStats int32 = MinMaxStats.IntStats.of(10, 20, 0L);
+        ResolvedPredicate longLeaf = new ResolvedPredicate.LongPredicate(0, Operator.GT, 5L);
+
+        assertThatThrownBy(() -> int32.canDrop(longLeaf))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("INT32 statistics cannot decide a LongPredicate");
+        assertThatThrownBy(() -> int32.alwaysMatches(longLeaf))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("INT32 statistics cannot decide a LongPredicate");
+    }
+
+    @Test
+    void aLeafThatReadsNoBoundsGetsNoneAndDiscardsNothing() {
+        // IS NULL and IS NOT NULL are decided by the null count; the bytes the file wrote are
+        // not theirs to read, and not discarded either — nothing should warn about them.
+        MinMaxStats stats = MinMaxStats.of(
+                new Statistics(intBytes(10), intBytes(20), 0L, null, false),
+                new ResolvedPredicate.IsNullPredicate(0));
+
+        assertThat(stats).isInstanceOf(MinMaxStats.NullCountOnlyStats.class);
+        assertThat(stats.discardReason()).isNull();
+        assertThat(stats.nullCount()).isZero();
+    }
+
+    @Test
+    void discardedBoundsSayWhereTheyCameFromAndWhy() {
+        MinMaxStats stats = MinMaxStats.of(
+                new Statistics(intBytes(20), intBytes(10), 0L, null, false), GT_MINUS_FIVE);
+
+        stats.reportIfDiscarded(chunk());
+
+        assertThat(warnings.messages()).containsExactly(
+                "[orders.parquet: row group 3, column 'order.price'] Ignoring the min/max "
+                        + "statistics for pruning: the minimum sorts above the maximum. Rows they "
+                        + "could have skipped are read and filtered instead.");
+    }
+
+    @Test
+    void aPageSaysWhichPageItWas() {
+        MinMaxStats stats = MinMaxStats.of(
+                new Statistics(intBytes(20), intBytes(10), 0L, null, false), GT_MINUS_FIVE);
+
+        stats.reportIfDiscarded(chunk().withPageIndex(7));
+
+        assertThat(warnings.messages()).singleElement().asString()
+                .startsWith("[orders.parquet: row group 3, column 'order.price', page 7] ");
+    }
+
+    @Test
+    void usableBoundsSayNothing() {
+        MinMaxStats stats = MinMaxStats.of(
+                new Statistics(intBytes(10), intBytes(20), 0L, null, false), GT_MINUS_FIVE);
+
+        stats.reportIfDiscarded(chunk());
+
+        assertThat(warnings.messages()).isEmpty();
+    }
+
+    @Test
+    void everyDiscardIsReported() {
+        // Repeats are not collapsed: statistics that will not compare are rare, and a reader
+        // who finds the volume unhelpful can raise the level on this logger.
+        MinMaxStats stats = MinMaxStats.of(
+                new Statistics(intBytes(20), intBytes(10), 0L, null, false), GT_MINUS_FIVE);
+        stats.reportIfDiscarded(chunk().withPageIndex(0));
+        stats.reportIfDiscarded(chunk().withPageIndex(1));
+
+        assertThat(warnings.messages()).hasSize(2);
+    }
+
+    private static LogContext chunk() {
+        return new LogContext("orders.parquet", 3).withColumn(FieldPath.of("order", "price"));
     }
 
     private static byte[] intBytes(int value) {

--- a/core/src/test/java/dev/hardwood/internal/predicate/NaNStatisticsFilterTest.java
+++ b/core/src/test/java/dev/hardwood/internal/predicate/NaNStatisticsFilterTest.java
@@ -7,6 +7,8 @@
  */
 package dev.hardwood.internal.predicate;
 
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
 import java.util.stream.Stream;
 
 import org.junit.jupiter.api.Test;
@@ -15,6 +17,7 @@ import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.EnumSource;
 import org.junit.jupiter.params.provider.MethodSource;
 
+import dev.hardwood.metadata.Statistics;
 import dev.hardwood.reader.FilterPredicate.Operator;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -25,12 +28,17 @@ import static org.assertj.core.api.Assertions.assertThat;
 /// The Parquet spec forbids writing `NaN` to `min`/`max`, but older or buggy writers have
 /// emitted such values. A conformant reader must treat a `NaN` bound as unusable for
 /// pruning (parquet-mr does the same).
+///
+/// The check lives where [MinMaxStats] sources the bounds, alongside the other reasons a pair
+/// of bounds can be unusable (#1172), so these cases go in through a leaf and its statistics
+/// rather than straight at a comparator. The comparators below are still exercised directly
+/// where the bounds they are given are usable ones.
 class NaNStatisticsFilterTest {
 
     @ParameterizedTest(name = "double {0} with NaN min")
     @EnumSource(Operator.class)
     void doubleNaNMinNeverDrops(Operator op) {
-        assertThat(StatisticsFilterSupport.canDropDouble(op, 1.0, Double.NaN, 10.0, false))
+        assertThat(dropsDouble(op, 1.0, Double.NaN, 10.0))
                 .as("NaN min must be treated as no-bound and never prune")
                 .isFalse();
     }
@@ -38,7 +46,7 @@ class NaNStatisticsFilterTest {
     @ParameterizedTest(name = "double {0} with NaN max")
     @EnumSource(Operator.class)
     void doubleNaNMaxNeverDrops(Operator op) {
-        assertThat(StatisticsFilterSupport.canDropDouble(op, 1.0, -10.0, Double.NaN, false))
+        assertThat(dropsDouble(op, 1.0, -10.0, Double.NaN))
                 .as("NaN max must be treated as no-bound and never prune")
                 .isFalse();
     }
@@ -46,14 +54,13 @@ class NaNStatisticsFilterTest {
     @ParameterizedTest(name = "double {0} with NaN min and max")
     @EnumSource(Operator.class)
     void doubleNaNBothNeverDrops(Operator op) {
-        assertThat(StatisticsFilterSupport.canDropDouble(op, 1.0, Double.NaN, Double.NaN, false))
-                .isFalse();
+        assertThat(dropsDouble(op, 1.0, Double.NaN, Double.NaN)).isFalse();
     }
 
     @ParameterizedTest(name = "float {0} with NaN min")
     @EnumSource(Operator.class)
     void floatNaNMinNeverDrops(Operator op) {
-        assertThat(StatisticsFilterSupport.canDropFloat(op, 1.0f, Float.NaN, 10.0f, false))
+        assertThat(dropsFloat(op, 1.0f, Float.NaN, 10.0f))
                 .as("NaN min must be treated as no-bound and never prune")
                 .isFalse();
     }
@@ -61,7 +68,7 @@ class NaNStatisticsFilterTest {
     @ParameterizedTest(name = "float {0} with NaN max")
     @EnumSource(Operator.class)
     void floatNaNMaxNeverDrops(Operator op) {
-        assertThat(StatisticsFilterSupport.canDropFloat(op, 1.0f, -10.0f, Float.NaN, false))
+        assertThat(dropsFloat(op, 1.0f, -10.0f, Float.NaN))
                 .as("NaN max must be treated as no-bound and never prune")
                 .isFalse();
     }
@@ -69,8 +76,35 @@ class NaNStatisticsFilterTest {
     @ParameterizedTest(name = "float {0} with NaN min and max")
     @EnumSource(Operator.class)
     void floatNaNBothNeverDrops(Operator op) {
-        assertThat(StatisticsFilterSupport.canDropFloat(op, 1.0f, Float.NaN, Float.NaN, false))
-                .isFalse();
+        assertThat(dropsFloat(op, 1.0f, Float.NaN, Float.NaN)).isFalse();
+    }
+
+    /// `FLOAT16` bounds are two bytes wide and decode through their own path, so the check
+    /// has to reach them as well as the four- and eight-byte ones.
+    @ParameterizedTest(name = "float16 {0} with a NaN bound")
+    @EnumSource(Operator.class)
+    void float16NaNNeverDrops(Operator op) {
+        ResolvedPredicate leaf = new ResolvedPredicate.Float16Predicate(0, op, 1.0f, false);
+        MinMaxStats stats = MinMaxStats.of(
+                new Statistics(float16Bytes(Float.NaN), float16Bytes(10.0f), 0L, null, false), leaf);
+
+        assertThat(stats.canDrop(leaf)).isFalse();
+        assertThat(stats.discardReason())
+                .isEqualTo("one of them is NaN, which sits outside the column's ordering");
+    }
+
+    /// A NaN bound is discarded rather than compared against, and says so.
+    @Test
+    void naNBoundsAreDiscardedAtTheSource() {
+        ResolvedPredicate leaf = new ResolvedPredicate.DoublePredicate(0, Operator.GT, 1.0, false);
+        MinMaxStats stats = MinMaxStats.of(
+                new Statistics(doubleBytes(Double.NaN), doubleBytes(10.0), 0L, null, false),
+                leaf);
+
+        assertThat(stats)
+                .isInstanceOf(MinMaxStats.NullCountOnlyStats.class)
+                .extracting(MinMaxStats::discardReason)
+                .isEqualTo("one of them is NaN, which sits outside the column's ordering");
     }
 
     /// Sanity check that non-NaN stats still prune as before — guarding against an
@@ -117,5 +151,35 @@ class NaNStatisticsFilterTest {
     void zeroBoundsStillPruneNonZeroValuesUnderBothOrders() {
         assertThat(StatisticsFilterSupport.canDropFloat(Operator.EQ, 5.0f, -0.0f, 0.0f, false)).isTrue();
         assertThat(StatisticsFilterSupport.canDropFloat(Operator.EQ, 5.0f, -0.0f, 0.0f, true)).isTrue();
+    }
+
+    // ==================== Fixtures ====================
+
+    /// Whether the leaf drops a unit with these bounds, sourced the way the evaluators source
+    /// them so that the usability check runs.
+    private static boolean dropsDouble(Operator op, double value, double min, double max) {
+        ResolvedPredicate leaf = new ResolvedPredicate.DoublePredicate(0, op, value, false);
+        return MinMaxStats.of(new Statistics(doubleBytes(min), doubleBytes(max), 0L, null, false), leaf)
+                .canDrop(leaf);
+    }
+
+    /// See [#dropsDouble].
+    private static boolean dropsFloat(Operator op, float value, float min, float max) {
+        ResolvedPredicate leaf = new ResolvedPredicate.FloatPredicate(0, op, value, false);
+        return MinMaxStats.of(new Statistics(floatBytes(min), floatBytes(max), 0L, null, false), leaf)
+                .canDrop(leaf);
+    }
+
+    private static byte[] float16Bytes(float value) {
+        short raw = Float.floatToFloat16(value);
+        return new byte[]{ (byte) (raw & 0xFF), (byte) ((raw >> 8) & 0xFF) };
+    }
+
+    private static byte[] floatBytes(float value) {
+        return ByteBuffer.allocate(4).order(ByteOrder.LITTLE_ENDIAN).putFloat(value).array();
+    }
+
+    private static byte[] doubleBytes(double value) {
+        return ByteBuffer.allocate(8).order(ByteOrder.LITTLE_ENDIAN).putDouble(value).array();
     }
 }

--- a/core/src/test/java/dev/hardwood/internal/predicate/PageDropPredicatesTest.java
+++ b/core/src/test/java/dev/hardwood/internal/predicate/PageDropPredicatesTest.java
@@ -1,0 +1,125 @@
+/*
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Copyright The original authors
+ *
+ *  Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package dev.hardwood.internal.predicate;
+
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
+import java.util.List;
+import java.util.Map;
+
+import org.junit.jupiter.api.Test;
+
+import dev.hardwood.metadata.FieldPath;
+import dev.hardwood.metadata.Statistics;
+import dev.hardwood.reader.FilterPredicate.Operator;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/// The inline-page-statistics drop path used by
+/// [dev.hardwood.internal.reader.SequentialFetchPlan] when a file carries no page index:
+/// which AND-necessary leaves reach a column, and whether a page's own statistics prove it
+/// holds no matching row.
+class PageDropPredicatesTest {
+
+    private static final int COLUMN = 0;
+    private static final LogContext PAGE = new LogContext("orders.parquet", 0)
+            .withColumn(FieldPath.of("order", "price")).withPageIndex(0);
+
+    // ==================== Collecting AND-necessary leaves ====================
+
+    @Test
+    void collectsLeavesUnderAndAndSkipsThoseUnderOr() {
+        ResolvedPredicate andNecessary = intEq(1);
+        ResolvedPredicate underOr = intEq(2);
+        ResolvedPredicate root = new ResolvedPredicate.And(List.of(
+                andNecessary,
+                new ResolvedPredicate.Or(List.of(underOr, intEq(3)))));
+
+        Map<Integer, List<ResolvedPredicate>> byColumn = PageDropPredicates.byColumn(root);
+
+        assertThat(byColumn).containsOnlyKeys(COLUMN);
+        assertThat(byColumn.get(COLUMN)).containsExactly(andNecessary);
+    }
+
+    // ==================== Dropping on the page's own statistics ====================
+
+    @Test
+    void boundsExcludingTheProbeDropThePage() {
+        assertThat(canDropPage(intEq(15), stats(intBytes(20), intBytes(30)))).isTrue();
+    }
+
+    @Test
+    void boundsContainingTheProbeKeepThePage() {
+        assertThat(canDropPage(intEq(15), stats(intBytes(10), intBytes(20)))).isFalse();
+    }
+
+    @Test
+    void invertedBoundsKeepThePage() {
+        // min = 20, max = 10 reads as an empty interval, so the drop check would skip a page
+        // that holds 15.
+        assertThat(canDropPage(intEq(15), stats(intBytes(20), intBytes(10)))).isFalse();
+    }
+
+    @Test
+    void deprecatedBoundsKeepThePage() {
+        Statistics deprecated = new Statistics(intBytes(20), intBytes(30), 0L, null, true);
+        assertThat(canDropPage(intEq(15), deprecated)).isFalse();
+    }
+
+    @Test
+    void absentStatisticsKeepThePage() {
+        assertThat(canDropPage(intEq(15), null)).isFalse();
+        assertThat(canDropPage(intEq(15), stats(null, null))).isFalse();
+    }
+
+    @Test
+    void noLeavesKeepThePage() {
+        assertThat(PageDropPredicates.canDropPage(List.of(), stats(intBytes(20), intBytes(30)),
+                PAGE)).isFalse();
+        assertThat(PageDropPredicates.canDropPage(null, stats(intBytes(20), intBytes(30)),
+                PAGE)).isFalse();
+    }
+
+    @Test
+    void anyOneLeafProvingNoMatchDropsThePage() {
+        // [10, 20] cannot match "> 25", though it can match "> 15".
+        List<ResolvedPredicate> leaves = List.of(
+                new ResolvedPredicate.IntPredicate(COLUMN, Operator.GT, 15),
+                new ResolvedPredicate.IntPredicate(COLUMN, Operator.GT, 25));
+
+        assertThat(PageDropPredicates.canDropPage(leaves, stats(intBytes(10), intBytes(20)),
+                PAGE)).isTrue();
+    }
+
+    @Test
+    void nullPredicatesNeverDropAPage() {
+        assertThat(canDropPage(new ResolvedPredicate.IsNullPredicate(COLUMN),
+                stats(intBytes(10), intBytes(20)))).isFalse();
+        assertThat(canDropPage(new ResolvedPredicate.IsNotNullPredicate(COLUMN),
+                stats(intBytes(10), intBytes(20)))).isFalse();
+    }
+
+    // ==================== Fixtures ====================
+
+    private static boolean canDropPage(ResolvedPredicate leaf, Statistics stats) {
+        return PageDropPredicates.canDropPage(List.of(leaf), stats,
+                PAGE);
+    }
+
+    private static ResolvedPredicate intEq(int value) {
+        return new ResolvedPredicate.IntPredicate(COLUMN, Operator.EQ, value);
+    }
+
+    private static Statistics stats(byte[] min, byte[] max) {
+        return new Statistics(min, max, 0L, null, false);
+    }
+
+    private static byte[] intBytes(int value) {
+        return ByteBuffer.allocate(4).order(ByteOrder.LITTLE_ENDIAN).putInt(value).array();
+    }
+}

--- a/core/src/test/java/dev/hardwood/internal/predicate/PageFilterEvaluatorTest.java
+++ b/core/src/test/java/dev/hardwood/internal/predicate/PageFilterEvaluatorTest.java
@@ -14,9 +14,11 @@ import java.nio.charset.StandardCharsets;
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 import java.util.stream.Stream;
 
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
@@ -29,21 +31,30 @@ import dev.hardwood.internal.thrift.ThriftCompactConstants.FieldType;
 import dev.hardwood.internal.thrift.ThriftStructBuilder;
 import dev.hardwood.metadata.ColumnChunk;
 import dev.hardwood.metadata.ColumnIndex;
+import dev.hardwood.metadata.ColumnMetaData;
+import dev.hardwood.metadata.CompressionCodec;
+import dev.hardwood.metadata.Encoding;
+import dev.hardwood.metadata.FieldPath;
 import dev.hardwood.metadata.FileMetaData;
 import dev.hardwood.metadata.OffsetIndex;
 import dev.hardwood.metadata.PageLocation;
+import dev.hardwood.metadata.PhysicalType;
 import dev.hardwood.metadata.RowGroup;
 import dev.hardwood.reader.FilterPredicate;
 import dev.hardwood.reader.FilterPredicate.Operator;
 import dev.hardwood.reader.ParquetReadException;
 import dev.hardwood.schema.FileSchema;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class PageFilterEvaluatorTest {
+
+    @RegisterExtension
+    final CapturedWarnings warnings = new CapturedWarnings();
 
     // Integer Filtering Tests
 
@@ -446,7 +457,8 @@ class PageFilterEvaluatorTest {
             ResolvedPredicate resolved = FilterPredicateResolver.resolve(filter, schema);
             RowGroup rowGroup = metaData.rowGroups().get(0);
             RowGroupIndexBuffers indexBuffers = RowGroupIndexBuffers.fetch(inputFile, rowGroup);
-            return PageFilterEvaluator.computeMatchingRows(resolved, rowGroup, indexBuffers);
+            return PageFilterEvaluator.computeMatchingRows(resolved, rowGroup, indexBuffers,
+                    new LogContext(inputFile.name(), 0));
         }
         finally {
             inputFile.close();
@@ -626,11 +638,58 @@ class PageFilterEvaluatorTest {
             // Called directly here; in the reader this runs while a column's pages are
             // planned, and the pipeline puts the file and row group in front of it.
             assertThatThrownBy(() -> PageFilterEvaluator.computeMatchingRows(
-                    new ResolvedPredicate.IsNotNullPredicate(0), rowGroup, buffers))
+                    new ResolvedPredicate.IsNotNullPredicate(0), rowGroup, buffers, new LogContext(inputFile.name(), 0)))
                     .isInstanceOf(ParquetReadException.class)
                     .hasMessage("Failed to parse the page index of column 0: Malformed Parquet"
                             + " metadata: ColumnIndex describes 3 pages but OffsetIndex locates 2");
         }
+    }
+
+    @Test
+    void discardedPageBoundsAreNamedByTheirColumnAndPage() throws IOException {
+        // Page 0 is bounded [1, 20] and holds the probe; page 1 carries min = 30 with
+        // max = 11, the wrong way round. The column path comes from the row group's metadata
+        // and the page index from the scan, and a pair that brackets nothing drops no page.
+        byte[] columnIndex = new ThriftStructBuilder()
+                .field(1, FieldType.LIST).boolList(false, false)
+                .field(2, FieldType.LIST).binaryList(intBytes(1), intBytes(30))
+                .field(3, FieldType.LIST).binaryList(intBytes(20), intBytes(11))
+                .stop().build();
+        byte[] offsetIndex = new ThriftStructBuilder()
+                .field(1, FieldType.LIST)
+                .structList(pageLocation(0, 0), pageLocation(100, 30))
+                .stop().build();
+
+        ByteBuffer file = ByteBuffer.allocate(offsetIndex.length + columnIndex.length);
+        file.put(offsetIndex).put(columnIndex).flip();
+        RowGroup rowGroup = new RowGroup(List.of(indexedChunk(offsetIndex.length, columnIndex.length)),
+                1000, 60);
+
+        try (InputFile inputFile = InputFile.of(file)) {
+            RowGroupIndexBuffers buffers = RowGroupIndexBuffers.fetch(inputFile, rowGroup);
+            RowRanges ranges = PageFilterEvaluator.computeMatchingRows(
+                    new ResolvedPredicate.IntPredicate(0, Operator.EQ, 15), rowGroup, buffers,
+                    new LogContext("orders.parquet", 4));
+
+            assertTrue(ranges.overlapsPage(0, 29), "the page holding the probe must be kept");
+            assertTrue(ranges.overlapsPage(30, 59),
+                    "read as an interval, min = 30 with max = 11 excludes 15 and would drop the page");
+            assertThat(warnings.messages()).containsExactly(
+                    "[orders.parquet: row group 4, column 'order.price', page 1] Ignoring the "
+                            + "min/max statistics for pruning: the minimum sorts above the maximum. "
+                            + "Rows they could have skipped are read and filtered instead.");
+        }
+    }
+
+    /// A column chunk whose page index sits at the head of the file: the offset index first,
+    /// the column index after it.
+    private static ColumnChunk indexedChunk(int offsetIndexLength, int columnIndexLength) {
+        ColumnMetaData metaData = new ColumnMetaData(
+                PhysicalType.INT32, List.of(Encoding.PLAIN), FieldPath.of("order", "price"),
+                CompressionCodec.UNCOMPRESSED, 100, 1000, 1000, Map.of(), 0, null, null,
+                null, null, null, List.of(), null);
+        return new ColumnChunk(metaData, 0L, offsetIndexLength,
+                (long) offsetIndexLength, columnIndexLength, "");
     }
 
     /// A PageLocation struct body: offset, compressed_page_size, first_row_index.

--- a/core/src/test/java/dev/hardwood/internal/predicate/RowGroupDecideTest.java
+++ b/core/src/test/java/dev/hardwood/internal/predicate/RowGroupDecideTest.java
@@ -14,7 +14,9 @@ import java.util.List;
 import java.util.Map;
 
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
 
+import dev.hardwood.internal.ExceptionContext;
 import dev.hardwood.metadata.ColumnChunk;
 import dev.hardwood.metadata.ColumnMetaData;
 import dev.hardwood.metadata.CompressionCodec;
@@ -35,7 +37,14 @@ import static org.assertj.core.api.Assertions.assertThat;
 /// decision against a single row group.
 class RowGroupDecideTest {
 
+    /// A position with nothing to point at: these cases assert decisions, not diagnostics.
+    private static final LogContext UNNAMED =
+            new LogContext(null, ExceptionContext.UNKNOWN_ROW_GROUP);
+
     private static final int COL = 0;
+
+    @RegisterExtension
+    final CapturedWarnings warnings = new CapturedWarnings();
 
     @Test
     void rangePredicateOverFullySatisfyingRowGroup() throws IOException {
@@ -98,7 +107,7 @@ class RowGroupDecideTest {
         // always-matching decision derived from statistics.
         RowGroup rg = intRowGroup(10, 20, 0L);
         BloomFilterSource noFilters = columnIndex -> null;
-        assertThat(RowGroupFilterEvaluator.decideRowGroup(intGt(5), rg, noFilters, null))
+        assertThat(RowGroupFilterEvaluator.decideRowGroup(intGt(5), rg, noFilters, null, UNNAMED))
                 .isEqualTo(ALWAYS_MATCHES);
     }
 
@@ -120,11 +129,29 @@ class RowGroupDecideTest {
         assertThat(decide(intGt(5), rg)).isEqualTo(MIGHT_MATCH);
     }
 
+    @Test
+    void discardedBoundsAreNamedByTheColumnTheRowGroupCarries() throws IOException {
+        // The column path comes from the row group's own metadata rather than from the leaf,
+        // which knows the column only by its index. A row group is the finest position the
+        // decision has, so no page is named.
+        RowGroup rg = rowGroup(PhysicalType.INT32,
+                new Statistics(intBytes(20), intBytes(10), 0L, null, false), 100);
+
+        FilterDecision decision = RowGroupFilterEvaluator.decideRowGroup(intGt(5), rg, null, null,
+                new LogContext("orders.parquet", 4));
+
+        assertThat(decision).isEqualTo(MIGHT_MATCH);
+        assertThat(warnings.messages()).containsExactly(
+                "[orders.parquet: row group 4, column 'order.price'] Ignoring the min/max "
+                        + "statistics for pruning: the minimum sorts above the maximum. Rows they "
+                        + "could have skipped are read and filtered instead.");
+    }
+
     // ==================== Fixtures ====================
 
     private static FilterDecision decide(ResolvedPredicate predicate, RowGroup rowGroup)
             throws IOException {
-        return RowGroupFilterEvaluator.decideRowGroup(predicate, rowGroup, null, null);
+        return RowGroupFilterEvaluator.decideRowGroup(predicate, rowGroup, null, null, UNNAMED);
     }
 
     private static ResolvedPredicate intGt(int value) {
@@ -158,7 +185,7 @@ class RowGroupDecideTest {
 
     private static RowGroup rowGroup(PhysicalType type, Statistics stats, long numRows) {
         ColumnMetaData cmd = new ColumnMetaData(
-                type, List.of(Encoding.PLAIN), FieldPath.of("col"),
+                type, List.of(Encoding.PLAIN), FieldPath.of("order", "price"),
                 CompressionCodec.UNCOMPRESSED, 100, 1000, 1000, Map.of(), 0, null, stats,
                 null, null, null, List.of(), null);
         ColumnChunk chunk = new ColumnChunk(cmd, null, null, null, null, "");

--- a/core/src/test/java/dev/hardwood/internal/thrift/StatisticsReaderTest.java
+++ b/core/src/test/java/dev/hardwood/internal/thrift/StatisticsReaderTest.java
@@ -88,6 +88,39 @@ class StatisticsReaderTest {
         assertThat(stats.nanCount()).isEqualTo(3L);
     }
 
+    @Test
+    void statisticsWithoutAnyBoundsReportNoDeprecatedBounds() throws IOException {
+        // An all-null column writes a null count and neither pair of bounds. Nothing was
+        // read from the deprecated fields, so nothing should say it was: the flag drives the
+        // `(deprecated)` cell in `inspect pages` and the warning the filter layer raises when
+        // it throws bounds away.
+        byte[] thrift = struct()
+                .field(3, FieldType.I64).i64(100)
+                .stop().build();
+
+        Statistics stats = read(thrift);
+
+        assertThat(stats.minValue()).isNull();
+        assertThat(stats.maxValue()).isNull();
+        assertThat(stats.nullCount()).isEqualTo(100L);
+        assertThat(stats.isMinMaxDeprecated()).isFalse();
+    }
+
+    @Test
+    void deprecatedMaxAloneStillReportsDeprecatedBounds() throws IOException {
+        // Only one of the two deprecated fields was written (field 1 is the deprecated
+        // `max`); the one bound that exists still came from them.
+        byte[] thrift = struct()
+                .field(1, FieldType.BINARY).binary(bytes(8))
+                .stop().build();
+
+        Statistics stats = read(thrift);
+
+        assertThat(stats.maxValue()).isEqualTo(bytes(8));
+        assertThat(stats.minValue()).isNull();
+        assertThat(stats.isMinMaxDeprecated()).isTrue();
+    }
+
     private static Statistics read(byte[] thrift) throws IOException {
         return StatisticsReader.read(new ThriftCompactReader(ByteBuffer.wrap(thrift)));
     }

--- a/docs/content/reference/query-controls.md
+++ b/docs/content/reference/query-controls.md
@@ -38,6 +38,22 @@ columns without logical types or for filtering on the underlying physical value 
 work with all reader types — `RowReader`, `ColumnReader`, `AvroRowReader`, and across multi-file
 readers.
 
+## When statistics are ignored
+
+Pruning compares a unit's `min` / `max` bounds. A pair a reader cannot compare against is
+ignored rather than trusted, so the row group or page is kept and its rows are read and filtered
+one by one. Results are the same either way; only the I/O saved is lost. Bounds are ignored for
+one of three reasons:
+
+| Reason | Bounds |
+|---|---|
+| The minimum sorts above the maximum | `min` and `max` are the wrong way round in the column's order, so the pair brackets nothing |
+| One of them is `NaN` | A `FLOAT`, `DOUBLE` or `FLOAT16` bound the Parquet spec forbids, sitting outside the column's ordering |
+| They come from the deprecated `min` / `max` fields | Superseded by `min_value` / `max_value`; the deprecated pair compares unsigned whatever the column's type is, so its order is wrong for every signed one |
+
+The bounds themselves are still reported as the file carries them, by `Statistics` on the metadata
+API and by `hardwood inspect` and `hardwood dive`.
+
 ## Column projection forms
 
 | Form | Description |

--- a/docs/content/release-notes.md
+++ b/docs/content/release-notes.md
@@ -15,6 +15,10 @@ See [GitHub Releases](https://github.com/hardwood-hq/hardwood/releases) for down
 
 ## 1.1.0-SNAPSHOT
 
+- Statistics whose `min` sorts above its `max` no longer prune ([#1172](https://github.com/hardwood-hq/hardwood/issues/1172)).
+
+- Statistics carrying a null count and no bounds are no longer reported as carrying deprecated `min` / `max` bounds ([#1172](https://github.com/hardwood-hq/hardwood/issues/1172)).
+
 - A `ParquetFileReader` no longer retains a read's `RowGroupIterator` after the reader consuming it is closed ([#1170](https://github.com/hardwood-hq/hardwood/issues/1170)).
 
 - A logical type annotation that a column's physical type cannot carry is now dropped, and the column is read as its physical type. Previously it surfaced as an `IllegalArgumentException` from whichever accessor first reached the column ([#1139](https://github.com/hardwood-hq/hardwood/issues/1139)). `FLOAT16` is defined as a two-byte payload, so a column annotated `FLOAT16` that declares three bytes is invalid; [parquet-format PR 606](https://github.com/apache/parquet-format/pull/606) specifies that readers ignore the annotation and use only the physical type. An annotation this version does not recognize is dropped the same way, so a file written against a newer format version can still be read. Both cases log a warning, naming the column and the reason, or the union field that was not recognized. **What changes for you:** `getFileSchema()` reports no logical type for such a column, `getValue` returns its physical value where it used to throw, and a logical accessor on it fails as it does on any unannotated column.


### PR DESCRIPTION
Fixes #1172.

`StatisticsFilterSupport` treated a unit's `min`/`max` as a usable interval without ever checking that `min <= max`. A pair that breaks the rule is wrong in both directions at once: the drop check reads it as an empty interval and skips row groups and pages holding matching rows, while the always-match check reads it as covering everything and returns rows that do not match. Both are silent wrong results.

Guarding each comparator would mean nine of them, and the next one added would have to remember. The check has to happen where the bounds are sourced — and putting it there turned out to be an argument for sourcing them properly.

`MinMaxStats` is now a sealed family whose variants hold the decoded primitives the comparisons use, so a leaf's physical type stops mattering once the bytes are read: eleven leaf types map onto six variants, because a `FLOAT16` bound is a `float` once decoded and an `IN` predicate reads the same bounds as the comparison of the same width. The three switches that each re-derived the type — the usability check, `canDropLeaf` and `alwaysMatchesLeaf` — collapse into one at construction, and bounds are decoded once per unit rather than once per comparison.

Bounds that cannot be compared against never become a typed variant. They become `NullCountOnlyStats`, which keeps the one statistic that does not depend on them and carries why the rest were dropped. It proves nothing about a value predicate, so `canDrop` is `false` and `decideLeaf` is `MIGHT_MATCH`, and the `NaN` case #566 guarded inside the floating-point comparators now reads the same way as an inverted pair and as the deprecated unsigned-order fields that were already discarded here.

Each variant validates itself at construction, which is where signedness enters: a `DECIMAL` over `FIXED_LEN_BYTE_ARRAY` with `min = -100, max = 100` is inverted read unsigned and correct read signed, and discarding it would cost pruning on every signed decimal column that holds a negative. `±0` bounds are widened under the type-defined ordering before comparing, exactly as the comparators widen them, so `(+0.0, -0.0)` stays usable there; under the IEEE 754 total order the same pair is genuinely the wrong way round and is discarded.

`StatisticsFilterSupport` keeps what an operator proves over an interval, as pure functions of primitives, and loses the 148 lines that asked which column it was working for.

Validation stays out of the footer parser deliberately. `dev.hardwood.metadata.Statistics` is what `inspect pages` and the dive column screens display, so a parser that dropped inverted bounds would hide the corruption from the tool used to diagnose it. What the filter layer will not use, `reportIfDiscarded` says instead, naming the file, row group, column and page through the prefix the read pipeline already uses for failures. Every discard is reported rather than deduplicated: bounds that will not compare are rare, and a reader who finds the volume unhelpful can raise the level on the logger.

The second commit fixes a misclassification that reporting would otherwise have made visible: `isMinMaxDeprecated` was derived as "the `min_value`/`max_value` fields were absent", which is equally true of a column that wrote a null count and no bounds at all — an all-null column, as PyArrow writes one. Nothing was read from the deprecated fields there, so nothing should say it was. `inspect pages` has been printing `(deprecated)` in place of its min and max cells for the same reason.

The third commit is unrelated to the read path: it tells the `hardwood-review` skill not to rebuild a branch whose CI is already green.

## Testing

`InvertedStatisticsFilterTest` covers both decision sides over every physical type and every operator, plus the `IN` leaves and the `±0` cases.

`MinMaxStatsTest` pins the warning text in full through a log4j appender, and refuses a leaf of a width the bounds were not sourced for. `RowGroupDecideTest` and `PageFilterEvaluatorTest` assert the same message through the evaluators, where the column path comes from the row group's metadata and the page index from the scan.

`PageDropPredicatesTest` covers the inline-page-statistics drop path, used when a file carries no page index.

`NaNStatisticsFilterTest` drives its `NaN` cases through the sourcing point now that the guard lives there, `FLOAT16` included, and keeps its `±0` and finite-pruning cases on the comparators, where the bounds given are usable ones.

`StatisticsReaderTest` pins the deprecated flag for a struct carrying no bounds and for one carrying a single deprecated field.

## Note for #1079

That branch adds `canDropDoubleIn` with its own inverted and `NaN` guards, and `FilterDecisionTest` cases there pass inverted bounds straight to it. Once this merges, those guards are redundant and a handful of its assertions want rewriting to go in through `MinMaxStats`.
