### PR TITLE
1101 jump to row or row group

### DIFF
--- a/_designs/DIVE_JUMP_TO_ROW.md
+++ b/_designs/DIVE_JUMP_TO_ROW.md
@@ -1,0 +1,103 @@
+# Design: jumping to a row or row group in dive
+
+**Status: Implemented.** Tracking issue: #1101. Related: #1100.
+
+## Goal
+
+A reader looking at row group 17 on the Row groups screen — suspicious
+statistics, an odd encoding — should be able to see the values behind it, and a
+reader who knows the record they want should be able to name it. Navigation in
+the Data preview is relative only, so today the route to a specific record is
+holding `PgDn`, and the route to a row group's first record is adding up
+`numRows()` by hand.
+
+The same vocabulary reaches the non-interactive side, so that what a reader
+finds in dive is reproducible on the command line.
+
+## Row ↔ row group mapping
+
+`ParquetModel` owns the mapping in both directions, over one prefix array of
+cumulative `RowGroup.numRows()` built when the model opens:
+
+- `long firstRowOf(int rowGroupIndex)` — the absolute index of a row group's
+  first row. Drives the jump.
+- `int rowGroupOf(long row)` — the row group an absolute row falls in, by binary
+  search over the same array. Drives the Data preview's row-group indicator
+  (#1100), which asks once per keystroke.
+
+Both reject an out-of-range argument rather than clamping: a jump that silently
+lands somewhere else is worse than one that does not happen.
+
+## Jumping within the Data preview
+
+`:` opens a prompt on the Data preview. It accepts either a record — `12345` —
+or a row group — `rg 17`. `Enter` seeks so that the target is the selected row,
+`Esc` closes the prompt and leaves the view where it was.
+
+`:` rather than `/`, because `/` is inline search on the Schema, Column index
+and Dictionary screens, and a Data preview that answers `/` with a jump prompt
+would make the key mean two different things one screen apart. `/` stays
+reserved for a value search over the preview.
+
+Both numbers are counted from zero, as the rest of the tool counts them:
+`hardwood inspect columns --row-group 0` names the first row group, and
+`hardwood print --row-index` numbers the first record 0. A row typed into the
+prompt is therefore the row `--skip` takes, which is what makes a position
+found in dive reproducible on the command line.
+
+The Data preview's title counts from one — `rows 1-20 of 300` — so a reader
+copying a number off the title lands one row past the record they pointed at.
+Aligning the title on zero is a change to what every dive reader already sees
+and is left to #1100, which revisits that line to name the current row group.
+
+Input out of range for the file — a row past the last row, a row group past the
+last row group — is reported in the prompt, which stays open with the text
+intact. Nothing is clamped and no seek happens.
+
+The prompt is a single line above the table, in the shape `DictionaryScreen`
+already uses for its filter, rather than a modal box. Typed input in dive is a
+bar; a modal is for content a reader scrolls (`HelpOverlay`) or dismisses
+(`ReadFailureOverlay`).
+
+The seek itself goes through the Data preview's existing absolute-position move,
+so a jump is the same operation as `G` with a different target, and the
+navigation model's two rules (`_designs/DIVE_NAVIGATION_MODEL.md`) hold
+unchanged: the prompt is a mode, not a new kind of cursor.
+
+`PreviewWindow` needs no invalidation path. Its buffer covers a range of
+absolute row indices and is fully replaced whenever the requested page falls
+outside that range, so an arbitrary seek either lands in a buffer that is still
+correct for it or triggers a refill.
+
+## Jumping from the Row groups screens
+
+`d` on `RowGroupsScreen` and `RowGroupDetailScreen` opens the Data preview at
+the first row of the selected row group. This is the common case and takes no
+typing.
+
+`Enter` on those screens keeps its meaning — drilling into the row group's
+detail and its column chunks — so the `▶` marker continues to mark what `Enter`
+acts on.
+
+## Command-line parity
+
+`print` and `convert` gain `--skip <n>` and `--row-group <i>`:
+
+- `--skip <n>` starts at row `n` instead of row 0, and composes with the
+  existing `--rows/-n`.
+- `--row-group <i>` prints exactly the rows of row group `i`, resolved through
+  `firstRowOf`.
+
+The two are mutually exclusive, and both are rejected before the read when out
+of range or negative — the CLI fails before it reads, as the interactive prompt
+refuses before it seeks. Neither combines with a negative `-n`, which counts
+from the end of the file and so has no starting point to move. `print
+--row-index` numbers rows by their position in the file, so a row reached with
+`--skip` carries the number it had in `dive`.
+
+Documented under `docs/content/reference/cli.md` alongside the existing `print`
+options, and in `skills/hardwood-cli/`.
+
+## Open decisions
+
+None outstanding.

--- a/_designs/DIVE_JUMP_TO_ROW.md
+++ b/_designs/DIVE_JUMP_TO_ROW.md
@@ -54,10 +54,10 @@ Input out of range for the file — a row past the last row, a row group past th
 last row group — is reported in the prompt, which stays open with the text
 intact. Nothing is clamped and no seek happens.
 
-The prompt is a single line above the table, in the shape `DictionaryScreen`
-already uses for its filter, rather than a modal box. Typed input in dive is a
-bar; a modal is for content a reader scrolls (`HelpOverlay`) or dismisses
-(`ReadFailureOverlay`).
+The prompt is a centred bordered box over the table, the shape `HelpOverlay`,
+`ReadFailureOverlay` and the Data preview's own record modal use. It carries
+its own keys, so the keybar stands down while it is open, and it costs the page
+behind it no rows.
 
 The seek itself goes through the Data preview's existing absolute-position move,
 so a jump is the same operation as `G` with a different target, and the

--- a/cli/src/main/java/dev/hardwood/cli/command/ConvertCommand.java
+++ b/cli/src/main/java/dev/hardwood/cli/command/ConvertCommand.java
@@ -57,6 +57,12 @@ public class ConvertCommand implements Command<CommandInvocation> {
     @Option(shortName = 'n', name = "rows", defaultValue = RowLimits.ALL, description = "Number of rows to convert. Positive values convert the first N rows (head), negative values convert the last N rows (tail), 'ALL' converts every row.")
     String n;
 
+    @Option(name = "skip", description = "Number of rows to skip before converting, counted from 0. Cannot be combined with --row-group.")
+    Long skip;
+
+    @Option(name = "row-group", description = "Convert the rows of a single row group, counted from 0. Cannot be combined with --skip.")
+    Integer rowGroup;
+
     @Option(name = "null-string", description = "CSV field to write for a null value (default: an empty field). CSV output only.")
     String nullString;
 
@@ -72,14 +78,15 @@ public class ConvertCommand implements Command<CommandInvocation> {
         }
 
         try (ParquetFileReader reader = ParquetFileReader.open(inputFile)) {
-            int rowLimit = RowLimits.parse(n);
+            RowLimits.RowWindow window = RowLimits.resolveWindow(
+                    reader.getFileMetaData(), skip, rowGroup, RowLimits.parse(n));
             ColumnProjection projection = parseColumnProjection();
             FileSchema fileSchema = reader.getFileSchema();
             List<SchemaNode> fields = projectedFields(fileSchema, projection);
 
             PrintWriter out = openOutput();
             String effectiveNullString = nullString == null ? "" : nullString;
-            try (RowReader rowReader = RowLimits.buildRowReader(reader, projection, rowLimit)) {
+            try (RowReader rowReader = RowLimits.buildRowReader(reader, projection, window)) {
                 switch (format) {
                     case CSV -> writeCsv(out, fields, rowReader, projection, effectiveNullString);
                     case JSON -> writeJson(out, fields, rowReader);

--- a/cli/src/main/java/dev/hardwood/cli/command/PrintCommand.java
+++ b/cli/src/main/java/dev/hardwood/cli/command/PrintCommand.java
@@ -68,6 +68,12 @@ public class PrintCommand implements Command<CommandInvocation> {
     @Option(shortName = 'c', name = "columns", description = "Comma-separated list of columns to include. Supports nested fields via dot notation (e.g. 'account.id').")
     String columns;
 
+    @Option(name = "skip", description = "Number of rows to skip before printing, counted from 0. Cannot be combined with --row-group.")
+    Long skip;
+
+    @Option(name = "row-group", description = "Print the rows of a single row group, counted from 0. Cannot be combined with --skip.")
+    Integer rowGroup;
+
     @Override
     public CommandResult execute(CommandInvocation ci) {
         InputFile inputFile = fileMixin.toInputFile();
@@ -77,13 +83,16 @@ public class PrintCommand implements Command<CommandInvocation> {
 
         try (ParquetFileReader reader = ParquetFileReader.open(inputFile)) {
             validateMaxWidth();
-            int rowLimit = RowLimits.parse(n);
+            RowLimits.RowWindow window = RowLimits.resolveWindow(
+                    reader.getFileMetaData(), skip, rowGroup, RowLimits.parse(n));
             ColumnProjection projection = parseColumnProjection();
             FileSchema fileSchema = reader.getFileSchema();
-            try (RowReader rowReader = RowLimits.buildRowReader(reader, projection, rowLimit)) {
+            try (RowReader rowReader = RowLimits.buildRowReader(reader, projection, window)) {
                 String[] headers = RowTable.topLevelFieldNames(fileSchema, projection);
                 List<SchemaNode> fields = projectedFields(fileSchema, projection);
-                AtomicLong rowIndex = addRowIndex ? new AtomicLong() : null;
+                // The row index names the row in the file, so it counts from where
+                // the read starts, not from the first row printed.
+                AtomicLong rowIndex = addRowIndex ? new AtomicLong(window.skip()) : null;
                 Stream<Object[]> stream = stream(rowReader).map(r -> toData(r, headers.length));
                 if (transpose) {
                     printTransposed(stream, headers, fields, rowIndex);

--- a/cli/src/main/java/dev/hardwood/cli/command/RowLimits.java
+++ b/cli/src/main/java/dev/hardwood/cli/command/RowLimits.java
@@ -8,14 +8,17 @@
 package dev.hardwood.cli.command;
 
 import java.io.IOException;
+import java.util.List;
 
+import dev.hardwood.metadata.FileMetaData;
+import dev.hardwood.metadata.RowGroup;
 import dev.hardwood.reader.ParquetFileReader;
 import dev.hardwood.reader.ParquetFileReader.RowReaderBuilder;
 import dev.hardwood.reader.RowReader;
 import dev.hardwood.schema.ColumnProjection;
 
-/// Shared `-n / --rows` parsing and application for CLI commands that
-/// support head / tail / ALL row limiting (`print`, `convert`, ...).
+/// Shared `-n / --rows`, `--skip` and `--row-group` parsing and application
+/// for CLI commands that read rows (`print`, `convert`, ...).
 final class RowLimits {
 
     static final String ALL = "ALL";
@@ -46,15 +49,63 @@ final class RowLimits {
         return parsed;
     }
 
-    /// Builds a [RowReader] applying the parsed row limit:
-    /// positive → `head(limit)`, negative → `tail(-limit)`, zero → no limit.
-    static RowReader buildRowReader(ParquetFileReader reader, ColumnProjection projection, int rowLimit) throws IOException {
-        RowReaderBuilder builder = reader.buildRowReader().projection(projection);
-        if (rowLimit > 0) {
-            builder.head(rowLimit);
+    /// The rows a command reads: where it starts, and how many it takes.
+    /// `limit` is positive for head, negative for tail, `0` for no limit.
+    record RowWindow(long skip, long limit) {
+    }
+
+    /// Resolves `--skip` and `--row-group` into the window to read, on top of
+    /// the already parsed `-n` limit. The two options name a starting point in
+    /// two ways, so only one of them may be given.
+    static RowWindow resolveWindow(FileMetaData metadata, Long skip, Integer rowGroup, int rowLimit) {
+        if (skip != null && rowGroup != null) {
+            throw new IllegalArgumentException("--skip and --row-group cannot be combined: both name where to start reading");
         }
-        else if (rowLimit < 0) {
-            builder.tail(-rowLimit);
+        if (skip == null && rowGroup == null) {
+            return new RowWindow(0, rowLimit);
+        }
+        if (rowLimit < 0) {
+            throw new IllegalArgumentException("A negative '-n' counts the last rows of the file, so it cannot be combined with "
+                    + (skip != null ? "--skip" : "--row-group"));
+        }
+        if (skip != null) {
+            if (skip < 0) {
+                throw new IllegalArgumentException(
+                        "Invalid value for option '--skip': expected a non-negative row number, got '" + skip + "'");
+            }
+            if (skip >= metadata.numRows()) {
+                throw new IllegalArgumentException(
+                        "Cannot skip " + skip + " rows (file has " + metadata.numRows() + ")");
+            }
+            return new RowWindow(skip, rowLimit);
+        }
+        List<RowGroup> rowGroups = metadata.rowGroups();
+        if (rowGroup < 0 || rowGroup >= rowGroups.size()) {
+            throw new IllegalArgumentException("No such row group: " + rowGroup + " (file has " + rowGroups.size() + ")");
+        }
+        long firstRow = 0;
+        for (int i = 0; i < rowGroup; i++) {
+            firstRow += rowGroups.get(i).numRows();
+        }
+        // The row group bounds the read; an explicit `-n` may narrow it further,
+        // but never past the group into the next one.
+        long numRows = rowGroups.get(rowGroup).numRows();
+        return new RowWindow(firstRow, rowLimit > 0 ? Math.min(rowLimit, numRows) : numRows);
+    }
+
+    /// Builds a [RowReader] over the window: `skip` rows are passed over, then
+    /// a positive limit takes that many rows from the start, a negative one
+    /// that many from the end, and zero takes every row.
+    static RowReader buildRowReader(ParquetFileReader reader, ColumnProjection projection, RowWindow window) throws IOException {
+        RowReaderBuilder builder = reader.buildRowReader().projection(projection);
+        if (window.skip() > 0) {
+            builder.skip(window.skip());
+        }
+        if (window.limit() > 0) {
+            builder.head(window.limit());
+        }
+        else if (window.limit() < 0) {
+            builder.tail(-window.limit());
         }
         return builder.build();
     }

--- a/cli/src/main/java/dev/hardwood/cli/dive/ParquetModel.java
+++ b/cli/src/main/java/dev/hardwood/cli/dive/ParquetModel.java
@@ -11,6 +11,7 @@ import java.io.IOException;
 import java.io.UncheckedIOException;
 import java.nio.ByteBuffer;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -57,6 +58,12 @@ public final class ParquetModel implements AutoCloseable {
     private final FileMetaData metadata;
     private final FileSchema schema;
     private final Facts facts;
+    /// Cumulative row counts, one entry longer than the row-group list:
+    /// `rowGroupFirstRows[i]` is the absolute index of row group `i`'s first
+    /// row, and the last entry is the file's row count. Built once at
+    /// construction — the metadata it sums is immutable for the session, and
+    /// [#rowGroupOf] is asked once per keystroke on the Data preview.
+    private final long[] rowGroupFirstRows;
     /// Cached set of all group node paths in the schema; computed once on
     /// first call to [#allGroupPaths]. Schema is immutable per session, so
     /// the result is safe to memoise.
@@ -106,6 +113,19 @@ public final class ParquetModel implements AutoCloseable {
         this.metadata = reader.getFileMetaData();
         this.schema = reader.getFileSchema();
         this.facts = computeFacts();
+        this.rowGroupFirstRows = computeRowGroupFirstRows();
+    }
+
+    private long[] computeRowGroupFirstRows() {
+        List<RowGroup> rowGroups = metadata.rowGroups();
+        long[] firstRows = new long[rowGroups.size() + 1];
+        long cumulative = 0;
+        for (int i = 0; i < rowGroups.size(); i++) {
+            firstRows[i] = cumulative;
+            cumulative += rowGroups.get(i).numRows();
+        }
+        firstRows[rowGroups.size()] = cumulative;
+        return firstRows;
     }
 
     public static ParquetModel open(InputFile inputFile, String displayPath) throws IOException {
@@ -175,6 +195,49 @@ public final class ParquetModel implements AutoCloseable {
 
     public RowGroup rowGroup(int index) {
         return metadata.rowGroups().get(index);
+    }
+
+    /// The absolute index of the first row of `rowGroupIndex`, counting from
+    /// the start of the file.
+    ///
+    /// @throws IndexOutOfBoundsException if there is no such row group
+    public long firstRowOf(int rowGroupIndex) {
+        if (rowGroupIndex < 0 || rowGroupIndex >= rowGroupCount()) {
+            throw new IndexOutOfBoundsException("Row group " + rowGroupIndex + " is out of range for "
+                    + displayPath + ", which has " + rowGroupCount() + " row groups");
+        }
+        return rowGroupFirstRows[rowGroupIndex];
+    }
+
+    /// The row group the absolute row index `row` falls in.
+    ///
+    /// Rejects a row past the end rather than clamping to the last row group:
+    /// a position that silently answers with a different one is worse than no
+    /// answer.
+    ///
+    /// @throws IndexOutOfBoundsException if `row` is negative or past the last
+    ///         row of the file
+    public int rowGroupOf(long row) {
+        long totalRows = rowGroupFirstRows[rowGroupFirstRows.length - 1];
+        if (row < 0 || row >= totalRows) {
+            throw new IndexOutOfBoundsException(
+                    "Row " + row + " is out of range for " + displayPath + ", which has " + totalRows + " rows");
+        }
+        return rowGroupOf(rowGroupFirstRows, row);
+    }
+
+    /// The search itself, over the cumulative counts alone, so that the empty
+    /// row groups a foreign writer may leave in a file can be exercised
+    /// without one on disk.
+    static int rowGroupOf(long[] firstRows, long row) {
+        int found = Arrays.binarySearch(firstRows, row);
+        int rowGroupIndex = found >= 0 ? found : -found - 2;
+        // Empty row groups repeat their predecessor's cumulative count, so the
+        // search can land on one; no row is ever inside them.
+        while (firstRows[rowGroupIndex + 1] <= row) {
+            rowGroupIndex++;
+        }
+        return rowGroupIndex;
     }
 
     public ColumnChunk chunk(int rowGroupIndex, int columnIndex) {

--- a/cli/src/main/java/dev/hardwood/cli/dive/ScreenState.java
+++ b/cli/src/main/java/dev/hardwood/cli/dive/ScreenState.java
@@ -292,8 +292,16 @@ public sealed interface ScreenState {
             boolean logicalTypes,
             java.util.Set<Integer> expandedColumns,
             int modalCursorLine,
-            int modalScroll)
+            int modalScroll,
+            JumpPrompt jump)
             implements ScreenState {
+
+        /// The `:` prompt, or `null` while it is closed. `input` is what has
+        /// been typed so far; `error` says why the last `Enter` did not move
+        /// anywhere, and is `null` until one does not.
+        public record JumpPrompt(String input, String error) {
+        }
+
         public DataPreview {
             columnNames = java.util.List.copyOf(columnNames);
             rows = java.util.List.copyOf(rows);
@@ -307,7 +315,17 @@ public sealed interface ScreenState {
                            int columnScroll, int selectedRow, int modalRow, boolean logicalTypes,
                            java.util.Set<Integer> expandedColumns, int modalCursorLine) {
             this(firstRow, pageSize, columnNames, rows, expandedRows, columnScroll, selectedRow,
-                    modalRow, logicalTypes, expandedColumns, modalCursorLine, 0);
+                    modalRow, logicalTypes, expandedColumns, modalCursorLine, 0, null);
+        }
+
+        public DataPreview(long firstRow, int pageSize, java.util.List<String> columnNames,
+                           java.util.List<java.util.List<String>> rows,
+                           java.util.List<java.util.List<String>> expandedRows,
+                           int columnScroll, int selectedRow, int modalRow, boolean logicalTypes,
+                           java.util.Set<Integer> expandedColumns, int modalCursorLine,
+                           int modalScroll) {
+            this(firstRow, pageSize, columnNames, rows, expandedRows, columnScroll, selectedRow,
+                    modalRow, logicalTypes, expandedColumns, modalCursorLine, modalScroll, null);
         }
     }
 }

--- a/cli/src/main/java/dev/hardwood/cli/dive/internal/DataPreviewScreen.java
+++ b/cli/src/main/java/dev/hardwood/cli/dive/internal/DataPreviewScreen.java
@@ -20,7 +20,6 @@ import dev.hardwood.cli.internal.Strings;
 import dev.hardwood.schema.SchemaNode;
 import dev.tamboui.buffer.Buffer;
 import dev.tamboui.layout.Constraint;
-import dev.tamboui.layout.Layout;
 import dev.tamboui.layout.Rect;
 import dev.tamboui.style.Style;
 import dev.tamboui.text.CharWidth;
@@ -48,6 +47,11 @@ public final class DataPreviewScreen {
     private static final int COLUMN_SPACING = 1;
     private static final int MIN_PARTIAL_COLUMN_WIDTH = 8;
     private static final int VALUE_TRUNCATE = 32;
+
+    /// The `:` box: wide enough for the longest refusal it prints, tall
+    /// enough for the input, the hint and the keys, plus two borders.
+    private static final int JUMP_MODAL_WIDTH = 48;
+    private static final int JUMP_MODAL_HEIGHT = 6;
 
     /// A sliding ±10×viewport row window of pre-formatted Data preview
     /// rows. Within-window navigation (PgUp/PgDn that stays inside the
@@ -214,7 +218,7 @@ public final class DataPreviewScreen {
         if (!(stack.top() instanceof ScreenState.DataPreview state) || state.modalRow() >= 0) {
             return;
         }
-        int viewport = viewportRows(body, state.jump() != null);
+        int viewport = viewportRows(body);
         if (state.pageSize() == viewport) {
             return;
         }
@@ -226,21 +230,13 @@ public final class DataPreviewScreen {
 
     /// Block borders (top + bottom) and the header row are 3 cells of chrome
     /// around the data rows.
-    private static int viewportRows(Rect body, boolean promptOpen) {
-        return Math.max(1, body.height() - 3 - (promptOpen ? 1 : 0));
+    private static int viewportRows(Rect body) {
+        return Math.max(1, body.height() - 3);
     }
 
     public static void render(Buffer buffer, Rect area, ParquetModel model, ScreenState.DataPreview state) {
-        Rect tableArea = area;
-        if (state.jump() != null) {
-            List<Rect> split = Layout.vertical()
-                    .constraints(new Constraint.Length(1), new Constraint.Fill(1))
-                    .split(area);
-            renderJumpPrompt(buffer, split.get(0), state.jump());
-            tableArea = split.get(1);
-        }
         Keys.observeDataPreviewArea(area.width(), area.height());
-        Keys.observeViewport(viewportRows(area, state.jump() != null));
+        Keys.observeViewport(viewportRows(area));
         Keys.observeViewportWidth(area.width());
         int columnCount = state.columnNames().size();
         ColumnWindow window = columnWindow(state, area.width());
@@ -287,27 +283,49 @@ public final class DataPreviewScreen {
         if (!state.rows().isEmpty()) {
             tableState.select(Math.min(state.selectedRow(), state.rows().size() - 1));
         }
-        table.render(tableArea, buffer, tableState);
+        table.render(area, buffer, tableState);
         if (state.modalRow() >= 0 && state.modalRow() < state.rows().size()) {
             buffer.setStyle(area, Theme.dim());
             renderRecordModal(buffer, area, model, state);
         }
+        if (state.jump() != null) {
+            buffer.setStyle(area, Theme.dim());
+            renderJumpPrompt(buffer, area, state.jump());
+        }
     }
 
-    /// The `:` prompt line: what has been typed, and — once an `Enter` has
+    /// The `:` prompt, in the same centred bordered box as the record modal
+    /// and the help overlay: what has been typed, and — once an `Enter` has
     /// been refused — why nothing moved.
-    private static void renderJumpPrompt(Buffer buffer, Rect area,
+    private static void renderJumpPrompt(Buffer buffer, Rect screenArea,
                                          ScreenState.DataPreview.JumpPrompt prompt) {
-        Line line = prompt.error() == null
-                ? Line.from(
-                        new Span(" : ", Theme.primary()),
-                        new Span(prompt.input() + "█", Theme.primary()),
-                        new Span("  (row, or rg followed by a row group)", Theme.dim()))
-                : Line.from(
-                        new Span(" : ", Theme.primary()),
-                        new Span(prompt.input() + "█", Theme.primary()),
-                        new Span("  " + prompt.error(), Theme.accent()));
-        Paragraph.builder().text(Text.from(line)).left().build().render(area, buffer);
+        int width = Math.min(JUMP_MODAL_WIDTH, Math.max(1, screenArea.width() - 4));
+        int height = Math.min(JUMP_MODAL_HEIGHT, Math.max(1, screenArea.height()));
+        Rect area = new Rect(
+                screenArea.left() + (screenArea.width() - width) / 2,
+                screenArea.top() + (screenArea.height() - height) / 2,
+                width, height);
+        Clear.INSTANCE.render(area, buffer);
+
+        List<Line> lines = new ArrayList<>();
+        lines.add(Line.from(
+                new Span(" : ", Theme.primary()),
+                new Span(prompt.input() + "\u2588", Theme.primary())));
+        lines.add(Line.empty());
+        lines.add(prompt.error() == null
+                ? Line.from(new Span(" a row, or rg followed by a row group", Theme.dim()))
+                : Line.from(new Span(" " + prompt.error(), Theme.accent())));
+        lines.add(Line.from(new Span(" Enter go \u00b7 Esc cancel", Theme.dim())));
+        Paragraph.builder()
+                .block(Block.builder()
+                        .title(" Jump to ")
+                        .borders(Borders.ALL)
+                        .borderType(BorderType.ROUNDED)
+                        .build())
+                .text(Text.from(lines))
+                .left()
+                .build()
+                .render(area, buffer);
     }
 
     private static void renderRecordModal(Buffer buffer, Rect screenArea, ParquetModel model,
@@ -514,7 +532,9 @@ public final class DataPreviewScreen {
     }
 
     public static String keybarKeys(ScreenState.DataPreview state, ParquetModel model) {
-        if (state.modalRow() >= 0) {
+        // Both boxes carry their own keys, so the keybar stands down while one
+        // of them is open rather than offering keys the box has taken.
+        if (state.modalRow() >= 0 || state.jump() != null) {
             return "";
         }
         long total = model.facts().totalRows();
@@ -528,12 +548,6 @@ public final class DataPreviewScreen {
                 anyLogical = true;
                 break;
             }
-        }
-        if (state.jump() != null) {
-            return new Keys.Hints()
-                    .add(true, "[Enter] go")
-                    .add(true, "[Esc] cancel")
-                    .build();
         }
         return new Keys.Hints()
                 .add(loaded > 1, "[↑↓] row")

--- a/cli/src/main/java/dev/hardwood/cli/dive/internal/DataPreviewScreen.java
+++ b/cli/src/main/java/dev/hardwood/cli/dive/internal/DataPreviewScreen.java
@@ -20,6 +20,7 @@ import dev.hardwood.cli.internal.Strings;
 import dev.hardwood.schema.SchemaNode;
 import dev.tamboui.buffer.Buffer;
 import dev.tamboui.layout.Constraint;
+import dev.tamboui.layout.Layout;
 import dev.tamboui.layout.Rect;
 import dev.tamboui.style.Style;
 import dev.tamboui.text.CharWidth;
@@ -39,9 +40,9 @@ import dev.tamboui.widgets.table.TableState;
 
 /// Projected-row preview. `firstRow` / `pageSize` define which rows are currently
 /// loaded; `←/→` scrolls the visible column window for wide schemas; `PgDn`/`PgUp`
-/// (or `Shift+↓/↑`) flip pages. [ParquetModel#readPreviewPage] maintains a
-/// forward-only cursor across calls, so stepping forward never re-iterates from
-/// row 0 — only backward moves (`PgUp`, `g` jump-to-top) recreate the reader.
+/// (or `Shift+↓/↑`) flip pages; `:` jumps to a row or a row group.
+/// [ParquetModel#readPreviewPage] builds a bounded cursor per call, so any page
+/// costs the same whichever direction the reader moved to reach it.
 public final class DataPreviewScreen {
 
     private static final int COLUMN_SPACING = 1;
@@ -71,11 +72,42 @@ public final class DataPreviewScreen {
         return loadPage(model, 0, pageSize, 0, true);
     }
 
+    /// The screen opened at `firstRow`, with that row selected — what the
+    /// Row groups screens push when the reader asks to see a group's records.
+    public static ScreenState.DataPreview stateAt(ParquetModel model, long firstRow) {
+        return loadPage(model, firstRow, Keys.viewportStride(), 0, true);
+    }
+
+    /// Opens the preview on the first row of `rowGroupIndex`, and reports
+    /// whether it did. What the Row groups screens do with `d`.
+    public static boolean openAtRowGroup(ParquetModel model, NavigationStack stack, int rowGroupIndex) {
+        if (!hasRows(model, rowGroupIndex)) {
+            return false;
+        }
+        stack.push(stateAt(model, model.firstRowOf(rowGroupIndex)));
+        return true;
+    }
+
+    /// Whether a row group has records to show. An empty one starts where its
+    /// successor does, so opening the preview on it would show another
+    /// group's rows under its number.
+    public static boolean hasRows(ParquetModel model, int rowGroupIndex) {
+        return rowGroupIndex >= 0 && rowGroupIndex < model.rowGroupCount()
+                && model.rowGroup(rowGroupIndex).numRows() > 0;
+    }
+
     public static boolean handle(KeyEvent event, ParquetModel model, dev.hardwood.cli.dive.NavigationStack stack) {
         ScreenState.DataPreview state = (ScreenState.DataPreview) stack.top();
         long total = model.facts().totalRows();
         if (state.modalRow() >= 0) {
             return handleModal(event, state, stack, model);
+        }
+        if (state.jump() != null) {
+            return handleJump(event, state, stack, model, total);
+        }
+        if (isJumpPrompt(event)) {
+            stack.replaceTop(withJump(state, new ScreenState.DataPreview.JumpPrompt("", null)));
+            return true;
         }
         // Plain ↑/↓ moves the selected-row cursor inside the current page; Shift+↑/↓
         // pages (handled by the PgDn/PgUp branches below). Enter opens the
@@ -182,23 +214,33 @@ public final class DataPreviewScreen {
         if (!(stack.top() instanceof ScreenState.DataPreview state) || state.modalRow() >= 0) {
             return;
         }
-        int viewport = viewportRows(body);
+        int viewport = viewportRows(body, state.jump() != null);
         if (state.pageSize() == viewport) {
             return;
         }
-        stack.replaceTop(loadPage(model, state.firstRow(), viewport,
-                state.columnScroll(), state.logicalTypes()));
+        // The prompt survives the re-load: it is a mode the reader is in, not
+        // a property of the page, and `loadPage` builds a state without one.
+        stack.replaceTop(withJump(loadPage(model, state.firstRow(), viewport,
+                state.columnScroll(), state.logicalTypes()), state.jump()));
     }
 
     /// Block borders (top + bottom) and the header row are 3 cells of chrome
     /// around the data rows.
-    private static int viewportRows(Rect body) {
-        return Math.max(1, body.height() - 3);
+    private static int viewportRows(Rect body, boolean promptOpen) {
+        return Math.max(1, body.height() - 3 - (promptOpen ? 1 : 0));
     }
 
     public static void render(Buffer buffer, Rect area, ParquetModel model, ScreenState.DataPreview state) {
+        Rect tableArea = area;
+        if (state.jump() != null) {
+            List<Rect> split = Layout.vertical()
+                    .constraints(new Constraint.Length(1), new Constraint.Fill(1))
+                    .split(area);
+            renderJumpPrompt(buffer, split.get(0), state.jump());
+            tableArea = split.get(1);
+        }
         Keys.observeDataPreviewArea(area.width(), area.height());
-        Keys.observeViewport(viewportRows(area));
+        Keys.observeViewport(viewportRows(area, state.jump() != null));
         Keys.observeViewportWidth(area.width());
         int columnCount = state.columnNames().size();
         ColumnWindow window = columnWindow(state, area.width());
@@ -245,11 +287,27 @@ public final class DataPreviewScreen {
         if (!state.rows().isEmpty()) {
             tableState.select(Math.min(state.selectedRow(), state.rows().size() - 1));
         }
-        table.render(area, buffer, tableState);
+        table.render(tableArea, buffer, tableState);
         if (state.modalRow() >= 0 && state.modalRow() < state.rows().size()) {
             buffer.setStyle(area, Theme.dim());
             renderRecordModal(buffer, area, model, state);
         }
+    }
+
+    /// The `:` prompt line: what has been typed, and — once an `Enter` has
+    /// been refused — why nothing moved.
+    private static void renderJumpPrompt(Buffer buffer, Rect area,
+                                         ScreenState.DataPreview.JumpPrompt prompt) {
+        Line line = prompt.error() == null
+                ? Line.from(
+                        new Span(" : ", Theme.primary()),
+                        new Span(prompt.input() + "█", Theme.primary()),
+                        new Span("  (row, or rg followed by a row group)", Theme.dim()))
+                : Line.from(
+                        new Span(" : ", Theme.primary()),
+                        new Span(prompt.input() + "█", Theme.primary()),
+                        new Span("  " + prompt.error(), Theme.accent()));
+        Paragraph.builder().text(Text.from(line)).left().build().render(area, buffer);
     }
 
     private static void renderRecordModal(Buffer buffer, Rect screenArea, ParquetModel model,
@@ -471,6 +529,12 @@ public final class DataPreviewScreen {
                 break;
             }
         }
+        if (state.jump() != null) {
+            return new Keys.Hints()
+                    .add(true, "[Enter] go")
+                    .add(true, "[Esc] cancel")
+                    .build();
+        }
         return new Keys.Hints()
                 .add(loaded > 1, "[↑↓] row")
                 .add(loaded > 0, "[Enter] view record")
@@ -478,8 +542,97 @@ public final class DataPreviewScreen {
                 .add(canPage, "[PgDn/PgUp or Shift+↓↑] page")
                 .add(canPage, "[g/G] start/end")
                 .add(anyLogical, "[t] logical types")
+                .add(total > 1, "[:] jump to row")
                 .add(true, "[Esc] back")
                 .build();
+    }
+
+    private static boolean isJumpPrompt(KeyEvent event) {
+        return event.code() == KeyCode.CHAR && event.character() == ':'
+                && !event.hasCtrl() && !event.hasAlt();
+    }
+
+    /// The `:` prompt. Typing edits the target, `Enter` seeks to it, `Esc`
+    /// closes the prompt and leaves the view where it was. A target outside
+    /// the file leaves the prompt open with the typed text intact and the
+    /// reason under it, rather than seeking to the nearest row that does
+    /// exist.
+    private static boolean handleJump(KeyEvent event, ScreenState.DataPreview state,
+                                      NavigationStack stack, ParquetModel model, long total) {
+        ScreenState.DataPreview.JumpPrompt prompt = state.jump();
+        if (event.isCancel()) {
+            stack.replaceTop(withJump(state, null));
+            return true;
+        }
+        if (event.isConfirm()) {
+            stack.replaceTop(jumped(state, prompt.input(), model, total));
+            return true;
+        }
+        if (event.isDeleteBackward()) {
+            String input = prompt.input();
+            String trimmed = input.isEmpty() ? input : input.substring(0, input.length() - 1);
+            stack.replaceTop(withJump(state, new ScreenState.DataPreview.JumpPrompt(trimmed, null)));
+            return true;
+        }
+        if (event.code() == KeyCode.CHAR) {
+            char c = event.character();
+            if (c >= ' ' && c != 127) {
+                stack.replaceTop(withJump(state,
+                        new ScreenState.DataPreview.JumpPrompt(prompt.input() + c, null)));
+                return true;
+            }
+        }
+        // Every other key is swallowed: a prompt that let PgDn through would
+        // move the view out from under the target being typed.
+        return true;
+    }
+
+    /// Resolves what was typed and either seeks to it, closing the prompt, or
+    /// keeps the prompt open carrying the reason it could not.
+    private static ScreenState.DataPreview jumped(ScreenState.DataPreview state, String input,
+                                                  ParquetModel model, long total) {
+        JumpTarget target = parseJump(input, model, total);
+        if (target.error() != null) {
+            return withJump(state, new ScreenState.DataPreview.JumpPrompt(input, target.error()));
+        }
+        return withJump(moveTo(state, target.row(), model, total, ScrollBias.TOP), null);
+    }
+
+    /// A resolved jump target: an absolute row, or the reason there isn't one.
+    private record JumpTarget(long row, String error) {
+    }
+
+    /// Accepts an absolute row — `120` — or a row group — `rg 1`, `rg1`.
+    /// Both count from zero, as `hardwood print --row-index` and
+    /// `hardwood inspect columns --row-group` do.
+    private static JumpTarget parseJump(String input, ParquetModel model, long total) {
+        String text = input.trim();
+        if (text.isEmpty()) {
+            return new JumpTarget(0, "Type a row, or rg followed by a row group");
+        }
+        boolean byRowGroup = text.length() > 2
+                && (text.charAt(0) == 'r' || text.charAt(0) == 'R')
+                && (text.charAt(1) == 'g' || text.charAt(1) == 'G');
+        String digits = byRowGroup ? text.substring(2).trim() : text;
+        long number;
+        try {
+            number = Long.parseLong(digits);
+        }
+        catch (NumberFormatException e) {
+            return new JumpTarget(0, "Type a row, or rg followed by a row group");
+        }
+        if (byRowGroup) {
+            int rowGroupCount = model.rowGroupCount();
+            if (number < 0 || number >= rowGroupCount) {
+                return new JumpTarget(0, Fmt.fmt("Row group %,d is outside 0–%,d",
+                        number, rowGroupCount - 1));
+            }
+            return new JumpTarget(model.firstRowOf(Math.toIntExact(number)), null);
+        }
+        if (number < 0 || number >= total) {
+            return new JumpTarget(0, Fmt.fmt("Row %,d is outside 0–%,d", number, total - 1));
+        }
+        return new JumpTarget(number, null);
     }
 
     private static boolean handleModal(KeyEvent event, ScreenState.DataPreview state,
@@ -711,6 +864,13 @@ public final class DataPreviewScreen {
             }
         }
         return 0;
+    }
+
+    private static ScreenState.DataPreview withJump(ScreenState.DataPreview s,
+                                                    ScreenState.DataPreview.JumpPrompt jump) {
+        return new ScreenState.DataPreview(s.firstRow(), s.pageSize(), s.columnNames(), s.rows(),
+                s.expandedRows(), s.columnScroll(), s.selectedRow(), s.modalRow(), s.logicalTypes(),
+                s.expandedColumns(), s.modalCursorLine(), s.modalScroll(), jump);
     }
 
     private static ScreenState.DataPreview withColumnScroll(ScreenState.DataPreview s, int scroll) {

--- a/cli/src/main/java/dev/hardwood/cli/dive/internal/HelpOverlay.java
+++ b/cli/src/main/java/dev/hardwood/cli/dive/internal/HelpOverlay.java
@@ -81,6 +81,10 @@ public final class HelpOverlay {
         lines.addAll(kv("← / →", "scroll visible columns", descBudget));
         lines.addAll(kv("Enter", "open / expand the record field", descBudget));
         lines.addAll(kv("e / c", "expand / collapse all fields", descBudget));
+        lines.addAll(kv(":", "jump to a row, or rg N for a row group", descBudget));
+        lines.add(Line.empty());
+        lines.add(Line.from(new Span("Row groups", Theme.accent().bold())));
+        lines.addAll(kv("d", "open the Data preview at this row group", descBudget));
         return lines;
     }
 

--- a/cli/src/main/java/dev/hardwood/cli/dive/internal/Keys.java
+++ b/cli/src/main/java/dev/hardwood/cli/dive/internal/Keys.java
@@ -17,6 +17,13 @@ public final class Keys {
     }
 
     /// `g` (no modifiers): jump to first visible row / page boundary.
+    /// `d` opens the Data preview at the row group under the cursor. Modifier
+    /// free, like the other single-letter keys.
+    public static boolean isOpenDataPreview(KeyEvent event) {
+        return event.code() == KeyCode.CHAR && event.character() == 'd'
+                && !event.hasCtrl() && !event.hasAlt();
+    }
+
     public static boolean isJumpTop(KeyEvent event) {
         return event.code() == KeyCode.CHAR
                 && event.character() == 'g'

--- a/cli/src/main/java/dev/hardwood/cli/dive/internal/RowGroupDetailScreen.java
+++ b/cli/src/main/java/dev/hardwood/cli/dive/internal/RowGroupDetailScreen.java
@@ -67,6 +67,12 @@ public final class RowGroupDetailScreen {
                     state.factsTop()));
             return true;
         }
+        // `d` works from either pane: it is about the row group the screen is
+        // showing, not about what has focus within it.
+        if (Keys.isOpenDataPreview(event)
+                && DataPreviewScreen.openAtRowGroup(model, stack, state.rowGroupIndex())) {
+            return true;
+        }
         if (state.focus() != ScreenState.RowGroupDetail.Pane.MENU) {
             return scrollFacts(event, model, stack, state);
         }
@@ -105,6 +111,7 @@ public final class RowGroupDetailScreen {
                 .add(onMenu && MenuItem.values().length > 1, "[↑↓] move")
                 .add(!onMenu, factsLines(model, state).hints(Keys.viewportStride()))
                 .add(onMenu, "[Enter] open")
+                .add(DataPreviewScreen.hasRows(model, state.rowGroupIndex()), "[d] data")
                 .add(true, "[Esc] back")
                 .build();
     }

--- a/cli/src/main/java/dev/hardwood/cli/dive/internal/RowGroupsScreen.java
+++ b/cli/src/main/java/dev/hardwood/cli/dive/internal/RowGroupsScreen.java
@@ -49,6 +49,10 @@ public final class RowGroupsScreen {
                     state.selection(), ScreenState.RowGroupDetail.Pane.MENU, 0));
             return true;
         }
+        if (Keys.isOpenDataPreview(event)
+                && DataPreviewScreen.openAtRowGroup(model, stack, state.selection())) {
+            return true;
+        }
         return false;
     }
 
@@ -122,6 +126,7 @@ public final class RowGroupsScreen {
         return new Keys.Hints()
                 .add(true, CursorPane.hints(count))
                 .add(count > 0, "[Enter] open")
+                .add(DataPreviewScreen.hasRows(model, state.selection()), "[d] data")
                 .add(true, "[Esc] back")
                 .build();
     }

--- a/cli/src/test/java/dev/hardwood/cli/command/ConvertCommandContract.java
+++ b/cli/src/test/java/dev/hardwood/cli/command/ConvertCommandContract.java
@@ -265,6 +265,38 @@ interface ConvertCommandContract {
     }
 
     @Test
+    default void skipStartsAtTheGivenRow() {
+        Cli.Result result = Cli.launch("convert", "-f", plainFile(), "--format", "csv", "--skip", "2");
+
+        assertThat(result.exitCode()).isZero();
+        assertThat(result.output()).isEqualTo("""
+                id,value
+                3,300""");
+    }
+
+    @Test
+    default void rowGroupConvertsThatGroupOnly() {
+        // filter_pushdown_int.parquet holds three row groups of 100 rows each.
+        Cli.Result result = Cli.launch("convert", "-f", multiRowGroupIntFile(), "--format", "csv",
+                "-c", "id", "--row-group", "2", "-n", "2");
+
+        assertThat(result.exitCode()).isZero();
+        assertThat(result.output()).isEqualTo("""
+                id
+                201
+                202""");
+    }
+
+    @Test
+    default void skipAndRowGroupAreRefusedTogether() {
+        Cli.Result result = Cli.launch("convert", "-f", multiRowGroupIntFile(), "--format", "csv",
+                "--skip", "1", "--row-group", "1");
+
+        assertThat(result.exitCode()).isNotZero();
+        assertThat(result.errorOutput()).contains("--skip and --row-group cannot be combined");
+    }
+
+    @Test
     default void rejectsNonIntegerRowLimit() {
         Cli.Result result = Cli.launch("convert", "-f", plainFile(), "--format", "csv", "-n", "abc");
 

--- a/cli/src/test/java/dev/hardwood/cli/command/PrintCommandContract.java
+++ b/cli/src/test/java/dev/hardwood/cli/command/PrintCommandContract.java
@@ -94,6 +94,109 @@ interface PrintCommandContract {
     }
 
     @Test
+    default void skipStartsAtTheGivenRow() {
+        Cli.Result result = Cli.launch("print", "-f", plainFile(), "--skip", "1");
+
+        assertThat(result.exitCode()).isZero();
+        assertThat(result.output()).isEqualTo("""
+                +----+-------+
+                | id | value |
+                +----+-------+
+                | 2  | 200   |
+                | 3  | 300   |
+                +----+-------+""");
+    }
+
+    @Test
+    default void skipComposesWithHead() {
+        Cli.Result result = Cli.launch("print", "-f", plainFile(), "--skip", "1", "-n", "1");
+
+        assertThat(result.exitCode()).isZero();
+        assertThat(result.output()).isEqualTo("""
+                +----+-------+
+                | id | value |
+                +----+-------+
+                | 2  | 200   |
+                +----+-------+""");
+    }
+
+    @Test
+    default void rowIndexKeepsCountingFromTheFile() {
+        Cli.Result result = Cli.launch("print", "-f", plainFile(), "--skip", "2", "--row-index");
+
+        assertThat(result.exitCode()).isZero();
+        assertThat(result.output()).isEqualTo("""
+                +----------+----+-------+
+                | rowIndex | id | value |
+                +----------+----+-------+
+                | 2        | 3  | 300   |
+                +----------+----+-------+""");
+    }
+
+    @Test
+    default void rowGroupPrintsThatGroupOnly() {
+        // filter_pushdown_int.parquet holds three row groups of 100 rows each.
+        Cli.Result result = Cli.launch("print", "-f", multiRowGroupIntFile(), "--row-group", "1", "-c", "id", "-n", "2");
+
+        assertThat(result.exitCode()).isZero();
+        assertThat(result.output()).isEqualTo("""
+                +-----+
+                | id  |
+                +-----+
+                | 101 |
+                | 102 |
+                +-----+""");
+    }
+
+    @Test
+    default void rowGroupStopsAtTheEndOfTheGroup() {
+        Cli.Result result = Cli.launch("print", "-f", multiRowGroupIntFile(), "--row-group", "0", "-c", "id", "-s", "100");
+
+        assertThat(result.exitCode()).isZero();
+        assertThat(result.output()).contains("| 1   ").contains("| 100 ").doesNotContain("| 101 ");
+    }
+
+    @Test
+    default void rowGroupRejectsAnIndexPastTheLast() {
+        Cli.Result result = Cli.launch("print", "-f", multiRowGroupIntFile(), "--row-group", "3");
+
+        assertThat(result.exitCode()).isOne();
+        assertThat(result.errorOutput()).contains("No such row group: 3 (file has 3)");
+    }
+
+    @Test
+    default void skipRejectsANegativeRow() {
+        Cli.Result result = Cli.launch("print", "-f", plainFile(), "--skip", "-1");
+
+        assertThat(result.exitCode()).isOne();
+        assertThat(result.errorOutput()).contains("Invalid value for option '--skip': expected a non-negative row number, got '-1'");
+    }
+
+    @Test
+    default void skipRejectsARowPastTheLast() {
+        Cli.Result result = Cli.launch("print", "-f", plainFile(), "--skip", "3");
+
+        assertThat(result.exitCode()).isOne();
+        assertThat(result.errorOutput()).contains("Cannot skip 3 rows (file has 3)");
+    }
+
+    @Test
+    default void skipAndRowGroupAreRefusedTogether() {
+        Cli.Result result = Cli.launch("print", "-f", multiRowGroupIntFile(), "--skip", "1", "--row-group", "1");
+
+        assertThat(result.exitCode()).isOne();
+        assertThat(result.errorOutput()).contains("--skip and --row-group cannot be combined");
+    }
+
+    @Test
+    default void skipIsRefusedWithATailLimit() {
+        Cli.Result result = Cli.launch("print", "-f", plainFile(), "--skip", "1", "-n", "-1");
+
+        assertThat(result.exitCode()).isOne();
+        assertThat(result.errorOutput()).contains("A negative '-n' counts the last rows of the file, so it cannot be combined with --skip");
+    }
+
+    @Test
     default void head() {
         Cli.Result result = Cli.launch("print", "-f", plainFile(), "-n", "2");
 

--- a/cli/src/test/java/dev/hardwood/cli/dive/DiveRenderTest.java
+++ b/cli/src/test/java/dev/hardwood/cli/dive/DiveRenderTest.java
@@ -1096,6 +1096,47 @@ class DiveRenderTest {
     }
 
     @Test
+    void jumpPromptShowsWhatWasTypedAndCostsTheTableOneRow() {
+        Rect body = new Rect(0, 0, 120, 20);
+        ScreenState.DataPreview state = DataPreviewScreen.initialState(model, 5);
+        NavigationStack stack = new NavigationStack(ScreenState.Overview.initial());
+        stack.push(state);
+        DataPreviewScreen.handle(new KeyEvent(KeyCode.CHAR, KeyModifiers.NONE, ':'), model, stack);
+        DataPreviewScreen.handle(new KeyEvent(KeyCode.CHAR, KeyModifiers.NONE, '7'), model, stack);
+        DataPreviewScreen.fitToViewport(model, stack, body);
+
+        ScreenState.DataPreview prompting = (ScreenState.DataPreview) stack.top();
+        RenderHarness.RenderedFrame frame = RenderHarness.render(body, prompting, model);
+
+        assertThat(frame.contains(": 7")).as("the typed target is on screen").isTrue();
+        assertThat(frame.contains("rg followed by a row group"))
+                .as("the prompt says what it accepts").isTrue();
+        // Block borders and header take 3 rows, the prompt line a 4th.
+        assertThat(prompting.rows())
+                .as("the prompt costs the table exactly one row")
+                .hasSize(body.height() - 4);
+    }
+
+    @Test
+    void jumpPromptShowsWhyARefusedTargetDidNotMove() {
+        Rect body = new Rect(0, 0, 120, 20);
+        ScreenState.DataPreview state = DataPreviewScreen.initialState(model, 5);
+        NavigationStack stack = new NavigationStack(ScreenState.Overview.initial());
+        stack.push(state);
+        DataPreviewScreen.handle(new KeyEvent(KeyCode.CHAR, KeyModifiers.NONE, ':'), model, stack);
+        for (char c : "99999".toCharArray()) {
+            DataPreviewScreen.handle(new KeyEvent(KeyCode.CHAR, KeyModifiers.NONE, c), model, stack);
+        }
+        DataPreviewScreen.handle(new KeyEvent(KeyCode.ENTER, KeyModifiers.NONE, '\0'), model, stack);
+
+        RenderHarness.RenderedFrame frame = RenderHarness.render(body, stack.top(), model);
+
+        assertThat(frame.contains("Row 99,999 is outside 0–9,999"))
+                .as("the reason is on screen, beside the text that caused it").isTrue();
+        assertThat(frame.contains(": 99999")).as("the typed target is kept").isTrue();
+    }
+
+    @Test
     void overviewFactsPaneKeepsTheKeyValueCursorOnScreen() throws Exception {
         // The facts pane moved a cursor it never scrolled to, so on a short
         // terminal the selected entry could sit below the fold while the

--- a/cli/src/test/java/dev/hardwood/cli/dive/DiveRenderTest.java
+++ b/cli/src/test/java/dev/hardwood/cli/dive/DiveRenderTest.java
@@ -1096,7 +1096,7 @@ class DiveRenderTest {
     }
 
     @Test
-    void jumpPromptShowsWhatWasTypedAndCostsTheTableOneRow() {
+    void jumpPromptShowsWhatWasTypedWithoutTakingTableRows() {
         Rect body = new Rect(0, 0, 120, 20);
         ScreenState.DataPreview state = DataPreviewScreen.initialState(model, 5);
         NavigationStack stack = new NavigationStack(ScreenState.Overview.initial());
@@ -1109,12 +1109,15 @@ class DiveRenderTest {
         RenderHarness.RenderedFrame frame = RenderHarness.render(body, prompting, model);
 
         assertThat(frame.contains(": 7")).as("the typed target is on screen").isTrue();
+        assertThat(frame.contains("Jump to")).as("the box says what it is").isTrue();
         assertThat(frame.contains("rg followed by a row group"))
                 .as("the prompt says what it accepts").isTrue();
-        // Block borders and header take 3 rows, the prompt line a 4th.
+        assertThat(frame.contains("Esc cancel")).as("the box says how to leave it").isTrue();
+        // The box floats over the table, so the page behind it is unchanged:
+        // block borders and the header take 3 rows, and nothing else does.
         assertThat(prompting.rows())
-                .as("the prompt costs the table exactly one row")
-                .hasSize(body.height() - 4);
+                .as("the prompt costs the table no rows")
+                .hasSize(body.height() - 3);
     }
 
     @Test

--- a/cli/src/test/java/dev/hardwood/cli/dive/DiveStateTest.java
+++ b/cli/src/test/java/dev/hardwood/cli/dive/DiveStateTest.java
@@ -1233,7 +1233,226 @@ class DiveStateTest {
         return stack;
     }
 
+    @Test
+    void jumpPromptOpensOnColonAndCollectsTyping() {
+        NavigationStack stack = rooted(DataPreviewScreen.initialState(model, 10));
+
+        type(model, stack, "43");
+
+        assertThat(preview(stack).jump()).isNotNull();
+        assertThat(preview(stack).jump().input()).isEqualTo("43");
+        assertThat(preview(stack).jump().error()).isNull();
+    }
+
+    @Test
+    void jumpPromptBackspaceTrimsTheTypedTarget() {
+        NavigationStack stack = rooted(DataPreviewScreen.initialState(model, 10));
+
+        type(model, stack, "43");
+        DataPreviewScreen.handle(key(KeyCode.BACKSPACE), model, stack);
+
+        assertThat(preview(stack).jump().input()).isEqualTo("4");
+    }
+
+    @Test
+    void jumpPromptEscapeClosesWithoutMoving() {
+        NavigationStack stack = rooted(DataPreviewScreen.initialState(model, 10));
+
+        type(model, stack, "4321");
+        DataPreviewScreen.handle(key(KeyCode.ESCAPE), model, stack);
+
+        assertThat(preview(stack).jump()).as("prompt closed").isNull();
+        assertThat(preview(stack).firstRow()).as("view stayed put").isZero();
+    }
+
+    @Test
+    void jumpToARowSelectsItAtTheTopOfTheViewport() {
+        NavigationStack stack = rooted(DataPreviewScreen.initialState(model, 10));
+
+        type(model, stack, "4321");
+        DataPreviewScreen.handle(key(KeyCode.ENTER), model, stack);
+
+        ScreenState.DataPreview state = preview(stack);
+        assertThat(state.jump()).as("prompt closed on a successful jump").isNull();
+        assertThat(state.firstRow()).isEqualTo(4321L);
+        assertThat(state.selectedRow()).isZero();
+        // `id` in column_index_pushdown.parquet is sorted 0..9999, so the
+        // selected row proves the seek landed on the row that was asked for.
+        assertThat(state.rows().get(0).get(0)).isEqualTo("4321");
+    }
+
+    @Test
+    void jumpToARowPastTheLastIsRefusedAndNothingMoves() {
+        NavigationStack stack = rooted(DataPreviewScreen.initialState(model, 10));
+
+        type(model, stack, "10000");
+        DataPreviewScreen.handle(key(KeyCode.ENTER), model, stack);
+
+        ScreenState.DataPreview state = preview(stack);
+        assertThat(state.jump()).as("prompt stayed open").isNotNull();
+        assertThat(state.jump().input()).as("typed text kept").isEqualTo("10000");
+        assertThat(state.jump().error()).isEqualTo("Row 10,000 is outside 0–9,999");
+        assertThat(state.firstRow()).as("not clamped to the last row").isZero();
+    }
+
+    @Test
+    void jumpToSomethingUnreadableIsRefused() {
+        NavigationStack stack = rooted(DataPreviewScreen.initialState(model, 10));
+
+        type(model, stack, "abc");
+        DataPreviewScreen.handle(key(KeyCode.ENTER), model, stack);
+
+        assertThat(preview(stack).jump().error())
+                .isEqualTo("Type a row, or rg followed by a row group");
+        assertThat(preview(stack).firstRow()).isZero();
+    }
+
+    @Test
+    void jumpWithNothingTypedIsRefused() {
+        NavigationStack stack = rooted(DataPreviewScreen.initialState(model, 10));
+
+        DataPreviewScreen.handle(charKey(':'), model, stack);
+        DataPreviewScreen.handle(key(KeyCode.ENTER), model, stack);
+
+        assertThat(preview(stack).jump().error())
+                .isEqualTo("Type a row, or rg followed by a row group");
+    }
+
+    @Test
+    void jumpPromptSwallowsNavigationKeys() {
+        // A PgDn that reached the table would move the view out from under
+        // the target being typed.
+        NavigationStack stack = rooted(DataPreviewScreen.initialState(model, 10));
+
+        type(model, stack, "43");
+        boolean handled = DataPreviewScreen.handle(key(KeyCode.PAGE_DOWN), model, stack);
+
+        assertThat(handled).isTrue();
+        assertThat(preview(stack).firstRow()).isZero();
+        assertThat(preview(stack).jump().input()).isEqualTo("43");
+    }
+
+    @Test
+    void jumpToARowGroupLandsOnItsFirstRow() throws Exception {
+        // 3 row groups of 100 rows; ids run 1..300.
+        Path file = Path.of(getClass().getResource("/filter_pushdown_int.parquet").getPath());
+        try (ParquetModel rowGroups = ParquetModel.open(InputFile.of(file), file.toString())) {
+            NavigationStack stack = rooted(DataPreviewScreen.initialState(rowGroups, 10));
+
+            type(rowGroups, stack, "rg 2");
+            DataPreviewScreen.handle(key(KeyCode.ENTER), rowGroups, stack);
+
+            ScreenState.DataPreview state = preview(stack);
+            assertThat(state.jump()).isNull();
+            assertThat(state.firstRow()).isEqualTo(200L);
+            assertThat(state.selectedRow()).isZero();
+            assertThat(state.rows().get(0).get(0)).isEqualTo("201");
+        }
+    }
+
+    @Test
+    void jumpToARowGroupAcceptsItWithoutASpace() throws Exception {
+        Path file = Path.of(getClass().getResource("/filter_pushdown_int.parquet").getPath());
+        try (ParquetModel rowGroups = ParquetModel.open(InputFile.of(file), file.toString())) {
+            NavigationStack stack = rooted(DataPreviewScreen.initialState(rowGroups, 10));
+
+            type(rowGroups, stack, "rg1");
+            DataPreviewScreen.handle(key(KeyCode.ENTER), rowGroups, stack);
+
+            assertThat(preview(stack).firstRow()).isEqualTo(100L);
+        }
+    }
+
+    @Test
+    void jumpToARowGroupPastTheLastIsRefused() throws Exception {
+        Path file = Path.of(getClass().getResource("/filter_pushdown_int.parquet").getPath());
+        try (ParquetModel rowGroups = ParquetModel.open(InputFile.of(file), file.toString())) {
+            NavigationStack stack = rooted(DataPreviewScreen.initialState(rowGroups, 10));
+
+            type(rowGroups, stack, "rg 3");
+            DataPreviewScreen.handle(key(KeyCode.ENTER), rowGroups, stack);
+
+            ScreenState.DataPreview state = preview(stack);
+            assertThat(state.jump().error()).isEqualTo("Row group 3 is outside 0–2");
+            assertThat(state.firstRow()).isZero();
+        }
+    }
+
+    @Test
+    void rowGroupsScreenOpensTheDataPreviewAtTheSelectedGroup() throws Exception {
+        // 3 row groups of 100 rows; ids run 1..300.
+        Path file = Path.of(getClass().getResource("/filter_pushdown_int.parquet").getPath());
+        try (ParquetModel rowGroups = ParquetModel.open(InputFile.of(file), file.toString())) {
+            NavigationStack stack = rooted(new ScreenState.RowGroups(0));
+            RowGroupsScreen.handle(key(KeyCode.DOWN), rowGroups, stack);
+
+            boolean handled = RowGroupsScreen.handle(charKey('d'), rowGroups, stack);
+
+            assertThat(handled).isTrue();
+            ScreenState.DataPreview state = preview(stack);
+            assertThat(state.firstRow()).isEqualTo(100L);
+            assertThat(state.selectedRow()).isZero();
+            assertThat(state.rows().get(0).get(0)).isEqualTo("101");
+        }
+    }
+
+    @Test
+    void rowGroupDetailScreenOpensTheDataPreviewAtItsGroup() throws Exception {
+        Path file = Path.of(getClass().getResource("/filter_pushdown_int.parquet").getPath());
+        try (ParquetModel rowGroups = ParquetModel.open(InputFile.of(file), file.toString())) {
+            NavigationStack stack = rooted(new ScreenState.RowGroupDetail(
+                    2, ScreenState.RowGroupDetail.Pane.MENU, 0));
+
+            boolean handled = RowGroupDetailScreen.handle(charKey('d'), rowGroups, stack);
+
+            assertThat(handled).isTrue();
+            assertThat(preview(stack).firstRow()).isEqualTo(200L);
+        }
+    }
+
+    @Test
+    void rowGroupDetailScreenOpensTheDataPreviewFromTheFactsPaneToo() throws Exception {
+        Path file = Path.of(getClass().getResource("/filter_pushdown_int.parquet").getPath());
+        try (ParquetModel rowGroups = ParquetModel.open(InputFile.of(file), file.toString())) {
+            NavigationStack stack = rooted(new ScreenState.RowGroupDetail(
+                    1, ScreenState.RowGroupDetail.Pane.FACTS, 0));
+
+            RowGroupDetailScreen.handle(charKey('d'), rowGroups, stack);
+
+            assertThat(preview(stack).firstRow()).isEqualTo(100L);
+        }
+    }
+
+    @Test
+    void openingTheDataPreviewLeavesTheRowGroupsScreenBehindToReturnTo() throws Exception {
+        Path file = Path.of(getClass().getResource("/filter_pushdown_int.parquet").getPath());
+        try (ParquetModel rowGroups = ParquetModel.open(InputFile.of(file), file.toString())) {
+            NavigationStack stack = rooted(new ScreenState.RowGroups(2));
+
+            RowGroupsScreen.handle(charKey('d'), rowGroups, stack);
+            stack.pop();
+
+            assertThat(stack.top()).isInstanceOf(ScreenState.RowGroups.class);
+        }
+    }
+
     private static KeyEvent key(KeyCode code) {
         return new KeyEvent(code, KeyModifiers.NONE, '\0');
+    }
+
+    private static KeyEvent charKey(char c) {
+        return new KeyEvent(KeyCode.CHAR, KeyModifiers.NONE, c);
+    }
+
+    /// Opens the `:` prompt and types `text` into it, one key at a time.
+    private static void type(ParquetModel model, NavigationStack stack, String text) {
+        DataPreviewScreen.handle(charKey(':'), model, stack);
+        for (int i = 0; i < text.length(); i++) {
+            DataPreviewScreen.handle(charKey(text.charAt(i)), model, stack);
+        }
+    }
+
+    private static ScreenState.DataPreview preview(NavigationStack stack) {
+        return (ScreenState.DataPreview) stack.top();
     }
 }

--- a/cli/src/test/java/dev/hardwood/cli/dive/RowGroupMappingTest.java
+++ b/cli/src/test/java/dev/hardwood/cli/dive/RowGroupMappingTest.java
@@ -1,0 +1,112 @@
+/*
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Copyright The original authors
+ *
+ *  Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package dev.hardwood.cli.dive;
+
+import java.io.IOException;
+import java.nio.file.Path;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import dev.hardwood.InputFile;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/// Covers the row ↔ row group mapping the Data preview jumps through:
+/// [ParquetModel#firstRowOf] and [ParquetModel#rowGroupOf].
+class RowGroupMappingTest {
+
+    /// 3 row groups of 100 rows each: rows 0..99, 100..199, 200..299.
+    private static final String FIXTURE = "filter_pushdown_int.parquet";
+
+    private ParquetModel model;
+
+    @BeforeEach
+    void open() throws IOException {
+        Path path = Path.of(RowGroupMappingTest.class.getResource("/" + FIXTURE).getPath());
+        model = ParquetModel.open(InputFile.of(path), FIXTURE);
+    }
+
+    @AfterEach
+    void close() throws IOException {
+        model.close();
+    }
+
+    @Test
+    void firstRowOfEachRowGroup() {
+        assertThat(model.rowGroupCount()).as("row groups in the fixture").isEqualTo(3);
+        assertThat(model.firstRowOf(0)).as("first row of RG 0").isEqualTo(0L);
+        assertThat(model.firstRowOf(1)).as("first row of RG 1").isEqualTo(100L);
+        assertThat(model.firstRowOf(2)).as("first row of RG 2").isEqualTo(200L);
+    }
+
+    @Test
+    void firstRowOfRejectsARowGroupPastTheLast() {
+        assertThatThrownBy(() -> model.firstRowOf(3))
+                .isInstanceOf(IndexOutOfBoundsException.class)
+                .hasMessage("Row group 3 is out of range for " + FIXTURE + ", which has 3 row groups");
+    }
+
+    @Test
+    void firstRowOfRejectsANegativeRowGroup() {
+        assertThatThrownBy(() -> model.firstRowOf(-1))
+                .isInstanceOf(IndexOutOfBoundsException.class)
+                .hasMessage("Row group -1 is out of range for " + FIXTURE + ", which has 3 row groups");
+    }
+
+    @Test
+    void rowGroupOfPlacesRowsOnBothSidesOfEveryBoundary() {
+        assertThat(model.rowGroupOf(0)).as("row group of row 0").isEqualTo(0);
+        assertThat(model.rowGroupOf(99)).as("row group of row 99").isEqualTo(0);
+        assertThat(model.rowGroupOf(100)).as("row group of row 100").isEqualTo(1);
+        assertThat(model.rowGroupOf(199)).as("row group of row 199").isEqualTo(1);
+        assertThat(model.rowGroupOf(200)).as("row group of row 200").isEqualTo(2);
+        assertThat(model.rowGroupOf(299)).as("row group of the last row").isEqualTo(2);
+    }
+
+    @Test
+    void rowGroupOfRejectsARowPastTheLast() {
+        assertThatThrownBy(() -> model.rowGroupOf(300))
+                .isInstanceOf(IndexOutOfBoundsException.class)
+                .hasMessage("Row 300 is out of range for " + FIXTURE + ", which has 300 rows");
+    }
+
+    @Test
+    void rowGroupOfRejectsANegativeRow() {
+        assertThatThrownBy(() -> model.rowGroupOf(-1))
+                .isInstanceOf(IndexOutOfBoundsException.class)
+                .hasMessage("Row -1 is out of range for " + FIXTURE + ", which has 300 rows");
+    }
+
+    /// An empty row group repeats its predecessor's cumulative count, so the
+    /// binary search can land on one. No row is inside it, and the mapping
+    /// must answer with the row group that actually holds the row.
+    @Test
+    void rowGroupOfSkipsEmptyRowGroups() {
+        // RG 0: rows 0..9, RG 1: empty, RG 2: empty, RG 3: rows 10..19.
+        long[] firstRows = {0, 10, 10, 10, 20};
+
+        assertThat(ParquetModel.rowGroupOf(firstRows, 0)).as("row group of row 0").isEqualTo(0);
+        assertThat(ParquetModel.rowGroupOf(firstRows, 9)).as("row group of row 9").isEqualTo(0);
+        assertThat(ParquetModel.rowGroupOf(firstRows, 10)).as("row group of row 10").isEqualTo(3);
+        assertThat(ParquetModel.rowGroupOf(firstRows, 19)).as("row group of row 19").isEqualTo(3);
+    }
+
+    /// A file whose first row groups are empty: the search lands on index 0
+    /// for row 0, and the walk has to move off it.
+    @Test
+    void rowGroupOfSkipsLeadingEmptyRowGroups() {
+        // RG 0: empty, RG 1: empty, RG 2: rows 0..4.
+        long[] firstRows = {0, 0, 0, 5};
+
+        assertThat(ParquetModel.rowGroupOf(firstRows, 0)).as("row group of row 0").isEqualTo(2);
+        assertThat(ParquetModel.rowGroupOf(firstRows, 4)).as("row group of row 4").isEqualTo(2);
+    }
+}

--- a/docs/content/reference/cli.md
+++ b/docs/content/reference/cli.md
@@ -64,6 +64,12 @@ hardwood print -n -5 -f data.parquet
 # Show all rows
 hardwood print -f data.parquet
 
+# Start at row 5000 (rows are counted from 0)
+hardwood print --skip 5000 -n 20 -f data.parquet
+
+# Show the rows of row group 3 (row groups are counted from 0)
+hardwood print --row-group 3 -f data.parquet
+
 # Convert to CSV
 hardwood convert --format csv -f data.parquet
 
@@ -87,6 +93,9 @@ hardwood convert -n 100 --format json -f data.parquet
 
 # Convert last 50 rows to CSV
 hardwood convert -n -50 --format csv -f data.parquet
+
+# Convert one row group to CSV
+hardwood convert --row-group 3 --format csv -f data.parquet
 
 # Convert to CSV, writing \N for null values
 hardwood convert --format csv --null-string '\N' -f data.parquet

--- a/skills/hardwood-cli/SKILL.md
+++ b/skills/hardwood-cli/SKILL.md
@@ -168,6 +168,12 @@ Row-limit semantics for `-n`/`--rows` (used by both `print` and `convert`):
 positive = first _N_ rows (head), negative = last _N_ rows (tail), `ALL` =
 every row, and `0` is rejected.
 
+`--skip <n>` starts the read at row _n_ and `--row-group <i>` reads that row
+group only, both counted from 0, on `print` and `convert`. They cannot be
+combined with each other, nor with a negative `-n` (which counts from the end
+of the file). `print --row-index` keeps numbering rows by their position in the
+file, so a row number seen in `hardwood dive` reproduces here.
+
 ## Playbook: "why isn't predicate pushdown / file skipping working?"
 
 A query is scanning far more data than expected. The engine skips at two


### PR DESCRIPTION
Closes #1101.

Navigation in the dive Data preview was relative only: reaching a known record meant holding PgDn, and reaching a row group's first record meant adding up numRows() by hand. This adds three ways in, and makes the position reproducible outside the TUI.

- : in the Data preview opens a prompt taking either a row (12345) or a row group (rg 17). Enter seeks so the target is the selected row, Esc leaves the view where it was.
- d on the Row groups and Row group detail screens opens the Data preview at that group's first row, no typing. Enter keeps its existing meaning, so the ▶ marker still marks what Enter acts on.
- --skip <n> and --row-group <i> on print and convert, so a position found in dive can be passed on the command line. print --row-index now numbers rows by their position in the file, so the number carries back.

ParquetModel gains the row ↔ row group mapping (firstRowOf, rowGroupOf) over one prefix array of cumulative row counts, which #1100 can reuse for the preview's row-group indicator. Design doc: _designs/DIVE_JUMP_TO_ROW.md.

Assumptions worth confirming:

1. Zero-based everywhere, following inspect columns --row-group 0 and print --row-index. The preview's title still counts from one (rows 1-20 of 300), so a number copied off the title lands one row late — left to #1100, which revisits that line anyway.
2. : rather than /, since / is inline filter on the Schema, Column index and Dictionary screens; / stays free for a value search over the preview.
3. PreviewWindow needed no invalidation path, contrary to the issue text: its buffer is keyed by an absolute row range and is fully replaced whenever the requested page falls outside it, so an arbitrary seek either lands in a buffer still correct for it or triggers a refill.
4. Nothing is clamped. A row or row group past the end, --skip past the end, and d on an empty row group are all refused with a message — an empty row group starts where its successor does, so opening it would show the next group's rows under the wrong number.
5. --skip/--row-group combine with neither each other nor a negative -n, which counts from the end of the file and so has no starting point to move. With --row-group, a positive -n narrows within the group and never crosses into the next.