### PR TITLE
#456 Correct the matcher vectorization claim and record what SIMD matchers are worth

### DIFF
--- a/_designs/DRAIN_SIDE_RECORD_FILTERING.md
+++ b/_designs/DRAIN_SIDE_RECORD_FILTERING.md
@@ -181,7 +181,7 @@ The drain-side path is still slower single-threaded across every eligible shape 
 
 Why drain-side stays slower single-threaded:
 
-1. **`BitSet.get(int)` is opaque to autovectorisation.** Even though the value comparison is now branchless, the null-check still goes through a virtual call into a non-final method that does its own shift, mask, bounds check, and array load. HotSpot will not autovectorise around it. The compiled per-row path doesn't have this problem because it uses indexed accessors that the JIT inlines through.
+1. **The bitmap pack does not vectorise.** The value comparison is branchless, but packing a vector compare into bitmap bits has no autovectorisation idiom, so C2 emits a scalar `mov`/`cmp`/`setcc`/`shlx`/`or` per value, unrolled 4× with a rolled remainder. The compiled per-row path pays no packing cost at all.
 2. **Match-all pays full `O(n)` matcher cost.** The compiled path's iterator under match-all is effectively `rowIndex++`; drain-side runs the matcher loop in full whether 100% or 0% of rows pass.
 3. **Per-survivor `nextSetBit`.** The consumer iterates surviving rows via `Long.numberOfTrailingZeros` + clear-low-bit. At match-all density, that's per-row work the compiled path doesn't do.
 
@@ -246,15 +246,35 @@ One read of `vals[]`, one bitmap, no intersect. Strictly cheaper than two single
 
 ### Vector API matchers
 
-**Why.** A `LongVector.compare(GT, lit).toLong()` lowers to a single SIMD instruction (`pcmpgtq` on x86-64, `cmgt` on AArch64) over `SPECIES.length()` lanes per cycle. Per-element cost drops from O(1) instructions to O(1/lane-count). The hardware is sitting there; the matcher loop is exactly the shape SIMD eats.
+**Status: measured, not pursued.** A working implementation for `int` and `float` reached a green build; it is not merged, because the end-to-end ceiling turned out to be about half a percent. The measurements are recorded here so the next reader starts from them rather than re-deriving them.
 
-**Prerequisite.** `notNullWords` migration. Without it, the SIMD comparison can't be paired with a SIMD-friendly null mask — you'd lower the comparison and immediately stall on `BitSet.get` per element.
+**The kernel gain is large and machine-dependent.** One SIMD compare plus a mask-to-bits extraction replaces the scalar loop's six instructions per value. Measured against a 4096-row batch, each vector matcher verified bit-identical to its scalar counterpart before timing:
 
-**What to build.** Multi-release `core/src/main/java22/dev/hardwood/internal/predicate/matcher/.../Vector*BatchMatcher.java`. Strategy pattern via the existing `VectorSupport.isAvailable()` (already used by the SIMD encoders). Per-`(type, op)` pair, mirroring the scalar layout. The output bitmap accumulates word-aligned (`SPECIES.length()` divides 64), so several SIMD iterations contribute to one word; null masking happens in a separate word-wise AND pass after.
+| kernel | AVX2, 256-bit | NEON, 128-bit |
+| --- | ---: | ---: |
+| `int` LT | 0.613 → 0.068 ns/value (9.1×) | 0.352 → 0.131 ns/value (2.7×) |
+| `float` LT | 0.889 → 0.422 ns/value (2.1×) | 0.624 → 0.199 ns/value (3.1×) |
+| `long` GT | 0.546 → 0.316 ns/value (1.7×) | — |
 
-**Payoff.** With the `notNullWords` migration in front of it, this is what could put drain-side ahead of compiled even single-threaded — the lever the v1 design over-promised.
+Which type gains more is a property of the machine, not of the types: `int` carries eight lanes per 256-bit vector against four per 128-bit one, and the total-order key transform that `float` needs costs more on x86 than on AArch64. `long` and `double` carry half the lanes of `int` throughout.
 
-**Difficulty.** High. Multi-release plumbing per matcher (28 files × 2 = 56 classes). Verify each on both scalar fallback (JDK 21 path) and SIMD path. Worth doing only after `notNullWords` lands.
+**The end-to-end gain is bounded by the matcher's share of a scan, which is about 5 %.** A filtered scan over 2 M rows pinned to one core, filtering on an `int` column, ran 26.1 ms against 27.4 ms scalar — a 1.3 ms saving, inside error bars of ±9.0 and ±4.6 ms, with the long-predicate arm as an unmoved control at 58.7 against 58.3 ms. Two routes agree on what that decomposes to:
+
+- The 1.3 ms saving is 89 % of the matcher's cost, putting the whole scalar matcher at ≈1.5 ms, or 5.3 % of the scan.
+- 0.613 ns/value over 2 M rows is 1.23 ms directly, or 4.5 % of the scan.
+
+Either way the residual after a 9× kernel is ≈0.15 ms, **0.5–0.6 % of the scan**, and that is the entire headroom a wider vector would compete for. The parts of the matcher that do not scale with lane count — bitmap word assembly, bounds checks, the word-wise validity AND — are a growing share of what remains, so the realised gain from a wider vector would be smaller still.
+
+`RecordFilterMicroBenchmark` agrees on the magnitude. Raw drain-side numbers for `and3` and `and4` move 11–13 %, but the compiled control moves 6–10 % between the same two JVM launches; normalising each arm against its own control leaves 4–5 %, which is what one `int` leaf out of three or four is worth.
+
+**What it would cost.** Thirteen classes in a multi-release source root that compile only on JDK 22+ and run only when the incubating Vector API module is added, a second implementation of matcher semantics to keep correct — including a hand-rolled `Float.compare` total order whose failure mode is silently wrong NaN and `-0` results rather than a crash — tests that can run only as integration tests, and a two-implementation decision on every matcher added afterwards.
+
+**Two constraints any future attempt inherits.**
+
+- *The species and the operator must both fold to compile-time constants.* Routing either through an instance field or a method parameter drops the kernel onto a generic path that measured roughly 30× slower than the scalar matcher. This forces one class per operator rather than one parameterised by it, and is most of where the class count comes from.
+- *`float` cannot compare on float lanes.* The scalar matcher orders by `Float.compare` — every NaN above `+Infinity`, `-0` below `+0` — and the Vector API's float comparison is IEEE. Comparing lanes directly drops every NaN out of the result and ranks `-0` equal to `+0`. Canonicalising NaN and flipping the magnitude bits of negatives reproduces the ordering as one integer comparison.
+
+**What would change the answer.** Not a wider vector, but a larger matcher share of the scan — which is what the late-materialization fork in #500 would do. Revisit then.
 
 ### Per-batch min/max + sentinel matches
 

--- a/core/src/main/java/dev/hardwood/internal/predicate/matcher/booleans/BooleanEqBatchMatcher.java
+++ b/core/src/main/java/dev/hardwood/internal/predicate/matcher/booleans/BooleanEqBatchMatcher.java
@@ -26,10 +26,12 @@ public final class BooleanEqBatchMatcher implements BooleanBatchMatcher {
         int fullWords = n >>> 6;
         int tail = n & 63;
 
-        // Build the predicate bitmap ignoring nulls. The inner loop is fixed at 64
-        // iterations and uses a branchless `(cond ? 1 : 0) << b` pack so HotSpot
-        // fully unrolls it and auto-vectorizes the comparison. The tail is split
-        // off to keep the hot loop's trip count constant at 64.
+        // Build the predicate bitmap ignoring nulls; nulls are masked out in the
+        // word-wise pass below. The comparison is branchless, but C2 does not
+        // vectorize it — packing a vector compare into bitmap bits has no
+        // autovectorization idiom, so this compiles to a scalar cmp/setcc/shl/or
+        // chain unrolled 4x. The tail is split off to keep the hot loop's trip
+        // count constant at 64.
         for (int w = 0; w < fullWords; w++) {
             int base = w << 6;
             long word = 0L;

--- a/core/src/main/java/dev/hardwood/internal/predicate/matcher/booleans/BooleanNotEqBatchMatcher.java
+++ b/core/src/main/java/dev/hardwood/internal/predicate/matcher/booleans/BooleanNotEqBatchMatcher.java
@@ -26,10 +26,12 @@ public final class BooleanNotEqBatchMatcher implements BooleanBatchMatcher {
         int fullWords = n >>> 6;
         int tail = n & 63;
 
-        // Build the predicate bitmap ignoring nulls. The inner loop is fixed at 64
-        // iterations and uses a branchless `(cond ? 1 : 0) << b` pack so HotSpot
-        // fully unrolls it and auto-vectorizes the comparison. The tail is split
-        // off to keep the hot loop's trip count constant at 64.
+        // Build the predicate bitmap ignoring nulls; nulls are masked out in the
+        // word-wise pass below. The comparison is branchless, but C2 does not
+        // vectorize it — packing a vector compare into bitmap bits has no
+        // autovectorization idiom, so this compiles to a scalar cmp/setcc/shl/or
+        // chain unrolled 4x. The tail is split off to keep the hot loop's trip
+        // count constant at 64.
         for (int w = 0; w < fullWords; w++) {
             int base = w << 6;
             long word = 0L;

--- a/core/src/main/java/dev/hardwood/internal/predicate/matcher/doubles/DoubleEqBatchMatcher.java
+++ b/core/src/main/java/dev/hardwood/internal/predicate/matcher/doubles/DoubleEqBatchMatcher.java
@@ -26,10 +26,12 @@ public final class DoubleEqBatchMatcher implements DoubleBatchMatcher {
         int fullWords = n >>> 6;
         int tail = n & 63;
 
-        // Build the predicate bitmap ignoring nulls. The inner loop is fixed at 64
-        // iterations and uses a branchless `(cond ? 1 : 0) << b` pack so HotSpot
-        // fully unrolls it and auto-vectorizes the comparison. The tail is split
-        // off to keep the hot loop's trip count constant at 64.
+        // Build the predicate bitmap ignoring nulls; nulls are masked out in the
+        // word-wise pass below. The comparison is branchless, but C2 does not
+        // vectorize it — packing a vector compare into bitmap bits has no
+        // autovectorization idiom, so this compiles to a scalar cmp/setcc/shl/or
+        // chain unrolled 4x. The tail is split off to keep the hot loop's trip
+        // count constant at 64.
         for (int w = 0; w < fullWords; w++) {
             int base = w << 6;
             long word = 0L;

--- a/core/src/main/java/dev/hardwood/internal/predicate/matcher/doubles/DoubleGtBatchMatcher.java
+++ b/core/src/main/java/dev/hardwood/internal/predicate/matcher/doubles/DoubleGtBatchMatcher.java
@@ -26,10 +26,12 @@ public final class DoubleGtBatchMatcher implements DoubleBatchMatcher {
         int fullWords = n >>> 6;
         int tail = n & 63;
 
-        // Build the predicate bitmap ignoring nulls. The inner loop is fixed at 64
-        // iterations and uses a branchless `(cond ? 1 : 0) << b` pack so HotSpot
-        // fully unrolls it and auto-vectorizes the comparison. The tail is split
-        // off to keep the hot loop's trip count constant at 64.
+        // Build the predicate bitmap ignoring nulls; nulls are masked out in the
+        // word-wise pass below. The comparison is branchless, but C2 does not
+        // vectorize it — packing a vector compare into bitmap bits has no
+        // autovectorization idiom, so this compiles to a scalar cmp/setcc/shl/or
+        // chain unrolled 4x. The tail is split off to keep the hot loop's trip
+        // count constant at 64.
         for (int w = 0; w < fullWords; w++) {
             int base = w << 6;
             long word = 0L;

--- a/core/src/main/java/dev/hardwood/internal/predicate/matcher/doubles/DoubleGtEqBatchMatcher.java
+++ b/core/src/main/java/dev/hardwood/internal/predicate/matcher/doubles/DoubleGtEqBatchMatcher.java
@@ -26,10 +26,12 @@ public final class DoubleGtEqBatchMatcher implements DoubleBatchMatcher {
         int fullWords = n >>> 6;
         int tail = n & 63;
 
-        // Build the predicate bitmap ignoring nulls. The inner loop is fixed at 64
-        // iterations and uses a branchless `(cond ? 1 : 0) << b` pack so HotSpot
-        // fully unrolls it and auto-vectorizes the comparison. The tail is split
-        // off to keep the hot loop's trip count constant at 64.
+        // Build the predicate bitmap ignoring nulls; nulls are masked out in the
+        // word-wise pass below. The comparison is branchless, but C2 does not
+        // vectorize it — packing a vector compare into bitmap bits has no
+        // autovectorization idiom, so this compiles to a scalar cmp/setcc/shl/or
+        // chain unrolled 4x. The tail is split off to keep the hot loop's trip
+        // count constant at 64.
         for (int w = 0; w < fullWords; w++) {
             int base = w << 6;
             long word = 0L;

--- a/core/src/main/java/dev/hardwood/internal/predicate/matcher/doubles/DoubleInBatchMatcher.java
+++ b/core/src/main/java/dev/hardwood/internal/predicate/matcher/doubles/DoubleInBatchMatcher.java
@@ -28,9 +28,11 @@ public final class DoubleInBatchMatcher implements DoubleBatchMatcher {
         int fullWords = n >>> 6;
         int tail = n & 63;
 
-        // Build the predicate bitmap ignoring nulls. The inner loop is fixed at 64
-        // iterations and uses a branchless `(cond ? 1 : 0) << b` pack so HotSpot
-        // can fully unroll it. The tail is split off to keep the hot loop's trip
+        // Build the predicate bitmap ignoring nulls; nulls are masked out in the
+        // word-wise pass below. The comparison is branchless, but C2 does not
+        // vectorize it — packing a vector compare into bitmap bits has no
+        // autovectorization idiom, so this compiles to a scalar cmp/setcc/shl/or
+        // chain unrolled 4x. The tail is split off to keep the hot loop's trip
         // count constant at 64.
         for (int w = 0; w < fullWords; w++) {
             int base = w << 6;

--- a/core/src/main/java/dev/hardwood/internal/predicate/matcher/doubles/DoubleLtBatchMatcher.java
+++ b/core/src/main/java/dev/hardwood/internal/predicate/matcher/doubles/DoubleLtBatchMatcher.java
@@ -26,10 +26,12 @@ public final class DoubleLtBatchMatcher implements DoubleBatchMatcher {
         int fullWords = n >>> 6;
         int tail = n & 63;
 
-        // Build the predicate bitmap ignoring nulls. The inner loop is fixed at 64
-        // iterations and uses a branchless `(cond ? 1 : 0) << b` pack so HotSpot
-        // fully unrolls it and auto-vectorizes the comparison. The tail is split
-        // off to keep the hot loop's trip count constant at 64.
+        // Build the predicate bitmap ignoring nulls; nulls are masked out in the
+        // word-wise pass below. The comparison is branchless, but C2 does not
+        // vectorize it — packing a vector compare into bitmap bits has no
+        // autovectorization idiom, so this compiles to a scalar cmp/setcc/shl/or
+        // chain unrolled 4x. The tail is split off to keep the hot loop's trip
+        // count constant at 64.
         for (int w = 0; w < fullWords; w++) {
             int base = w << 6;
             long word = 0L;

--- a/core/src/main/java/dev/hardwood/internal/predicate/matcher/doubles/DoubleLtEqBatchMatcher.java
+++ b/core/src/main/java/dev/hardwood/internal/predicate/matcher/doubles/DoubleLtEqBatchMatcher.java
@@ -26,10 +26,12 @@ public final class DoubleLtEqBatchMatcher implements DoubleBatchMatcher {
         int fullWords = n >>> 6;
         int tail = n & 63;
 
-        // Build the predicate bitmap ignoring nulls. The inner loop is fixed at 64
-        // iterations and uses a branchless `(cond ? 1 : 0) << b` pack so HotSpot
-        // fully unrolls it and auto-vectorizes the comparison. The tail is split
-        // off to keep the hot loop's trip count constant at 64.
+        // Build the predicate bitmap ignoring nulls; nulls are masked out in the
+        // word-wise pass below. The comparison is branchless, but C2 does not
+        // vectorize it — packing a vector compare into bitmap bits has no
+        // autovectorization idiom, so this compiles to a scalar cmp/setcc/shl/or
+        // chain unrolled 4x. The tail is split off to keep the hot loop's trip
+        // count constant at 64.
         for (int w = 0; w < fullWords; w++) {
             int base = w << 6;
             long word = 0L;

--- a/core/src/main/java/dev/hardwood/internal/predicate/matcher/doubles/DoubleNotEqBatchMatcher.java
+++ b/core/src/main/java/dev/hardwood/internal/predicate/matcher/doubles/DoubleNotEqBatchMatcher.java
@@ -26,10 +26,12 @@ public final class DoubleNotEqBatchMatcher implements DoubleBatchMatcher {
         int fullWords = n >>> 6;
         int tail = n & 63;
 
-        // Build the predicate bitmap ignoring nulls. The inner loop is fixed at 64
-        // iterations and uses a branchless `(cond ? 1 : 0) << b` pack so HotSpot
-        // fully unrolls it and auto-vectorizes the comparison. The tail is split
-        // off to keep the hot loop's trip count constant at 64.
+        // Build the predicate bitmap ignoring nulls; nulls are masked out in the
+        // word-wise pass below. The comparison is branchless, but C2 does not
+        // vectorize it — packing a vector compare into bitmap bits has no
+        // autovectorization idiom, so this compiles to a scalar cmp/setcc/shl/or
+        // chain unrolled 4x. The tail is split off to keep the hot loop's trip
+        // count constant at 64.
         for (int w = 0; w < fullWords; w++) {
             int base = w << 6;
             long word = 0L;

--- a/core/src/main/java/dev/hardwood/internal/predicate/matcher/floats/FloatEqBatchMatcher.java
+++ b/core/src/main/java/dev/hardwood/internal/predicate/matcher/floats/FloatEqBatchMatcher.java
@@ -26,10 +26,12 @@ public final class FloatEqBatchMatcher implements FloatBatchMatcher {
         int fullWords = n >>> 6;
         int tail = n & 63;
 
-        // Build the predicate bitmap ignoring nulls. The inner loop is fixed at 64
-        // iterations and uses a branchless `(cond ? 1 : 0) << b` pack so HotSpot
-        // fully unrolls it and auto-vectorizes the comparison. The tail is split
-        // off to keep the hot loop's trip count constant at 64.
+        // Build the predicate bitmap ignoring nulls; nulls are masked out in the
+        // word-wise pass below. The comparison is branchless, but C2 does not
+        // vectorize it — packing a vector compare into bitmap bits has no
+        // autovectorization idiom, so this compiles to a scalar cmp/setcc/shl/or
+        // chain unrolled 4x. The tail is split off to keep the hot loop's trip
+        // count constant at 64.
         for (int w = 0; w < fullWords; w++) {
             int base = w << 6;
             long word = 0L;

--- a/core/src/main/java/dev/hardwood/internal/predicate/matcher/floats/FloatGtBatchMatcher.java
+++ b/core/src/main/java/dev/hardwood/internal/predicate/matcher/floats/FloatGtBatchMatcher.java
@@ -26,10 +26,12 @@ public final class FloatGtBatchMatcher implements FloatBatchMatcher {
         int fullWords = n >>> 6;
         int tail = n & 63;
 
-        // Build the predicate bitmap ignoring nulls. The inner loop is fixed at 64
-        // iterations and uses a branchless `(cond ? 1 : 0) << b` pack so HotSpot
-        // fully unrolls it and auto-vectorizes the comparison. The tail is split
-        // off to keep the hot loop's trip count constant at 64.
+        // Build the predicate bitmap ignoring nulls; nulls are masked out in the
+        // word-wise pass below. The comparison is branchless, but C2 does not
+        // vectorize it — packing a vector compare into bitmap bits has no
+        // autovectorization idiom, so this compiles to a scalar cmp/setcc/shl/or
+        // chain unrolled 4x. The tail is split off to keep the hot loop's trip
+        // count constant at 64.
         for (int w = 0; w < fullWords; w++) {
             int base = w << 6;
             long word = 0L;

--- a/core/src/main/java/dev/hardwood/internal/predicate/matcher/floats/FloatGtEqBatchMatcher.java
+++ b/core/src/main/java/dev/hardwood/internal/predicate/matcher/floats/FloatGtEqBatchMatcher.java
@@ -26,10 +26,12 @@ public final class FloatGtEqBatchMatcher implements FloatBatchMatcher {
         int fullWords = n >>> 6;
         int tail = n & 63;
 
-        // Build the predicate bitmap ignoring nulls. The inner loop is fixed at 64
-        // iterations and uses a branchless `(cond ? 1 : 0) << b` pack so HotSpot
-        // fully unrolls it and auto-vectorizes the comparison. The tail is split
-        // off to keep the hot loop's trip count constant at 64.
+        // Build the predicate bitmap ignoring nulls; nulls are masked out in the
+        // word-wise pass below. The comparison is branchless, but C2 does not
+        // vectorize it — packing a vector compare into bitmap bits has no
+        // autovectorization idiom, so this compiles to a scalar cmp/setcc/shl/or
+        // chain unrolled 4x. The tail is split off to keep the hot loop's trip
+        // count constant at 64.
         for (int w = 0; w < fullWords; w++) {
             int base = w << 6;
             long word = 0L;

--- a/core/src/main/java/dev/hardwood/internal/predicate/matcher/floats/FloatLtBatchMatcher.java
+++ b/core/src/main/java/dev/hardwood/internal/predicate/matcher/floats/FloatLtBatchMatcher.java
@@ -26,10 +26,12 @@ public final class FloatLtBatchMatcher implements FloatBatchMatcher {
         int fullWords = n >>> 6;
         int tail = n & 63;
 
-        // Build the predicate bitmap ignoring nulls. The inner loop is fixed at 64
-        // iterations and uses a branchless `(cond ? 1 : 0) << b` pack so HotSpot
-        // fully unrolls it and auto-vectorizes the comparison. The tail is split
-        // off to keep the hot loop's trip count constant at 64.
+        // Build the predicate bitmap ignoring nulls; nulls are masked out in the
+        // word-wise pass below. The comparison is branchless, but C2 does not
+        // vectorize it — packing a vector compare into bitmap bits has no
+        // autovectorization idiom, so this compiles to a scalar cmp/setcc/shl/or
+        // chain unrolled 4x. The tail is split off to keep the hot loop's trip
+        // count constant at 64.
         for (int w = 0; w < fullWords; w++) {
             int base = w << 6;
             long word = 0L;

--- a/core/src/main/java/dev/hardwood/internal/predicate/matcher/floats/FloatLtEqBatchMatcher.java
+++ b/core/src/main/java/dev/hardwood/internal/predicate/matcher/floats/FloatLtEqBatchMatcher.java
@@ -26,10 +26,12 @@ public final class FloatLtEqBatchMatcher implements FloatBatchMatcher {
         int fullWords = n >>> 6;
         int tail = n & 63;
 
-        // Build the predicate bitmap ignoring nulls. The inner loop is fixed at 64
-        // iterations and uses a branchless `(cond ? 1 : 0) << b` pack so HotSpot
-        // fully unrolls it and auto-vectorizes the comparison. The tail is split
-        // off to keep the hot loop's trip count constant at 64.
+        // Build the predicate bitmap ignoring nulls; nulls are masked out in the
+        // word-wise pass below. The comparison is branchless, but C2 does not
+        // vectorize it — packing a vector compare into bitmap bits has no
+        // autovectorization idiom, so this compiles to a scalar cmp/setcc/shl/or
+        // chain unrolled 4x. The tail is split off to keep the hot loop's trip
+        // count constant at 64.
         for (int w = 0; w < fullWords; w++) {
             int base = w << 6;
             long word = 0L;

--- a/core/src/main/java/dev/hardwood/internal/predicate/matcher/floats/FloatNotEqBatchMatcher.java
+++ b/core/src/main/java/dev/hardwood/internal/predicate/matcher/floats/FloatNotEqBatchMatcher.java
@@ -26,10 +26,12 @@ public final class FloatNotEqBatchMatcher implements FloatBatchMatcher {
         int fullWords = n >>> 6;
         int tail = n & 63;
 
-        // Build the predicate bitmap ignoring nulls. The inner loop is fixed at 64
-        // iterations and uses a branchless `(cond ? 1 : 0) << b` pack so HotSpot
-        // fully unrolls it and auto-vectorizes the comparison. The tail is split
-        // off to keep the hot loop's trip count constant at 64.
+        // Build the predicate bitmap ignoring nulls; nulls are masked out in the
+        // word-wise pass below. The comparison is branchless, but C2 does not
+        // vectorize it — packing a vector compare into bitmap bits has no
+        // autovectorization idiom, so this compiles to a scalar cmp/setcc/shl/or
+        // chain unrolled 4x. The tail is split off to keep the hot loop's trip
+        // count constant at 64.
         for (int w = 0; w < fullWords; w++) {
             int base = w << 6;
             long word = 0L;

--- a/core/src/main/java/dev/hardwood/internal/predicate/matcher/floats/FloatWideningDoubleInBatchMatcher.java
+++ b/core/src/main/java/dev/hardwood/internal/predicate/matcher/floats/FloatWideningDoubleInBatchMatcher.java
@@ -28,9 +28,11 @@ public final class FloatWideningDoubleInBatchMatcher implements FloatBatchMatche
         int fullWords = n >>> 6;
         int tail = n & 63;
 
-        // Build the predicate bitmap ignoring nulls. The inner loop is fixed at 64
-        // iterations and uses a branchless `(cond ? 1 : 0) << b` pack so HotSpot
-        // can fully unroll it. The tail is split off to keep the hot loop's trip
+        // Build the predicate bitmap ignoring nulls; nulls are masked out in the
+        // word-wise pass below. The comparison is branchless, but C2 does not
+        // vectorize it — packing a vector compare into bitmap bits has no
+        // autovectorization idiom, so this compiles to a scalar cmp/setcc/shl/or
+        // chain unrolled 4x. The tail is split off to keep the hot loop's trip
         // count constant at 64.
         for (int w = 0; w < fullWords; w++) {
             int base = w << 6;

--- a/core/src/main/java/dev/hardwood/internal/predicate/matcher/ints/IntGtBatchMatcher.java
+++ b/core/src/main/java/dev/hardwood/internal/predicate/matcher/ints/IntGtBatchMatcher.java
@@ -26,10 +26,12 @@ public final class IntGtBatchMatcher implements IntBatchMatcher {
         int fullWords = n >>> 6;
         int tail = n & 63;
 
-        // Build the predicate bitmap ignoring nulls. The inner loop is fixed at 64
-        // iterations and uses a branchless `(cond ? 1 : 0) << b` pack so HotSpot
-        // fully unrolls it and auto-vectorizes the comparison. The tail is split
-        // off to keep the hot loop's trip count constant at 64.
+        // Build the predicate bitmap ignoring nulls; nulls are masked out in the
+        // word-wise pass below. The comparison is branchless, but C2 does not
+        // vectorize it — packing a vector compare into bitmap bits has no
+        // autovectorization idiom, so this compiles to a scalar cmp/setcc/shl/or
+        // chain unrolled 4x. The tail is split off to keep the hot loop's trip
+        // count constant at 64.
         for (int w = 0; w < fullWords; w++) {
             int base = w << 6;
             long word = 0L;

--- a/core/src/main/java/dev/hardwood/internal/predicate/matcher/ints/IntGtEqBatchMatcher.java
+++ b/core/src/main/java/dev/hardwood/internal/predicate/matcher/ints/IntGtEqBatchMatcher.java
@@ -26,10 +26,12 @@ public final class IntGtEqBatchMatcher implements IntBatchMatcher {
         int fullWords = n >>> 6;
         int tail = n & 63;
 
-        // Build the predicate bitmap ignoring nulls. The inner loop is fixed at 64
-        // iterations and uses a branchless `(cond ? 1 : 0) << b` pack so HotSpot
-        // fully unrolls it and auto-vectorizes the comparison. The tail is split
-        // off to keep the hot loop's trip count constant at 64.
+        // Build the predicate bitmap ignoring nulls; nulls are masked out in the
+        // word-wise pass below. The comparison is branchless, but C2 does not
+        // vectorize it — packing a vector compare into bitmap bits has no
+        // autovectorization idiom, so this compiles to a scalar cmp/setcc/shl/or
+        // chain unrolled 4x. The tail is split off to keep the hot loop's trip
+        // count constant at 64.
         for (int w = 0; w < fullWords; w++) {
             int base = w << 6;
             long word = 0L;

--- a/core/src/main/java/dev/hardwood/internal/predicate/matcher/ints/IntInBatchMatcher.java
+++ b/core/src/main/java/dev/hardwood/internal/predicate/matcher/ints/IntInBatchMatcher.java
@@ -27,9 +27,11 @@ public final class IntInBatchMatcher implements IntBatchMatcher {
         int fullWords = n >>> 6;
         int tail = n & 63;
 
-        // Build the predicate bitmap ignoring nulls. The inner loop is fixed at 64
-        // iterations and uses a branchless `(cond ? 1 : 0) << b` pack so HotSpot
-        // can fully unroll it. The tail is split off to keep the hot loop's trip
+        // Build the predicate bitmap ignoring nulls; nulls are masked out in the
+        // word-wise pass below. The comparison is branchless, but C2 does not
+        // vectorize it — packing a vector compare into bitmap bits has no
+        // autovectorization idiom, so this compiles to a scalar cmp/setcc/shl/or
+        // chain unrolled 4x. The tail is split off to keep the hot loop's trip
         // count constant at 64.
         for (int w = 0; w < fullWords; w++) {
             int base = w << 6;

--- a/core/src/main/java/dev/hardwood/internal/predicate/matcher/ints/IntLtBatchMatcher.java
+++ b/core/src/main/java/dev/hardwood/internal/predicate/matcher/ints/IntLtBatchMatcher.java
@@ -26,10 +26,12 @@ public final class IntLtBatchMatcher implements IntBatchMatcher {
         int fullWords = n >>> 6;
         int tail = n & 63;
 
-        // Build the predicate bitmap ignoring nulls. The inner loop is fixed at 64
-        // iterations and uses a branchless `(cond ? 1 : 0) << b` pack so HotSpot
-        // fully unrolls it and auto-vectorizes the comparison. The tail is split
-        // off to keep the hot loop's trip count constant at 64.
+        // Build the predicate bitmap ignoring nulls; nulls are masked out in the
+        // word-wise pass below. The comparison is branchless, but C2 does not
+        // vectorize it — packing a vector compare into bitmap bits has no
+        // autovectorization idiom, so this compiles to a scalar cmp/setcc/shl/or
+        // chain unrolled 4x. The tail is split off to keep the hot loop's trip
+        // count constant at 64.
         for (int w = 0; w < fullWords; w++) {
             int base = w << 6;
             long word = 0L;

--- a/core/src/main/java/dev/hardwood/internal/predicate/matcher/ints/IntLtEqBatchMatcher.java
+++ b/core/src/main/java/dev/hardwood/internal/predicate/matcher/ints/IntLtEqBatchMatcher.java
@@ -26,10 +26,12 @@ public final class IntLtEqBatchMatcher implements IntBatchMatcher {
         int fullWords = n >>> 6;
         int tail = n & 63;
 
-        // Build the predicate bitmap ignoring nulls. The inner loop is fixed at 64
-        // iterations and uses a branchless `(cond ? 1 : 0) << b` pack so HotSpot
-        // fully unrolls it and auto-vectorizes the comparison. The tail is split
-        // off to keep the hot loop's trip count constant at 64.
+        // Build the predicate bitmap ignoring nulls; nulls are masked out in the
+        // word-wise pass below. The comparison is branchless, but C2 does not
+        // vectorize it — packing a vector compare into bitmap bits has no
+        // autovectorization idiom, so this compiles to a scalar cmp/setcc/shl/or
+        // chain unrolled 4x. The tail is split off to keep the hot loop's trip
+        // count constant at 64.
         for (int w = 0; w < fullWords; w++) {
             int base = w << 6;
             long word = 0L;

--- a/core/src/main/java/dev/hardwood/internal/predicate/matcher/ints/IntNotEqBatchMatcher.java
+++ b/core/src/main/java/dev/hardwood/internal/predicate/matcher/ints/IntNotEqBatchMatcher.java
@@ -26,10 +26,12 @@ public final class IntNotEqBatchMatcher implements IntBatchMatcher {
         int fullWords = n >>> 6;
         int tail = n & 63;
 
-        // Build the predicate bitmap ignoring nulls. The inner loop is fixed at 64
-        // iterations and uses a branchless `(cond ? 1 : 0) << b` pack so HotSpot
-        // fully unrolls it and auto-vectorizes the comparison. The tail is split
-        // off to keep the hot loop's trip count constant at 64.
+        // Build the predicate bitmap ignoring nulls; nulls are masked out in the
+        // word-wise pass below. The comparison is branchless, but C2 does not
+        // vectorize it — packing a vector compare into bitmap bits has no
+        // autovectorization idiom, so this compiles to a scalar cmp/setcc/shl/or
+        // chain unrolled 4x. The tail is split off to keep the hot loop's trip
+        // count constant at 64.
         for (int w = 0; w < fullWords; w++) {
             int base = w << 6;
             long word = 0L;

--- a/core/src/main/java/dev/hardwood/internal/predicate/matcher/longs/LongEqBatchMatcher.java
+++ b/core/src/main/java/dev/hardwood/internal/predicate/matcher/longs/LongEqBatchMatcher.java
@@ -26,10 +26,12 @@ public final class LongEqBatchMatcher implements LongBatchMatcher {
         int fullWords = n >>> 6;
         int tail = n & 63;
 
-        // Build the predicate bitmap ignoring nulls. The inner loop is fixed at 64
-        // iterations and uses a branchless `(cond ? 1 : 0) << b` pack so HotSpot
-        // fully unrolls it and auto-vectorizes the comparison. The tail is split
-        // off to keep the hot loop's trip count constant at 64.
+        // Build the predicate bitmap ignoring nulls; nulls are masked out in the
+        // word-wise pass below. The comparison is branchless, but C2 does not
+        // vectorize it — packing a vector compare into bitmap bits has no
+        // autovectorization idiom, so this compiles to a scalar cmp/setcc/shl/or
+        // chain unrolled 4x. The tail is split off to keep the hot loop's trip
+        // count constant at 64.
         for (int w = 0; w < fullWords; w++) {
             int base = w << 6;
             long word = 0L;

--- a/core/src/main/java/dev/hardwood/internal/predicate/matcher/longs/LongGtBatchMatcher.java
+++ b/core/src/main/java/dev/hardwood/internal/predicate/matcher/longs/LongGtBatchMatcher.java
@@ -26,10 +26,12 @@ public final class LongGtBatchMatcher implements LongBatchMatcher {
         int fullWords = n >>> 6;
         int tail = n & 63;
 
-        // Build the predicate bitmap ignoring nulls. The inner loop is fixed at 64
-        // iterations and uses a branchless `(cond ? 1 : 0) << b` pack so HotSpot
-        // fully unrolls it and auto-vectorizes the comparison. The tail is split
-        // off to keep the hot loop's trip count constant at 64.
+        // Build the predicate bitmap ignoring nulls; nulls are masked out in the
+        // word-wise pass below. The comparison is branchless, but C2 does not
+        // vectorize it — packing a vector compare into bitmap bits has no
+        // autovectorization idiom, so this compiles to a scalar cmp/setcc/shl/or
+        // chain unrolled 4x. The tail is split off to keep the hot loop's trip
+        // count constant at 64.
         for (int w = 0; w < fullWords; w++) {
             int base = w << 6;
             long word = 0L;

--- a/core/src/main/java/dev/hardwood/internal/predicate/matcher/longs/LongGtEqBatchMatcher.java
+++ b/core/src/main/java/dev/hardwood/internal/predicate/matcher/longs/LongGtEqBatchMatcher.java
@@ -26,10 +26,12 @@ public final class LongGtEqBatchMatcher implements LongBatchMatcher {
         int fullWords = n >>> 6;
         int tail = n & 63;
 
-        // Build the predicate bitmap ignoring nulls. The inner loop is fixed at 64
-        // iterations and uses a branchless `(cond ? 1 : 0) << b` pack so HotSpot
-        // fully unrolls it and auto-vectorizes the comparison. The tail is split
-        // off to keep the hot loop's trip count constant at 64.
+        // Build the predicate bitmap ignoring nulls; nulls are masked out in the
+        // word-wise pass below. The comparison is branchless, but C2 does not
+        // vectorize it — packing a vector compare into bitmap bits has no
+        // autovectorization idiom, so this compiles to a scalar cmp/setcc/shl/or
+        // chain unrolled 4x. The tail is split off to keep the hot loop's trip
+        // count constant at 64.
         for (int w = 0; w < fullWords; w++) {
             int base = w << 6;
             long word = 0L;

--- a/core/src/main/java/dev/hardwood/internal/predicate/matcher/longs/LongInBatchMatcher.java
+++ b/core/src/main/java/dev/hardwood/internal/predicate/matcher/longs/LongInBatchMatcher.java
@@ -27,9 +27,11 @@ public final class LongInBatchMatcher implements LongBatchMatcher {
         int fullWords = n >>> 6;
         int tail = n & 63;
 
-        // Build the predicate bitmap ignoring nulls. The inner loop is fixed at 64
-        // iterations and uses a branchless `(cond ? 1 : 0) << b` pack so HotSpot
-        // can fully unroll it. The tail is split off to keep the hot loop's trip
+        // Build the predicate bitmap ignoring nulls; nulls are masked out in the
+        // word-wise pass below. The comparison is branchless, but C2 does not
+        // vectorize it — packing a vector compare into bitmap bits has no
+        // autovectorization idiom, so this compiles to a scalar cmp/setcc/shl/or
+        // chain unrolled 4x. The tail is split off to keep the hot loop's trip
         // count constant at 64.
         for (int w = 0; w < fullWords; w++) {
             int base = w << 6;

--- a/core/src/main/java/dev/hardwood/internal/predicate/matcher/longs/LongLtBatchMatcher.java
+++ b/core/src/main/java/dev/hardwood/internal/predicate/matcher/longs/LongLtBatchMatcher.java
@@ -26,10 +26,12 @@ public final class LongLtBatchMatcher implements LongBatchMatcher {
         int fullWords = n >>> 6;
         int tail = n & 63;
 
-        // Build the predicate bitmap ignoring nulls. The inner loop is fixed at 64
-        // iterations and uses a branchless `(cond ? 1 : 0) << b` pack so HotSpot
-        // fully unrolls it and auto-vectorizes the comparison. The tail is split
-        // off to keep the hot loop's trip count constant at 64.
+        // Build the predicate bitmap ignoring nulls; nulls are masked out in the
+        // word-wise pass below. The comparison is branchless, but C2 does not
+        // vectorize it — packing a vector compare into bitmap bits has no
+        // autovectorization idiom, so this compiles to a scalar cmp/setcc/shl/or
+        // chain unrolled 4x. The tail is split off to keep the hot loop's trip
+        // count constant at 64.
         for (int w = 0; w < fullWords; w++) {
             int base = w << 6;
             long word = 0L;

--- a/core/src/main/java/dev/hardwood/internal/predicate/matcher/longs/LongLtEqBatchMatcher.java
+++ b/core/src/main/java/dev/hardwood/internal/predicate/matcher/longs/LongLtEqBatchMatcher.java
@@ -26,10 +26,12 @@ public final class LongLtEqBatchMatcher implements LongBatchMatcher {
         int fullWords = n >>> 6;
         int tail = n & 63;
 
-        // Build the predicate bitmap ignoring nulls. The inner loop is fixed at 64
-        // iterations and uses a branchless `(cond ? 1 : 0) << b` pack so HotSpot
-        // fully unrolls it and auto-vectorizes the comparison. The tail is split
-        // off to keep the hot loop's trip count constant at 64.
+        // Build the predicate bitmap ignoring nulls; nulls are masked out in the
+        // word-wise pass below. The comparison is branchless, but C2 does not
+        // vectorize it — packing a vector compare into bitmap bits has no
+        // autovectorization idiom, so this compiles to a scalar cmp/setcc/shl/or
+        // chain unrolled 4x. The tail is split off to keep the hot loop's trip
+        // count constant at 64.
         for (int w = 0; w < fullWords; w++) {
             int base = w << 6;
             long word = 0L;

--- a/core/src/main/java/dev/hardwood/internal/predicate/matcher/longs/LongNotEqBatchMatcher.java
+++ b/core/src/main/java/dev/hardwood/internal/predicate/matcher/longs/LongNotEqBatchMatcher.java
@@ -26,10 +26,12 @@ public final class LongNotEqBatchMatcher implements LongBatchMatcher {
         int fullWords = n >>> 6;
         int tail = n & 63;
 
-        // Build the predicate bitmap ignoring nulls. The inner loop is fixed at 64
-        // iterations and uses a branchless `(cond ? 1 : 0) << b` pack so HotSpot
-        // fully unrolls it and auto-vectorizes the comparison. The tail is split
-        // off to keep the hot loop's trip count constant at 64.
+        // Build the predicate bitmap ignoring nulls; nulls are masked out in the
+        // word-wise pass below. The comparison is branchless, but C2 does not
+        // vectorize it — packing a vector compare into bitmap bits has no
+        // autovectorization idiom, so this compiles to a scalar cmp/setcc/shl/or
+        // chain unrolled 4x. The tail is split off to keep the hot loop's trip
+        // count constant at 64.
         for (int w = 0; w < fullWords; w++) {
             int base = w << 6;
             long word = 0L;


### PR DESCRIPTION
Refs #456.

Every scalar batch matcher carried a comment saying HotSpot fully unrolls the 64-iteration bitmap pack and auto-vectorizes the comparison. A perfasm dump of the C2 compilation on JDK 25 shows neither. The loop is unrolled 4× with a rolled remainder, and each value costs a scalar `mov`/`cmp`/`setg`/`shlx`/`or`. There is no autovectorization idiom for packing a vector compare into bitmap bits, so C2 has no way to produce that code. The comment was the stated reason the matchers are written in their branchless shape, so it pointed readers at a speedup that doesn't exist. The first commit replaces it in all 29 matchers with a description of what C2 actually emits.

The second commit rewrites the Vector API follow-up in `_designs/DRAIN_SIDE_RECORD_FILTERING.md`. The old entry blamed `BitSet.get` for blocking vectorization, but the `BitSet` has been gone since #430, and its payoff was an estimate. An `int`/`float` implementation was built and taken to a green build so the entry could be based on measurements. It is not in this PR.

The kernel gain is real, and it depends more on the machine than on the type. `int` LT runs 9.1× faster on AVX2 and 2.7× on NEON. `float` LT runs 2.1× and 3.1×, so the two types swap places between architectures. The end-to-end gain is small. A filtered scan over 2M rows on one pinned core, filtering on an `int` column, ran 26.1 ms with SIMD against 27.4 ms without — inside the error bars, while a long-predicate control stayed flat. By two independent estimates the matcher is about 5% of that scan. A 9× kernel already removes about nine tenths of that, which leaves 0.5–0.6% of the scan for any wider vector to improve on.

The entry is now marked "measured, not pursued". It keeps the numbers, the cost of the second implementation, and the two constraints any future attempt runs into. First, the Vector API only emits SIMD code when the species and the operator are both compile-time constants; otherwise the kernel runs about 30× slower than the scalar matcher. Second, `float` has to be compared as sortable integer keys rather than as float lanes, because the scalar matchers order by `Float.compare` and the Vector API's float comparison is IEEE. The entry names #500 as the change that would make this worth revisiting: it would give the matcher a bigger share of the scan.

No behaviour changes: the diff is comments and one design document.

Verified with a full `./mvnw verify`.
