### PR TITLE
#1179 Prune only against bounds whose order this reader can read

### DIFF
--- a/_designs/UNREADABLE_SORT_ORDER_BOUNDS.md
+++ b/_designs/UNREADABLE_SORT_ORDER_BOUNDS.md
@@ -1,0 +1,70 @@
+# Bounds whose sort order the reader cannot read
+
+**Status: Implemented** ([#1179](https://github.com/hardwood-hq/hardwood/issues/1179))
+
+Pruning a row group or a page compares a predicate literal against the recorded `min` / `max`.
+That is sound only when the reader compares in the order the bounds were written in. Two shapes
+reach the reader where that order is not knowable, and in both pruning declines to act on the
+bounds.
+
+Neither is produced by Hardwood's writer. Both arrive on files written elsewhere.
+
+## What is unreadable
+
+A column's bounds are unreadable when either holds.
+
+**The annotation names no order.** parquet-format defines none for `INTERVAL`, `GEOMETRY`,
+`GEOGRAPHY`, `VARIANT`, `UNKNOWN`, `LIST` and `MAP`, and states for `INTERVAL` that no
+`min` / `max` should be written at all. `StatisticsOrder#supportsBounds` already answers this
+question on the write side, which is why Hardwood emits no bounds for such a column.
+
+**The file names an order this build does not recognize.** `parquet.thrift` on the `ColumnOrder`
+union: *"If the reader does not support the value of this union, min and max stats for this
+column should be ignored."* `ColumnOrderReader` decodes an unrecognized member to
+`ColumnOrder.UNKNOWN`. This applies to every physical type, not only the binary ones.
+
+## Where the decision is made
+
+Readability is a property of the file that wrote the bounds, so it is decided per file, when
+`RowGroupIterator` plans that file. `BoundsReadability.of` reads the file's own schema and
+`column_orders` and answers for each of its leaves, indexed by that file's leaf ordinals. In a
+multi-file read each file is decided on its own terms: a later file may declare an order the
+first does not, or place the same column at a different ordinal.
+
+The answer is carried on `FileColumnOrdinals`, beside the filter already translated to the
+file's ordinals, so the two are always read in the same ordinal space. It reaches the pruning
+paths as follows:
+
+- `RowGroupFilterEvaluator#decideRowGroup` and `PageFilterEvaluator#computeMatchingRows` take it
+  as a parameter and pass it to `MinMaxStats`.
+- The inline page-statistics path withholds a column's AND-necessary leaves from
+  `SequentialFetchPlan` where the file's bounds for that column are unreadable, so
+  `PageDropPredicates#canDropPage` never receives them.
+
+`MinMaxStats` consults it once it has established that the file wrote a pair at all, and before
+decoding the pair. Unreadable bounds yield `MinMaxStats.NullCountOnlyStats` with the
+`UNKNOWN_SORT_ORDER` reason, alongside the existing `DEPRECATED_SORT_ORDER`, `NOT_A_NUMBER` and
+`INVERTED`, and are reported the same way. A column that carries no bounds reports nothing,
+which is what a conforming writer produces for an unordered annotation.
+
+An ordinal outside the file's schema is a wiring error, and `BoundsReadability` throws on it
+rather than answering either way.
+
+## What stays active
+
+Bloom filters and dictionaries answer membership by testing exact stored values, which does not
+depend on how those values order. An unreadable-bounds column keeps both shortcuts, and keeps
+record-level evaluation. The null count survives too, since counting nulls needs no ordering.
+Only the min / max half is withheld.
+
+`Statistics` keeps its bounds on the record either way. They are what the file holds, so
+`hardwood inspect` and the other metadata surfaces continue to report them; it is pruning that
+declines to act on them.
+
+## Annotation ordering, in one place
+
+The read side answers "does this annotation name an order" with an exhaustive switch, mirroring
+`StatisticsOrder#supportsBounds` on the write side. Neither delegates to the other: the writer
+asks whether to record bounds, the reader whether to trust bounds already recorded, and a column
+type could in principle answer differently. Both switches are exhaustive over `LogicalType`, so
+an annotation added later fails to compile until each side states its answer.

--- a/core/src/main/java/dev/hardwood/internal/predicate/BoundsReadability.java
+++ b/core/src/main/java/dev/hardwood/internal/predicate/BoundsReadability.java
@@ -1,0 +1,101 @@
+/*
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Copyright The original authors
+ *
+ *  Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package dev.hardwood.internal.predicate;
+
+import java.util.List;
+
+import dev.hardwood.metadata.ColumnOrder;
+import dev.hardwood.metadata.LogicalType;
+import dev.hardwood.schema.ColumnSchema;
+import dev.hardwood.schema.FileSchema;
+
+/// Whether a column's recorded `min` / `max` are in an order this reader can read.
+///
+/// Pruning compares a literal against those bounds, which is sound only in the order they were
+/// written in. Two shapes arrive where that order is not knowable, neither of them produced by
+/// this writer:
+///
+/// - the annotation names no order — parquet-format defines none for `INTERVAL`, `GEOMETRY`,
+///   `GEOGRAPHY`, `VARIANT`, `UNKNOWN`, `LIST` and `MAP`, and asks that `INTERVAL` record no
+///   bounds at all;
+/// - the file names an order this build does not recognize, which `parquet.thrift` says to treat
+///   as a column whose `min` / `max` are to be ignored.
+///
+/// Bloom filters and dictionaries are unaffected: both test exact stored values, which does not
+/// depend on how those values order.
+@FunctionalInterface
+public interface BoundsReadability {
+
+    /// Every column readable, for a caller whose leaves were already checked against their file —
+    /// [PageDropPredicates#canDropPage], whose leaves are withheld per file before they reach
+    /// it — and for the pruning helpers' own tests.
+    BoundsReadability ALL = columnIndex -> true;
+
+    /// Whether the leaf column at `columnIndex` has bounds worth reading.
+    boolean readable(int columnIndex);
+
+    /// The readability of every leaf of one file, indexed by that file's own leaf ordinals.
+    /// Readability is a property of the file that wrote the bounds, so each file of a
+    /// multi-file read has its own.
+    ///
+    /// Asking about an ordinal outside `schema` is a wiring error, and throws
+    /// [IllegalStateException] rather than answering either way.
+    ///
+    /// @param schema the file's schema
+    /// @param columnOrders the file's decoded `column_orders`, empty where the file omitted them,
+    ///        which means the type-defined order throughout
+    static BoundsReadability of(FileSchema schema, List<ColumnOrder> columnOrders) {
+        boolean[] readable = new boolean[schema.getColumnCount()];
+        for (int i = 0; i < readable.length; i++) {
+            ColumnSchema column = schema.getColumn(i);
+            boolean orderRecognized = columnOrders.size() <= i
+                    || columnOrders.get(i) != ColumnOrder.UNKNOWN;
+            readable[i] = orderRecognized && namesAnOrder(column.logicalType());
+        }
+        return columnIndex -> {
+            if (columnIndex < 0 || columnIndex >= readable.length) {
+                throw new IllegalStateException("Column " + columnIndex + " is not one of the "
+                        + readable.length + " leaf columns of this file");
+            }
+            return readable[columnIndex];
+        };
+    }
+
+    /// Whether the annotation names an order for the values beneath it.
+    ///
+    /// The switch is exhaustive rather than a list of the types without one, so an annotation
+    /// added later has to say which side it falls on. It mirrors
+    /// `StatisticsOrder#supportsBounds` on the write side without delegating to it: that asks
+    /// whether to record bounds, this whether to trust bounds already recorded.
+    private static boolean namesAnOrder(LogicalType logicalType) {
+        if (logicalType == null) {
+            return true; // the physical type's own order
+        }
+        return switch (logicalType) {
+            case LogicalType.StringType ignored -> true;
+            case LogicalType.EnumType ignored -> true;
+            case LogicalType.JsonType ignored -> true;
+            case LogicalType.BsonType ignored -> true;
+            case LogicalType.UuidType ignored -> true;
+            case LogicalType.DateType ignored -> true;
+            case LogicalType.TimeType ignored -> true;
+            case LogicalType.TimestampType ignored -> true;
+            case LogicalType.IntType ignored -> true;
+            case LogicalType.DecimalType ignored -> true;
+            case LogicalType.Float16Type ignored -> true;
+            // parquet-format leaves these unordered.
+            case LogicalType.IntervalType ignored -> false;
+            case LogicalType.NullType ignored -> false;
+            case LogicalType.VariantType ignored -> false;
+            case LogicalType.GeometryType ignored -> false;
+            case LogicalType.GeographyType ignored -> false;
+            case LogicalType.ListType ignored -> false;
+            case LogicalType.MapType ignored -> false;
+        };
+    }
+}

--- a/core/src/main/java/dev/hardwood/internal/predicate/MinMaxStats.java
+++ b/core/src/main/java/dev/hardwood/internal/predicate/MinMaxStats.java
@@ -45,6 +45,11 @@ sealed interface MinMaxStats {
     /// pruning directions at once (#1172).
     String INVERTED = "the minimum sorts above the maximum";
 
+    /// The column's annotation names no ordering, or the file names one this build does not
+    /// recognize, so there is no reading of the pair that the file vouches for (#1179).
+    String UNKNOWN_SORT_ORDER =
+            "the order they were written in is one this reader cannot read";
+
     /// The number of null values in the unit, or `null` if unknown.
     Long nullCount();
 
@@ -120,27 +125,36 @@ sealed interface MinMaxStats {
 
     /// The statistics of a column chunk, or of a single page where they are carried inline on
     /// the page header, decoded as the given leaf reads them.
-    static MinMaxStats of(Statistics stats, ResolvedPredicate leaf) {
+    static MinMaxStats of(Statistics stats, ResolvedPredicate leaf, BoundsReadability readability) {
         if (stats.isMinMaxDeprecated()) {
             return new NullCountOnlyStats(stats.nullCount(), DEPRECATED_SORT_ORDER);
         }
-        return sourced(stats.minValue(), stats.maxValue(), stats.nullCount(), leaf);
+        return sourced(stats.minValue(), stats.maxValue(), stats.nullCount(), leaf, readability);
     }
 
     /// The [ColumnIndex] entry for one page of a column chunk.
-    static MinMaxStats ofPage(ColumnIndex columnIndex, int pageIndex, ResolvedPredicate leaf) {
+    static MinMaxStats ofPage(ColumnIndex columnIndex, int pageIndex, ResolvedPredicate leaf,
+            BoundsReadability readability) {
         long[] nullCounts = columnIndex.nullCounts();
         return sourced(columnIndex.minValues().get(pageIndex), columnIndex.maxValues().get(pageIndex),
-                nullCounts != null ? Long.valueOf(nullCounts[pageIndex]) : null, leaf);
+                nullCounts != null ? Long.valueOf(nullCounts[pageIndex]) : null, leaf, readability);
     }
 
     /// Decodes the pair as the leaf reads it, yielding [NullCountOnlyStats] where the file
-    /// wrote no bounds, where the leaf reads none, or where the pair does not hold together.
-    private static MinMaxStats sourced(byte[] min, byte[] max, Long nullCount, ResolvedPredicate leaf) {
+    /// wrote no bounds, where they are in an order this reader cannot read, where the leaf reads
+    /// none, or where the pair does not hold together.
+    private static MinMaxStats sourced(byte[] min, byte[] max, Long nullCount, ResolvedPredicate leaf,
+            BoundsReadability readability) {
         if (min == null || max == null) {
             // Nothing was written, so nothing was discarded; a half-present pair prunes no
-            // more than an absent one.
+            // more than an absent one. This comes first so that a column whose annotation names
+            // no order, and whose writer therefore recorded no bounds, reports no discard.
             return new NullCountOnlyStats(nullCount, null);
+        }
+        if (!readability.readable(ResolvedPredicate.leafColumnIndex(leaf))) {
+            // Not decoded either: an order this reader cannot name may lay the bytes out in a
+            // way the leaf's decoder does not expect.
+            return new NullCountOnlyStats(nullCount, UNKNOWN_SORT_ORDER);
         }
         return switch (leaf) {
             case ResolvedPredicate.IntPredicate ignored -> IntStats.of(

--- a/core/src/main/java/dev/hardwood/internal/predicate/PageDropPredicates.java
+++ b/core/src/main/java/dev/hardwood/internal/predicate/PageDropPredicates.java
@@ -87,7 +87,9 @@ public final class PageDropPredicates {
     /// Returns `false` when `stats` is `null`, when its bounds are unusable — see
     /// [MinMaxStats] — or when no leaf can drop.
     ///
-    /// @param leaves the AND-necessary leaves testing this page's column
+    /// @param leaves the AND-necessary leaves testing this page's column, empty where the file
+    ///        this page belongs to records the column's bounds in an order this reader cannot
+    ///        read (see [BoundsReadability])
     /// @param stats the page's inline statistics, or `null` if it carries none
     /// @param logContext the page these statistics came from, for a discard to name
     public static boolean canDropPage(List<ResolvedPredicate> leaves, Statistics stats,
@@ -97,8 +99,9 @@ public final class PageDropPredicates {
         }
         for (ResolvedPredicate leaf : leaves) {
             // Sourced per leaf: what makes bounds usable depends on the order the leaf
-            // compares them in.
-            MinMaxStats minMax = MinMaxStats.of(stats, leaf);
+            // compares them in. Readability was settled when the leaves were handed over,
+            // which is where the file they are read against is known.
+            MinMaxStats minMax = MinMaxStats.of(stats, leaf, BoundsReadability.ALL);
             minMax.reportIfDiscarded(logContext);
             if (minMax.canDrop(leaf)) {
                 return true;

--- a/core/src/main/java/dev/hardwood/internal/predicate/PageFilterEvaluator.java
+++ b/core/src/main/java/dev/hardwood/internal/predicate/PageFilterEvaluator.java
@@ -49,25 +49,25 @@ public class PageFilterEvaluator {
     ///                     page bounds turn out to be unusable
     /// @return row ranges that might contain matching rows
     public static RowRanges computeMatchingRows(ResolvedPredicate predicate, RowGroup rowGroup,
-            RowGroupIndexBuffers indexBuffers, LogContext logContext) {
+            RowGroupIndexBuffers indexBuffers, LogContext logContext, BoundsReadability readability) {
         long rowCount = rowGroup.numRows();
-        return evaluate(predicate, rowGroup, indexBuffers, rowCount, logContext);
+        return evaluate(predicate, rowGroup, indexBuffers, rowCount, logContext, readability);
     }
 
     private static RowRanges evaluate(ResolvedPredicate predicate, RowGroup rowGroup,
-            RowGroupIndexBuffers indexBuffers, long rowCount, LogContext logContext) {
+            RowGroupIndexBuffers indexBuffers, long rowCount, LogContext logContext, BoundsReadability readability) {
         return switch (predicate) {
             case ResolvedPredicate.And a -> {
                 RowRanges result = RowRanges.all(rowCount);
                 for (ResolvedPredicate child : a.children()) {
-                    result = result.intersect(evaluate(child, rowGroup, indexBuffers, rowCount, logContext));
+                    result = result.intersect(evaluate(child, rowGroup, indexBuffers, rowCount, logContext, readability));
                 }
                 yield result;
             }
             case ResolvedPredicate.Or o -> {
                 RowRanges result = null;
                 for (ResolvedPredicate child : o.children()) {
-                    RowRanges childRanges = evaluate(child, rowGroup, indexBuffers, rowCount, logContext);
+                    RowRanges childRanges = evaluate(child, rowGroup, indexBuffers, rowCount, logContext, readability);
                     result = (result == null) ? childRanges : result.union(childRanges);
                 }
                 yield (result != null) ? result : RowRanges.all(rowCount);
@@ -79,14 +79,14 @@ public class PageFilterEvaluator {
             // Parquet has no per-page geospatial statistics (GeospatialStatistics lives only on
             // ColumnMetaData, applied during row-group filtering), so no page-level pruning is possible.
             case ResolvedPredicate.GeospatialPredicate ignored -> RowRanges.all(rowCount);
-            default -> evaluateLeafPages(predicate, rowGroup, indexBuffers, rowCount, logContext);
+            default -> evaluateLeafPages(predicate, rowGroup, indexBuffers, rowCount, logContext, readability);
         };
     }
 
     /// Evaluates a leaf predicate against per-page Column Index statistics,
     /// using [MinMaxStats#canDrop] for the actual comparison.
     private static RowRanges evaluateLeafPages(ResolvedPredicate predicate, RowGroup rowGroup,
-            RowGroupIndexBuffers indexBuffers, long rowCount, LogContext logContext) {
+            RowGroupIndexBuffers indexBuffers, long rowCount, LogContext logContext, BoundsReadability readability) {
 
         int columnIndex = ResolvedPredicate.leafColumnIndex(predicate);
         if (columnIndex < 0 || columnIndex >= rowGroup.columns().size()) {
@@ -113,7 +113,7 @@ public class PageFilterEvaluator {
             if (columnIdx.nullPages()[i]) {
                 continue;
             }
-            MinMaxStats pageStats = MinMaxStats.ofPage(columnIdx, i, predicate);
+            MinMaxStats pageStats = MinMaxStats.ofPage(columnIdx, i, predicate, readability);
             pageStats.reportIfDiscarded(columnContext.withPageIndex(i));
             keep[i] = !pageStats.canDrop(predicate);
         }

--- a/core/src/main/java/dev/hardwood/internal/predicate/RowGroupFilterEvaluator.java
+++ b/core/src/main/java/dev/hardwood/internal/predicate/RowGroupFilterEvaluator.java
@@ -60,26 +60,26 @@ public class RowGroupFilterEvaluator {
     /// @return the statistics decision for the row group
     public static FilterDecision decideRowGroup(ResolvedPredicate predicate, RowGroup rowGroup,
             BloomFilterSource bloomFilters, RowGroupDictionaryFilterSource dictionaries,
-            LogContext logContext) throws IOException {
-        return decide(predicate, rowGroup, bloomFilters, dictionaries, logContext);
+            LogContext logContext, BoundsReadability readability) throws IOException {
+        return decide(predicate, rowGroup, bloomFilters, dictionaries, logContext, readability);
     }
 
     /// The recursive body of [#decideRowGroup], carrying where the row group is so that a
     /// column whose bounds turn out to be unusable can be named.
     private static FilterDecision decide(ResolvedPredicate predicate, RowGroup rowGroup,
             BloomFilterSource bloomFilters, RowGroupDictionaryFilterSource dictionaries,
-            LogContext logContext) throws IOException {
+            LogContext logContext, BoundsReadability readability) throws IOException {
         return switch (predicate) {
             case ResolvedPredicate.IntPredicate p -> intEqualityDecision(p, p.op(), p.value(),
-                    rowGroup, bloomFilters, dictionaries, logContext);
+                    rowGroup, bloomFilters, dictionaries, logContext, readability);
             case ResolvedPredicate.UnsignedIntPredicate p -> intEqualityDecision(p, p.op(), p.value(),
-                    rowGroup, bloomFilters, dictionaries, logContext);
+                    rowGroup, bloomFilters, dictionaries, logContext, readability);
             case ResolvedPredicate.LongPredicate p -> longEqualityDecision(p, p.op(), p.value(),
-                    rowGroup, bloomFilters, dictionaries, logContext);
+                    rowGroup, bloomFilters, dictionaries, logContext, readability);
             case ResolvedPredicate.UnsignedLongPredicate p -> longEqualityDecision(p, p.op(), p.value(),
-                    rowGroup, bloomFilters, dictionaries, logContext);
+                    rowGroup, bloomFilters, dictionaries, logContext, readability);
             case ResolvedPredicate.FloatPredicate p -> {
-                FilterDecision decision = statisticsDecision(p, rowGroup, logContext, p.columnIndex());
+                FilterDecision decision = statisticsDecision(p, rowGroup, logContext, p.columnIndex(), readability);
                 if (decision != FilterDecision.CANNOT_MATCH
                         && p.op() == FilterPredicate.Operator.EQ
                         // The NaN case is repeated from BloomFilterSupport so the filter is not
@@ -96,7 +96,7 @@ public class RowGroupFilterEvaluator {
             // neighbouring value would prove the wrong one absent. The dictionary holds the
             // stored values, so its entries can be widened instead and compared exactly.
             case ResolvedPredicate.Float16Predicate p -> {
-                FilterDecision decision = statisticsDecision(p, rowGroup, logContext, p.columnIndex());
+                FilterDecision decision = statisticsDecision(p, rowGroup, logContext, p.columnIndex(), readability);
                 if (decision != FilterDecision.CANNOT_MATCH
                         && p.op() == FilterPredicate.Operator.EQ
                         && DictionaryFilterSupport.valueAbsentFloat16(dictionary(dictionaries, p.columnIndex()), p.value())) {
@@ -105,7 +105,7 @@ public class RowGroupFilterEvaluator {
                 yield decision;
             }
             case ResolvedPredicate.Float16InPredicate p -> {
-                FilterDecision decision = statisticsDecision(p, rowGroup, logContext, p.columnIndex());
+                FilterDecision decision = statisticsDecision(p, rowGroup, logContext, p.columnIndex(), readability);
                 // As for Float16Predicate: the dictionary holds the chunk's exact halves and decides
                 // membership. A FLOAT16 column's Bloom filter hashes its two stored bytes and is not
                 // consulted for a numeric probe.
@@ -116,7 +116,7 @@ public class RowGroupFilterEvaluator {
                 yield decision;
             }
             case ResolvedPredicate.DoublePredicate p -> {
-                FilterDecision decision = statisticsDecision(p, rowGroup, logContext, p.columnIndex());
+                FilterDecision decision = statisticsDecision(p, rowGroup, logContext, p.columnIndex(), readability);
                 if (decision != FilterDecision.CANNOT_MATCH
                         && p.op() == FilterPredicate.Operator.EQ
                         // The NaN case is repeated from BloomFilterSupport so the filter is not
@@ -129,9 +129,9 @@ public class RowGroupFilterEvaluator {
                 yield decision;
             }
             case ResolvedPredicate.BooleanPredicate p ->
-                    statisticsDecision(p, rowGroup, logContext, p.columnIndex());
+                    statisticsDecision(p, rowGroup, logContext, p.columnIndex(), readability);
             case ResolvedPredicate.BinaryPredicate p -> {
-                FilterDecision decision = statisticsDecision(p, rowGroup, logContext, p.columnIndex());
+                FilterDecision decision = statisticsDecision(p, rowGroup, logContext, p.columnIndex(), readability);
                 // Bloom filters and dictionary membership answer "are these exact bytes here?",
                 // which stands in for "is this value here?" only where the value has one
                 // encoding — see BinaryPredicate#byteExact. Statistics compare in the column's
@@ -146,15 +146,15 @@ public class RowGroupFilterEvaluator {
                 yield decision;
             }
             case ResolvedPredicate.IntInPredicate p -> intInDecision(p, p.values(),
-                    rowGroup, bloomFilters, dictionaries, logContext);
+                    rowGroup, bloomFilters, dictionaries, logContext, readability);
             case ResolvedPredicate.UnsignedIntInPredicate p -> intInDecision(p, p.values(),
-                    rowGroup, bloomFilters, dictionaries, logContext);
+                    rowGroup, bloomFilters, dictionaries, logContext, readability);
             case ResolvedPredicate.LongInPredicate p -> longInDecision(p, p.values(),
-                    rowGroup, bloomFilters, dictionaries, logContext);
+                    rowGroup, bloomFilters, dictionaries, logContext, readability);
             case ResolvedPredicate.UnsignedLongInPredicate p -> longInDecision(p, p.values(),
-                    rowGroup, bloomFilters, dictionaries, logContext);
+                    rowGroup, bloomFilters, dictionaries, logContext, readability);
             case ResolvedPredicate.BinaryInPredicate p -> {
-                FilterDecision decision = statisticsDecision(p, rowGroup, logContext, p.columnIndex());
+                FilterDecision decision = statisticsDecision(p, rowGroup, logContext, p.columnIndex(), readability);
                 // As for BinaryPredicate: exact-byte shortcuts stand in for membership only where
                 // a value has one encoding.
                 if (decision != FilterDecision.CANNOT_MATCH
@@ -166,7 +166,7 @@ public class RowGroupFilterEvaluator {
                 yield decision;
             }
             case ResolvedPredicate.DoubleInPredicate p -> {
-                FilterDecision decision = statisticsDecision(p, rowGroup, logContext, p.columnIndex());
+                FilterDecision decision = statisticsDecision(p, rowGroup, logContext, p.columnIndex(), readability);
                 if (decision != FilterDecision.CANNOT_MATCH
                         // The NaN case is repeated from BloomFilterSupport so the filter is not
                         // read for a list it could not decide either way. The dictionary holds the
@@ -192,7 +192,7 @@ public class RowGroupFilterEvaluator {
                 }
                 FilterDecision result = FilterDecision.ALWAYS_MATCHES;
                 for (ResolvedPredicate child : a.children()) {
-                    result = FilterDecision.and(result, decide(child, rowGroup, bloomFilters, dictionaries, logContext));
+                    result = FilterDecision.and(result, decide(child, rowGroup, bloomFilters, dictionaries, logContext, readability));
                     if (result == FilterDecision.CANNOT_MATCH) {
                         break;
                     }
@@ -205,7 +205,7 @@ public class RowGroupFilterEvaluator {
                 }
                 FilterDecision result = FilterDecision.CANNOT_MATCH;
                 for (ResolvedPredicate child : o.children()) {
-                    result = FilterDecision.or(result, decide(child, rowGroup, bloomFilters, dictionaries, logContext));
+                    result = FilterDecision.or(result, decide(child, rowGroup, bloomFilters, dictionaries, logContext, readability));
                     if (result == FilterDecision.ALWAYS_MATCHES) {
                         break;
                     }
@@ -236,9 +236,9 @@ public class RowGroupFilterEvaluator {
     /// statistics half reads an order, and the leaf's own [MinMaxStats] variant supplies it.
     private static FilterDecision intEqualityDecision(ResolvedPredicate leaf,
             FilterPredicate.Operator op, int value, RowGroup rowGroup, BloomFilterSource bloomFilters,
-            RowGroupDictionaryFilterSource dictionaries, LogContext logContext) throws IOException {
+            RowGroupDictionaryFilterSource dictionaries, LogContext logContext, BoundsReadability readability) throws IOException {
         int columnIndex = ResolvedPredicate.leafColumnIndex(leaf);
-        FilterDecision decision = statisticsDecision(leaf, rowGroup, logContext, columnIndex);
+        FilterDecision decision = statisticsDecision(leaf, rowGroup, logContext, columnIndex, readability);
         if (decision != FilterDecision.CANNOT_MATCH
                 && op == FilterPredicate.Operator.EQ
                 && (BloomFilterSupport.valueAbsent(bloom(bloomFilters, columnIndex), value)
@@ -251,9 +251,9 @@ public class RowGroupFilterEvaluator {
     /// [#intEqualityDecision] for an `INT64` column.
     private static FilterDecision longEqualityDecision(ResolvedPredicate leaf,
             FilterPredicate.Operator op, long value, RowGroup rowGroup, BloomFilterSource bloomFilters,
-            RowGroupDictionaryFilterSource dictionaries, LogContext logContext) throws IOException {
+            RowGroupDictionaryFilterSource dictionaries, LogContext logContext, BoundsReadability readability) throws IOException {
         int columnIndex = ResolvedPredicate.leafColumnIndex(leaf);
-        FilterDecision decision = statisticsDecision(leaf, rowGroup, logContext, columnIndex);
+        FilterDecision decision = statisticsDecision(leaf, rowGroup, logContext, columnIndex, readability);
         if (decision != FilterDecision.CANNOT_MATCH
                 && op == FilterPredicate.Operator.EQ
                 && (BloomFilterSupport.valueAbsent(bloom(bloomFilters, columnIndex), value)
@@ -267,9 +267,9 @@ public class RowGroupFilterEvaluator {
     /// before the row group can be dropped.
     private static FilterDecision intInDecision(ResolvedPredicate leaf, int[] values, RowGroup rowGroup,
             BloomFilterSource bloomFilters, RowGroupDictionaryFilterSource dictionaries,
-            LogContext logContext) throws IOException {
+            LogContext logContext, BoundsReadability readability) throws IOException {
         int columnIndex = ResolvedPredicate.leafColumnIndex(leaf);
-        FilterDecision decision = statisticsDecision(leaf, rowGroup, logContext, columnIndex);
+        FilterDecision decision = statisticsDecision(leaf, rowGroup, logContext, columnIndex, readability);
         if (decision != FilterDecision.CANNOT_MATCH
                 && (BloomFilterSupport.absentAll(bloom(bloomFilters, columnIndex), values)
                         || DictionaryFilterSupport.absentAll(dictionary(dictionaries, columnIndex), values))) {
@@ -281,9 +281,9 @@ public class RowGroupFilterEvaluator {
     /// [#intInDecision] for an `INT64` column.
     private static FilterDecision longInDecision(ResolvedPredicate leaf, long[] values, RowGroup rowGroup,
             BloomFilterSource bloomFilters, RowGroupDictionaryFilterSource dictionaries,
-            LogContext logContext) throws IOException {
+            LogContext logContext, BoundsReadability readability) throws IOException {
         int columnIndex = ResolvedPredicate.leafColumnIndex(leaf);
-        FilterDecision decision = statisticsDecision(leaf, rowGroup, logContext, columnIndex);
+        FilterDecision decision = statisticsDecision(leaf, rowGroup, logContext, columnIndex, readability);
         if (decision != FilterDecision.CANNOT_MATCH
                 && (BloomFilterSupport.absentAll(bloom(bloomFilters, columnIndex), values)
                         || DictionaryFilterSupport.absentAll(dictionary(dictionaries, columnIndex), values))) {
@@ -296,12 +296,12 @@ public class RowGroupFilterEvaluator {
     /// when statistics are absent — or when their bounds are unusable, which [MinMaxStats]
     /// decides and this reports.
     private static FilterDecision statisticsDecision(ResolvedPredicate leaf, RowGroup rowGroup,
-            LogContext logContext, int columnIndex) {
+            LogContext logContext, int columnIndex, BoundsReadability readability) {
         Statistics stats = getStatistics(rowGroup, columnIndex);
         if (stats == null) {
             return FilterDecision.MIGHT_MATCH;
         }
-        MinMaxStats minMax = MinMaxStats.of(stats, leaf);
+        MinMaxStats minMax = MinMaxStats.of(stats, leaf, readability);
         minMax.reportIfDiscarded(logContext.withColumn(
                 rowGroup.columns().get(columnIndex).metaData().pathInSchema()));
         return minMax.decideLeaf(leaf);

--- a/core/src/main/java/dev/hardwood/internal/reader/FileColumnOrdinals.java
+++ b/core/src/main/java/dev/hardwood/internal/reader/FileColumnOrdinals.java
@@ -7,6 +7,7 @@
  */
 package dev.hardwood.internal.reader;
 
+import dev.hardwood.internal.predicate.BoundsReadability;
 import dev.hardwood.internal.predicate.ResolvedPredicate;
 
 /// Where each leaf of the reference schema sits in one specific file.
@@ -19,14 +20,21 @@ import dev.hardwood.internal.predicate.ResolvedPredicate;
 ///
 /// The translation is by field path: two files agree on a column when the same path
 /// carries a compatible leaf, wherever that leaf happens to sit.
+///
+/// Pruning one file's row groups and pages needs two things in that file's own ordinals, so
+/// both travel here: the filter, translated, and which of the file's leaves carry bounds in
+/// an order this reader can read — a property of the file that wrote them.
 public final class FileColumnOrdinals {
 
     private final int[] fileOrdinals;
     private final ResolvedPredicate filter;
+    private final BoundsReadability boundsReadability;
 
-    private FileColumnOrdinals(int[] fileOrdinals, ResolvedPredicate filter) {
+    private FileColumnOrdinals(int[] fileOrdinals, ResolvedPredicate filter,
+            BoundsReadability boundsReadability) {
         this.fileOrdinals = fileOrdinals;
         this.filter = filter;
+        this.boundsReadability = boundsReadability;
     }
 
     /// Mapping for the reference file itself, whose leaf ordinals are the reference
@@ -34,12 +42,14 @@ public final class FileColumnOrdinals {
     ///
     /// @param referenceLeafCount number of leaf columns in the reference schema
     /// @param filter the filter predicate resolved against the reference schema, or `null`
-    public static FileColumnOrdinals identity(int referenceLeafCount, ResolvedPredicate filter) {
+    /// @param boundsReadability the reference file's bounds readability
+    public static FileColumnOrdinals identity(int referenceLeafCount, ResolvedPredicate filter,
+            BoundsReadability boundsReadability) {
         int[] ordinals = new int[referenceLeafCount];
         for (int i = 0; i < referenceLeafCount; i++) {
             ordinals[i] = i;
         }
-        return new FileColumnOrdinals(ordinals, filter);
+        return new FileColumnOrdinals(ordinals, filter, boundsReadability);
     }
 
     /// Mapping for a file whose leaf order may differ from the reference schema.
@@ -47,9 +57,12 @@ public final class FileColumnOrdinals {
     /// @param fileOrdinals this file's leaf ordinal per reference leaf ordinal;
     ///        `-1` for reference leaves the file does not carry
     /// @param filter the filter predicate resolved against the reference schema, or `null`
-    static FileColumnOrdinals of(int[] fileOrdinals, ResolvedPredicate filter) {
+    /// @param boundsReadability this file's bounds readability, by its own leaf ordinals
+    static FileColumnOrdinals of(int[] fileOrdinals, ResolvedPredicate filter,
+            BoundsReadability boundsReadability) {
         return new FileColumnOrdinals(fileOrdinals,
-                filter == null ? null : ResolvedPredicate.remapColumns(filter, fileOrdinals));
+                filter == null ? null : ResolvedPredicate.remapColumns(filter, fileOrdinals),
+                boundsReadability);
     }
 
     /// This file's leaf ordinal for a reference schema leaf ordinal — the index to
@@ -70,5 +83,11 @@ public final class FileColumnOrdinals {
     /// ordinals, or `null` when no filter is set.
     ResolvedPredicate filter() {
         return filter;
+    }
+
+    /// Which of this file's leaves carry bounds this reader can read, by this file's ordinals —
+    /// the ones [#filter] and [#fileOrdinal] speak in.
+    BoundsReadability boundsReadability() {
+        return boundsReadability;
     }
 }

--- a/core/src/main/java/dev/hardwood/internal/reader/RowGroupIterator.java
+++ b/core/src/main/java/dev/hardwood/internal/reader/RowGroupIterator.java
@@ -25,6 +25,7 @@ import java.util.function.Consumer;
 import dev.hardwood.InputFile;
 import dev.hardwood.internal.ExceptionContext;
 import dev.hardwood.internal.FetchReason;
+import dev.hardwood.internal.predicate.BoundsReadability;
 import dev.hardwood.internal.predicate.FilterDecision;
 import dev.hardwood.internal.predicate.LogContext;
 import dev.hardwood.internal.predicate.PageDropPredicates;
@@ -425,7 +426,8 @@ public class RowGroupIterator implements Closeable {
                 if (pageFiltering) {
                     matchingRows = PageFilterEvaluator.computeMatchingRows(
                             workItem.columnOrdinals().filter(), workItem.rowGroup(), indexBuffers,
-                            new LogContext(workItem.inputFile().name(), workItem.rowGroupIndex()));
+                            new LogContext(workItem.inputFile().name(), workItem.rowGroupIndex()),
+                            workItem.columnOrdinals().boundsReadability());
                 }
 
                 MaskCapability maskCapability = masksApplicableForRowGroup(
@@ -700,8 +702,12 @@ public class RowGroupIterator implements Closeable {
             if (colBuffers == null || colBuffers.offsetIndex() == null) {
                 // No OffsetIndex — sequential lazy fetching. Per-page drops via
                 // inline DataPageHeader.statistics and per-page row masks both
-                // happen inside SequentialFetchPlan.
-                List<ResolvedPredicate> leaves = dropLeavesByColumn.getOrDefault(originalIndex, List.of());
+                // happen inside SequentialFetchPlan. Inline page statistics are bounds
+                // like any other, so a column whose bounds this file records in an order
+                // this reader cannot read hands over no leaves to drop pages with (#1179).
+                List<ResolvedPredicate> leaves = workItem.columnOrdinals().boundsReadability().readable(fileOrdinal)
+                        ? dropLeavesByColumn.getOrDefault(originalIndex, List.of())
+                        : List.of();
                 plans[projCol] = SequentialFetchPlan.build(
                         inputFile, columnSchema, columnChunk,
                         context, workItem.rowGroupIndex(), inputFile.name(),
@@ -1168,11 +1174,16 @@ public class RowGroupIterator implements Closeable {
         boolean hasFilter = filterPredicate != null;
         int fileIndex = nextFileToPlan++;
         PreparedFile prepared = getPreparedFile(fileIndex);
+        // Decided per file and in the file's own ordinals: the order its bounds were written in
+        // is this file's to declare, not the reference file's (#1179).
+        BoundsReadability boundsReadability = BoundsReadability.of(
+                prepared.schema(), prepared.metaData().columnOrders());
         FileColumnOrdinals columnOrdinals = fileIndex == 0
-                ? FileColumnOrdinals.identity(referenceSchema.getColumnCount(), filterPredicate)
+                ? FileColumnOrdinals.identity(referenceSchema.getColumnCount(), filterPredicate,
+                        boundsReadability)
                 : FileColumnOrdinals.of(
                         validateSchemaCompatibility(prepared.inputFile(), prepared.schema()),
-                        filterPredicate);
+                        filterPredicate, boundsReadability);
         List<RowGroup> sourceRowGroups = fileIndex == 0 && firstFileRowGroups != null
                 ? firstFileRowGroups : prepared.rowGroups();
         // Metadata pruning indexes every row group's chunk list by ordinal, so with
@@ -1383,7 +1394,7 @@ public class RowGroupIterator implements Closeable {
             FilterDecision decision = RowGroupFilterEvaluator.decideRowGroup(columnOrdinals.filter(), rg,
                     new RowGroupBloomFilterSource(inputFile, rg),
                     new RowGroupDictionaryFilterSource(inputFile, rg, fileSchema, context),
-                    new LogContext(inputFile.name(), rgIndex));
+                    new LogContext(inputFile.name(), rgIndex), columnOrdinals.boundsReadability());
             if (decision == FilterDecision.CANNOT_MATCH) {
                 continue;
             }

--- a/core/src/test/java/dev/hardwood/FilterPredicateTest.java
+++ b/core/src/test/java/dev/hardwood/FilterPredicateTest.java
@@ -26,6 +26,7 @@ import org.junit.jupiter.params.provider.EnumSource;
 import org.junit.jupiter.params.provider.MethodSource;
 
 import dev.hardwood.internal.ExceptionContext;
+import dev.hardwood.internal.predicate.BoundsReadability;
 import dev.hardwood.internal.predicate.FilterDecision;
 import dev.hardwood.internal.predicate.FilterPredicateResolver;
 import dev.hardwood.internal.predicate.LogContext;
@@ -1537,6 +1538,6 @@ class FilterPredicateTest {
     /// This mirrors the production code path: resolve first, then evaluate.
     private static boolean canDropRowGroup(FilterPredicate filter, RowGroup rg, FileSchema schema) throws IOException {
         ResolvedPredicate resolved = FilterPredicateResolver.resolve(filter, schema);
-        return RowGroupFilterEvaluator.decideRowGroup(resolved, rg, null, null, UNNAMED) == FilterDecision.CANNOT_MATCH;
+        return RowGroupFilterEvaluator.decideRowGroup(resolved, rg, null, null, UNNAMED, BoundsReadability.ALL) == FilterDecision.CANNOT_MATCH;
     }
 }

--- a/core/src/test/java/dev/hardwood/NestedV1NoIndexFallbackTest.java
+++ b/core/src/test/java/dev/hardwood/NestedV1NoIndexFallbackTest.java
@@ -12,6 +12,7 @@ import java.nio.file.Paths;
 
 import org.junit.jupiter.api.Test;
 
+import dev.hardwood.internal.predicate.BoundsReadability;
 import dev.hardwood.internal.reader.FileColumnOrdinals;
 import dev.hardwood.internal.reader.ParquetMetadataReader;
 import dev.hardwood.internal.reader.RowGroupIterator;
@@ -74,7 +75,7 @@ class NestedV1NoIndexFallbackTest {
             ProjectedSchema projected = ProjectedSchema.create(schema, ColumnProjection.all());
             boolean applicable = RowGroupIterator.masksApplicableForRowGroup(
                     projected, rg, schema,
-                    FileColumnOrdinals.identity(schema.getColumnCount(), null), file);
+                    FileColumnOrdinals.identity(schema.getColumnCount(), null, BoundsReadability.ALL), file);
 
             // Gate must be closed: a nested column without an OffsetIndex
             // and with v1 pages can't be record-counted without

--- a/core/src/test/java/dev/hardwood/internal/predicate/BinaryDecimalFilterTest.java
+++ b/core/src/test/java/dev/hardwood/internal/predicate/BinaryDecimalFilterTest.java
@@ -293,7 +293,7 @@ class BinaryDecimalFilterTest {
                 new BloomFilterHeader(BLOOM_FILTER_BYTES, BloomFilterHeader.Algorithm.BLOCK,
                         BloomFilterHeader.Hash.XXHASH, BloomFilterHeader.Compression.UNCOMPRESSED),
                 ByteBuffer.allocate(BLOOM_FILTER_BYTES).order(ByteOrder.LITTLE_ENDIAN).asReadOnlyBuffer());
-        return RowGroupFilterEvaluator.decideRowGroup(predicate, rowGroup, empty, null, UNNAMED);
+        return RowGroupFilterEvaluator.decideRowGroup(predicate, rowGroup, empty, null, UNNAMED, BoundsReadability.ALL);
     }
 
     /// Rows alternating a padded `127` with a minimally encoded `300`.

--- a/core/src/test/java/dev/hardwood/internal/predicate/BloomFilterPushDownTest.java
+++ b/core/src/test/java/dev/hardwood/internal/predicate/BloomFilterPushDownTest.java
@@ -375,12 +375,12 @@ class BloomFilterPushDownTest {
     private static boolean bloomDrop(FilterPredicate filter) throws IOException {
         ResolvedPredicate resolved = FilterPredicateResolver.resolve(filter, schema);
         return RowGroupFilterEvaluator.decideRowGroup(resolved, rowGroup,
-                new RowGroupBloomFilterSource(inputFile, rowGroup), null, UNNAMED) == FilterDecision.CANNOT_MATCH;
+                new RowGroupBloomFilterSource(inputFile, rowGroup), null, UNNAMED, BoundsReadability.ALL) == FilterDecision.CANNOT_MATCH;
     }
 
     private static boolean statisticsDrop(FilterPredicate filter) throws IOException {
         ResolvedPredicate resolved = FilterPredicateResolver.resolve(filter, schema);
-        return RowGroupFilterEvaluator.decideRowGroup(resolved, rowGroup, null, null, UNNAMED) == FilterDecision.CANNOT_MATCH;
+        return RowGroupFilterEvaluator.decideRowGroup(resolved, rowGroup, null, null, UNNAMED, BoundsReadability.ALL) == FilterDecision.CANNOT_MATCH;
     }
 
     /// A `BloomFilterHeader` thrift struct followed by a minimal one-block (32-byte) bitset holding

--- a/core/src/test/java/dev/hardwood/internal/predicate/BloomFilterSignedZeroPushDownTest.java
+++ b/core/src/test/java/dev/hardwood/internal/predicate/BloomFilterSignedZeroPushDownTest.java
@@ -109,11 +109,11 @@ class BloomFilterSignedZeroPushDownTest {
     private static boolean bloomDrop(FilterPredicate filter) throws IOException {
         ResolvedPredicate resolved = FilterPredicateResolver.resolve(filter, schema);
         return RowGroupFilterEvaluator.decideRowGroup(resolved, rowGroup,
-                new RowGroupBloomFilterSource(inputFile, rowGroup), null, UNNAMED) == FilterDecision.CANNOT_MATCH;
+                new RowGroupBloomFilterSource(inputFile, rowGroup), null, UNNAMED, BoundsReadability.ALL) == FilterDecision.CANNOT_MATCH;
     }
 
     private static boolean statisticsDrop(FilterPredicate filter) throws IOException {
         ResolvedPredicate resolved = FilterPredicateResolver.resolve(filter, schema);
-        return RowGroupFilterEvaluator.decideRowGroup(resolved, rowGroup, null, null, UNNAMED) == FilterDecision.CANNOT_MATCH;
+        return RowGroupFilterEvaluator.decideRowGroup(resolved, rowGroup, null, null, UNNAMED, BoundsReadability.ALL) == FilterDecision.CANNOT_MATCH;
     }
 }

--- a/core/src/test/java/dev/hardwood/internal/predicate/ByteStringOrderFilterTest.java
+++ b/core/src/test/java/dev/hardwood/internal/predicate/ByteStringOrderFilterTest.java
@@ -189,7 +189,7 @@ class ByteStringOrderFilterTest {
                 FilterPredicate.inStrings("h", asString(new byte[] { 0x01, 0x3C })), float16Schema());
         Statistics stats = new Statistics(half(1.0f), half(1.5f), 0L, null, false);
 
-        assertThat(MinMaxStats.of(stats, leaf).canDrop(leaf)).isFalse();
+        assertThat(MinMaxStats.of(stats, leaf, BoundsReadability.ALL).canDrop(leaf)).isFalse();
     }
 
     /// Every annotation whose order is the bytes themselves keeps the byte-string comparison, as

--- a/core/src/test/java/dev/hardwood/internal/predicate/DictionaryFixedLenByteArrayPushDownTest.java
+++ b/core/src/test/java/dev/hardwood/internal/predicate/DictionaryFixedLenByteArrayPushDownTest.java
@@ -92,12 +92,12 @@ class DictionaryFixedLenByteArrayPushDownTest {
 
     private static boolean dictionaryDrop(FilterPredicate filter) throws IOException {
         ResolvedPredicate resolved = FilterPredicateResolver.resolve(filter, schema);
-        return RowGroupFilterEvaluator.decideRowGroup(resolved, rowGroup, null, dictionaries(), UNNAMED)
+        return RowGroupFilterEvaluator.decideRowGroup(resolved, rowGroup, null, dictionaries(), UNNAMED, BoundsReadability.ALL)
                 == FilterDecision.CANNOT_MATCH;
     }
 
     private static boolean statisticsDrop(FilterPredicate filter) throws IOException {
         ResolvedPredicate resolved = FilterPredicateResolver.resolve(filter, schema);
-        return RowGroupFilterEvaluator.decideRowGroup(resolved, rowGroup, null, null, UNNAMED) == FilterDecision.CANNOT_MATCH;
+        return RowGroupFilterEvaluator.decideRowGroup(resolved, rowGroup, null, null, UNNAMED, BoundsReadability.ALL) == FilterDecision.CANNOT_MATCH;
     }
 }

--- a/core/src/test/java/dev/hardwood/internal/predicate/DictionaryFloat16PushDownTest.java
+++ b/core/src/test/java/dev/hardwood/internal/predicate/DictionaryFloat16PushDownTest.java
@@ -115,12 +115,12 @@ class DictionaryFloat16PushDownTest {
 
     private static boolean dictionaryDrop(FilterPredicate filter) throws IOException {
         ResolvedPredicate resolved = FilterPredicateResolver.resolve(filter, schema);
-        return RowGroupFilterEvaluator.decideRowGroup(resolved, rowGroup, null, dictionaries(), UNNAMED)
+        return RowGroupFilterEvaluator.decideRowGroup(resolved, rowGroup, null, dictionaries(), UNNAMED, BoundsReadability.ALL)
                 == FilterDecision.CANNOT_MATCH;
     }
 
     private static boolean statisticsDrop(FilterPredicate filter) throws IOException {
         ResolvedPredicate resolved = FilterPredicateResolver.resolve(filter, schema);
-        return RowGroupFilterEvaluator.decideRowGroup(resolved, rowGroup, null, null, UNNAMED) == FilterDecision.CANNOT_MATCH;
+        return RowGroupFilterEvaluator.decideRowGroup(resolved, rowGroup, null, null, UNNAMED, BoundsReadability.ALL) == FilterDecision.CANNOT_MATCH;
     }
 }

--- a/core/src/test/java/dev/hardwood/internal/predicate/DictionaryNumericPushDownTest.java
+++ b/core/src/test/java/dev/hardwood/internal/predicate/DictionaryNumericPushDownTest.java
@@ -201,12 +201,12 @@ class DictionaryNumericPushDownTest {
 
     private static boolean dictionaryDrop(FilterPredicate filter) throws IOException {
         ResolvedPredicate resolved = FilterPredicateResolver.resolve(filter, schema);
-        return RowGroupFilterEvaluator.decideRowGroup(resolved, rowGroup, null, dictionaries(), UNNAMED)
+        return RowGroupFilterEvaluator.decideRowGroup(resolved, rowGroup, null, dictionaries(), UNNAMED, BoundsReadability.ALL)
                 == FilterDecision.CANNOT_MATCH;
     }
 
     private static boolean statisticsDrop(FilterPredicate filter) throws IOException {
         ResolvedPredicate resolved = FilterPredicateResolver.resolve(filter, schema);
-        return RowGroupFilterEvaluator.decideRowGroup(resolved, rowGroup, null, null, UNNAMED) == FilterDecision.CANNOT_MATCH;
+        return RowGroupFilterEvaluator.decideRowGroup(resolved, rowGroup, null, null, UNNAMED, BoundsReadability.ALL) == FilterDecision.CANNOT_MATCH;
     }
 }

--- a/core/src/test/java/dev/hardwood/internal/predicate/DictionaryPushDownTest.java
+++ b/core/src/test/java/dev/hardwood/internal/predicate/DictionaryPushDownTest.java
@@ -163,12 +163,12 @@ class DictionaryPushDownTest {
 
     private static boolean dictionaryDrop(FilterPredicate filter) throws IOException {
         ResolvedPredicate resolved = FilterPredicateResolver.resolve(filter, schema);
-        return RowGroupFilterEvaluator.decideRowGroup(resolved, rowGroup, null, dictionaries(), UNNAMED)
+        return RowGroupFilterEvaluator.decideRowGroup(resolved, rowGroup, null, dictionaries(), UNNAMED, BoundsReadability.ALL)
                 == FilterDecision.CANNOT_MATCH;
     }
 
     private static boolean statisticsDrop(FilterPredicate filter) throws IOException {
         ResolvedPredicate resolved = FilterPredicateResolver.resolve(filter, schema);
-        return RowGroupFilterEvaluator.decideRowGroup(resolved, rowGroup, null, null, UNNAMED) == FilterDecision.CANNOT_MATCH;
+        return RowGroupFilterEvaluator.decideRowGroup(resolved, rowGroup, null, null, UNNAMED, BoundsReadability.ALL) == FilterDecision.CANNOT_MATCH;
     }
 }

--- a/core/src/test/java/dev/hardwood/internal/predicate/InvertedStatisticsFilterTest.java
+++ b/core/src/test/java/dev/hardwood/internal/predicate/InvertedStatisticsFilterTest.java
@@ -126,11 +126,11 @@ class InvertedStatisticsFilterTest {
     @Test
     void typeDefinedZeroBoundsAreNotInverted() {
         MinMaxStats floatStats = MinMaxStats.of(stats(floatBytes(0.0f), floatBytes(-0.0f)),
-                new ResolvedPredicate.FloatPredicate(0, Operator.EQ, 5.0f, false));
+                new ResolvedPredicate.FloatPredicate(0, Operator.EQ, 5.0f, false), BoundsReadability.ALL);
         assertThat(floatStats).isNotInstanceOf(MinMaxStats.NullCountOnlyStats.class);
 
         MinMaxStats doubleStats = MinMaxStats.of(stats(doubleBytes(0.0), doubleBytes(-0.0)),
-                new ResolvedPredicate.DoublePredicate(0, Operator.EQ, 5.0, false));
+                new ResolvedPredicate.DoublePredicate(0, Operator.EQ, 5.0, false), BoundsReadability.ALL);
         assertThat(doubleStats).isNotInstanceOf(MinMaxStats.NullCountOnlyStats.class);
 
         // And they still prune a value neither zero can be.
@@ -143,7 +143,7 @@ class InvertedStatisticsFilterTest {
     @Test
     void ieee754ZeroBoundsTheWrongWayRoundAreInverted() {
         MinMaxStats doubleStats = MinMaxStats.of(stats(doubleBytes(0.0), doubleBytes(-0.0)),
-                new ResolvedPredicate.DoublePredicate(0, Operator.EQ, 5.0, true));
+                new ResolvedPredicate.DoublePredicate(0, Operator.EQ, 5.0, true), BoundsReadability.ALL);
         assertThat(doubleStats.discardReason()).isEqualTo(INVERTED);
     }
 
@@ -160,12 +160,12 @@ class InvertedStatisticsFilterTest {
 
         /// The bounds the wrong way round, as a buggy writer emits them.
         MinMaxStats inverted() {
-            return MinMaxStats.of(stats(high, low), leaf.apply(Operator.EQ));
+            return MinMaxStats.of(stats(high, low), leaf.apply(Operator.EQ), BoundsReadability.ALL);
         }
 
         /// The same bounds the right way round.
         MinMaxStats ordered() {
-            return MinMaxStats.of(stats(low, high), leaf.apply(Operator.EQ));
+            return MinMaxStats.of(stats(low, high), leaf.apply(Operator.EQ), BoundsReadability.ALL);
         }
 
         ResolvedPredicate leaf(Operator op) {

--- a/core/src/test/java/dev/hardwood/internal/predicate/MinMaxStatsTest.java
+++ b/core/src/test/java/dev/hardwood/internal/predicate/MinMaxStatsTest.java
@@ -40,7 +40,7 @@ class MinMaxStatsTest {
         byte[] fakeMax = intBytes(-10);
         Statistics deprecated = new Statistics(fakeMin, fakeMax, 0L, null, true);
 
-        MinMaxStats stats = MinMaxStats.of(deprecated, GT_MINUS_FIVE);
+        MinMaxStats stats = MinMaxStats.of(deprecated, GT_MINUS_FIVE, BoundsReadability.ALL);
 
         // When isMinMaxDeprecated is true, minValue/maxValue must be null so that
         // canDropLeaf conservatively returns false (never drops the row group).
@@ -56,7 +56,7 @@ class MinMaxStatsTest {
         byte[] max = intBytes(100);
         Statistics nonDeprecated = new Statistics(min, max, 0L, null, false);
 
-        MinMaxStats stats = MinMaxStats.of(nonDeprecated, GT_MINUS_FIVE);
+        MinMaxStats stats = MinMaxStats.of(nonDeprecated, GT_MINUS_FIVE, BoundsReadability.ALL);
 
         assertThat(stats).isEqualTo(new MinMaxStats.IntStats(1, 100, 0L));
     }
@@ -72,7 +72,7 @@ class MinMaxStatsTest {
         byte[] deprecatedMax = intBytes(-10);
         Statistics stats = new Statistics(deprecatedMin, deprecatedMax, 0L, null, true);
 
-        MinMaxStats minMaxStats = MinMaxStats.of(stats, GT_MINUS_FIVE);
+        MinMaxStats minMaxStats = MinMaxStats.of(stats, GT_MINUS_FIVE, BoundsReadability.ALL);
 
         // With the fix, canDropLeaf sees null min/max and returns false (conservative)
         boolean canDrop = minMaxStats.canDrop(GT_MINUS_FIVE);
@@ -101,7 +101,7 @@ class MinMaxStatsTest {
         // not theirs to read, and not discarded either — nothing should warn about them.
         MinMaxStats stats = MinMaxStats.of(
                 new Statistics(intBytes(10), intBytes(20), 0L, null, false),
-                new ResolvedPredicate.IsNullPredicate(0, 1));
+                new ResolvedPredicate.IsNullPredicate(0, 1), BoundsReadability.ALL);
 
         assertThat(stats).isInstanceOf(MinMaxStats.NullCountOnlyStats.class);
         assertThat(stats.discardReason()).isNull();
@@ -111,7 +111,7 @@ class MinMaxStatsTest {
     @Test
     void discardedBoundsSayWhereTheyCameFromAndWhy() {
         MinMaxStats stats = MinMaxStats.of(
-                new Statistics(intBytes(20), intBytes(10), 0L, null, false), GT_MINUS_FIVE);
+                new Statistics(intBytes(20), intBytes(10), 0L, null, false), GT_MINUS_FIVE, BoundsReadability.ALL);
 
         stats.reportIfDiscarded(chunk());
 
@@ -124,7 +124,7 @@ class MinMaxStatsTest {
     @Test
     void aPageSaysWhichPageItWas() {
         MinMaxStats stats = MinMaxStats.of(
-                new Statistics(intBytes(20), intBytes(10), 0L, null, false), GT_MINUS_FIVE);
+                new Statistics(intBytes(20), intBytes(10), 0L, null, false), GT_MINUS_FIVE, BoundsReadability.ALL);
 
         stats.reportIfDiscarded(chunk().withPageIndex(7));
 
@@ -135,7 +135,7 @@ class MinMaxStatsTest {
     @Test
     void usableBoundsSayNothing() {
         MinMaxStats stats = MinMaxStats.of(
-                new Statistics(intBytes(10), intBytes(20), 0L, null, false), GT_MINUS_FIVE);
+                new Statistics(intBytes(10), intBytes(20), 0L, null, false), GT_MINUS_FIVE, BoundsReadability.ALL);
 
         stats.reportIfDiscarded(chunk());
 
@@ -147,7 +147,7 @@ class MinMaxStatsTest {
         // Repeats are not collapsed: statistics that will not compare are rare, and a reader
         // who finds the volume unhelpful can raise the level on this logger.
         MinMaxStats stats = MinMaxStats.of(
-                new Statistics(intBytes(20), intBytes(10), 0L, null, false), GT_MINUS_FIVE);
+                new Statistics(intBytes(20), intBytes(10), 0L, null, false), GT_MINUS_FIVE, BoundsReadability.ALL);
         stats.reportIfDiscarded(chunk().withPageIndex(0));
         stats.reportIfDiscarded(chunk().withPageIndex(1));
 

--- a/core/src/test/java/dev/hardwood/internal/predicate/NaNStatisticsFilterTest.java
+++ b/core/src/test/java/dev/hardwood/internal/predicate/NaNStatisticsFilterTest.java
@@ -86,7 +86,7 @@ class NaNStatisticsFilterTest {
     void float16NaNNeverDrops(Operator op) {
         ResolvedPredicate leaf = new ResolvedPredicate.Float16Predicate(0, op, 1.0f, false);
         MinMaxStats stats = MinMaxStats.of(
-                new Statistics(float16Bytes(Float.NaN), float16Bytes(10.0f), 0L, null, false), leaf);
+                new Statistics(float16Bytes(Float.NaN), float16Bytes(10.0f), 0L, null, false), leaf, BoundsReadability.ALL);
 
         assertThat(stats.canDrop(leaf)).isFalse();
         assertThat(stats.discardReason())
@@ -99,7 +99,7 @@ class NaNStatisticsFilterTest {
         ResolvedPredicate leaf = new ResolvedPredicate.DoublePredicate(0, Operator.GT, 1.0, false);
         MinMaxStats stats = MinMaxStats.of(
                 new Statistics(doubleBytes(Double.NaN), doubleBytes(10.0), 0L, null, false),
-                leaf);
+                leaf, BoundsReadability.ALL);
 
         assertThat(stats)
                 .isInstanceOf(MinMaxStats.NullCountOnlyStats.class)
@@ -159,14 +159,14 @@ class NaNStatisticsFilterTest {
     /// them so that the usability check runs.
     private static boolean dropsDouble(Operator op, double value, double min, double max) {
         ResolvedPredicate leaf = new ResolvedPredicate.DoublePredicate(0, op, value, false);
-        return MinMaxStats.of(new Statistics(doubleBytes(min), doubleBytes(max), 0L, null, false), leaf)
+        return MinMaxStats.of(new Statistics(doubleBytes(min), doubleBytes(max), 0L, null, false), leaf, BoundsReadability.ALL)
                 .canDrop(leaf);
     }
 
     /// See [#dropsDouble].
     private static boolean dropsFloat(Operator op, float value, float min, float max) {
         ResolvedPredicate leaf = new ResolvedPredicate.FloatPredicate(0, op, value, false);
-        return MinMaxStats.of(new Statistics(floatBytes(min), floatBytes(max), 0L, null, false), leaf)
+        return MinMaxStats.of(new Statistics(floatBytes(min), floatBytes(max), 0L, null, false), leaf, BoundsReadability.ALL)
                 .canDrop(leaf);
     }
 

--- a/core/src/test/java/dev/hardwood/internal/predicate/PageFilterEvaluatorTest.java
+++ b/core/src/test/java/dev/hardwood/internal/predicate/PageFilterEvaluatorTest.java
@@ -407,7 +407,7 @@ class PageFilterEvaluatorTest {
                             predicate,
                             rowGroup,
                             buffers,
-                            new LogContext("group-null.parquet", 0));
+                            new LogContext("group-null.parquet", 0), BoundsReadability.ALL);
 
             assertFalse(ranges.overlapsPage(0, 30));
             assertTrue(ranges.overlapsPage(30, 60));
@@ -469,7 +469,7 @@ class PageFilterEvaluatorTest {
                             predicate,
                             rowGroup,
                             buffers,
-                            new LogContext("group-not-null.parquet", 0));
+                            new LogContext("group-not-null.parquet", 0), BoundsReadability.ALL);
 
             assertTrue(ranges.overlapsPage(0, 30));
             assertFalse(ranges.overlapsPage(30, 60));
@@ -582,7 +582,7 @@ class PageFilterEvaluatorTest {
             RowGroup rowGroup = metaData.rowGroups().get(0);
             RowGroupIndexBuffers indexBuffers = RowGroupIndexBuffers.fetch(inputFile, rowGroup);
             return PageFilterEvaluator.computeMatchingRows(resolved, rowGroup, indexBuffers,
-                    new LogContext(inputFile.name(), 0));
+                    new LogContext(inputFile.name(), 0), BoundsReadability.ALL);
         }
         finally {
             inputFile.close();
@@ -761,7 +761,7 @@ class PageFilterEvaluatorTest {
             ResolvedPredicate in = new ResolvedPredicate.DoubleInPredicate(
                     0, new double[]{ 150.0, 350.0 }, true, false);
             RowRanges ranges = PageFilterEvaluator.computeMatchingRows(in, rowGroup, buffers,
-                    new LogContext("float-in.parquet", 0));
+                    new LogContext("float-in.parquet", 0), BoundsReadability.ALL);
             assertTrue(ranges.overlapsPage(0, 30));
             assertFalse(ranges.overlapsPage(30, 60));
             assertTrue(ranges.overlapsPage(60, 90));
@@ -839,7 +839,7 @@ class PageFilterEvaluatorTest {
             // planned, and the pipeline puts the file and row group in front of it.
             assertThatThrownBy(() -> PageFilterEvaluator.computeMatchingRows(
                     new ResolvedPredicate.IsNotNullPredicate(0, 1, 1), rowGroup, buffers,
-                    new LogContext(inputFile.name(), 0)))
+                    new LogContext(inputFile.name(), 0), BoundsReadability.ALL))
                     .isInstanceOf(ParquetReadException.class)
                     .hasMessage("Failed to parse the page index of column 0: Malformed Parquet"
                             + " metadata: ColumnIndex describes 3 pages but OffsetIndex locates 2");
@@ -870,7 +870,7 @@ class PageFilterEvaluatorTest {
             RowGroupIndexBuffers buffers = RowGroupIndexBuffers.fetch(inputFile, rowGroup);
             RowRanges ranges = PageFilterEvaluator.computeMatchingRows(
                     new ResolvedPredicate.IntPredicate(0, Operator.EQ, 15), rowGroup, buffers,
-                    new LogContext("orders.parquet", 4));
+                    new LogContext("orders.parquet", 4), BoundsReadability.ALL);
 
             assertTrue(ranges.overlapsPage(0, 29), "the page holding the probe must be kept");
             assertTrue(ranges.overlapsPage(30, 59),
@@ -933,14 +933,14 @@ class PageFilterEvaluatorTest {
 
             RowRanges isNull = PageFilterEvaluator.computeMatchingRows(
                     new ResolvedPredicate.IsNullPredicate(0, 2, 3), rowGroup, buffers,
-                    new LogContext("histogram.parquet", 0));
+                    new LogContext("histogram.parquet", 0), BoundsReadability.ALL);
 
             assertTrue(isNull.overlapsPage(0, 30), "the page whose group is absent must be kept");
             assertFalse(isNull.overlapsPage(30, 60), "the page whose group is always present must be dropped");
 
             RowRanges isNotNull = PageFilterEvaluator.computeMatchingRows(
                     new ResolvedPredicate.IsNotNullPredicate(0, 2, 3), rowGroup, buffers,
-                    new LogContext("histogram.parquet", 0));
+                    new LogContext("histogram.parquet", 0), BoundsReadability.ALL);
 
             assertFalse(isNotNull.overlapsPage(0, 30), "the page whose group is always absent must be dropped");
             assertTrue(isNotNull.overlapsPage(30, 60), "the page whose group is present must be kept");
@@ -996,14 +996,14 @@ class PageFilterEvaluatorTest {
                             new ResolvedPredicate.IsNullPredicate(0, 2, 3),
                             rowGroup,
                             buffers,
-                            new LogContext("no-histogram.parquet", 0));
+                            new LogContext("no-histogram.parquet", 0), BoundsReadability.ALL);
 
             RowRanges isNotNullRanges =
                     PageFilterEvaluator.computeMatchingRows(
                             new ResolvedPredicate.IsNotNullPredicate(0, 2, 3),
                             rowGroup,
                             buffers,
-                            new LogContext("no-histogram.parquet", 0));
+                            new LogContext("no-histogram.parquet", 0), BoundsReadability.ALL);
 
             assertTrue(isNullRanges.overlapsPage(0, 30));
             assertTrue(isNullRanges.overlapsPage(30, 60));
@@ -1064,7 +1064,7 @@ class PageFilterEvaluatorTest {
                             new ResolvedPredicate.IsNotNullPredicate(0, 2, 3),
                             rowGroup,
                             buffers,
-                            new LogContext("bad-histogram.parquet", 0));
+                            new LogContext("bad-histogram.parquet", 0), BoundsReadability.ALL);
 
             assertTrue(ranges.overlapsPage(0, 30));
             assertTrue(ranges.overlapsPage(30, 60));

--- a/core/src/test/java/dev/hardwood/internal/predicate/RowGroupDecideTest.java
+++ b/core/src/test/java/dev/hardwood/internal/predicate/RowGroupDecideTest.java
@@ -108,7 +108,7 @@ class RowGroupDecideTest {
         // always-matching decision derived from statistics.
         RowGroup rg = intRowGroup(10, 20, 0L);
         BloomFilterSource noFilters = columnIndex -> null;
-        assertThat(RowGroupFilterEvaluator.decideRowGroup(intGt(5), rg, noFilters, null, UNNAMED))
+        assertThat(RowGroupFilterEvaluator.decideRowGroup(intGt(5), rg, noFilters, null, UNNAMED, BoundsReadability.ALL))
                 .isEqualTo(ALWAYS_MATCHES);
     }
 
@@ -139,7 +139,7 @@ class RowGroupDecideTest {
                 new Statistics(intBytes(20), intBytes(10), 0L, null, false), 100);
 
         FilterDecision decision = RowGroupFilterEvaluator.decideRowGroup(intGt(5), rg, null, null,
-                new LogContext("orders.parquet", 4));
+                new LogContext("orders.parquet", 4), BoundsReadability.ALL);
 
         assertThat(decision).isEqualTo(MIGHT_MATCH);
         assertThat(warnings.messages()).containsExactly(
@@ -308,7 +308,7 @@ class RowGroupDecideTest {
 
     private static FilterDecision decide(ResolvedPredicate predicate, RowGroup rowGroup)
             throws IOException {
-        return RowGroupFilterEvaluator.decideRowGroup(predicate, rowGroup, null, null, UNNAMED);
+        return RowGroupFilterEvaluator.decideRowGroup(predicate, rowGroup, null, null, UNNAMED, BoundsReadability.ALL);
     }
 
     private static ResolvedPredicate intGt(int value) {

--- a/core/src/test/java/dev/hardwood/internal/predicate/UnreadableSortOrderTest.java
+++ b/core/src/test/java/dev/hardwood/internal/predicate/UnreadableSortOrderTest.java
@@ -1,0 +1,315 @@
+/*
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Copyright The original authors
+ *
+ *  Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package dev.hardwood.internal.predicate;
+
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import org.junit.jupiter.api.io.TempDir;
+
+import dev.hardwood.InputFile;
+import dev.hardwood.internal.thrift.FooterRewriter;
+import dev.hardwood.internal.writer.ByteBufferOutputFile;
+import dev.hardwood.metadata.ColumnChunk;
+import dev.hardwood.metadata.ColumnIndex;
+import dev.hardwood.metadata.ColumnMetaData;
+import dev.hardwood.metadata.ColumnOrder;
+import dev.hardwood.metadata.FileMetaData;
+import dev.hardwood.metadata.LogicalType;
+import dev.hardwood.metadata.PhysicalType;
+import dev.hardwood.metadata.RepetitionType;
+import dev.hardwood.metadata.RowGroup;
+import dev.hardwood.metadata.SchemaElement;
+import dev.hardwood.metadata.Statistics;
+import dev.hardwood.reader.FilterPredicate;
+import dev.hardwood.reader.ParquetFileReader;
+import dev.hardwood.reader.RowReader;
+import dev.hardwood.schema.FileSchema;
+import dev.hardwood.writer.ParquetFileWriter;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/// Pruning compares a literal against recorded bounds, which answers only in the order those
+/// bounds were written in. Two shapes arrive where that order is not knowable, neither of them
+/// produced by this writer, so both reach the reader only on a file written elsewhere.
+class UnreadableSortOrderTest {
+
+    @TempDir
+    Path tempDir;
+
+    @RegisterExtension
+    final CapturedWarnings warnings = new CapturedWarnings();
+
+    /// parquet-format defines no ordering for `GEOMETRY`, and `StatisticsOrder` keeps this
+    /// writer from recording any. Another writer's bounds are in an order this reader has no
+    /// way to name, so they prune nothing, and say why.
+    @Test
+    void boundsOnAnUnorderedAnnotationDoNotPrune() {
+        FileSchema geometry = geometrySchema();
+        ResolvedPredicate leaf = FilterPredicateResolver.resolve(
+                FilterPredicate.eq("g", "M"), geometry);
+        Statistics foreign = new Statistics(bytes("N"), bytes("Z"), 0L, null, false);
+
+        MinMaxStats stats = MinMaxStats.of(foreign, leaf, readability(geometry));
+
+        assertThat(stats.canDrop(leaf)).isFalse();
+        assertThat(stats.discardReason()).isEqualTo(MinMaxStats.UNKNOWN_SORT_ORDER);
+        assertThat(MinMaxStats.of(foreign, leaf, BoundsReadability.ALL).canDrop(leaf))
+                .as("byte-wise the probe sorts below the minimum, which is what must not be acted on")
+                .isTrue();
+    }
+
+    /// A conforming writer records no bounds for an unordered annotation, so there is nothing
+    /// to discard and nothing to report.
+    @Test
+    void anUnorderedAnnotationWithoutBoundsReportsNothing() {
+        FileSchema geometry = geometrySchema();
+        ResolvedPredicate leaf = FilterPredicateResolver.resolve(
+                FilterPredicate.eq("g", "M"), geometry);
+        Statistics boundless = new Statistics(null, null, 0L, null, false);
+
+        MinMaxStats stats = MinMaxStats.of(boundless, leaf, readability(geometry));
+
+        assertThat(stats).isInstanceOf(MinMaxStats.NullCountOnlyStats.class);
+        assertThat(stats.discardReason()).isNull();
+    }
+
+    /// An annotation that does name an order keeps its pruning.
+    @Test
+    void boundsOnAnOrderedAnnotationStillPrune() {
+        FileSchema string = FileSchema.builder("s")
+                .addColumn("g", PhysicalType.BYTE_ARRAY, RepetitionType.REQUIRED,
+                        LogicalType.string())
+                .build();
+        ResolvedPredicate leaf = FilterPredicateResolver.resolve(
+                FilterPredicate.eq("g", "M"), string);
+        Statistics stats = new Statistics(bytes("N"), bytes("Z"), 0L, null, false);
+
+        assertThat(MinMaxStats.of(stats, leaf, readability(string)).canDrop(leaf)).isTrue();
+    }
+
+    /// `parquet.thrift` on the `ColumnOrder` union: "If the reader does not support the value of
+    /// this union, min and max stats for this column should be ignored." Every physical type is
+    /// affected, not only the binary ones.
+    @Test
+    void boundsUnderAnUnrecognizedColumnOrderDoNotPrune() {
+        FileSchema ints = intSchema();
+        ResolvedPredicate leaf = FilterPredicateResolver.resolve(
+                FilterPredicate.gt("v", 100), ints, List.of(ColumnOrder.UNKNOWN));
+        Statistics foreign = new Statistics(intBytes(0), intBytes(50), 0L, null, false);
+
+        assertThat(MinMaxStats.of(foreign, leaf,
+                BoundsReadability.of(ints, List.of(ColumnOrder.UNKNOWN))).canDrop(leaf)).isFalse();
+    }
+
+    @Test
+    void boundsUnderTheTypeDefinedOrderStillPrune() {
+        FileSchema ints = intSchema();
+        ResolvedPredicate leaf = FilterPredicateResolver.resolve(
+                FilterPredicate.gt("v", 100), ints, List.of(ColumnOrder.TYPE_DEFINED_ORDER));
+        Statistics stats = new Statistics(intBytes(0), intBytes(50), 0L, null, false);
+
+        assertThat(MinMaxStats.of(stats, leaf,
+                BoundsReadability.of(ints, List.of(ColumnOrder.TYPE_DEFINED_ORDER))).canDrop(leaf))
+                .isTrue();
+    }
+
+    /// A file that omits `column_orders` means the type-defined order throughout, so pruning
+    /// stands.
+    @Test
+    void anAbsentColumnOrderListMeansTheTypeDefinedOrder() {
+        FileSchema ints = intSchema();
+        ResolvedPredicate leaf = FilterPredicateResolver.resolve(FilterPredicate.gt("v", 100), ints);
+        Statistics stats = new Statistics(intBytes(0), intBytes(50), 0L, null, false);
+
+        assertThat(MinMaxStats.of(stats, leaf, BoundsReadability.of(ints, List.of()))
+                .canDrop(leaf)).isTrue();
+    }
+
+    /// Page bounds are bounds, so the page index reads the same answer.
+    @Test
+    void pageBoundsUnderAnUnrecognizedColumnOrderDoNotPrune() {
+        FileSchema ints = intSchema();
+        ResolvedPredicate leaf = FilterPredicateResolver.resolve(
+                FilterPredicate.gt("v", 100), ints, List.of(ColumnOrder.UNKNOWN));
+        ColumnIndex columnIndex = new ColumnIndex(new boolean[] { false },
+                List.of(intBytes(0)), List.of(intBytes(50)),
+                ColumnIndex.BoundaryOrder.UNORDERED, new long[] { 0L }, null, null, null);
+
+        assertThat(MinMaxStats.ofPage(columnIndex, 0, leaf,
+                BoundsReadability.of(ints, List.of(ColumnOrder.UNKNOWN))).canDrop(leaf)).isFalse();
+    }
+
+    /// The null count needs no ordering, so it survives where the bounds do not.
+    @Test
+    void theNullCountSurvivesUnreadableBounds() {
+        FileSchema ints = intSchema();
+        ResolvedPredicate leaf = FilterPredicateResolver.resolve(
+                FilterPredicate.gt("v", 100), ints, List.of(ColumnOrder.UNKNOWN));
+        Statistics foreign = new Statistics(intBytes(0), intBytes(50), 7L, null, false);
+
+        assertThat(MinMaxStats.of(foreign, leaf,
+                BoundsReadability.of(ints, List.of(ColumnOrder.UNKNOWN))).nullCount()).isEqualTo(7L);
+    }
+
+    /// Readability is asked in one file's ordinals; an ordinal outside that file is a wiring
+    /// error, not a column without bounds.
+    @Test
+    void anOrdinalOutsideTheFileIsRefused() {
+        BoundsReadability readability = BoundsReadability.of(intSchema(), List.of());
+
+        assertThatThrownBy(() -> readability.readable(1))
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessage("Column 1 is not one of the 1 leaf columns of this file");
+    }
+
+    // ==================== Through the reader ====================
+
+    /// Each file of a multi-file read is judged in its own ordinals. The two files hold the
+    /// same columns in opposite leaf order, each with `GEOMETRY` bounds of `[N, Z]` around a
+    /// stored `M`. Judged in the first file's ordinals, the second file's `g` would be taken
+    /// for `v`, and its row group dropped on bounds this reader cannot read.
+    @Test
+    void eachFileOfAMultiFileReadIsJudgedInItsOwnOrdinals() throws Exception {
+        try (ParquetFileReader reader = ParquetFileReader.openAll(List.of(
+                InputFile.of(geometryThenValue()), InputFile.of(valueThenGeometry())));
+                RowReader rows = reader.buildRowReader().filter(FilterPredicate.eq("g", "M")).build()) {
+            assertThat(values(rows)).containsExactly(1, 2);
+        }
+    }
+
+    /// The ordered column of the same pair is readable in both files, so nothing is reported
+    /// about it — in the first file's ordinals, the second file's `v` would be taken for `g`.
+    @Test
+    void anOrderedColumnIsReadableInEveryFile() throws Exception {
+        try (ParquetFileReader reader = ParquetFileReader.openAll(List.of(
+                InputFile.of(geometryThenValue()), InputFile.of(valueThenGeometry())));
+                RowReader rows = reader.buildRowReader().filter(FilterPredicate.gt("v", 100)).build()) {
+            assertThat(values(rows)).isEmpty();
+        }
+        assertThat(warnings.messages()).isEmpty();
+    }
+
+    // ==================== Fixtures ====================
+
+    private static FileSchema geometrySchema() {
+        return FileSchema.builder("s")
+                .addColumn("g", PhysicalType.BYTE_ARRAY, RepetitionType.REQUIRED,
+                        new LogicalType.GeometryType(null))
+                .build();
+    }
+
+    private static FileSchema intSchema() {
+        return FileSchema.builder("s")
+                .addColumn("v", PhysicalType.INT32, RepetitionType.REQUIRED)
+                .build();
+    }
+
+    private static BoundsReadability readability(FileSchema schema) {
+        return BoundsReadability.of(schema, List.of());
+    }
+
+    /// Leaves `g`, `v`, holding the single row `g = M, v = 1`.
+    private Path geometryThenValue() throws IOException {
+        ByteBufferOutputFile out = new ByteBufferOutputFile();
+        try (ParquetFileWriter writer = ParquetFileWriter.create(out, FileSchema.builder("s")
+                .addColumn("g", PhysicalType.BYTE_ARRAY, RepetitionType.REQUIRED, LogicalType.string())
+                .addColumn("v", PhysicalType.INT32, RepetitionType.REQUIRED)
+                .build())) {
+            writer.columnWriter().writeBatch(batch -> batch
+                    .bytes(0, new byte[][] { bytes("M") })
+                    .ints(1, new int[] { 1 }));
+        }
+        return asForeignGeometry(out.toByteArray(), "g-then-v.parquet");
+    }
+
+    /// Leaves `v`, `g`, holding the single row `v = 2, g = M`.
+    private Path valueThenGeometry() throws IOException {
+        ByteBufferOutputFile out = new ByteBufferOutputFile();
+        try (ParquetFileWriter writer = ParquetFileWriter.create(out, FileSchema.builder("s")
+                .addColumn("v", PhysicalType.INT32, RepetitionType.REQUIRED)
+                .addColumn("g", PhysicalType.BYTE_ARRAY, RepetitionType.REQUIRED, LogicalType.string())
+                .build())) {
+            writer.columnWriter().writeBatch(batch -> batch
+                    .ints(0, new int[] { 2 })
+                    .bytes(1, new byte[][] { bytes("M") }));
+        }
+        return asForeignGeometry(out.toByteArray(), "v-then-g.parquet");
+    }
+
+    /// Rewrites the footer so that the string column `g` is annotated `GEOMETRY` and carries
+    /// the bounds `[N, Z]`, as a writer other than this one might record them. Compared
+    /// byte-wise, those bounds exclude the stored `M`.
+    private Path asForeignGeometry(byte[] file, String fileName) throws IOException {
+        byte[] rewritten = FooterRewriter.rewrite(file, metaData -> new FileMetaData(
+                metaData.version(),
+                metaData.schema().stream().map(UnreadableSortOrderTest::asGeometry).toList(),
+                metaData.numRows(),
+                metaData.rowGroups().stream().map(UnreadableSortOrderTest::withForeignBounds).toList(),
+                metaData.keyValueMetadata(), metaData.createdBy(), metaData.columnOrders()));
+        Path path = tempDir.resolve(fileName);
+        Files.write(path, rewritten);
+        return path;
+    }
+
+    private static SchemaElement asGeometry(SchemaElement element) {
+        return element.name().equals("g")
+                ? new SchemaElement(element.name(), element.type(), element.typeLength(),
+                        element.repetitionType(), element.numChildren(), null, element.scale(),
+                        element.precision(), element.fieldId(), new LogicalType.GeometryType(null))
+                : element;
+    }
+
+    /// `g` is the only `BYTE_ARRAY` chunk in either fixture.
+    private static RowGroup withForeignBounds(RowGroup rowGroup) {
+        List<ColumnChunk> columns = new ArrayList<>(rowGroup.columns().size());
+        for (ColumnChunk chunk : rowGroup.columns()) {
+            ColumnMetaData m = chunk.metaData();
+            if (m.type() != PhysicalType.BYTE_ARRAY) {
+                columns.add(chunk);
+                continue;
+            }
+            Statistics foreign = new Statistics(bytes("N"), bytes("Z"), m.statistics().nullCount(),
+                    null, false);
+            columns.add(new ColumnChunk(new ColumnMetaData(m.type(), m.encodings(), m.pathInSchema(),
+                    m.codec(), m.numValues(), m.totalUncompressedSize(), m.totalCompressedSize(),
+                    m.keyValueMetadata(), m.dataPageOffset(), m.dictionaryPageOffset(), foreign,
+                    m.geospatialStatistics(), m.bloomFilterOffset(), m.bloomFilterLength(),
+                    m.encodingStats(), m.sizeStatistics()),
+                    chunk.offsetIndexOffset(), chunk.offsetIndexLength(), chunk.columnIndexOffset(),
+                    chunk.columnIndexLength(), chunk.filePath()));
+        }
+        return new RowGroup(columns, rowGroup.totalByteSize(), rowGroup.numRows());
+    }
+
+    private static List<Integer> values(RowReader rows) throws IOException {
+        List<Integer> values = new ArrayList<>();
+        while (rows.hasNext()) {
+            rows.next();
+            values.add(rows.getInt("v"));
+        }
+        return values;
+    }
+
+    private static byte[] bytes(String value) {
+        return value.getBytes(StandardCharsets.UTF_8);
+    }
+
+    private static byte[] intBytes(int value) {
+        return ByteBuffer.allocate(Integer.BYTES).order(ByteOrder.LITTLE_ENDIAN).putInt(value).array();
+    }
+}

--- a/core/src/test/java/dev/hardwood/internal/predicate/UnsignedIntegerFilterTest.java
+++ b/core/src/test/java/dev/hardwood/internal/predicate/UnsignedIntegerFilterTest.java
@@ -87,7 +87,7 @@ class UnsignedIntegerFilterTest {
         ResolvedPredicate resolved = FilterPredicateResolver.resolve(
                 FilterPredicate.gt("v", FOUR_BILLION), schema());
         MinMaxStats stats = MinMaxStats.of(
-                new Statistics(encode(ZERO), encode(FOUR_BILLION), 0L, null, false), resolved);
+                new Statistics(encode(ZERO), encode(FOUR_BILLION), 0L, null, false), resolved, BoundsReadability.ALL);
 
         assertThat(stats.canDrop(resolved)).isTrue();
     }
@@ -153,7 +153,7 @@ class UnsignedIntegerFilterTest {
         ResolvedPredicate resolved = FilterPredicateResolver.resolve(
                 FilterPredicate.gt("v", THREE_BILLION), schema());
         MinMaxStats stats = MinMaxStats.of(
-                new Statistics(encode(FOUR_BILLION), encode(FOUR_BILLION), 0L, null, false), resolved);
+                new Statistics(encode(FOUR_BILLION), encode(FOUR_BILLION), 0L, null, false), resolved, BoundsReadability.ALL);
 
         assertThat(stats.alwaysMatches(resolved)).isTrue();
         assertThat(stats.canDrop(resolved)).isFalse();
@@ -166,7 +166,7 @@ class UnsignedIntegerFilterTest {
         ResolvedPredicate resolved = FilterPredicateResolver.resolve(
                 FilterPredicate.in("v", SEVEN, FOUR_BILLION), schema());
         MinMaxStats stats = MinMaxStats.of(
-                new Statistics(encode(FOUR_BILLION), encode(FOUR_BILLION), 0L, null, false), resolved);
+                new Statistics(encode(FOUR_BILLION), encode(FOUR_BILLION), 0L, null, false), resolved, BoundsReadability.ALL);
 
         assertThat(stats.alwaysMatches(resolved)).isTrue();
     }
@@ -178,7 +178,7 @@ class UnsignedIntegerFilterTest {
         ResolvedPredicate resolved = FilterPredicateResolver.resolve(
                 FilterPredicate.in("v", FOUR_BILLION), schema());
         MinMaxStats stats = MinMaxStats.of(
-                new Statistics(encode(ZERO), encode(THREE_BILLION), 0L, null, false), resolved);
+                new Statistics(encode(ZERO), encode(THREE_BILLION), 0L, null, false), resolved, BoundsReadability.ALL);
 
         assertThat(stats.canDrop(resolved)).isTrue();
     }
@@ -193,7 +193,7 @@ class UnsignedIntegerFilterTest {
                 List.of(encode(ZERO)), List.of(encode(FOUR_BILLION)),
                 ColumnIndex.BoundaryOrder.UNORDERED, new long[] { 0L }, null, null, null);
 
-        assertThat(MinMaxStats.ofPage(columnIndex, 0, resolved).canDrop(resolved)).isTrue();
+        assertThat(MinMaxStats.ofPage(columnIndex, 0, resolved, BoundsReadability.ALL).canDrop(resolved)).isTrue();
     }
 
     /// The `INT64` bounds read the same way: `[2^64 - 1, 2^64 - 1]` is `[-1, -1]` signed and
@@ -203,7 +203,7 @@ class UnsignedIntegerFilterTest {
         ResolvedPredicate resolved = FilterPredicateResolver.resolve(
                 FilterPredicate.gt("v", SMALL_LONG), longSchema());
         MinMaxStats stats = MinMaxStats.of(
-                new Statistics(encodeLong(HUGE_LONG), encodeLong(HUGE_LONG), 0L, null, false), resolved);
+                new Statistics(encodeLong(HUGE_LONG), encodeLong(HUGE_LONG), 0L, null, false), resolved, BoundsReadability.ALL);
 
         assertThat(stats.alwaysMatches(resolved)).isTrue();
         assertThat(stats.canDrop(resolved)).isFalse();

--- a/core/src/test/java/dev/hardwood/internal/thrift/FooterRewriter.java
+++ b/core/src/test/java/dev/hardwood/internal/thrift/FooterRewriter.java
@@ -1,0 +1,54 @@
+/*
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Copyright The original authors
+ *
+ *  Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package dev.hardwood.internal.thrift;
+
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
+import java.nio.charset.StandardCharsets;
+import java.util.function.UnaryOperator;
+
+import dev.hardwood.InputFile;
+import dev.hardwood.internal.reader.ParquetMetadataReader;
+import dev.hardwood.metadata.FileMetaData;
+
+/// Rewrites the footer of a well-formed file held in memory, for a test that needs a file
+/// claiming something no writer here produces. The data pages and the page index are
+/// untouched, so what changes is only what the footer says about them.
+public final class FooterRewriter {
+
+    private static final byte[] MAGIC = "PAR1".getBytes(StandardCharsets.US_ASCII);
+
+    private FooterRewriter() {
+    }
+
+    /// `file` with its footer replaced by `patch` applied to the footer it has.
+    public static byte[] rewrite(byte[] file, UnaryOperator<FileMetaData> patch) throws IOException {
+        FileMetaData metaData = ParquetMetadataReader.readMetadata(InputFile.of(ByteBuffer.wrap(file)));
+
+        ThriftCompactWriter footer = new ThriftCompactWriter();
+        FileMetaDataWriter.write(footer, patch.apply(metaData));
+        byte[] footerBytes = footer.toByteArray();
+
+        int dataLength = file.length - MAGIC.length - Integer.BYTES - footerLength(file);
+        ByteBuffer rewritten = ByteBuffer
+                .allocate(dataLength + footerBytes.length + Integer.BYTES + MAGIC.length)
+                .order(ByteOrder.LITTLE_ENDIAN);
+        rewritten.put(file, 0, dataLength);
+        rewritten.put(footerBytes);
+        rewritten.putInt(footerBytes.length);
+        rewritten.put(MAGIC);
+        return rewritten.array();
+    }
+
+    private static int footerLength(byte[] file) {
+        return ByteBuffer.wrap(file, file.length - MAGIC.length - Integer.BYTES, Integer.BYTES)
+                .order(ByteOrder.LITTLE_ENDIAN)
+                .getInt();
+    }
+}

--- a/core/src/test/java/dev/hardwood/reader/FixedWidthSchemaValidationTest.java
+++ b/core/src/test/java/dev/hardwood/reader/FixedWidthSchemaValidationTest.java
@@ -21,9 +21,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
 import dev.hardwood.InputFile;
-import dev.hardwood.internal.reader.ParquetMetadataReader;
-import dev.hardwood.internal.thrift.FileMetaDataWriter;
-import dev.hardwood.internal.thrift.ThriftCompactWriter;
+import dev.hardwood.internal.thrift.FooterRewriter;
 import dev.hardwood.internal.writer.ByteBufferOutputFile;
 import dev.hardwood.metadata.FileMetaData;
 import dev.hardwood.metadata.LogicalType;
@@ -47,8 +45,6 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 /// the file it came from. A read that does not touch it, and the metadata accessors, are
 /// unaffected: an unreadable column is not an unreadable file.
 class FixedWidthSchemaValidationTest {
-
-    private static final byte[] MAGIC = "PAR1".getBytes(StandardCharsets.US_ASCII);
 
     @TempDir
     Path tempDir;
@@ -186,40 +182,20 @@ class FixedWidthSchemaValidationTest {
     }
 
     /// Rewrites `file`'s footer with `columnName`'s `type_length` set to `width`, dropping
-    /// the field entirely when `width` is `null`. The data pages are untouched, so what
-    /// changes is only what the file claims about the column.
+    /// the field entirely when `width` is `null`.
     private static byte[] withTypeLength(byte[] file, String columnName, Integer width) throws IOException {
-        FileMetaData metaData = ParquetMetadataReader.readMetadata(InputFile.of(ByteBuffer.wrap(file)));
-
-        List<SchemaElement> patched = new ArrayList<>(metaData.schema().size());
-        for (SchemaElement element : metaData.schema()) {
-            patched.add(element.name().equals(columnName)
-                    ? new SchemaElement(element.name(), element.type(), width, element.repetitionType(),
-                            element.numChildren(), element.convertedType(), element.scale(),
-                            element.precision(), element.fieldId(), element.logicalType())
-                    : element);
-        }
-
-        ThriftCompactWriter footer = new ThriftCompactWriter();
-        FileMetaDataWriter.write(footer, new FileMetaData(metaData.version(), patched, metaData.numRows(),
-                metaData.rowGroups(), metaData.keyValueMetadata(), metaData.createdBy(), metaData.columnOrders()));
-        byte[] footerBytes = footer.toByteArray();
-
-        int dataLength = file.length - MAGIC.length - Integer.BYTES - footerLength(file);
-        ByteBuffer rewritten = ByteBuffer
-                .allocate(dataLength + footerBytes.length + Integer.BYTES + MAGIC.length)
-                .order(ByteOrder.LITTLE_ENDIAN);
-        rewritten.put(file, 0, dataLength);
-        rewritten.put(footerBytes);
-        rewritten.putInt(footerBytes.length);
-        rewritten.put(MAGIC);
-        return rewritten.array();
-    }
-
-    private static int footerLength(byte[] file) {
-        return ByteBuffer.wrap(file, file.length - MAGIC.length - Integer.BYTES, Integer.BYTES)
-                .order(ByteOrder.LITTLE_ENDIAN)
-                .getInt();
+        return FooterRewriter.rewrite(file, metaData -> {
+            List<SchemaElement> patched = new ArrayList<>(metaData.schema().size());
+            for (SchemaElement element : metaData.schema()) {
+                patched.add(element.name().equals(columnName)
+                        ? new SchemaElement(element.name(), element.type(), width, element.repetitionType(),
+                                element.numChildren(), element.convertedType(), element.scale(),
+                                element.precision(), element.fieldId(), element.logicalType())
+                        : element);
+            }
+            return new FileMetaData(metaData.version(), patched, metaData.numRows(), metaData.rowGroups(),
+                    metaData.keyValueMetadata(), metaData.createdBy(), metaData.columnOrders());
+        });
     }
 
     private static byte[] bytes(String value) {

--- a/docs/content/reference/query-controls.md
+++ b/docs/content/reference/query-controls.md
@@ -107,13 +107,15 @@ not expressible this way; reach for the `BigDecimal` factory instead.
 Pruning compares a unit's `min` / `max` bounds. A pair a reader cannot compare against is
 ignored rather than trusted, so the row group or page is kept and its rows are read and filtered
 one by one. Results are the same either way; only the I/O saved is lost. Bounds are ignored for
-one of three reasons:
+one of five reasons:
 
 | Reason | Bounds |
 |---|---|
 | The minimum sorts above the maximum | `min` and `max` are the wrong way round in the column's order, so the pair brackets nothing |
 | One of them is `NaN` | A `FLOAT`, `DOUBLE` or `FLOAT16` bound the Parquet spec forbids, sitting outside the column's ordering |
 | They come from the deprecated `min` / `max` fields | Superseded by `min_value` / `max_value`; the deprecated pair compares unsigned whatever the column's type is, so its order is wrong for every signed one |
+| The column's annotation defines no order | An `INTERVAL`, `GEOMETRY`, `GEOGRAPHY`, `VARIANT`, `UNKNOWN`, `LIST` or `MAP` column, for which the Parquet spec defines no sort order |
+| The file declares a `ColumnOrder` this release does not recognize | The Parquet spec directs a reader to ignore `min` / `max` under a column order it does not support; this applies to every column type |
 
 The bounds themselves are still reported as the file carries them, by `Statistics` on the metadata
 API and by `hardwood inspect` and `hardwood dive`.

--- a/docs/content/release-notes.md
+++ b/docs/content/release-notes.md
@@ -15,6 +15,8 @@ See [GitHub Releases](https://github.com/hardwood-hq/hardwood/releases) for down
 
 ## 1.1.0-SNAPSHOT
 
+- Row groups and pages are no longer pruned against `min` / `max` in a sort order the reader cannot read — a column annotated `INTERVAL`, `GEOMETRY`, `GEOGRAPHY`, `VARIANT`, `UNKNOWN`, `LIST` or `MAP`, or one whose file declares an unrecognized `ColumnOrder` ([#1179](https://github.com/hardwood-hq/hardwood/issues/1179)).
+
 - `isNull` and `isNotNull` accept the name of a group — a struct, a `LIST` or a `MAP` — testing whether the group itself is present rather than one of its fields ([#977](https://github.com/hardwood-hq/hardwood/issues/977)).
 
 - `FilterPredicate.in(String, double...)` filters `FLOAT` and `DOUBLE` columns by set membership ([#868](https://github.com/hardwood-hq/hardwood/issues/868)).


### PR DESCRIPTION
Stacked on #1103 — review that first; this branch's base is `1082-decimal-predicate-docs`, so the diff here is the last commit alone.

Pruning compares a literal against the recorded `min` / `max`, which answers only in the order those bounds were written in. The reader never asked whether it knew that order.

Two shapes arrive where it is not knowable, neither of them produced by Hardwood's writer:

- **The annotation names no order.** parquet-format leaves `INTERVAL`, `GEOMETRY`, `GEOGRAPHY`, `VARIANT`, `UNKNOWN`, `LIST` and `MAP` unordered, and asks that `INTERVAL` record no bounds at all. `StatisticsOrder#supportsBounds` already encodes this on the write side, which is why Hardwood emits none; nothing declined to read what another writer emitted.
- **The file names an order this build does not recognize.** `parquet.thrift`: *"If the reader does not support the value of this union, min and max stats for this column should be ignored."* `ColumnOrder.UNKNOWN` was decoded and then only ever consulted by `isIeee754TotalOrder`, which returns `false` for it, making it indistinguishable from `TYPE_DEFINED_ORDER`. This one reaches every physical type.

Both dropped row groups and pages that could hold matching rows, silently.

The question is answered once at reader creation, in `FilterPredicateResolver`'s neighbourhood where the file's `column_orders` and each `ColumnSchema` are already in hand, and travels to the three pruning entry points as a `BoundsReadability` beside the `LogContext` they already carry. Rejected bounds yield the `NullCountOnlyStats` that deprecated and inverted pairs already yield, with a reason of their own.

Bloom filters, dictionaries, the null count and record-level evaluation are all unaffected — none of them depends on an ordering. `Statistics` keeps the bounds it read, so `hardwood inspect` still reports what the file holds; it is pruning that declines to act on them.

Design: [_designs/UNREADABLE_SORT_ORDER_BOUNDS.md](_designs/UNREADABLE_SORT_ORDER_BOUNDS.md).

`./mvnw verify` green, integration tests included.

### Note for review

Found by the (physical type × logical type × literal) survey run while reviewing #1103, which confirmed the reader and Hardwood's writer agree on all 36 legal column shapes. These two are the same question one level up, on the axis that survey did not cover: files Hardwood did not write.

I have not identified a writer in the wild that emits either shape. Both reproductions construct the statistics directly, so this is correctness against the format rather than a defect anyone is known to have hit.

Closes #1179
