### PR TITLE
#1177 Decide every leaf through one statistics abstraction per unit

### DIFF
--- a/_designs/UNIT_STATISTICS_CONVERGENCE.md
+++ b/_designs/UNIT_STATISTICS_CONVERGENCE.md
@@ -1,0 +1,294 @@
+# Design: one statistics abstraction for row group and page filtering (#1177)
+
+**Status: In progress** (stage 1 implemented). Related: #795 (`ALWAYS_MATCH_STATISTICS.md`), #977, #1030, #1107.
+
+## Problem
+
+Row group filtering and page filtering ask the same question at two granularities: what a unit's
+statistics prove about a leaf predicate. Three statistics answer it — min/max, the null count and
+the definition level histogram — and each is carried per column chunk by `ColumnMetaData` and per
+page by the `ColumnIndex`.
+
+A statistic sourced per evaluator rather than per unit has to be written twice, and the two
+granularities then come to prove different things from the same bytes. The row-group side derives
+`ALWAYS_MATCHES`; `PageFilterEvaluator.computeMatchingRows` returns one `RowRanges` and has no way
+to express it.
+
+A third kind of unit sits outside the two evaluators: `SequentialFetchPlan` drops pages from the
+inline `DataPageHeader.statistics` through `PageDropPredicates.canDropPage`, which routes to
+`MinMaxStats.of` alone. A file with no column index reaches page pruning only here.
+
+## The unit
+
+Sourcing resolves *where a statistic came from* once, and each statistic then has one
+implementation of *what it proves*.
+
+```java
+sealed interface UnitStats permits ChunkStats, IndexPageStats, InlinePageStats {
+
+    /// Rows the unit covers, or UNKNOWN_ROW_COUNT when the source does not carry it.
+    long rowCount();
+
+    /// What this unit's statistics prove about one leaf predicate. The single entry point;
+    /// see "What the evaluators share".
+    FilterDecision decide(ResolvedPredicate leaf, LogContext logContext);
+
+    // The statistic decide() routes to, package-private so each can be pinned on its own.
+
+    MinMaxStats minMax(ResolvedPredicate leaf);
+
+    NullStats nulls();
+
+    DefinitionLevelStats definitionLevels();
+
+    /// Narrows the position enclosing the unit to the unit itself — a column for a chunk, a page
+    /// index for a page — for a discard to name.
+    LogContext locate(LogContext enclosing);
+}
+```
+
+| Implementation | Sourced from | `rowCount()` |
+| --- | --- | --- |
+| `ChunkStats` | `ColumnMetaData.statistics()`, `ColumnMetaData.sizeStatistics()` | `RowGroup.numRows()` |
+| `IndexPageStats` | `ColumnIndex` and `OffsetIndex` at one page index | `pages.get(i + 1).firstRowIndex() - pages.get(i).firstRowIndex()`, and `rowGroupRowCount - firstRowIndex` for the last page |
+| `InlinePageStats` | `DataPageHeader.statistics()` | `DataPageHeaderV2.numRows()`; `UNKNOWN_ROW_COUNT` for a v1 header, which carries `num_values` only |
+
+`UNKNOWN_ROW_COUNT` is `-1`. Every proof that needs a row count yields `MIGHT_MATCH` without one,
+so a v1 inline header proves no more than its min/max.
+
+Sourcing absorbs the guards against statistics that are not there: a column ordinal the row group
+does not carry, absent `ColumnMetaData`, absent `Statistics`, an absent null count or histogram. A
+unit that cannot be sourced is a unit whose every statistic is unknown. `PageFilterEvaluator` keeps
+its own column ordinal check and absent-`ColumnIndexBuffers` check, since it needs the parsed
+indexes to know how many page units there are.
+
+## The three statistics
+
+Each statistic answers a `FilterDecision`.
+
+### Min/max
+
+`UnitStats.minMax(leaf)` is the entry point, and the static factories `MinMaxStats.of` and
+`MinMaxStats.ofPage` are the sourcing step of `ChunkStats` and `IndexPageStats`. `InlinePageStats`
+decodes the same `Statistics` shape as `ChunkStats`.
+
+`MinMaxStats` keeps its own null count. `decideLeaf` composes the interval proof with a proven-zero
+null count, and splitting that conjunction across two objects would return null rows to a caller
+that asked for a value. The copy cannot disagree with `NullStats`, both being sourced from the same
+unit in the same call.
+
+### Null counts
+
+`NullStats` carries the unit's null count and answers a **leaf** null predicate, one whose
+`definitionLevel` equals its `leafDefinitionLevel`:
+
+- `IS NULL` is `CANNOT_MATCH` on `nullCount == 0`.
+- `IS NOT NULL` is `CANNOT_MATCH` on `nullCount == rowCount`, and `ALWAYS_MATCHES` on
+  `nullCount == 0`.
+- A value predicate is `CANNOT_MATCH` on `nullCount == rowCount`, since a null satisfies none of
+  them, `NOT_EQ` included. It is tested before the min/max, which on a page the column index
+  flags null-only are placeholders rather than bounds.
+- `IS NULL` is `ALWAYS_MATCHES` on `nullCount == rowCount`.
+
+The last rule arrives in stage 3; the others hold from stage 1. The rules reading
+`nullCount == rowCount` are sound for a leaf predicate because
+`FilterPredicateResolver.rejectRepeated` refuses a repeated column to a directly named leaf, value
+predicates included, so the unit writes exactly one entry per row and a null count equal to the
+row count accounts for all of them.
+
+**A group predicate must not reach these rules.** `FilterPredicateResolver.resolveNullTarget`
+answers a group from a leaf below it, chosen by `leafToAnswerFrom`, and that leaf is repeated
+whenever the group is a `LIST` or a `MAP` with no non-repeated leaf beneath it — `rejectRepeated`
+runs on the directly-named-leaf branch only. Two things then fail at once. A null count tallies
+every entry below `leafDefinitionLevel`, which is the group being absent *or* the group being
+present with a null below it, so `nullCount == rowCount` does not prove the group absent; that
+conflation is the reason the definition level histogram was introduced. And a repeated leaf writes
+one entry per element, so the row count is not the entry count and the comparison means nothing in
+either direction.
+
+On the page side `ColumnIndex.nullPages()[i]` is the same fact as `nullCount == rowCount` for that
+page, and the two must agree. `IndexPageStats` sources the null count from `nullCounts()` and treats
+a set `nullPages` entry as `nullCount == rowCount()`, so one rule serves both.
+
+### Definition level histograms
+
+`DefinitionLevelStats` carries one histogram, holding one bucket per definition level up to the
+leaf's maximum. A null predicate on a node in the leaf's path splits the buckets at the node's own
+level: everything below was written with the node absent, everything at or above with it present.
+
+- `CANNOT_MATCH` when no bucket on the predicate's side of the split holds an entry.
+- `ALWAYS_MATCHES` when no bucket on the other side holds an entry **and** the histogram totals
+  `rowCount()` entries, which is what makes "every entry" mean "every row".
+- `MIGHT_MATCH` when the file omits the histogram, or wrote one whose length is not
+  `leafDefinitionLevel + 1`.
+
+A leaf null predicate is the group case with `definitionLevel == leafDefinitionLevel`: `IS NULL`
+then scans buckets `[0, leafDefinitionLevel)` and `IS NOT NULL` scans the single bucket at
+`leafDefinitionLevel`. So one histogram rule serves both, and the routing is:
+
+> A group predicate is answered from `definitionLevels()` alone, and is `MIGHT_MATCH` where the
+> histogram is absent or ill-formed. A leaf predicate is answered from `definitionLevels()` where
+> the histogram is present and well-formed, and falls back to `nulls()` otherwise.
+
+The gate is `definitionLevel < leafDefinitionLevel`, which `group()` on the two null predicates
+tests, because it is what makes the fallback legitimate. It is tested once, in `UnitStats.decide`,
+which both evaluators call.
+
+Preferring the histogram for a leaf predicate counts entries directly, where the null-count rules
+reach the same answer by way of the non-repeated-leaf argument above.
+
+The length guard is load-bearing once leaf predicates take this path.
+`ResolvedPredicate.IsNotNullPredicate.ofLeaf` fabricates both definition levels as `0` for a caller
+holding no schema, and a histogram indexed at a fabricated level would answer about the wrong node.
+A histogram whose length is not `leafDefinitionLevel + 1` is therefore refused before it is read,
+which sends every such predicate to `nulls()` — safe, because a fabricated pair is equal and so
+names a leaf.
+
+## What the evaluators share
+
+Sourcing converges the statistics. It does not merge the evaluators, and only one part of them is
+shared.
+
+**The leaf decision is shared.** Which statistic answers which predicate shape is written once, in
+a single method both evaluators hand every leaf to:
+
+```java
+FilterDecision decide(ResolvedPredicate leaf, LogContext logContext);
+```
+
+`decide` names every leaf predicate type, so a new one does not compile until it states which
+statistic answers it — in particular whether a null can satisfy it, which is what the value rule
+on `nullCount == rowCount` rests on.
+
+`minMax()`, `nulls()` and `definitionLevels()` are the internals of it, package-private for the
+tests that pin each statistic on its own. `PageDropPredicates.canDropPage` is the third caller, and
+routing through `decide` is what turns its boolean drop into the same three-valued answer.
+
+`decide` builds only what its branch reads: one statistic for a null predicate, the null count and
+the min/max for a value predicate. A unit is constructed per page per leaf, so a thousand-page
+column chunk builds a thousand of them.
+
+**The recursion is not shared.** `AND` and `OR` fold to one `FilterDecision` on the row-group side
+and to a pair of `RowRanges` on the page side. The two are the same fold over different algebras;
+the page fold works on `RowRanges` directly, so each evaluator keeps its own.
+
+**Absence probes are not shared.** Bloom filters and dictionaries are row-group scoped; Parquet
+carries no per-page equivalent. They stay in `RowGroupFilterEvaluator`, applied on top of the
+statistics decision, and consolidate within that class rather than across the two. Geospatial
+statistics are the same case: `GeospatialStatistics` lives on `ColumnMetaData` alone, so
+`IndexPageStats` reports it unknown and `GeospatialPredicate` stays a row-group-only decision.
+
+Each evaluator therefore holds its recursion and its own sources of absence, and no
+per-predicate-shape leaf dispatch. `PageFilterEvaluator` has one per-page loop for every leaf, and
+its `switch` names no null predicate; `decide` routes them.
+
+## Three-valued page filtering
+
+The asymmetry the issue asks about is not inherent to page filtering. Everything downstream of the
+page evaluator already carries a per-page always-match flag:
+
+- `ColumnWorker` fills `filterAlwaysMatchesBuffer[slot]` per page, and publishes the current batch
+  when a page's flag differs from the batch's, so batches are already split on the boundary.
+- `SequentialFetchPlan` already threads a `RowRanges` per column and asks it `overlapsPage(first,
+  last)` and `maskForPage(first, last)`.
+- `PageInfo` already carries the resulting `PageRowMask`.
+
+Only the producer is missing. `PageFilterEvaluator.computeMatchingRows` returns one `RowRanges` and
+collapses every statistic to a boolean drop.
+
+### Two range sets
+
+`computeMatchingRows` returns `matching` and `alwaysMatching`, with `alwaysMatching ⊆ matching`.
+Each leaf fills two `boolean[]` from the per-page `FilterDecision` — `keep` on anything but
+`CANNOT_MATCH`, `always` on `ALWAYS_MATCHES` — and both become `RowRanges` through
+`RowRanges.fromPages`.
+
+Composition is `FilterDecision.and` and `or` lifted to sets, which `RowRanges` already implements:
+
+| | `matching` | `alwaysMatching` |
+| --- | --- | --- |
+| `AND` | `intersect` | `intersect` |
+| `OR` | `union` | `union` |
+
+### Threading it down
+
+`alwaysMatching` travels the path `matching` already takes:
+`RowGroupIterator.SharedRowGroupMetadata` → `SequentialFetchPlan` → `PageInfo`.
+
+`RowRanges` gains `containsPage(long pageFirstRow, long pageLastRow)`, the full-containment
+counterpart of `overlapsPage`. A page is flagged when its whole row span is contained, which is
+conservative for a masked page and needs no reasoning about which rows the mask kept.
+
+`PageInfo` gains `alwaysMatches()`. `ColumnWorker` reads the flag from the `PageInfo` in hand rather
+than from `pageSource.isCurrentFilterAlwaysMatches()`, so the value is fixed by the plan that
+produced the page.
+
+The row-group decision seeds the page decision instead of being the only source of it: an
+`ALWAYS_MATCHES` row group marks every page, and a `MIGHT_MATCH` row group can still have most of
+its pages marked. This is #1107's argument one level down, and it is the follow-up
+`ALWAYS_MATCH_STATISTICS.md` records under "Boundaries".
+
+## What becomes reachable
+
+Each of these is computable from statistics the reader already parses. A cell names the stage that
+brings the proof to that unit, or `prior` where the unit had it before this design. Every staged
+cell is an existing rule reaching a unit it did not have, except `IS NULL` `ALWAYS_MATCHES`, which
+is a new rule.
+
+| Proof | Row group | Page |
+| --- | --- | --- |
+| value leaf `ALWAYS_MATCHES` from min/max and a zero null count | prior | stage 2 |
+| value leaf `CANNOT_MATCH` from `nullCount == rowCount` | stage 1 | prior, as `nullPages` |
+| `IS NOT NULL` `ALWAYS_MATCHES` from `nullCount == 0` | prior | stage 2 |
+| `IS NULL` `CANNOT_MATCH` from `nullCount == 0` | prior | prior |
+| `IS NOT NULL` `CANNOT_MATCH` from `nullCount == rowCount` | prior | prior, as `nullPages` |
+| `IS NULL` `ALWAYS_MATCHES` from `nullCount == rowCount`, leaf predicates only | stage 3 | stage 3 |
+| group null `CANNOT_MATCH` from the histogram | prior | prior |
+| group null `ALWAYS_MATCHES` from the histogram and the row count | prior | stage 2 |
+
+Floating-point value leaves remain a deliberate non-promise at both granularities: NaN sits outside
+the min/max ordering and `nan_count` is not consumed (#898).
+
+## Observability
+
+`RowGroupFilterEvent.rowGroupsFullyMatching` reports the row-group half. `PageFilterEvent` gains
+`pagesFullyMatching` alongside `pagesKept` and `pagesSkipped`, emitted from the same site in
+`RowGroupIterator`.
+
+## Implementation stages
+
+1. **Sourcing.** Introduce `UnitStats`, `NullStats` and `DefinitionLevelStats` over `ChunkStats`
+   and `IndexPageStats`. Both evaluators consult them, and a leaf null predicate is answered from
+   `nulls()` alone. It changes the reach of one proof, the table's `stage 1` cell: the value leaf
+   `CANNOT_MATCH` on `nullCount == rowCount`, which the page side applies and the shared routing
+   hands to row groups with it. Every other proof holds as before, and the existing assertions
+   pass unchanged; that is the acceptance criterion.
+2. **Three-valued page filtering.** Two `RowRanges` out of `PageFilterEvaluator`,
+   `RowRanges.containsPage`, `PageInfo.alwaysMatches()`, `PageFilterEvent.pagesFullyMatching`.
+   `InlinePageStats` joins here, which is what gives a file with no column index the same proofs.
+   The table's `stage 2` cells arrive with it, and none of them is a new rule:
+   `MinMaxStats.decideLeaf`, the `nullCount == 0` rule and the histogram rule are all written and
+   reach a page unit for the first time. The channel and what flows through it land together, so
+   each is tested by the other.
+3. **`IS NULL` proven in full.** `ALWAYS_MATCHES` on `nullCount == rowCount` for a leaf predicate,
+   the one row of the table that is a new rule. Leaf null predicates start preferring
+   `definitionLevels()` here, since a well-formed histogram proves the same thing by counting
+   entries. It is independent of stage 2, being a rule `NullStats` gains rather than a unit it
+   reaches.
+
+Stage 1 carries one tripwire beyond the existing suite: a group null predicate on a `LIST`, against
+a file carrying no definition level histogram, must stay `MIGHT_MATCH` at both granularities. That
+is the case where the leaf is repeated and the null count answers a different question, and it is
+the one a fallback written the obvious way gets wrong.
+
+## Boundaries
+
+- **`ColumnReader` / `SelectionEngine`.** `computeSelection` has an every-record fast path;
+  feeding it from a page-level proof is the remaining half of the #795 follow-up and is not part
+  of this work.
+- **Bloom filters and dictionaries** prove absence only, are row-group scoped, and stay outside
+  `UnitStats`. `RowGroupFilterEvaluator` keeps applying them after the statistics decision.
+- **Geospatial statistics** live on `ColumnMetaData` alone, so `GeospatialPredicate` has no page
+  unit to source. It stays a row-group-only decision and `IndexPageStats` reports it unknown.
+- **`nan_count`** would let a floating-point leaf promise a full match. It is parsed and written
+  but not consumed; consuming it is #898 and lands as a fourth statistic on `UnitStats`.

--- a/core/src/main/java/dev/hardwood/internal/predicate/DefinitionLevelStats.java
+++ b/core/src/main/java/dev/hardwood/internal/predicate/DefinitionLevelStats.java
@@ -1,0 +1,90 @@
+/*
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Copyright The original authors
+ *
+ *  Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package dev.hardwood.internal.predicate;
+
+/// One unit's definition level histogram, and what it proves about a null predicate on a node in
+/// the leaf's path — the only statistic that separates an absent group from a present one whose
+/// children are null.
+///
+/// The histogram holds one bucket per definition level up to the leaf's maximum, counting the
+/// entries written at that level. A null predicate on a node splits the buckets at the node's own
+/// level: everything below was written with the node absent, everything at or above with it
+/// present.
+///
+/// @param histogram the unit's histogram, or `null` where the file omits it
+/// @param rowCount the number of rows the unit covers, or [UnitStats#UNKNOWN_ROW_COUNT]
+record DefinitionLevelStats(long[] histogram, long rowCount) {
+
+    /// `IS NULL` on the node present at or above `definitionLevel`, which the entries below it
+    /// match.
+    FilterDecision decideIsNull(int definitionLevel, int leafDefinitionLevel) {
+        if (!sizedFor(leafDefinitionLevel)) {
+            return FilterDecision.MIGHT_MATCH;
+        }
+        return decide(hasEntryIn(0, definitionLevel), hasEntryIn(definitionLevel, histogram.length));
+    }
+
+    /// `IS NOT NULL` on the node present at or above `definitionLevel`, which the entries at or
+    /// above it match.
+    FilterDecision decideIsNotNull(int definitionLevel, int leafDefinitionLevel) {
+        if (!sizedFor(leafDefinitionLevel)) {
+            return FilterDecision.MIGHT_MATCH;
+        }
+        return decide(hasEntryIn(definitionLevel, histogram.length), hasEntryIn(0, definitionLevel));
+    }
+
+    /// Whether the file wrote a histogram for a leaf at `leafDefinitionLevel`, one bucket per
+    /// level up to it. A histogram it omits, or wrote at another length, proves nothing.
+    private boolean sizedFor(int leafDefinitionLevel) {
+        return histogram != null && histogram.length == leafDefinitionLevel + 1;
+    }
+
+    /// The decision, given whether the histogram counts an entry on the predicate's side of the
+    /// split and on the other side.
+    ///
+    /// A unit with no entry on the predicate's side cannot match: a row with the node absent
+    /// writes one entry below the split into every leaf beneath it, so no such entry means no
+    /// such row.
+    ///
+    /// One whose every entry is on the predicate's side matches throughout — but only where the
+    /// histogram accounts for exactly one entry per row, since otherwise "every entry" is not
+    /// "every row". A non-repeated leaf writes one entry per row; a leaf below a `LIST` or a
+    /// `MAP` writes one per element, so the row count is what separates the two rather than the
+    /// schema.
+    private FilterDecision decide(boolean matchingEntry, boolean otherEntry) {
+        if (!matchingEntry) {
+            return FilterDecision.CANNOT_MATCH;
+        }
+
+        return !otherEntry && rowCount >= 0 && totalEntries() == rowCount
+                ? FilterDecision.ALWAYS_MATCHES
+                : FilterDecision.MIGHT_MATCH;
+    }
+
+    /// Whether any bucket from level `from` up to, but excluding, level `to` counts an entry.
+    private boolean hasEntryIn(int from, int to) {
+        for (int level = from; level < to; level++) {
+            if (histogram[level] > 0) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /// The number of leaf entries the histogram accounts for.
+    private long totalEntries() {
+        long total = 0;
+
+        for (long count : histogram) {
+            total += count;
+        }
+
+        return total;
+    }
+}

--- a/core/src/main/java/dev/hardwood/internal/predicate/MinMaxStats.java
+++ b/core/src/main/java/dev/hardwood/internal/predicate/MinMaxStats.java
@@ -107,10 +107,10 @@ sealed interface MinMaxStats {
     /// Truncated (inexact) bounds are safe by construction: they only widen the interval,
     /// and a predicate satisfied by the widened interval is satisfied by the actual values.
     ///
-    /// `IS NULL` and `IS NOT NULL` are not value predicates and do not come here.
-    /// [RowGroupFilterEvaluator] decides them from the null count against the row count,
-    /// which lets it drop a wholly-null row group — something this cannot see, holding no
-    /// row count of its own.
+    /// `IS NULL` and `IS NOT NULL` are not value predicates and do not come here. [UnitStats]
+    /// decides them from the null count or the definition level histogram, and drops a unit
+    /// null on every row from the null count against the unit's row count before these bounds
+    /// are consulted — something this cannot see, holding no row count of its own.
     default FilterDecision decideLeaf(ResolvedPredicate leaf) {
         if (canDrop(leaf)) {
             return FilterDecision.CANNOT_MATCH;

--- a/core/src/main/java/dev/hardwood/internal/predicate/NullStats.java
+++ b/core/src/main/java/dev/hardwood/internal/predicate/NullStats.java
@@ -1,0 +1,48 @@
+/*
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Copyright The original authors
+ *
+ *  Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package dev.hardwood.internal.predicate;
+
+/// One unit's null count, and what it proves about a predicate on the leaf column itself.
+///
+/// [FilterPredicateResolver] refuses a repeated column to a directly named leaf, so such a leaf
+/// writes exactly one entry per row, and its null count is a count of rows. That is what lets
+/// the count be held against the unit's row count at all. A null predicate on an enclosing group
+/// is answered from a leaf that may be repeated, where it does not hold, and goes to
+/// [DefinitionLevelStats] instead; [UnitStats#decide] is what keeps it from reaching here.
+///
+/// @param nullCount the number of null entries in the unit, or [#UNKNOWN_NULL_COUNT]
+/// @param rowCount the number of rows the unit covers, or [UnitStats#UNKNOWN_ROW_COUNT]
+record NullStats(long nullCount, long rowCount) {
+
+    /// The null count of a unit whose source does not carry one.
+    static final long UNKNOWN_NULL_COUNT = -1;
+
+    /// Whether the unit is proven to hold no nulls.
+    boolean noNulls() {
+        return nullCount == 0;
+    }
+
+    /// Whether the unit is proven to be null on every row.
+    boolean allNull() {
+        return rowCount >= 0 && nullCount == rowCount;
+    }
+
+    /// `IS NULL` on the leaf, which no row matches where no entry is null.
+    FilterDecision decideIsNull() {
+        return noNulls() ? FilterDecision.CANNOT_MATCH : FilterDecision.MIGHT_MATCH;
+    }
+
+    /// `IS NOT NULL` on the leaf, which no row matches where every row is null, and every row
+    /// matches where none is.
+    FilterDecision decideIsNotNull() {
+        if (allNull()) {
+            return FilterDecision.CANNOT_MATCH;
+        }
+        return noNulls() ? FilterDecision.ALWAYS_MATCHES : FilterDecision.MIGHT_MATCH;
+    }
+}

--- a/core/src/main/java/dev/hardwood/internal/predicate/PageFilterEvaluator.java
+++ b/core/src/main/java/dev/hardwood/internal/predicate/PageFilterEvaluator.java
@@ -16,6 +16,7 @@ import dev.hardwood.internal.thrift.ColumnIndexReader;
 import dev.hardwood.internal.thrift.OffsetIndexReader;
 import dev.hardwood.internal.thrift.ThriftCompactReader;
 import dev.hardwood.metadata.ColumnIndex;
+import dev.hardwood.metadata.ColumnMetaData;
 import dev.hardwood.metadata.OffsetIndex;
 import dev.hardwood.metadata.PageLocation;
 import dev.hardwood.metadata.RowGroup;
@@ -28,8 +29,9 @@ import dev.hardwood.reader.ParquetReadException;
 /// decides whether an entire row group can be skipped, this class determines which
 /// pages within a surviving row group can be skipped.
 ///
-/// Leaf predicate evaluation is delegated to [MinMaxStats#canDrop], which decodes each page's
-/// bounds once and answers for the leaf they were decoded for.
+/// Each leaf is decided page by page through [UnitStats#decide], the same decision
+/// [RowGroupFilterEvaluator] asks of a column chunk, and a page is kept unless it is
+/// [FilterDecision#CANNOT_MATCH].
 ///
 /// When the `ColumnIndex` is absent, this evaluator returns `RowRanges.all()` — page
 /// skipping then happens per-column inside [dev.hardwood.internal.reader.SequentialFetchPlan]
@@ -37,7 +39,7 @@ import dev.hardwood.reader.ParquetReadException;
 public class PageFilterEvaluator {
 
     /// Computes the row ranges within a row group that might match the given predicate,
-    /// based on per-page min/max statistics from the Column Index.
+    /// based on per-page statistics from the Column Index.
     ///
     /// Returns `RowRanges.all()` when the Column Index is absent or the predicate
     /// cannot be evaluated at the page level (conservative fallback).
@@ -72,10 +74,6 @@ public class PageFilterEvaluator {
                 }
                 yield (result != null) ? result : RowRanges.all(rowCount);
             }
-            case ResolvedPredicate.IsNullPredicate p -> evaluateNullPages(p.columnIndex(), p.definitionLevel(),
-                    p.leafDefinitionLevel(), true, rowGroup, indexBuffers, rowCount);
-            case ResolvedPredicate.IsNotNullPredicate p -> evaluateNullPages(p.columnIndex(), p.definitionLevel(),
-                    p.leafDefinitionLevel(), false, rowGroup, indexBuffers, rowCount);
             // Parquet has no per-page geospatial statistics (GeospatialStatistics lives only on
             // ColumnMetaData, applied during row-group filtering), so no page-level pruning is possible.
             case ResolvedPredicate.GeospatialPredicate ignored -> RowRanges.all(rowCount);
@@ -83,12 +81,12 @@ public class PageFilterEvaluator {
         };
     }
 
-    /// Evaluates a leaf predicate against per-page Column Index statistics,
-    /// using [MinMaxStats#canDrop] for the actual comparison.
-    private static RowRanges evaluateLeafPages(ResolvedPredicate predicate, RowGroup rowGroup,
+    /// Evaluates a leaf predicate against the Column Index of the column it tests, keeping every
+    /// page where the column has none.
+    private static RowRanges evaluateLeafPages(ResolvedPredicate leaf, RowGroup rowGroup,
             RowGroupIndexBuffers indexBuffers, long rowCount, LogContext logContext, BoundsReadability readability) {
 
-        int columnIndex = ResolvedPredicate.leafColumnIndex(predicate);
+        int columnIndex = ResolvedPredicate.leafColumnIndex(leaf);
         if (columnIndex < 0 || columnIndex >= rowGroup.columns().size()) {
             return RowRanges.all(rowCount);
         }
@@ -99,143 +97,31 @@ public class PageFilterEvaluator {
         }
 
         IndexPair indexPair = readIndexPair(colBuffers, columnIndex);
-        ColumnIndex columnIdx = indexPair.columnIndex;
-        OffsetIndex offsetIdx = indexPair.offsetIndex;
 
-        List<PageLocation> pages = offsetIdx.pageLocations();
-        int pageCount = pages.size();
-        boolean[] keep = new boolean[pageCount];
+        ColumnMetaData metaData = rowGroup.columns().get(columnIndex).metaData();
+        LogContext columnContext = metaData == null ? logContext : logContext.withColumn(metaData.pathInSchema());
 
-        LogContext columnContext = logContext.withColumn(
-                rowGroup.columns().get(columnIndex).metaData().pathInSchema());
-
-        for (int i = 0; i < pageCount; i++) {
-            if (columnIdx.nullPages()[i]) {
-                continue;
-            }
-            MinMaxStats pageStats = MinMaxStats.ofPage(columnIdx, i, predicate, readability);
-            pageStats.reportIfDiscarded(columnContext.withPageIndex(i));
-            keep[i] = !pageStats.canDrop(predicate);
-        }
-
-        return RowRanges.fromPages(pages, keep, rowCount);
+        return evaluatePages(indexPair.columnIndex, indexPair.offsetIndex, rowCount, leaf, columnContext,
+                readability);
     }
 
-    /// Evaluates IS NULL / IS NOT NULL predicates against per-page null information
-    /// from the Column Index to produce [RowRanges] representing rows that might match.
+    /// Decides a leaf page by page over a pre-parsed Column Index and Offset Index, keeping every
+    /// page the decision does not rule out. Used by [#evaluateLeafPages] and directly by tests.
     ///
-    /// A predicate on an enclosing group is answered from the per-page definition level histogram
-    /// instead, which is the only per-page statistic that separates an absent group from a present
-    /// one. A page whose histogram the file omits, or wrote at a length that does not match the
-    /// column, is kept.
-    ///
-    /// @param columnIndex         the leaf column to check
-    /// @param definitionLevel     the level at or above which the tested node is present
-    /// @param leafDefinitionLevel the leaf column's maximum definition level
-    /// @param seekingNulls        `true` for IS NULL (keep pages that might contain nulls),
-    ///                            `false` for IS NOT NULL (keep pages that might contain non-nulls)
-    /// @param rowGroup            the row group being evaluated
-    /// @param indexBuffers        pre-fetched index buffers
-    /// @param rowCount            total rows in the row group
-    /// @return row ranges that might contain matching rows
-    private static RowRanges evaluateNullPages(int columnIndex, int definitionLevel, int leafDefinitionLevel,
-            boolean seekingNulls, RowGroup rowGroup, RowGroupIndexBuffers indexBuffers, long rowCount) {
-
-        if (columnIndex < 0 || columnIndex >= rowGroup.columns().size()) {
-            return RowRanges.all(rowCount);
-        }
-
-        ColumnIndexBuffers colBuffers = indexBuffers.forColumn(columnIndex);
-        if (colBuffers == null || colBuffers.columnIndex() == null || colBuffers.offsetIndex() == null) {
-            return RowRanges.all(rowCount);
-        }
-
-        IndexPair indexPair = readIndexPair(colBuffers, columnIndex);
-        ColumnIndex columnIdx = indexPair.columnIndex;
-        OffsetIndex offsetIdx = indexPair.offsetIndex;
-
-        List<PageLocation> pages = offsetIdx.pageLocations();
-        int pageCount = pages.size();
-        boolean[] keep = new boolean[pageCount];
-
-        if (definitionLevel < leafDefinitionLevel) {
-            for (int i = 0; i < pageCount; i++) {
-                long[] histogram = columnIdx.definitionLevelHistogram(i);
-                keep[i] = histogram == null
-                        || histogram.length != leafDefinitionLevel + 1
-                        || hasEntryOnSideOf(histogram, definitionLevel, seekingNulls);
-            }
-
-            return RowRanges.fromPages(pages, keep, rowCount);
-        }
-
-        long[] nullCounts = columnIdx.nullCounts();
-
-        for (int i = 0; i < pageCount; i++) {
-            if (seekingNulls) {
-                // IS NULL: keep page if it might contain nulls
-                // Drop page only if we KNOW it has no nulls (nullCounts[i] == 0)
-                if (nullCounts != null && nullCounts[i] == 0) {
-                    keep[i] = false;
-                }
-                else {
-                    keep[i] = true;
-                }
-            }
-            else {
-                // IS NOT NULL: keep page if it might contain non-nulls
-                // Drop page if nullPages[i] == true (entire page is null)
-                keep[i] = !columnIdx.nullPages()[i];
-            }
-        }
-
-        return RowRanges.fromPages(pages, keep, rowCount);
-    }
-
-    /// Whether `histogram` counts an entry on the side of `definitionLevel` a null predicate
-    /// matches: below it for IS NULL, at or above it for IS NOT NULL.
-    ///
-    /// A definition level histogram holds one bucket per level up to the leaf's maximum, counting
-    /// the entries written at that level. A null predicate on a node in the leaf's path splits
-    /// those buckets at the node's own level: everything below was written with the node absent,
-    /// everything at or above with it present. No entry on the matching side proves no row
-    /// matches, which is what lets a page be dropped.
-    private static boolean hasEntryOnSideOf(long[] histogram, int definitionLevel, boolean seekingNulls) {
-        int from = seekingNulls ? 0 : definitionLevel;
-        int to = seekingNulls ? definitionLevel : histogram.length;
-
-        for (int level = from; level < to; level++) {
-            if (histogram[level] > 0) {
-                return true;
-            }
-        }
-
-        return false;
-    }
-
-    /// Evaluates a keep bitmap for pages using pre-parsed Column Index and Offset Index.
-    /// Used by [#evaluateLeafPages] and directly by tests.
-    static RowRanges evaluatePages(ColumnIndex columnIdx, OffsetIndex offsetIdx,
-            long rowCount, PageCanDropTest canDropTest) {
+    /// @param columnContext the column chunk the two indexes describe, which each page narrows
+    ///        to itself to report bounds it had to discard
+    static RowRanges evaluatePages(ColumnIndex columnIdx, OffsetIndex offsetIdx, long rowCount,
+            ResolvedPredicate leaf, LogContext columnContext, BoundsReadability readability) {
         List<PageLocation> pages = offsetIdx.pageLocations();
         int pageCount = pages.size();
         boolean[] keep = new boolean[pageCount];
 
         for (int i = 0; i < pageCount; i++) {
-            if (columnIdx.nullPages()[i]) {
-                continue;
-            }
-            keep[i] = !canDropTest.canDrop(columnIdx, i);
+            UnitStats page = UnitStats.IndexPageStats.of(columnIdx, pages, i, rowCount, readability);
+            keep[i] = page.decide(leaf, columnContext) != FilterDecision.CANNOT_MATCH;
         }
 
         return RowRanges.fromPages(pages, keep, rowCount);
-    }
-
-    /// Functional interface for testing whether a page can be dropped based on its
-    /// Column Index min/max values.
-    @FunctionalInterface
-    interface PageCanDropTest {
-        boolean canDrop(ColumnIndex columnIndex, int pageIndex);
     }
 
     /// Parses one column chunk's `ColumnIndex` and `OffsetIndex` together.

--- a/core/src/main/java/dev/hardwood/internal/predicate/RowGroupFilterEvaluator.java
+++ b/core/src/main/java/dev/hardwood/internal/predicate/RowGroupFilterEvaluator.java
@@ -18,8 +18,6 @@ import dev.hardwood.metadata.BoundingBox;
 import dev.hardwood.metadata.ColumnMetaData;
 import dev.hardwood.metadata.GeospatialStatistics;
 import dev.hardwood.metadata.RowGroup;
-import dev.hardwood.metadata.SizeStatistics;
-import dev.hardwood.metadata.Statistics;
 import dev.hardwood.reader.FilterPredicate;
 
 /// Evaluates filter predicates against row group statistics and bloom filters to determine
@@ -180,12 +178,10 @@ public class RowGroupFilterEvaluator {
                 }
                 yield decision;
             }
-            case ResolvedPredicate.IsNullPredicate p -> p.group()
-                    ? groupNullDecision(p.columnIndex(), p.definitionLevel(), p.leafDefinitionLevel(), true, rowGroup)
-                    : leafIsNullDecision(rowGroup, p.columnIndex());
-            case ResolvedPredicate.IsNotNullPredicate p -> p.group()
-                    ? groupNullDecision(p.columnIndex(), p.definitionLevel(), p.leafDefinitionLevel(), false, rowGroup)
-                    : leafIsNotNullDecision(rowGroup, p.columnIndex());
+            case ResolvedPredicate.IsNullPredicate p ->
+                    statisticsDecision(p, rowGroup, logContext, p.columnIndex(), readability);
+            case ResolvedPredicate.IsNotNullPredicate p ->
+                    statisticsDecision(p, rowGroup, logContext, p.columnIndex(), readability);
             case ResolvedPredicate.And a -> {
                 if (a.children().isEmpty()) {
                     yield FilterDecision.MIGHT_MATCH;
@@ -292,138 +288,13 @@ public class RowGroupFilterEvaluator {
         return decision;
     }
 
-    /// The column's min/max statistics decision for the leaf, [FilterDecision#MIGHT_MATCH]
-    /// when statistics are absent — or when their bounds are unusable, which [MinMaxStats]
-    /// decides and this reports.
+    /// What the column chunk's statistics prove about the leaf; [UnitStats#decide] says which
+    /// statistic answers which leaf. [FilterDecision#MIGHT_MATCH] when the chunk carries none
+    /// that apply — or when its bounds are unusable, which [MinMaxStats] decides and the unit
+    /// reports.
     private static FilterDecision statisticsDecision(ResolvedPredicate leaf, RowGroup rowGroup,
             LogContext logContext, int columnIndex, BoundsReadability readability) {
-        Statistics stats = getStatistics(rowGroup, columnIndex);
-        if (stats == null) {
-            return FilterDecision.MIGHT_MATCH;
-        }
-        MinMaxStats minMax = MinMaxStats.of(stats, leaf, readability);
-        minMax.reportIfDiscarded(logContext.withColumn(
-                rowGroup.columns().get(columnIndex).metaData().pathInSchema()));
-        return minMax.decideLeaf(leaf);
-    }
-
-    /// Decides IS NULL on a leaf column from its null count.
-    ///
-    /// Can drop IS NULL if the null count is known to be 0 (no nulls exist). The always-matching
-    /// dual (every row null) is deliberately not derived: for nested columns the null count tallies
-    /// leaf values, not rows, so nullCount == numRows does not prove every row's leaf is null.
-    private static FilterDecision leafIsNullDecision(RowGroup rowGroup, int columnIndex) {
-        Statistics stats = getStatistics(rowGroup, columnIndex);
-        return stats != null && stats.nullCount() != null && stats.nullCount() == 0
-                ? FilterDecision.CANNOT_MATCH
-                : FilterDecision.MIGHT_MATCH;
-    }
-
-    /// Decides IS NOT NULL on a leaf column from its null count.
-    private static FilterDecision leafIsNotNullDecision(RowGroup rowGroup, int columnIndex) {
-        Statistics stats = getStatistics(rowGroup, columnIndex);
-        if (stats == null || stats.nullCount() == null) {
-            return FilterDecision.MIGHT_MATCH;
-        }
-        // Can drop IS NOT NULL if all values are null (nullCount == numRows)
-        if (stats.nullCount() == rowGroup.numRows()) {
-            return FilterDecision.CANNOT_MATCH;
-        }
-        return stats.nullCount() == 0
-                ? FilterDecision.ALWAYS_MATCHES
-                : FilterDecision.MIGHT_MATCH;
-    }
-
-    /// Decides a null predicate on a group enclosing the leaf column from the chunk's definition
-    /// level histogram, the only column chunk statistic that separates an absent group from a
-    /// present one whose children are null.
-    ///
-    /// A chunk with no entry on the predicate's side of the split cannot match: a row whose group
-    /// is absent writes one entry below the split into every leaf under it, so no such entry means
-    /// no such row.
-    ///
-    /// One whose every entry is on the matching side matches throughout, which lets the read skip
-    /// per-row evaluation for the whole row group — but only where the histogram accounts for
-    /// exactly one entry per row, since otherwise "every entry" is not "every row". A non-repeated
-    /// leaf writes one entry per row; a leaf below a `LIST` or a `MAP` writes one per element, so
-    /// the row count is what separates the two rather than the schema. A histogram totalling
-    /// anything else is not read as proof.
-    ///
-    /// A file that omits the histogram, or wrote one at a length that does not match the column,
-    /// leaves the row group undecided.
-    private static FilterDecision groupNullDecision(int columnIndex, int definitionLevel,
-            int leafDefinitionLevel, boolean seekingNulls, RowGroup rowGroup) {
-
-        long[] histogram = definitionLevelHistogram(rowGroup, columnIndex);
-
-        if (histogram == null || histogram.length != leafDefinitionLevel + 1) {
-            return FilterDecision.MIGHT_MATCH;
-        }
-
-        if (!hasEntryOnSideOf(histogram, definitionLevel, seekingNulls)) {
-            return FilterDecision.CANNOT_MATCH;
-        }
-
-        return !hasEntryOnSideOf(histogram, definitionLevel, !seekingNulls)
-                && totalEntries(histogram) == rowGroup.numRows()
-                        ? FilterDecision.ALWAYS_MATCHES
-                        : FilterDecision.MIGHT_MATCH;
-    }
-
-    /// Whether `histogram` counts an entry on the side of `definitionLevel` a null predicate
-    /// matches: below it for IS NULL, at or above it for IS NOT NULL.
-    ///
-    /// A definition level histogram holds one bucket per level up to the leaf's maximum, counting
-    /// the entries written at that level. A null predicate on a node in the leaf's path splits
-    /// those buckets at the node's own level: everything below was written with the node absent,
-    /// everything at or above with it present.
-    private static boolean hasEntryOnSideOf(long[] histogram, int definitionLevel, boolean seekingNulls) {
-        int from = seekingNulls ? 0 : definitionLevel;
-        int to = seekingNulls ? definitionLevel : histogram.length;
-
-        for (int level = from; level < to; level++) {
-            if (histogram[level] > 0) {
-                return true;
-            }
-        }
-
-        return false;
-    }
-
-    /// The number of leaf entries `histogram` accounts for.
-    private static long totalEntries(long[] histogram) {
-        long total = 0;
-
-        for (long count : histogram) {
-            total += count;
-        }
-
-        return total;
-    }
-
-    /// Gets a column's definition level histogram by its pre-resolved index.
-    /// Returns null if the column index is out of bounds or the file omits size statistics.
-    private static long[] definitionLevelHistogram(RowGroup rowGroup, int columnIndex) {
-        if (columnIndex < 0 || columnIndex >= rowGroup.columns().size()) {
-            return null;
-        }
-
-        ColumnMetaData metadata = rowGroup.columns().get(columnIndex).metaData();
-        if (metadata == null) {
-            return null;
-        }
-
-        SizeStatistics sizeStatistics = metadata.sizeStatistics();
-        return sizeStatistics == null ? null : sizeStatistics.definitionLevelHistogram();
-    }
-
-    /// Gets statistics for a column by its pre-resolved index.
-    /// Returns null if the column index is out of bounds or statistics are absent.
-    private static Statistics getStatistics(RowGroup rowGroup, int columnIndex) {
-        if (columnIndex < 0 || columnIndex >= rowGroup.columns().size()) {
-            return null;
-        }
-        return rowGroup.columns().get(columnIndex).metaData().statistics();
+        return UnitStats.ChunkStats.of(rowGroup, columnIndex, readability).decide(leaf, logContext);
     }
 
     /// Resolves the column's bloom filter, or `null` when no source is supplied or the column

--- a/core/src/main/java/dev/hardwood/internal/predicate/UnitStats.java
+++ b/core/src/main/java/dev/hardwood/internal/predicate/UnitStats.java
@@ -1,0 +1,219 @@
+/*
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Copyright The original authors
+ *
+ *  Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package dev.hardwood.internal.predicate;
+
+import java.util.List;
+
+import dev.hardwood.metadata.ColumnIndex;
+import dev.hardwood.metadata.ColumnMetaData;
+import dev.hardwood.metadata.PageLocation;
+import dev.hardwood.metadata.RowGroup;
+import dev.hardwood.metadata.SizeStatistics;
+import dev.hardwood.metadata.Statistics;
+
+/// The statistics one unit of a column carries — a column chunk, or a single page of one — and
+/// what they prove about a leaf predicate.
+///
+/// Each implementation resolves where the unit's statistics come from. What each statistic
+/// proves is written once, in [MinMaxStats], [NullStats] and [DefinitionLevelStats], and which
+/// of them answers which predicate is written once, in [#decide]. [RowGroupFilterEvaluator] and
+/// [PageFilterEvaluator] both ask [#decide], so the two prove the same things from the same
+/// statistics.
+///
+/// A unit that cannot be sourced — a column the row group does not carry, or one it carries no
+/// metadata for — is a unit whose every statistic is unknown, and it proves nothing.
+///
+/// Bloom filters, dictionaries and geospatial statistics are not statistics of a unit: Parquet
+/// carries them per column chunk only, and [RowGroupFilterEvaluator] applies them itself.
+sealed interface UnitStats {
+
+    /// The row count of a unit whose source does not carry one. Every proof that needs a row
+    /// count yields [FilterDecision#MIGHT_MATCH] without one.
+    long UNKNOWN_ROW_COUNT = -1;
+
+    /// The number of rows the unit covers, or [#UNKNOWN_ROW_COUNT].
+    long rowCount();
+
+    /// The unit's min/max statistics, decoded as `leaf` reads them.
+    MinMaxStats minMax(ResolvedPredicate leaf);
+
+    /// The unit's null count.
+    NullStats nulls();
+
+    /// The unit's definition level histogram.
+    DefinitionLevelStats definitionLevels();
+
+    /// Narrows `enclosing`, the position of whatever holds this unit, to the unit itself.
+    LogContext locate(LogContext enclosing);
+
+    /// What this unit's statistics prove about one leaf predicate.
+    ///
+    /// A null predicate on a group enclosing the leaf is answered from [#definitionLevels]
+    /// alone. The leaf it is answered from may be repeated, and then its null count tallies
+    /// absent groups and null elements alike, over more entries than there are rows, so neither
+    /// null count rule holds for it.
+    ///
+    /// A null predicate on the leaf itself is answered from [#nulls].
+    ///
+    /// A value predicate cannot match a unit that is null on every row, since a null satisfies
+    /// none of them, `NOT_EQ` included. Otherwise it is answered from [#minMax]. Every value
+    /// predicate type is named here rather than reached by a `default`, so a new one does not
+    /// compile until it is placed — and a predicate a null can satisfy must not be placed with
+    /// these.
+    ///
+    /// @param leaf a leaf predicate; `AND` and `OR` are folded by the evaluators
+    /// @param logContext the position enclosing this unit, which the unit narrows to itself to
+    ///        report bounds it had to discard
+    default FilterDecision decide(ResolvedPredicate leaf, LogContext logContext) {
+        return switch (leaf) {
+            case ResolvedPredicate.IsNullPredicate p -> p.group()
+                    ? definitionLevels().decideIsNull(p.definitionLevel(), p.leafDefinitionLevel())
+                    : nulls().decideIsNull();
+            case ResolvedPredicate.IsNotNullPredicate p -> p.group()
+                    ? definitionLevels().decideIsNotNull(p.definitionLevel(), p.leafDefinitionLevel())
+                    : nulls().decideIsNotNull();
+            case ResolvedPredicate.IntPredicate ignored -> decideValue(leaf, logContext);
+            case ResolvedPredicate.LongPredicate ignored -> decideValue(leaf, logContext);
+            case ResolvedPredicate.UnsignedIntPredicate ignored -> decideValue(leaf, logContext);
+            case ResolvedPredicate.UnsignedLongPredicate ignored -> decideValue(leaf, logContext);
+            case ResolvedPredicate.FloatPredicate ignored -> decideValue(leaf, logContext);
+            case ResolvedPredicate.Float16Predicate ignored -> decideValue(leaf, logContext);
+            case ResolvedPredicate.DoublePredicate ignored -> decideValue(leaf, logContext);
+            case ResolvedPredicate.BooleanPredicate ignored -> decideValue(leaf, logContext);
+            case ResolvedPredicate.BinaryPredicate ignored -> decideValue(leaf, logContext);
+            case ResolvedPredicate.IntInPredicate ignored -> decideValue(leaf, logContext);
+            case ResolvedPredicate.LongInPredicate ignored -> decideValue(leaf, logContext);
+            case ResolvedPredicate.UnsignedIntInPredicate ignored -> decideValue(leaf, logContext);
+            case ResolvedPredicate.UnsignedLongInPredicate ignored -> decideValue(leaf, logContext);
+            case ResolvedPredicate.BinaryInPredicate ignored -> decideValue(leaf, logContext);
+            case ResolvedPredicate.DoubleInPredicate ignored -> decideValue(leaf, logContext);
+            case ResolvedPredicate.Float16InPredicate ignored -> decideValue(leaf, logContext);
+            // Geospatial statistics sit on the column chunk's metadata alone, outside any unit.
+            case ResolvedPredicate.GeospatialPredicate ignored -> FilterDecision.MIGHT_MATCH;
+            case ResolvedPredicate.And ignored -> throw notALeaf(leaf);
+            case ResolvedPredicate.Or ignored -> throw notALeaf(leaf);
+        };
+    }
+
+    private FilterDecision decideValue(ResolvedPredicate leaf, LogContext logContext) {
+        if (nulls().allNull()) {
+            return FilterDecision.CANNOT_MATCH;
+        }
+        MinMaxStats minMax = minMax(leaf);
+        minMax.reportIfDiscarded(locate(logContext));
+        return minMax.decideLeaf(leaf);
+    }
+
+    private static IllegalArgumentException notALeaf(ResolvedPredicate predicate) {
+        return new IllegalArgumentException(
+                "Unit statistics decide a leaf predicate, not " + predicate.getClass().getSimpleName());
+    }
+
+    // ==================== Sourcing ====================
+
+    /// A column chunk, sourced from its [ColumnMetaData].
+    ///
+    /// @param metaData the chunk's metadata, or `null` where there is none to source from
+    /// @param rowCount the row group's row count
+    record ChunkStats(ColumnMetaData metaData, long rowCount, BoundsReadability readability)
+            implements UnitStats {
+
+        /// The chunk of the leaf column at `columnIndex` in `rowGroup`.
+        static ChunkStats of(RowGroup rowGroup, int columnIndex, BoundsReadability readability) {
+            ColumnMetaData metaData = columnIndex >= 0 && columnIndex < rowGroup.columns().size()
+                    ? rowGroup.columns().get(columnIndex).metaData()
+                    : null;
+            return new ChunkStats(metaData, rowGroup.numRows(), readability);
+        }
+
+        @Override
+        public MinMaxStats minMax(ResolvedPredicate leaf) {
+            Statistics statistics = statistics();
+            return statistics == null
+                    ? new MinMaxStats.NullCountOnlyStats(null, null)
+                    : MinMaxStats.of(statistics, leaf, readability);
+        }
+
+        @Override
+        public NullStats nulls() {
+            Statistics statistics = statistics();
+            Long nullCount = statistics == null ? null : statistics.nullCount();
+            return new NullStats(nullCount == null ? NullStats.UNKNOWN_NULL_COUNT : nullCount, rowCount);
+        }
+
+        @Override
+        public DefinitionLevelStats definitionLevels() {
+            SizeStatistics sizeStatistics = metaData == null ? null : metaData.sizeStatistics();
+            return new DefinitionLevelStats(
+                    sizeStatistics == null ? null : sizeStatistics.definitionLevelHistogram(), rowCount);
+        }
+
+        @Override
+        public LogContext locate(LogContext enclosing) {
+            return metaData == null ? enclosing : enclosing.withColumn(metaData.pathInSchema());
+        }
+
+        private Statistics statistics() {
+            return metaData == null ? null : metaData.statistics();
+        }
+    }
+
+    /// One page of a column chunk, sourced from the chunk's [ColumnIndex] at the page's position.
+    ///
+    /// A page the index flags as null-only is null on every row, so its null count is its row
+    /// count: the flag and the count state the same fact, and one rule serves both. Its
+    /// `min_values` and `max_values` entries are placeholders rather than bounds, and are not
+    /// decoded.
+    ///
+    /// @param rowCount the rows from this page's first row up to the next page's, or up to the
+    ///        row group's end for the last page
+    record IndexPageStats(ColumnIndex columnIndex, int pageIndex, long rowCount,
+            BoundsReadability readability) implements UnitStats {
+
+        /// Page `pageIndex` of the column chunk that `columnIndex` describes and `pages` locates.
+        static IndexPageStats of(ColumnIndex columnIndex, List<PageLocation> pages, int pageIndex,
+                long rowGroupRowCount, BoundsReadability readability) {
+            long firstRow = pages.get(pageIndex).firstRowIndex();
+            long endRow = pageIndex + 1 < pages.size()
+                    ? pages.get(pageIndex + 1).firstRowIndex()
+                    : rowGroupRowCount;
+            return new IndexPageStats(columnIndex, pageIndex, endRow - firstRow, readability);
+        }
+
+        @Override
+        public MinMaxStats minMax(ResolvedPredicate leaf) {
+            return nullPage()
+                    ? new MinMaxStats.NullCountOnlyStats(rowCount, null)
+                    : MinMaxStats.ofPage(columnIndex, pageIndex, leaf, readability);
+        }
+
+        @Override
+        public NullStats nulls() {
+            if (nullPage()) {
+                return new NullStats(rowCount, rowCount);
+            }
+            long[] nullCounts = columnIndex.nullCounts();
+            return new NullStats(nullCounts == null ? NullStats.UNKNOWN_NULL_COUNT : nullCounts[pageIndex],
+                    rowCount);
+        }
+
+        @Override
+        public DefinitionLevelStats definitionLevels() {
+            return new DefinitionLevelStats(columnIndex.definitionLevelHistogram(pageIndex), rowCount);
+        }
+
+        @Override
+        public LogContext locate(LogContext enclosing) {
+            return enclosing.withPageIndex(pageIndex);
+        }
+
+        private boolean nullPage() {
+            return columnIndex.nullPages()[pageIndex];
+        }
+    }
+}

--- a/core/src/test/java/dev/hardwood/internal/predicate/PageFilterEvaluatorTest.java
+++ b/core/src/test/java/dev/hardwood/internal/predicate/PageFilterEvaluatorTest.java
@@ -24,6 +24,7 @@ import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 
 import dev.hardwood.InputFile;
+import dev.hardwood.internal.ExceptionContext;
 import dev.hardwood.internal.reader.ParquetMetadataReader;
 import dev.hardwood.internal.reader.RowGroupIndexBuffers;
 import dev.hardwood.internal.reader.RowRanges;
@@ -53,6 +54,10 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class PageFilterEvaluatorTest {
 
+    /// A position with nothing to point at: the cases using it assert decisions, not diagnostics.
+    private static final LogContext UNNAMED =
+            new LogContext(null, ExceptionContext.UNKNOWN_ROW_GROUP);
+
     @RegisterExtension
     final CapturedWarnings warnings = new CapturedWarnings();
 
@@ -68,12 +73,8 @@ class PageFilterEvaluatorTest {
     @ParameterizedTest(name = "{0} {1} → pages kept: [{2}, {3}, {4}]")
     @MethodSource
     void testIntPageFiltering(Operator op, int value, boolean page0Kept, boolean page1Kept, boolean page2Kept) {
-        RowRanges ranges = PageFilterEvaluator.evaluatePages(INT_COLUMN_INDEX, THREE_PAGE_OFFSET_INDEX, THREE_PAGE_ROW_COUNT,
-                (columnIndex, pageIndex) -> {
-                    int min = StatisticsDecoder.decodeInt(columnIndex.minValues().get(pageIndex));
-                    int max = StatisticsDecoder.decodeInt(columnIndex.maxValues().get(pageIndex));
-                    return StatisticsFilterSupport.canDrop(op, value, min, max);
-                });
+        RowRanges ranges = evaluatePages(INT_COLUMN_INDEX, THREE_PAGE_OFFSET_INDEX, THREE_PAGE_ROW_COUNT,
+                new ResolvedPredicate.IntPredicate(0, op, value));
 
         assertEquals(page0Kept, ranges.overlapsPage(0, 30),  "page 0 (rows 0-30)");
         assertEquals(page1Kept, ranges.overlapsPage(30, 60), "page 1 (rows 30-60)");
@@ -117,12 +118,8 @@ class PageFilterEvaluatorTest {
 
     @Test
     void testAllPagesMatch() {
-        RowRanges ranges = PageFilterEvaluator.evaluatePages(INT_COLUMN_INDEX, THREE_PAGE_OFFSET_INDEX, THREE_PAGE_ROW_COUNT,
-                (columnIndex, pageIndex) -> {
-                    int min = StatisticsDecoder.decodeInt(columnIndex.minValues().get(pageIndex));
-                    int max = StatisticsDecoder.decodeInt(columnIndex.maxValues().get(pageIndex));
-                    return StatisticsFilterSupport.canDrop(Operator.GT, 0, min, max);
-                });
+        RowRanges ranges = evaluatePages(INT_COLUMN_INDEX, THREE_PAGE_OFFSET_INDEX, THREE_PAGE_ROW_COUNT,
+                new ResolvedPredicate.IntPredicate(0, Operator.GT, 0));
 
         assertEquals(1, ranges.intervalCount());
         assertTrue(ranges.overlapsPage(0, 90));
@@ -130,12 +127,8 @@ class PageFilterEvaluatorTest {
 
     @Test
     void testNoPagesMatch() {
-        RowRanges ranges = PageFilterEvaluator.evaluatePages(INT_COLUMN_INDEX, THREE_PAGE_OFFSET_INDEX, THREE_PAGE_ROW_COUNT,
-                (columnIndex, pageIndex) -> {
-                    int min = StatisticsDecoder.decodeInt(columnIndex.minValues().get(pageIndex));
-                    int max = StatisticsDecoder.decodeInt(columnIndex.maxValues().get(pageIndex));
-                    return StatisticsFilterSupport.canDrop(Operator.GT, 100, min, max);
-                });
+        RowRanges ranges = evaluatePages(INT_COLUMN_INDEX, THREE_PAGE_OFFSET_INDEX, THREE_PAGE_ROW_COUNT,
+                new ResolvedPredicate.IntPredicate(0, Operator.GT, 100));
 
         assertEquals(0, ranges.intervalCount());
     }
@@ -150,12 +143,8 @@ class PageFilterEvaluatorTest {
                 ColumnIndex.BoundaryOrder.UNORDERED,
                 null, null, null, null);
 
-        RowRanges ranges = PageFilterEvaluator.evaluatePages(nullPageColumnIndex, THREE_PAGE_OFFSET_INDEX, THREE_PAGE_ROW_COUNT,
-                (columnIndex, pageIndex) -> {
-                    int min = StatisticsDecoder.decodeInt(columnIndex.minValues().get(pageIndex));
-                    int max = StatisticsDecoder.decodeInt(columnIndex.maxValues().get(pageIndex));
-                    return StatisticsFilterSupport.canDrop(Operator.GT, 0, min, max);
-                });
+        RowRanges ranges = evaluatePages(nullPageColumnIndex, THREE_PAGE_OFFSET_INDEX, THREE_PAGE_ROW_COUNT,
+                new ResolvedPredicate.IntPredicate(0, Operator.GT, 0));
 
         assertTrue(ranges.overlapsPage(0, 30));
         assertFalse(ranges.overlapsPage(30, 60));
@@ -174,12 +163,8 @@ class PageFilterEvaluatorTest {
     @ParameterizedTest(name = "{0} {1} → pages kept: [{2}, {3}]")
     @MethodSource
     void testLongPageFiltering(Operator op, long value, boolean page0Kept, boolean page1Kept) {
-        RowRanges ranges = PageFilterEvaluator.evaluatePages(LONG_COLUMN_INDEX, TWO_PAGE_OFFSET_INDEX, TWO_PAGE_ROW_COUNT,
-                (columnIndex, pageIndex) -> {
-                    long min = StatisticsDecoder.decodeLong(columnIndex.minValues().get(pageIndex));
-                    long max = StatisticsDecoder.decodeLong(columnIndex.maxValues().get(pageIndex));
-                    return StatisticsFilterSupport.canDrop(op, value, min, max);
-                });
+        RowRanges ranges = evaluatePages(LONG_COLUMN_INDEX, TWO_PAGE_OFFSET_INDEX, TWO_PAGE_ROW_COUNT,
+                new ResolvedPredicate.LongPredicate(0, op, value));
 
         assertEquals(page0Kept, ranges.overlapsPage(0, 50),  "page 0 (rows 0-50)");
         assertEquals(page1Kept, ranges.overlapsPage(50, 100), "page 1 (rows 50-100)");
@@ -212,12 +197,8 @@ class PageFilterEvaluatorTest {
     @ParameterizedTest(name = "{0} {1} → pages kept: [{2}, {3}]")
     @MethodSource
     void testFloatPageFiltering(Operator op, float value, boolean page0Kept, boolean page1Kept) {
-        RowRanges ranges = PageFilterEvaluator.evaluatePages(FLOAT_COLUMN_INDEX, TWO_PAGE_OFFSET_INDEX, TWO_PAGE_ROW_COUNT,
-                (columnIndex, pageIndex) -> {
-                    float min = StatisticsDecoder.decodeFloat(columnIndex.minValues().get(pageIndex));
-                    float max = StatisticsDecoder.decodeFloat(columnIndex.maxValues().get(pageIndex));
-                    return StatisticsFilterSupport.canDropFloat(op, value, min, max, false);
-                });
+        RowRanges ranges = evaluatePages(FLOAT_COLUMN_INDEX, TWO_PAGE_OFFSET_INDEX, TWO_PAGE_ROW_COUNT,
+                new ResolvedPredicate.FloatPredicate(0, op, value));
 
         assertEquals(page0Kept, ranges.overlapsPage(0, 50),  "page 0 (rows 0-50)");
         assertEquals(page1Kept, ranges.overlapsPage(50, 100), "page 1 (rows 50-100)");
@@ -250,12 +231,8 @@ class PageFilterEvaluatorTest {
     @ParameterizedTest(name = "{0} {1} → pages kept: [{2}, {3}]")
     @MethodSource
     void testDoublePageFiltering(Operator op, double value, boolean page0Kept, boolean page1Kept) {
-        RowRanges ranges = PageFilterEvaluator.evaluatePages(DOUBLE_COLUMN_INDEX, TWO_PAGE_OFFSET_INDEX, TWO_PAGE_ROW_COUNT,
-                (columnIndex, pageIndex) -> {
-                    double min = StatisticsDecoder.decodeDouble(columnIndex.minValues().get(pageIndex));
-                    double max = StatisticsDecoder.decodeDouble(columnIndex.maxValues().get(pageIndex));
-                    return StatisticsFilterSupport.canDropDouble(op, value, min, max, false);
-                });
+        RowRanges ranges = evaluatePages(DOUBLE_COLUMN_INDEX, TWO_PAGE_OFFSET_INDEX, TWO_PAGE_ROW_COUNT,
+                new ResolvedPredicate.DoublePredicate(0, op, value));
 
         assertEquals(page0Kept, ranges.overlapsPage(0, 50),  "page 0 (rows 0-50)");
         assertEquals(page1Kept, ranges.overlapsPage(50, 100), "page 1 (rows 50-100)");
@@ -288,13 +265,8 @@ class PageFilterEvaluatorTest {
     @ParameterizedTest(name = "{0} {1} → pages kept: [{2}, {3}]")
     @MethodSource
     void testBooleanPageFiltering(Operator op, boolean value, boolean page0Kept, boolean page1Kept) {
-        RowRanges ranges = PageFilterEvaluator.evaluatePages(BOOLEAN_COLUMN_INDEX, TWO_PAGE_OFFSET_INDEX, TWO_PAGE_ROW_COUNT,
-                (columnIndex, pageIndex) -> {
-                    int min = StatisticsDecoder.decodeBoolean(columnIndex.minValues().get(pageIndex)) ? 1 : 0;
-                    int max = StatisticsDecoder.decodeBoolean(columnIndex.maxValues().get(pageIndex)) ? 1 : 0;
-                    int val = value ? 1 : 0;
-                    return StatisticsFilterSupport.canDrop(op, val, min, max);
-                });
+        RowRanges ranges = evaluatePages(BOOLEAN_COLUMN_INDEX, TWO_PAGE_OFFSET_INDEX, TWO_PAGE_ROW_COUNT,
+                new ResolvedPredicate.BooleanPredicate(0, op, value));
 
         assertEquals(page0Kept, ranges.overlapsPage(0, 50),  "page 0 (rows 0-50)");
         assertEquals(page1Kept, ranges.overlapsPage(50, 100), "page 1 (rows 50-100)");
@@ -321,15 +293,9 @@ class PageFilterEvaluatorTest {
     @MethodSource
     void testBinaryPageFiltering(Operator op, String value, boolean page0Kept, boolean page1Kept) {
         byte[] searchValue = value.getBytes(StandardCharsets.UTF_8);
-        RowRanges ranges = PageFilterEvaluator.evaluatePages(BINARY_COLUMN_INDEX, TWO_PAGE_OFFSET_INDEX, TWO_PAGE_ROW_COUNT,
-                (columnIndex, pageIndex) -> {
-                    byte[] min = columnIndex.minValues().get(pageIndex);
-                    byte[] max = columnIndex.maxValues().get(pageIndex);
-                    int cmpMin = BinaryComparator.compareUnsigned(searchValue, min);
-                    int cmpMax = BinaryComparator.compareUnsigned(searchValue, max);
-                    return StatisticsFilterSupport.canDropCompared(op,
-                            cmpMin, cmpMax, BinaryComparator.compareUnsigned(min, max));
-                });
+        RowRanges ranges = evaluatePages(BINARY_COLUMN_INDEX, TWO_PAGE_OFFSET_INDEX, TWO_PAGE_ROW_COUNT,
+                new ResolvedPredicate.BinaryPredicate(0, op, searchValue,
+                        ResolvedPredicate.BinaryPredicate.Comparison.BYTE_STRING));
 
         assertEquals(page0Kept, ranges.overlapsPage(0, 50),  "page 0 (rows 0-50)");
         assertEquals(page1Kept, ranges.overlapsPage(50, 100), "page 1 (rows 50-100)");
@@ -633,12 +599,8 @@ class PageFilterEvaluatorTest {
 
     @Test
     void testIntInPageFiltering() {
-        RowRanges ranges = PageFilterEvaluator.evaluatePages(INT_COLUMN_INDEX, THREE_PAGE_OFFSET_INDEX, THREE_PAGE_ROW_COUNT,
-                (ci, i) -> {
-                    int min = StatisticsDecoder.decodeInt(ci.minValues().get(i));
-                    int max = StatisticsDecoder.decodeInt(ci.maxValues().get(i));
-                    return StatisticsFilterSupport.canDropIntIn(new int[]{ 5, 15 }, min, max);
-                });
+        RowRanges ranges = evaluatePages(INT_COLUMN_INDEX, THREE_PAGE_OFFSET_INDEX, THREE_PAGE_ROW_COUNT,
+                new ResolvedPredicate.IntInPredicate(0, new int[]{ 5, 15 }));
         assertTrue(ranges.overlapsPage(0, 30));
         assertTrue(ranges.overlapsPage(30, 60));
         assertFalse(ranges.overlapsPage(60, 90));
@@ -646,12 +608,8 @@ class PageFilterEvaluatorTest {
 
     @Test
     void testIntInPageFilteringAllOutside() {
-        RowRanges ranges = PageFilterEvaluator.evaluatePages(INT_COLUMN_INDEX, THREE_PAGE_OFFSET_INDEX, THREE_PAGE_ROW_COUNT,
-                (ci, i) -> {
-                    int min = StatisticsDecoder.decodeInt(ci.minValues().get(i));
-                    int max = StatisticsDecoder.decodeInt(ci.maxValues().get(i));
-                    return StatisticsFilterSupport.canDropIntIn(new int[]{ 50, 60 }, min, max);
-                });
+        RowRanges ranges = evaluatePages(INT_COLUMN_INDEX, THREE_PAGE_OFFSET_INDEX, THREE_PAGE_ROW_COUNT,
+                new ResolvedPredicate.IntInPredicate(0, new int[]{ 50, 60 }));
         assertFalse(ranges.overlapsPage(0, 30));
         assertFalse(ranges.overlapsPage(30, 60));
         assertFalse(ranges.overlapsPage(60, 90));
@@ -662,12 +620,8 @@ class PageFilterEvaluatorTest {
         ColumnIndex longIdx = longColumnIndex(new long[]{ 100, 200, 300 }, new long[]{ 199, 299, 399 });
         OffsetIndex oi = offsetIndex(30, 30, 30);
 
-        RowRanges ranges = PageFilterEvaluator.evaluatePages(longIdx, oi, 90,
-                (ci, i) -> {
-                    long min = StatisticsDecoder.decodeLong(ci.minValues().get(i));
-                    long max = StatisticsDecoder.decodeLong(ci.maxValues().get(i));
-                    return StatisticsFilterSupport.canDropLongIn(new long[]{ 150, 350 }, min, max);
-                });
+        RowRanges ranges = evaluatePages(longIdx, oi, 90,
+                new ResolvedPredicate.LongInPredicate(0, new long[]{ 150, 350 }));
         assertTrue(ranges.overlapsPage(0, 30));
         assertFalse(ranges.overlapsPage(30, 60));
         assertTrue(ranges.overlapsPage(60, 90));
@@ -680,14 +634,10 @@ class PageFilterEvaluatorTest {
                 List.of("cherry".getBytes(StandardCharsets.UTF_8), "fig".getBytes(StandardCharsets.UTF_8)));
         OffsetIndex oi = offsetIndex(30, 30);
 
-        RowRanges ranges = PageFilterEvaluator.evaluatePages(binIdx, oi, 60,
-                (ci, i) -> {
-                    byte[] min = ci.minValues().get(i);
-                    byte[] max = ci.maxValues().get(i);
-                    return StatisticsFilterSupport.canDropBinaryIn(
-                            new byte[][]{ "banana".getBytes(StandardCharsets.UTF_8), "zebra".getBytes(StandardCharsets.UTF_8) },
-                            min, max, false);
-                });
+        RowRanges ranges = evaluatePages(binIdx, oi, 60,
+                new ResolvedPredicate.BinaryInPredicate(0,
+                        new byte[][]{ "banana".getBytes(StandardCharsets.UTF_8), "zebra".getBytes(StandardCharsets.UTF_8) },
+                        ResolvedPredicate.BinaryPredicate.Comparison.BYTE_STRING));
         assertTrue(ranges.overlapsPage(0, 30));
         assertFalse(ranges.overlapsPage(30, 60));
     }
@@ -697,12 +647,8 @@ class PageFilterEvaluatorTest {
         ColumnIndex doubleIdx = doubleColumnIndex(new double[]{ 100.0, 200.0, 300.0 }, new double[]{ 199.0, 299.0, 399.0 });
         OffsetIndex oi = offsetIndex(30, 30, 30);
 
-        RowRanges ranges = PageFilterEvaluator.evaluatePages(doubleIdx, oi, 90,
-                (ci, i) -> StatisticsFilterSupport.canDropDoubleIn(
-                        new double[]{ 150.0, 350.0 },
-                        StatisticsDecoder.decodeDouble(ci.minValues().get(i)),
-                        StatisticsDecoder.decodeDouble(ci.maxValues().get(i)),
-                        false));
+        RowRanges ranges = evaluatePages(doubleIdx, oi, 90,
+                new ResolvedPredicate.DoubleInPredicate(0, new double[]{ 150.0, 350.0 }, false, false));
         assertTrue(ranges.overlapsPage(0, 30));
         assertFalse(ranges.overlapsPage(30, 60));
         assertTrue(ranges.overlapsPage(60, 90));
@@ -714,32 +660,23 @@ class PageFilterEvaluatorTest {
         ColumnIndex floatIdx = floatColumnIndex(new float[]{ 100.0f, 200.0f, 300.0f }, new float[]{ 199.0f, 299.0f, 399.0f });
         OffsetIndex oi = offsetIndex(30, 30, 30);
 
-        RowRanges ranges = PageFilterEvaluator.evaluatePages(floatIdx, oi, 90,
-                (ci, i) -> StatisticsFilterSupport.canDropDoubleIn(
-                        new double[]{ 150.0, 350.0 },
-                        StatisticsDecoder.decodeFloat(ci.minValues().get(i)),
-                        StatisticsDecoder.decodeFloat(ci.maxValues().get(i)),
-                        false));
+        RowRanges ranges = evaluatePages(floatIdx, oi, 90,
+                new ResolvedPredicate.DoubleInPredicate(0, new double[]{ 150.0, 350.0 }, true, false));
         assertTrue(ranges.overlapsPage(0, 30));
         assertFalse(ranges.overlapsPage(30, 60));
         assertTrue(ranges.overlapsPage(60, 90));
 
         // NaN probe keeps every page.
-        RowRanges nanRanges = PageFilterEvaluator.evaluatePages(floatIdx, oi, 90,
-                (ci, i) -> StatisticsFilterSupport.canDropDoubleIn(
-                        new double[]{ 150.0, Double.NaN },
-                        StatisticsDecoder.decodeFloat(ci.minValues().get(i)),
-                        StatisticsDecoder.decodeFloat(ci.maxValues().get(i)),
-                        false));
+        RowRanges nanRanges = evaluatePages(floatIdx, oi, 90,
+                new ResolvedPredicate.DoubleInPredicate(0, new double[]{ 150.0, Double.NaN }, true, false));
         assertTrue(nanRanges.overlapsPage(0, 90));
     }
 
     @Test
     void testDoubleInPageDispatchFiltersThroughResolvedLeaf() throws IOException {
-        // End-to-end page dispatch: a resolved DoubleInPredicate must flow through
-        // PageFilterEvaluator's leaf switch (unlike the decode-lambda tests above, removing
-        // the DoubleIn arm from the evaluator fails this). Three FLOAT-column pages
-        // [100,199], [200,299], [300,399]; probes 150/350 keep pages 0 and 2 only.
+        // End-to-end page dispatch: a resolved DoubleInPredicate against a page index read from
+        // its wire bytes. Three FLOAT-column pages [100,199], [200,299], [300,399]; probes
+        // 150/350 keep pages 0 and 2 only.
         byte[] columnIndex = new ThriftStructBuilder()
                 .field(1, FieldType.LIST).boolList(false, false, false)
                 .field(2, FieldType.LIST)
@@ -1069,6 +1006,38 @@ class PageFilterEvaluatorTest {
             assertTrue(ranges.overlapsPage(0, 30));
             assertTrue(ranges.overlapsPage(30, 60));
         }
+    }
+
+    @Test
+    void listNullPredicateWithoutPageHistogramKeepsEveryPage() {
+        // An optional LIST of optional elements: the list is present at level 1, an element
+        // non-null at level 3. Every row holds one null and one non-null element, so each page's
+        // null count equals its row count although no list on it is absent. Without a histogram
+        // the null count is all there is, and it answers a different question than either null
+        // predicate on the list asks.
+        ColumnIndex listIndex = new ColumnIndex(
+                new boolean[]{ false, false },
+                List.of(intBytes(1), intBytes(1)),
+                List.of(intBytes(9), intBytes(9)),
+                ColumnIndex.BoundaryOrder.UNORDERED,
+                new long[]{ 30, 30 }, null, null, null);
+        OffsetIndex oi = offsetIndex(30, 30);
+
+        RowRanges isNull = evaluatePages(listIndex, oi, 60, new ResolvedPredicate.IsNullPredicate(0, 1, 3));
+        RowRanges isNotNull = evaluatePages(listIndex, oi, 60, new ResolvedPredicate.IsNotNullPredicate(0, 1, 3));
+
+        assertTrue(isNull.overlapsPage(0, 30));
+        assertTrue(isNull.overlapsPage(30, 60));
+        assertTrue(isNotNull.overlapsPage(0, 30));
+        assertTrue(isNotNull.overlapsPage(30, 60));
+    }
+
+    /// Decides `leaf` page by page over the two indexes, as the evaluator does once it has read
+    /// them.
+    private static RowRanges evaluatePages(ColumnIndex columnIndex, OffsetIndex offsetIndex,
+            long rowCount, ResolvedPredicate leaf) {
+        return PageFilterEvaluator.evaluatePages(columnIndex, offsetIndex, rowCount, leaf, UNNAMED,
+                BoundsReadability.ALL);
     }
 
     /// A PageLocation struct body: offset, compressed_page_size, first_row_index.

--- a/core/src/test/java/dev/hardwood/internal/predicate/RowGroupDecideTest.java
+++ b/core/src/test/java/dev/hardwood/internal/predicate/RowGroupDecideTest.java
@@ -103,6 +103,16 @@ class RowGroupDecideTest {
     }
 
     @Test
+    void valuePredicateCannotMatchARowGroupNullOnEveryRow() throws IOException {
+        // No bounds, as a writer records for a chunk holding no value, and a null count equal to
+        // the row count. A null satisfies no value predicate, NOT_EQ included.
+        RowGroup rg = rowGroup(PhysicalType.INT32, new Statistics(null, null, 100L, null, false), 100);
+        assertThat(decide(intGt(5), rg)).isEqualTo(CANNOT_MATCH);
+        assertThat(decide(new ResolvedPredicate.IntPredicate(COL, FilterPredicate.Operator.NOT_EQ, 5), rg))
+                .isEqualTo(CANNOT_MATCH);
+    }
+
+    @Test
     void bloomFilterSourceDoesNotAffectAlwaysMatches() throws IOException {
         // A bloom filter proves absence only; its presence must not change the
         // always-matching decision derived from statistics.
@@ -227,6 +237,20 @@ class RowGroupDecideTest {
 
         assertThat(decide(isNotNull, rg))
                 .isEqualTo(MIGHT_MATCH);
+    }
+
+    @Test
+    void listNullPredicateWithoutHistogramStaysUndecided() throws IOException {
+        // An optional LIST of optional elements: the list is present at level 1, an element
+        // non-null at level 3. Each of the 100 rows holds one null and one non-null element, so
+        // the null count equals the row count although no list is absent. Without a histogram
+        // the null count is all there is, and it answers a different question than either null
+        // predicate on the list asks.
+        RowGroup rg = rowGroup(PhysicalType.INT32,
+                new Statistics(intBytes(1), intBytes(9), 100L, null, false), 100);
+
+        assertThat(decide(new ResolvedPredicate.IsNullPredicate(COL, 1, 3), rg)).isEqualTo(MIGHT_MATCH);
+        assertThat(decide(new ResolvedPredicate.IsNotNullPredicate(COL, 1, 3), rg)).isEqualTo(MIGHT_MATCH);
     }
 
     @Test

--- a/core/src/test/java/dev/hardwood/internal/predicate/UnitStatsTest.java
+++ b/core/src/test/java/dev/hardwood/internal/predicate/UnitStatsTest.java
@@ -1,0 +1,188 @@
+/*
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Copyright The original authors
+ *
+ *  Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package dev.hardwood.internal.predicate;
+
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Stream;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import dev.hardwood.internal.ExceptionContext;
+import dev.hardwood.metadata.ColumnChunk;
+import dev.hardwood.metadata.ColumnIndex;
+import dev.hardwood.metadata.ColumnMetaData;
+import dev.hardwood.metadata.CompressionCodec;
+import dev.hardwood.metadata.Encoding;
+import dev.hardwood.metadata.FieldPath;
+import dev.hardwood.metadata.PageLocation;
+import dev.hardwood.metadata.PhysicalType;
+import dev.hardwood.metadata.RowGroup;
+import dev.hardwood.metadata.SizeStatistics;
+import dev.hardwood.metadata.Statistics;
+import dev.hardwood.reader.FilterPredicate.Operator;
+
+import static dev.hardwood.internal.predicate.FilterDecision.ALWAYS_MATCHES;
+import static dev.hardwood.internal.predicate.FilterDecision.CANNOT_MATCH;
+import static dev.hardwood.internal.predicate.FilterDecision.MIGHT_MATCH;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/// [UnitStats#decide] over a column chunk and over a page carrying the same statistics: the two
+/// units are sourced from different structures, and must prove the same things from them.
+class UnitStatsTest {
+
+    private static final LogContext UNNAMED =
+            new LogContext(null, ExceptionContext.UNKNOWN_ROW_GROUP);
+
+    private static final int ROWS = 100;
+
+    @ParameterizedTest(name = "{0}")
+    @MethodSource
+    void chunkAndPageProveTheSameFromTheSameStatistics(String name, ResolvedPredicate leaf,
+            long nullCount, long[] histogram, FilterDecision expected) {
+        assertThat(chunk(nullCount, histogram).decide(leaf, UNNAMED)).isEqualTo(expected);
+        assertThat(page(nullCount, histogram).decide(leaf, UNNAMED)).isEqualTo(expected);
+    }
+
+    static Stream<Arguments> chunkAndPageProveTheSameFromTheSameStatistics() {
+        ResolvedPredicate isNull = new ResolvedPredicate.IsNullPredicate(0, 1);
+        ResolvedPredicate isNotNull = new ResolvedPredicate.IsNotNullPredicate(0, 1);
+        ResolvedPredicate groupIsNull = new ResolvedPredicate.IsNullPredicate(0, 2, 3);
+        ResolvedPredicate groupIsNotNull = new ResolvedPredicate.IsNotNullPredicate(0, 2, 3);
+        ResolvedPredicate gt5 = new ResolvedPredicate.IntPredicate(0, Operator.GT, 5);
+        ResolvedPredicate gt15 = new ResolvedPredicate.IntPredicate(0, Operator.GT, 15);
+
+        return Stream.of(
+                Arguments.of("IS NULL, no nulls", isNull, 0L, null, CANNOT_MATCH),
+                Arguments.of("IS NULL, some nulls", isNull, 40L, null, MIGHT_MATCH),
+                Arguments.of("IS NULL, every row null", isNull, 100L, null, MIGHT_MATCH),
+                Arguments.of("IS NULL, null count unknown", isNull, NullStats.UNKNOWN_NULL_COUNT, null, MIGHT_MATCH),
+                Arguments.of("IS NOT NULL, no nulls", isNotNull, 0L, null, ALWAYS_MATCHES),
+                Arguments.of("IS NOT NULL, some nulls", isNotNull, 40L, null, MIGHT_MATCH),
+                Arguments.of("IS NOT NULL, every row null", isNotNull, 100L, null, CANNOT_MATCH),
+                Arguments.of("value, bounds satisfy it, no nulls", gt5, 0L, null, ALWAYS_MATCHES),
+                Arguments.of("value, bounds straddle it", gt15, 0L, null, MIGHT_MATCH),
+                Arguments.of("value, bounds satisfy it, some nulls", gt5, 40L, null, MIGHT_MATCH),
+                Arguments.of("value, every row null", gt5, 100L, null, CANNOT_MATCH),
+                Arguments.of("group IS NULL, group always absent", groupIsNull, 100L,
+                        new long[]{ 30, 70, 0, 0 }, ALWAYS_MATCHES),
+                Arguments.of("group IS NULL, group always present", groupIsNull, 40L,
+                        new long[]{ 0, 0, 40, 60 }, CANNOT_MATCH),
+                Arguments.of("group IS NOT NULL, group always present", groupIsNotNull, 40L,
+                        new long[]{ 0, 0, 40, 60 }, ALWAYS_MATCHES),
+                Arguments.of("group IS NOT NULL, histogram short of the rows", groupIsNotNull, 40L,
+                        new long[]{ 0, 0, 40, 50 }, MIGHT_MATCH),
+                // The null count equals the row count, which a fallback to it would read as the
+                // group absent throughout.
+                Arguments.of("group IS NOT NULL, no histogram", groupIsNotNull, 100L, null, MIGHT_MATCH),
+                Arguments.of("group IS NULL, histogram of the wrong length", groupIsNull, 100L,
+                        new long[]{ 30, 70, 0 }, MIGHT_MATCH));
+    }
+
+    @Test
+    void chunkOfAColumnTheRowGroupDoesNotCarryProvesNothing() {
+        RowGroup rowGroup = new RowGroup(List.of(chunkWith(0L, new long[]{ 0, 0, 40, 60 })), 1000, ROWS);
+        UnitStats absent = UnitStats.ChunkStats.of(rowGroup, 1, BoundsReadability.ALL);
+
+        assertThat(absent.decide(new ResolvedPredicate.IsNullPredicate(1, 1), UNNAMED)).isEqualTo(MIGHT_MATCH);
+        assertThat(absent.decide(new ResolvedPredicate.IsNotNullPredicate(1, 1), UNNAMED)).isEqualTo(MIGHT_MATCH);
+        assertThat(absent.decide(new ResolvedPredicate.IsNullPredicate(1, 2, 3), UNNAMED)).isEqualTo(MIGHT_MATCH);
+        assertThat(absent.decide(new ResolvedPredicate.IntPredicate(1, Operator.GT, 5), UNNAMED))
+                .isEqualTo(MIGHT_MATCH);
+    }
+
+    @Test
+    void pageSpansTheRowsUpToTheNextPage() {
+        ColumnIndex columnIndex = columnIndex(new boolean[]{ false, false }, null, null);
+        List<PageLocation> pages = List.of(new PageLocation(0, 100, 0), new PageLocation(100, 100, 30));
+
+        assertThat(UnitStats.IndexPageStats.of(columnIndex, pages, 0, 70, BoundsReadability.ALL).rowCount())
+                .isEqualTo(30);
+        assertThat(UnitStats.IndexPageStats.of(columnIndex, pages, 1, 70, BoundsReadability.ALL).rowCount())
+                .isEqualTo(40);
+    }
+
+    @Test
+    void pageNullOnEveryRowIsProvenByItsCountAlone() {
+        // Neither page is flagged null-only. The second page's null count equals the 40 rows it
+        // spans; the first page's falls one short of its 30.
+        ColumnIndex columnIndex = columnIndex(new boolean[]{ false, false }, new long[]{ 29, 40 }, null);
+        List<PageLocation> pages = List.of(new PageLocation(0, 100, 0), new PageLocation(100, 100, 30));
+        UnitStats first = UnitStats.IndexPageStats.of(columnIndex, pages, 0, 70, BoundsReadability.ALL);
+        UnitStats second = UnitStats.IndexPageStats.of(columnIndex, pages, 1, 70, BoundsReadability.ALL);
+        ResolvedPredicate isNotNull = new ResolvedPredicate.IsNotNullPredicate(0, 1);
+        ResolvedPredicate gt5 = new ResolvedPredicate.IntPredicate(0, Operator.GT, 5);
+
+        assertThat(first.decide(isNotNull, UNNAMED)).isEqualTo(MIGHT_MATCH);
+        assertThat(first.decide(gt5, UNNAMED)).isEqualTo(MIGHT_MATCH);
+        assertThat(second.decide(isNotNull, UNNAMED)).isEqualTo(CANNOT_MATCH);
+        assertThat(second.decide(gt5, UNNAMED)).isEqualTo(CANNOT_MATCH);
+    }
+
+    @Test
+    void compoundPredicateIsNotALeaf() {
+        ResolvedPredicate and = new ResolvedPredicate.And(List.of(
+                new ResolvedPredicate.IntPredicate(0, Operator.GT, 5),
+                new ResolvedPredicate.IntPredicate(0, Operator.LT, 25)));
+
+        assertThatThrownBy(() -> chunk(0L, null).decide(and, UNNAMED))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("Unit statistics decide a leaf predicate, not And");
+    }
+
+    // ==================== Fixtures ====================
+
+    /// A chunk of [#ROWS] rows bounded `[10, 20]`.
+    private static UnitStats chunk(long nullCount, long[] histogram) {
+        RowGroup rowGroup = new RowGroup(List.of(chunkWith(nullCount, histogram)), 1000, ROWS);
+        return UnitStats.ChunkStats.of(rowGroup, 0, BoundsReadability.ALL);
+    }
+
+    /// The only page of a chunk of [#ROWS] rows bounded `[10, 20]`, flagged null-only exactly
+    /// when its null count is its row count.
+    private static UnitStats page(long nullCount, long[] histogram) {
+        ColumnIndex columnIndex = columnIndex(
+                new boolean[]{ nullCount == ROWS },
+                nullCount == NullStats.UNKNOWN_NULL_COUNT ? null : new long[]{ nullCount },
+                histogram);
+        return UnitStats.IndexPageStats.of(columnIndex, List.of(new PageLocation(0, 100, 0)), 0, ROWS,
+                BoundsReadability.ALL);
+    }
+
+    private static ColumnChunk chunkWith(long nullCount, long[] histogram) {
+        Statistics statistics = new Statistics(intBytes(10), intBytes(20),
+                nullCount == NullStats.UNKNOWN_NULL_COUNT ? null : nullCount, null, false);
+        ColumnMetaData metaData = new ColumnMetaData(
+                PhysicalType.INT32, List.of(Encoding.PLAIN), FieldPath.of("order", "price"),
+                CompressionCodec.UNCOMPRESSED, ROWS, 1000, 1000, Map.of(), 0, null, statistics,
+                null, null, null, List.of(), new SizeStatistics(null, null, histogram));
+        return new ColumnChunk(metaData, null, null, null, null, "");
+    }
+
+    private static ColumnIndex columnIndex(boolean[] nullPages, long[] nullCounts, long[] histograms) {
+        List<byte[]> minValues = new ArrayList<>();
+        List<byte[]> maxValues = new ArrayList<>();
+        for (int i = 0; i < nullPages.length; i++) {
+            minValues.add(intBytes(10));
+            maxValues.add(intBytes(20));
+        }
+        return new ColumnIndex(nullPages, minValues, maxValues, ColumnIndex.BoundaryOrder.UNORDERED,
+                nullCounts, null, histograms, null);
+    }
+
+    private static byte[] intBytes(int value) {
+        return ByteBuffer.allocate(4).order(ByteOrder.LITTLE_ENDIAN).putInt(value).array();
+    }
+}


### PR DESCRIPTION
Part of #1177: stage 1 of `_designs/UNIT_STATISTICS_CONVERGENCE.md`, which this PR adds.

`RowGroupFilterEvaluator` and `PageFilterEvaluator` each sourced the null count and the definition level histogram on their own, and each decided which statistic answers which predicate. The histogram rule was duplicated between them, and the null count rules had drifted apart.

`UnitStats` resolves where a column chunk's (`ChunkStats`) or a page's (`IndexPageStats`) statistics come from, and `decide(leaf, logContext)` routes a leaf to `MinMaxStats`, `NullStats` or `DefinitionLevelStats`. Both evaluators ask it. Bloom filters, dictionaries and geospatial statistics stay row-group-only in `RowGroupFilterEvaluator`.

One behaviour changes: a row group whose null count equals its row count is now dropped for a value predicate, as a page the column index flags null-only already was. It is sound because every value predicate names a non-repeated leaf, and no value predicate matches a null, `NOT_EQ` included. Page filtering still collapses the decision to "keep unless `CANNOT_MATCH`"; the three-valued page path is stage 2.

`UnitStatsTest` pins that a chunk and a page carrying the same statistics decide alike. The design's LIST tripwire — a null predicate on a list with no histogram, whose null count equals the row count — stays `MIGHT_MATCH` at both granularities. The page tests that fed the evaluator a hand-written decode lambda now pass resolved leaves through the real per-page path.
