### PR TITLE
#1177 Prove IS NULL on a leaf that is null on every row

### DIFF
--- a/_designs/ALWAYS_MATCH_STATISTICS.md
+++ b/_designs/ALWAYS_MATCH_STATISTICS.md
@@ -53,8 +53,12 @@ actual values.
 - **Floating point** (`FLOAT`, `DOUBLE`, `FLOAT16`): NaN sits outside the min/max
   ordering and `nan_count` is not consumed (#607), so a fully-satisfying interval may
   still hide non-matching NaN rows. FP value leaves never yield `ALWAYS_MATCHES`.
-- **`IS NULL`**: the null count tallies leaf values, not rows, so `null_count ==
-  numRows` does not prove every row's leaf is null for nested columns.
+- **`IS NULL` on a group a definition level separates from its leaf, from the null count**:
+  that leaf counts a null wherever the group is present with a null below it, and below a
+  `LIST` or a `MAP` it writes one value per element, so `null_count == numRows` does not prove
+  the group absent. The definition level histogram answers such a group instead. `IS NULL` on a
+  non-repeated leaf, or on a group with only required nodes down to its leaf, is
+  `ALWAYS_MATCHES` on `null_count == numRows` (see `UNIT_STATISTICS_CONVERGENCE.md`).
 - **Bloom filters** prove absence only; they can force `CANNOT_MATCH` but never upgrade
   a decision.
 - **Composition**: `AND` is `ALWAYS_MATCHES` only when every child is; `OR` when any

--- a/_designs/UNIT_STATISTICS_CONVERGENCE.md
+++ b/_designs/UNIT_STATISTICS_CONVERGENCE.md
@@ -1,6 +1,6 @@
 # Design: one statistics abstraction for row group and page filtering (#1177)
 
-**Status: In progress** (stage 1 implemented). Related: #795 (`ALWAYS_MATCH_STATISTICS.md`), #977, #1030, #1107.
+**Status: In progress** (stages 1 and 3 implemented). Related: #795 (`ALWAYS_MATCH_STATISTICS.md`), #977, #1030, #1107.
 
 ## Problem
 
@@ -96,10 +96,11 @@ The last rule arrives in stage 3; the others hold from stage 1. The rules readin
 predicates included, so the unit writes exactly one entry per row and a null count equal to the
 row count accounts for all of them.
 
-**A group predicate must not reach these rules.** `FilterPredicateResolver.resolveNullTarget`
-answers a group from a leaf below it, chosen by `leafToAnswerFrom`, and that leaf is repeated
-whenever the group is a `LIST` or a `MAP` with no non-repeated leaf beneath it — `rejectRepeated`
-runs on the directly-named-leaf branch only. Two things then fail at once. A null count tallies
+**A group predicate, one whose `definitionLevel` is below its `leafDefinitionLevel`, must not
+reach these rules.** `FilterPredicateResolver.resolveNullTarget` answers a group from a leaf below
+it, chosen by `leafToAnswerFrom`, and that leaf is repeated whenever the group is a `LIST` or a
+`MAP` with no non-repeated leaf beneath it — `rejectRepeated` runs on the directly-named-leaf
+branch only. Two things then fail at once. A null count tallies
 every entry below `leafDefinitionLevel`, which is the group being absent *or* the group being
 present with a null below it, so `nullCount == rowCount` does not prove the group absent; that
 conflation is the reason the definition level histogram was introduced. And a repeated leaf writes
@@ -134,10 +135,17 @@ The gate is `definitionLevel < leafDefinitionLevel`, which `group()` on the two 
 tests, because it is what makes the fallback legitimate. It is tested once, in `UnitStats.decide`,
 which both evaluators call.
 
+The gate follows the schema's structure, not its annotations. Every repeated node adds a
+definition level, so a `LIST` or a `MAP` — in the standard encoding and in every legacy one: the
+two-level lists, the repeated group named `array` or `<list>_tuple`, `MAP_KEY_VALUE` on either
+group — has a repeated node between it and its leaf and passes the gate as a group. A group whose
+levels are equal has nothing but required nodes down to its leaf, which is then non-repeated and
+null exactly where the group is absent, so the null count answers it as it answers the leaf.
+
 Preferring the histogram for a leaf predicate counts entries directly, where the null-count rules
 reach the same answer by way of the non-repeated-leaf argument above.
 
-The length guard is load-bearing once leaf predicates take this path.
+The length guard is load-bearing for a leaf predicate.
 `ResolvedPredicate.IsNotNullPredicate.ofLeaf` fabricates both definition levels as `0` for a caller
 holding no schema, and a histogram indexed at a fabricated level would answer about the wrong node.
 A histogram whose length is not `leafDefinitionLevel + 1` is therefore refused before it is read,
@@ -164,9 +172,11 @@ on `nullCount == rowCount` rests on.
 tests that pin each statistic on its own. `PageDropPredicates.canDropPage` is the third caller, and
 routing through `decide` is what turns its boolean drop into the same three-valued answer.
 
-`decide` builds only what its branch reads: one statistic for a null predicate, the null count and
-the min/max for a value predicate. A unit is constructed per page per leaf, so a thousand-page
-column chunk builds a thousand of them.
+`decide` builds only what its branch reads: the histogram for a null predicate, and the null count
+as well where a leaf predicate falls back to it; the null count and the min/max for a value
+predicate. A unit is constructed per page per leaf, so a thousand-page column chunk builds a
+thousand of them, and under a null predicate each copies its page's histogram out of the
+column index.
 
 **The recursion is not shared.** `AND` and `OR` fold to one `FilterDecision` on the row-group side
 and to a pair of `RowRanges` on the page side. The two are the same fold over different algebras;

--- a/core/src/main/java/dev/hardwood/internal/predicate/DefinitionLevelStats.java
+++ b/core/src/main/java/dev/hardwood/internal/predicate/DefinitionLevelStats.java
@@ -40,7 +40,7 @@ record DefinitionLevelStats(long[] histogram, long rowCount) {
 
     /// Whether the file wrote a histogram for a leaf at `leafDefinitionLevel`, one bucket per
     /// level up to it. A histogram it omits, or wrote at another length, proves nothing.
-    private boolean sizedFor(int leafDefinitionLevel) {
+    boolean sizedFor(int leafDefinitionLevel) {
         return histogram != null && histogram.length == leafDefinitionLevel + 1;
     }
 

--- a/core/src/main/java/dev/hardwood/internal/predicate/NullStats.java
+++ b/core/src/main/java/dev/hardwood/internal/predicate/NullStats.java
@@ -7,12 +7,15 @@
  */
 package dev.hardwood.internal.predicate;
 
-/// One unit's null count, and what it proves about a predicate on the leaf column itself.
+/// One unit's null count, and what it proves about a predicate on the leaf column itself or on
+/// a group with only required nodes down to it.
 ///
-/// [FilterPredicateResolver] refuses a repeated column to a directly named leaf, so such a leaf
-/// writes exactly one entry per row, and its null count is a count of rows. That is what lets
-/// the count be held against the unit's row count at all. A null predicate on an enclosing group
-/// is answered from a leaf that may be repeated, where it does not hold, and goes to
+/// [FilterPredicateResolver] refuses a repeated column to a directly named leaf, and a repeated
+/// group to a null predicate, so a leaf with no definition level between it and the named node
+/// writes exactly one entry per row, is null exactly where the node is absent, and has a null
+/// count that is a count of rows. That is what lets the count be held against the unit's row
+/// count at all. A null predicate on a group that a definition level separates from its leaf is
+/// answered from a leaf that may be repeated, where it does not hold, and goes to
 /// [DefinitionLevelStats] instead; [UnitStats#decide] is what keeps it from reaching here.
 ///
 /// @param nullCount the number of null entries in the unit, or [#UNKNOWN_NULL_COUNT]
@@ -32,9 +35,13 @@ record NullStats(long nullCount, long rowCount) {
         return rowCount >= 0 && nullCount == rowCount;
     }
 
-    /// `IS NULL` on the leaf, which no row matches where no entry is null.
+    /// `IS NULL` on the leaf, which no row matches where no entry is null, and every row matches
+    /// where every row is null.
     FilterDecision decideIsNull() {
-        return noNulls() ? FilterDecision.CANNOT_MATCH : FilterDecision.MIGHT_MATCH;
+        if (noNulls()) {
+            return FilterDecision.CANNOT_MATCH;
+        }
+        return allNull() ? FilterDecision.ALWAYS_MATCHES : FilterDecision.MIGHT_MATCH;
     }
 
     /// `IS NOT NULL` on the leaf, which no row matches where every row is null, and every row

--- a/core/src/main/java/dev/hardwood/internal/predicate/ResolvedPredicate.java
+++ b/core/src/main/java/dev/hardwood/internal/predicate/ResolvedPredicate.java
@@ -204,11 +204,12 @@ public sealed interface ResolvedPredicate {
     /// `columnIndex` itself or a non-repeated group enclosing it.
     ///
     /// `definitionLevel` is the level at or above which that node is present, and
-    /// `leafDefinitionLevel` is the leaf column's maximum definition level. A leaf predicate has
-    /// the two equal; a group predicate has `definitionLevel` below `leafDefinitionLevel`, and the
-    /// gap between them is where a present group with a null child sits. Carrying both means an
-    /// evaluator can tell the two apart, and can size a definition level histogram, without the
-    /// schema the resolver read them from.
+    /// `leafDefinitionLevel` is the leaf column's maximum definition level. The gap between them
+    /// is where a present group with a null child sits. A leaf predicate has the two equal, and so
+    /// does a group with only required nodes down to the leaf, which is null exactly where the
+    /// group is absent and is answered as that leaf. Carrying both means an evaluator can tell the
+    /// two apart, and can size a definition level histogram, without the schema the resolver read
+    /// them from.
     record IsNullPredicate(int columnIndex, int definitionLevel, int leafDefinitionLevel)
             implements ResolvedPredicate {
 
@@ -221,7 +222,9 @@ public sealed interface ResolvedPredicate {
             this(columnIndex, definitionLevel, definitionLevel);
         }
 
-        /// Whether the tested node is a group enclosing the leaf rather than the leaf itself.
+        /// Whether a definition level separates the tested node from the leaf, so that the leaf
+        /// can be null where the node is present. `false` for the leaf itself and for a group with
+        /// only required nodes down to it.
         public boolean group() {
             return definitionLevel < leafDefinitionLevel;
         }
@@ -243,13 +246,17 @@ public sealed interface ResolvedPredicate {
         /// A predicate on the leaf column itself, for a caller holding no schema to read the
         /// leaf's definition level from — a negation rewritten into a null check, say.
         ///
-        /// A leaf predicate's readers consult the two levels only to establish that it is not a
-        /// group predicate, which equal levels settle on their own.
+        /// Both levels are `0`. Being equal, they settle that the predicate is not [#group()].
+        /// They also size a definition level histogram, and `0` fits only a required column's,
+        /// where it is the real level; `UnitStats.decide` refuses a histogram of any other length
+        /// and answers the predicate from the null count.
         public static IsNotNullPredicate ofLeaf(int columnIndex) {
             return new IsNotNullPredicate(columnIndex, 0, 0);
         }
 
-        /// Whether the tested node is a group enclosing the leaf rather than the leaf itself.
+        /// Whether a definition level separates the tested node from the leaf, so that the leaf
+        /// can be null where the node is present. `false` for the leaf itself and for a group with
+        /// only required nodes down to it.
         public boolean group() {
             return definitionLevel < leafDefinitionLevel;
         }

--- a/core/src/main/java/dev/hardwood/internal/predicate/UnitStats.java
+++ b/core/src/main/java/dev/hardwood/internal/predicate/UnitStats.java
@@ -53,12 +53,21 @@ sealed interface UnitStats {
 
     /// What this unit's statistics prove about one leaf predicate.
     ///
-    /// A null predicate on a group enclosing the leaf is answered from [#definitionLevels]
-    /// alone. The leaf it is answered from may be repeated, and then its null count tallies
-    /// absent groups and null elements alike, over more entries than there are rows, so neither
-    /// null count rule holds for it.
+    /// A null predicate on a group that a definition level separates from the leaf — an optional
+    /// or repeated node between the two — is answered from [#definitionLevels] alone. The leaf it
+    /// is answered from may be repeated, and then its null count tallies absent groups and null
+    /// elements alike, over more entries than there are rows, so neither null count rule holds
+    /// for it.
     ///
-    /// A null predicate on the leaf itself is answered from [#nulls].
+    /// A null predicate on the leaf itself, or on a group with only required nodes down to the
+    /// leaf, is answered from [#definitionLevels] where the file wrote a histogram sized for the
+    /// leaf, and from [#nulls] otherwise. The leaf is then not repeated and is null exactly where
+    /// the node is absent, so it writes one entry per row and the two agree wherever both are
+    /// present. The size check is
+    /// what keeps a predicate whose levels were not read from the schema — see
+    /// `IsNotNullPredicate.ofLeaf` — from reading a histogram at the wrong level: its levels are
+    /// both `0`, which only a required column's histogram is sized for, and for that column `0`
+    /// is its real level.
     ///
     /// A value predicate cannot match a unit that is null on every row, since a null satisfies
     /// none of them, `NOT_EQ` included. Otherwise it is answered from [#minMax]. Every value
@@ -71,12 +80,18 @@ sealed interface UnitStats {
     ///        report bounds it had to discard
     default FilterDecision decide(ResolvedPredicate leaf, LogContext logContext) {
         return switch (leaf) {
-            case ResolvedPredicate.IsNullPredicate p -> p.group()
-                    ? definitionLevels().decideIsNull(p.definitionLevel(), p.leafDefinitionLevel())
-                    : nulls().decideIsNull();
-            case ResolvedPredicate.IsNotNullPredicate p -> p.group()
-                    ? definitionLevels().decideIsNotNull(p.definitionLevel(), p.leafDefinitionLevel())
-                    : nulls().decideIsNotNull();
+            case ResolvedPredicate.IsNullPredicate p -> {
+                DefinitionLevelStats levels = definitionLevels();
+                yield p.group() || levels.sizedFor(p.leafDefinitionLevel())
+                        ? levels.decideIsNull(p.definitionLevel(), p.leafDefinitionLevel())
+                        : nulls().decideIsNull();
+            }
+            case ResolvedPredicate.IsNotNullPredicate p -> {
+                DefinitionLevelStats levels = definitionLevels();
+                yield p.group() || levels.sizedFor(p.leafDefinitionLevel())
+                        ? levels.decideIsNotNull(p.definitionLevel(), p.leafDefinitionLevel())
+                        : nulls().decideIsNotNull();
+            }
             case ResolvedPredicate.IntPredicate ignored -> decideValue(leaf, logContext);
             case ResolvedPredicate.LongPredicate ignored -> decideValue(leaf, logContext);
             case ResolvedPredicate.UnsignedIntPredicate ignored -> decideValue(leaf, logContext);

--- a/core/src/test/java/dev/hardwood/RowGroupFilterEventTest.java
+++ b/core/src/test/java/dev/hardwood/RowGroupFilterEventTest.java
@@ -7,19 +7,30 @@
  */
 package dev.hardwood;
 
+import java.nio.ByteBuffer;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.util.ArrayList;
 import java.util.List;
+import java.util.stream.IntStream;
 
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
+import dev.hardwood.internal.writer.ByteBufferOutputFile;
 import dev.hardwood.jfr.AbstractJfrRecorderTest;
+import dev.hardwood.metadata.LogicalType;
+import dev.hardwood.metadata.PhysicalType;
+import dev.hardwood.metadata.RepetitionType;
 import dev.hardwood.reader.ColumnReaders;
 import dev.hardwood.reader.FilterPredicate;
 import dev.hardwood.reader.ParquetFileReader;
 import dev.hardwood.reader.RowGroupPredicate;
+import dev.hardwood.reader.RowReader;
 import dev.hardwood.schema.ColumnProjection;
+import dev.hardwood.schema.FileSchema;
+import dev.hardwood.writer.ParquetFileWriter;
+import dev.hardwood.writer.RowWriter;
 import jdk.jfr.consumer.RecordedEvent;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -38,6 +49,7 @@ class RowGroupFilterEventTest extends AbstractJfrRecorderTest {
     private static final Path FIXTURE = Paths.get("src/test/resources/filter_pushdown_int.parquet");
     private static final String BYTE_RANGE_EVENT = "dev.hardwood.RowGroupByteRangeFilter";
     private static final String PUSH_DOWN_EVENT = "dev.hardwood.RowGroupFilter";
+    private static final int NULL_ROWS = 10;
 
     private static long fileLen;
 
@@ -134,6 +146,97 @@ class RowGroupFilterEventTest extends AbstractJfrRecorderTest {
         assertThat(events(PUSH_DOWN_EVENT).count())
                 .as("statistics evaluated once: one push-down event")
                 .isEqualTo(1);
+    }
+
+    @Test
+    void isNullOnALeafNullOnEveryRowFullyMatches() throws Exception {
+        // Every row's city is null: the address is absent on even rows and present without a city
+        // on odd ones. The leaf's null count is the row count either way, which proves IS NULL on
+        // every row.
+        FileSchema schema = FileSchema.builder("schema")
+                .addColumn("id", PhysicalType.INT32, RepetitionType.REQUIRED)
+                .struct("address", RepetitionType.OPTIONAL, address -> address
+                        .addColumn("city", PhysicalType.BYTE_ARRAY, RepetitionType.OPTIONAL, LogicalType.string()))
+                .build();
+        byte[] file = writeRows(schema, rows -> {
+            for (int i = 0; i < NULL_ROWS; i++) {
+                int id = i;
+                rows.writeRow(row -> {
+                    row.setInt("id", id);
+                    if (id % 2 == 1) {
+                        row.setStruct("address", address -> address.setString("city", null));
+                    }
+                });
+            }
+        });
+
+        // The column readers' record count is not asserted: they drop the rows where the address
+        // is present (#1189).
+        readFullyMatching(file, FilterPredicate.isNull("address.city"));
+    }
+
+    @Test
+    void isNullOnAStructOfRequiredFieldsAbsentOnEveryRowFullyMatches() throws Exception {
+        // No definition level separates `c` from `a`, so `a` is null exactly where `c` is absent
+        // and its null count answers IS NULL on `c`.
+        FileSchema schema = FileSchema.builder("schema")
+                .addColumn("id", PhysicalType.INT32, RepetitionType.REQUIRED)
+                .struct("c", RepetitionType.OPTIONAL, c -> c
+                        .addColumn("a", PhysicalType.INT32, RepetitionType.REQUIRED))
+                .build();
+        byte[] file = writeRows(schema, rows -> {
+            for (int i = 0; i < NULL_ROWS; i++) {
+                int id = i;
+                rows.writeRow(row -> row.setInt("id", id));
+            }
+        });
+
+        assertThat(readFullyMatching(file, FilterPredicate.isNull("c")))
+                .as("column readers return every row")
+                .isEqualTo(NULL_ROWS);
+    }
+
+    /// Reads `file` under `filter` through a row reader and through column readers, asserts that
+    /// the row reader returns every row and that each read reports its one row group fully
+    /// matching, and returns the number of records the column readers returned.
+    private int readFullyMatching(byte[] file, FilterPredicate filter) throws Exception {
+        List<Integer> rowIds = new ArrayList<>();
+        try (ParquetFileReader reader = ParquetFileReader.open(InputFile.of(ByteBuffer.wrap(file)));
+             RowReader rows = reader.buildRowReader().filter(filter).build()) {
+            while (rows.hasNext()) {
+                rows.next();
+                rowIds.add(rows.getInt("id"));
+            }
+        }
+        int columnRecords = 0;
+        try (ParquetFileReader reader = ParquetFileReader.open(InputFile.of(ByteBuffer.wrap(file)));
+             ColumnReaders cols = reader.buildColumnReaders(ColumnProjection.columns("id"))
+                     .filter(filter)
+                     .build()) {
+            while (cols.nextBatch()) {
+                columnRecords += cols.getRecordCount();
+            }
+        }
+        awaitEvents();
+
+        assertThat(rowIds).containsExactlyElementsOf(IntStream.range(0, NULL_ROWS).boxed().toList());
+        assertThat(events(PUSH_DOWN_EVENT).map(event -> event.getInt("rowGroupsFullyMatching")).toList())
+                .as("one push-down event per read, each proving its one row group fully matching")
+                .containsExactly(1, 1);
+        return columnRecords;
+    }
+
+    private static byte[] writeRows(FileSchema schema, RowWrite filler) throws Exception {
+        ByteBufferOutputFile out = new ByteBufferOutputFile();
+        try (ParquetFileWriter writer = ParquetFileWriter.create(out, schema)) {
+            filler.accept(writer.rowWriter());
+        }
+        return out.toByteArray();
+    }
+
+    @FunctionalInterface
+    private interface RowWrite {
+        void accept(RowWriter rows) throws Exception;
     }
 
     /// Builds a [ColumnReaders] over the fixture via `build`, then stops the recording.

--- a/core/src/test/java/dev/hardwood/internal/predicate/FilterPredicateResolverTest.java
+++ b/core/src/test/java/dev/hardwood/internal/predicate/FilterPredicateResolverTest.java
@@ -14,10 +14,15 @@ import java.time.LocalDate;
 import java.time.LocalTime;
 import java.util.List;
 import java.util.UUID;
+import java.util.stream.Stream;
 
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 
 import dev.hardwood.metadata.ColumnOrder;
+import dev.hardwood.metadata.ConvertedType;
 import dev.hardwood.metadata.LogicalType;
 import dev.hardwood.metadata.PhysicalType;
 import dev.hardwood.metadata.RepetitionType;
@@ -417,6 +422,90 @@ class FilterPredicateResolverTest {
 
         assertThat(FilterPredicateResolver.resolve(FilterPredicate.isNull("tags"), schema))
                 .isEqualTo(new ResolvedPredicate.IsNullPredicate(0, 1, 3));
+    }
+
+    /// A `LIST` or a `MAP` is answered from a leaf below a repeated node, and every repeated node
+    /// adds a definition level, so the collection sits strictly below its leaf in every encoding.
+    /// That keeps the predicate on the definition level histogram: the leaf is repeated, and an
+    /// absent collection and an empty one both count among its nulls.
+    @ParameterizedTest(name = "{0}")
+    @MethodSource
+    void nullPredicateOnACollectionIsAnsweredAsAGroup(String shape, List<SchemaElement> elements,
+            int definitionLevel, int leafDefinitionLevel) {
+        FileSchema schema = FileSchema.fromSchemaElements(elements);
+
+        assertThat(FilterPredicateResolver.resolve(FilterPredicate.isNull("c"), schema))
+                .isEqualTo(new ResolvedPredicate.IsNullPredicate(0, definitionLevel, leafDefinitionLevel));
+        assertThat(FilterPredicateResolver.resolve(FilterPredicate.isNotNull("c"), schema))
+                .isEqualTo(new ResolvedPredicate.IsNotNullPredicate(0, definitionLevel, leafDefinitionLevel));
+    }
+
+    static Stream<Arguments> nullPredicateOnACollectionIsAnsweredAsAGroup() {
+        SchemaElement root = SchemaElement.root("root", 1);
+        SchemaElement key = SchemaElement.primitive("key", PhysicalType.BYTE_ARRAY, RepetitionType.REQUIRED);
+        SchemaElement value = SchemaElement.primitive("value", PhysicalType.INT32, RepetitionType.OPTIONAL);
+
+        return Stream.of(
+                Arguments.of("two-level list of a primitive", List.of(root,
+                        legacyGroup("c", RepetitionType.OPTIONAL, 1, ConvertedType.LIST),
+                        SchemaElement.primitive("element", PhysicalType.INT32, RepetitionType.REPEATED)), 1, 2),
+                Arguments.of("two-level list, element group of several fields", List.of(root,
+                        legacyGroup("c", RepetitionType.OPTIONAL, 1, ConvertedType.LIST),
+                        SchemaElement.group("element", RepetitionType.REPEATED, 2),
+                        SchemaElement.primitive("a", PhysicalType.INT32, RepetitionType.REQUIRED),
+                        SchemaElement.primitive("b", PhysicalType.INT32, RepetitionType.REQUIRED)), 1, 2),
+                Arguments.of("two-level list of lists", List.of(root,
+                        legacyGroup("c", RepetitionType.OPTIONAL, 1, ConvertedType.LIST),
+                        SchemaElement.group("element", RepetitionType.REPEATED, 1),
+                        SchemaElement.primitive("x", PhysicalType.INT32, RepetitionType.REPEATED)), 1, 3),
+                Arguments.of("two-level list, element named array", List.of(root,
+                        legacyGroup("c", RepetitionType.OPTIONAL, 1, ConvertedType.LIST),
+                        SchemaElement.group("array", RepetitionType.REPEATED, 1),
+                        SchemaElement.primitive("x", PhysicalType.INT32, RepetitionType.REQUIRED)), 1, 2),
+                Arguments.of("two-level list, element named c_tuple", List.of(root,
+                        legacyGroup("c", RepetitionType.OPTIONAL, 1, ConvertedType.LIST),
+                        SchemaElement.group("c_tuple", RepetitionType.REPEATED, 1),
+                        SchemaElement.primitive("x", PhysicalType.INT32, RepetitionType.REQUIRED)), 1, 2),
+                Arguments.of("three-level list under other names", List.of(root,
+                        legacyGroup("c", RepetitionType.OPTIONAL, 1, ConvertedType.LIST),
+                        SchemaElement.group("bag", RepetitionType.REPEATED, 1),
+                        SchemaElement.primitive("item", PhysicalType.INT32, RepetitionType.OPTIONAL)), 1, 3),
+                // Never absent, so its IS NULL splits the histogram at level 0: no bucket below.
+                Arguments.of("required two-level list", List.of(root,
+                        legacyGroup("c", RepetitionType.REQUIRED, 1, ConvertedType.LIST),
+                        SchemaElement.primitive("element", PhysicalType.INT32, RepetitionType.REPEATED)), 0, 1),
+                Arguments.of("map", List.of(root,
+                        legacyGroup("c", RepetitionType.OPTIONAL, 1, ConvertedType.MAP),
+                        SchemaElement.group("key_value", RepetitionType.REPEATED, 2), key, value), 1, 2),
+                Arguments.of("map whose repeated group is marked MAP_KEY_VALUE", List.of(root,
+                        legacyGroup("c", RepetitionType.OPTIONAL, 1, ConvertedType.MAP),
+                        legacyGroup("map", RepetitionType.REPEATED, 2, ConvertedType.MAP_KEY_VALUE), key, value),
+                        1, 2),
+                Arguments.of("map marked MAP_KEY_VALUE itself", List.of(root,
+                        legacyGroup("c", RepetitionType.OPTIONAL, 1, ConvertedType.MAP_KEY_VALUE),
+                        SchemaElement.group("map", RepetitionType.REPEATED, 2), key, value), 1, 2));
+    }
+
+    @Test
+    void nullPredicateOnAStructOfRequiredFieldsIsAnsweredAsItsLeaf() {
+        // `optional group c { required int32 a; }`: nothing between `c` and `a` adds a definition
+        // level, so the two share one and the predicate takes the leaf's path. It may: `a` is not
+        // repeated, writes one entry per row, and is null exactly where `c` is absent.
+        FileSchema schema = FileSchema.fromSchemaElements(List.of(
+                SchemaElement.root("root", 1),
+                SchemaElement.group("c", RepetitionType.OPTIONAL, 1),
+                SchemaElement.primitive("a", PhysicalType.INT32, RepetitionType.REQUIRED)));
+
+        assertThat(FilterPredicateResolver.resolve(FilterPredicate.isNull("c"), schema))
+                .isEqualTo(new ResolvedPredicate.IsNullPredicate(0, 1, 1));
+    }
+
+    /// A group annotated only by the legacy `converted_type`, as files written before the logical
+    /// type union carry `LIST`, `MAP` and `MAP_KEY_VALUE`.
+    private static SchemaElement legacyGroup(String name, RepetitionType repetitionType, int numChildren,
+            ConvertedType convertedType) {
+        return new SchemaElement(name, null, null, repetitionType, numChildren, convertedType,
+                null, null, null, null);
     }
 
     @Test

--- a/core/src/test/java/dev/hardwood/internal/predicate/RowGroupDecideTest.java
+++ b/core/src/test/java/dev/hardwood/internal/predicate/RowGroupDecideTest.java
@@ -95,10 +95,11 @@ class RowGroupDecideTest {
     }
 
     @Test
-    void isNullNeverPromisesAlwaysMatches() throws IOException {
-        // Even a fully-null row group is not promised: null counts tally values, not rows.
+    void isNullDecisions() throws IOException {
+        // All 100 rows null. A predicate names a non-repeated leaf, so its null count counts rows.
         assertThat(decide(isNull(), rowGroup(PhysicalType.INT32,
-                new Statistics(null, null, 100L, null, false), 100))).isEqualTo(MIGHT_MATCH);
+                new Statistics(null, null, 100L, null, false), 100))).isEqualTo(ALWAYS_MATCHES);
+        assertThat(decide(isNull(), intRowGroup(10, 20, 5L))).isEqualTo(MIGHT_MATCH);
         assertThat(decide(isNull(), intRowGroup(10, 20, 0L))).isEqualTo(CANNOT_MATCH);
     }
 

--- a/core/src/test/java/dev/hardwood/internal/predicate/UnitStatsTest.java
+++ b/core/src/test/java/dev/hardwood/internal/predicate/UnitStatsTest.java
@@ -61,14 +61,34 @@ class UnitStatsTest {
         ResolvedPredicate isNotNull = new ResolvedPredicate.IsNotNullPredicate(0, 1);
         ResolvedPredicate groupIsNull = new ResolvedPredicate.IsNullPredicate(0, 2, 3);
         ResolvedPredicate groupIsNotNull = new ResolvedPredicate.IsNotNullPredicate(0, 2, 3);
+        // An optional MAP, answered from its required key one level down.
+        ResolvedPredicate mapIsNull = new ResolvedPredicate.IsNullPredicate(0, 1, 2);
+        ResolvedPredicate mapIsNotNull = new ResolvedPredicate.IsNotNullPredicate(0, 1, 2);
         ResolvedPredicate gt5 = new ResolvedPredicate.IntPredicate(0, Operator.GT, 5);
         ResolvedPredicate gt15 = new ResolvedPredicate.IntPredicate(0, Operator.GT, 15);
 
         return Stream.of(
                 Arguments.of("IS NULL, no nulls", isNull, 0L, null, CANNOT_MATCH),
                 Arguments.of("IS NULL, some nulls", isNull, 40L, null, MIGHT_MATCH),
-                Arguments.of("IS NULL, every row null", isNull, 100L, null, MIGHT_MATCH),
+                Arguments.of("IS NULL, every row null", isNull, 100L, null, ALWAYS_MATCHES),
                 Arguments.of("IS NULL, null count unknown", isNull, NullStats.UNKNOWN_NULL_COUNT, null, MIGHT_MATCH),
+                Arguments.of("IS NULL, no null count, histogram all below the leaf", isNull,
+                        NullStats.UNKNOWN_NULL_COUNT, new long[]{ 100, 0 }, ALWAYS_MATCHES),
+                Arguments.of("IS NULL, no null count, histogram all at the leaf", isNull,
+                        NullStats.UNKNOWN_NULL_COUNT, new long[]{ 0, 100 }, CANNOT_MATCH),
+                Arguments.of("IS NOT NULL, no null count, histogram all at the leaf", isNotNull,
+                        NullStats.UNKNOWN_NULL_COUNT, new long[]{ 0, 100 }, ALWAYS_MATCHES),
+                Arguments.of("IS NOT NULL, no null count, histogram all below the leaf", isNotNull,
+                        NullStats.UNKNOWN_NULL_COUNT, new long[]{ 100, 0 }, CANNOT_MATCH),
+                Arguments.of("IS NOT NULL, histogram short of the rows", isNotNull,
+                        NullStats.UNKNOWN_NULL_COUNT, new long[]{ 0, 90 }, MIGHT_MATCH),
+                Arguments.of("IS NULL, histogram of the wrong length, null count decides", isNull, 100L,
+                        new long[]{ 30, 70, 0 }, ALWAYS_MATCHES),
+                // Levels of 0 fit only a one-bucket histogram. Read at level 0, this two-bucket
+                // one would count every entry as present and promise every row.
+                Arguments.of("IS NOT NULL with no schema levels, optional column",
+                        ResolvedPredicate.IsNotNullPredicate.ofLeaf(0),
+                        40L, new long[]{ 40, 60 }, MIGHT_MATCH),
                 Arguments.of("IS NOT NULL, no nulls", isNotNull, 0L, null, ALWAYS_MATCHES),
                 Arguments.of("IS NOT NULL, some nulls", isNotNull, 40L, null, MIGHT_MATCH),
                 Arguments.of("IS NOT NULL, every row null", isNotNull, 100L, null, CANNOT_MATCH),
@@ -88,7 +108,17 @@ class UnitStatsTest {
                 // group absent throughout.
                 Arguments.of("group IS NOT NULL, no histogram", groupIsNotNull, 100L, null, MIGHT_MATCH),
                 Arguments.of("group IS NULL, histogram of the wrong length", groupIsNull, 100L,
-                        new long[]{ 30, 70, 0 }, MIGHT_MATCH));
+                        new long[]{ 30, 70, 0 }, MIGHT_MATCH),
+                // Every row holds an empty map, which writes one key entry below the key's level,
+                // so the key's null count equals the row count although no map is null. Read as a
+                // leaf's, that count would promise IS NULL on every row and rule out IS NOT NULL.
+                Arguments.of("map IS NULL, every map empty, no histogram", mapIsNull, 100L, null, MIGHT_MATCH),
+                Arguments.of("map IS NOT NULL, every map empty, no histogram", mapIsNotNull, 100L, null,
+                        MIGHT_MATCH),
+                Arguments.of("map IS NULL, every map empty", mapIsNull, 100L, new long[]{ 0, 100, 0 },
+                        CANNOT_MATCH),
+                Arguments.of("map IS NOT NULL, every map empty", mapIsNotNull, 100L, new long[]{ 0, 100, 0 },
+                        ALWAYS_MATCHES));
     }
 
     @Test


### PR DESCRIPTION
Part of #1177: stage 3 of `_designs/UNIT_STATISTICS_CONVERGENCE.md`.

A null predicate on a leaf that is not repeated sees one entry per row, so the leaf's null count counts rows, and a null count equal to the row count proves every row null. `IS NOT NULL` and value predicates already draw `CANNOT_MATCH` from that; `NullStats.decideIsNull` now draws `ALWAYS_MATCHES` from it, so a row group null throughout skips per-row evaluation. Page filtering still keeps a page unless it is `CANNOT_MATCH`, so pages gain nothing from the new rule until stage 2.

A null predicate on a group reaches that rule only when its levels are equal, which happens when nothing but required nodes lie between the group and its leaf: the leaf is then non-repeated and null exactly where the group is absent. A `LIST` or a `MAP` never gets there. Every repeated node adds a definition level, so in the standard encoding and in every legacy one — two-level lists, element groups named `array` or `<list>_tuple`, `MAP_KEY_VALUE` on either group — the collection sits below its leaf and is answered from the definition level histogram alone. Its leaf is repeated, and an absent collection and an empty one both count among its nulls.

Leaf `IS NULL` / `IS NOT NULL` now read the definition level histogram where the file wrote one sized for the leaf, and fall back to the null count otherwise. The histogram answers where a writer recorded it without a null count. The size check keeps `IsNotNullPredicate.ofLeaf`, whose levels are not read from the schema, off every histogram but a required column's, where its level 0 is the real one.

`RowGroupDecideTest.isNullNeverPromisesAlwaysMatches` becomes `isNullDecisions`, expecting `ALWAYS_MATCHES` for an all-null row group. `FilterPredicateResolverTest` pins the levels a null predicate resolves to for ten collection shapes, the legacy list and map encodings among them, and for a struct of required fields, the one group shape that takes the leaf's path. `UnitStatsTest` adds chunk-and-page cases for the histogram answering without a null count, a histogram short of the row count, a wrong-length histogram falling back to the null count, the no-schema-levels predicate against an optional column's histogram, and a MAP whose every entry is empty, where the key's null count equals the row count although no map is null.

`RowGroupFilterEventTest` reads an all-null row group through the row reader and the column readers and pins `rowGroupsFullyMatching` through the JFR event, for a null leaf under an optional struct and for a struct of required fields absent on every row. The first leaves the column readers' record count unasserted until #1189, a column-reader bug on `main` that drops the rows where the struct is present.
