### PR TITLE
#1190 Resolve a byte literal on a fixed-width DECIMAL to the column width

### DIFF
--- a/core/src/main/java/dev/hardwood/internal/predicate/FilterPredicateResolver.java
+++ b/core/src/main/java/dev/hardwood/internal/predicate/FilterPredicateResolver.java
@@ -126,7 +126,7 @@ public class FilterPredicateResolver {
                     // Every value is padded to the column width, so the literal is too and the
                     // encoding of a given number is the only one the column can hold.
                     yield new ResolvedPredicate.BinaryPredicate(cs.columnIndex(), p.op(),
-                            toFixedLenDecimalBytes(scaled.unscaledValue(),
+                            toFixedLenDecimalBytes(p.column(), scaled.unscaledValue(),
                                     FixedWidthValidator.requireWidth(null, cs)),
                             Comparison.FIXED_DECIMAL);
                 }
@@ -191,16 +191,17 @@ public class FilterPredicateResolver {
                             float16ToFloat(p.column(), p.value()),
                             isIeee754TotalOrder(cs.columnIndex(), columnOrders));
                 }
-                yield new ResolvedPredicate.BinaryPredicate(cs.columnIndex(), p.op(), p.value(),
-                        byteComparison(cs));
+                Comparison comparison = byteComparison(cs);
+                yield new ResolvedPredicate.BinaryPredicate(cs.columnIndex(), p.op(),
+                        comparedBytes(p.column(), p.value(), comparison, cs), comparison);
             }
             case FilterPredicate.SignedBinaryColumnPredicate p -> {
                 ColumnSchema cs = resolveColumn(p.column(), schema);
                 rejectRepeated(p.column(), cs);
                 validateType(p.column(), PhysicalType.FIXED_LEN_BYTE_ARRAY, cs);
                 validateLogicalType(p.column(), LogicalType.DecimalType.class, cs);
-                yield new ResolvedPredicate.BinaryPredicate(cs.columnIndex(), p.op(), p.value(),
-                        Comparison.FIXED_DECIMAL);
+                yield new ResolvedPredicate.BinaryPredicate(cs.columnIndex(), p.op(),
+                        comparedBytes(p.column(), p.value(), Comparison.FIXED_DECIMAL, cs), Comparison.FIXED_DECIMAL);
             }
             case FilterPredicate.UUIDColumnPredicate p -> {
                 ColumnSchema cs = resolveColumn(p.column(), schema);
@@ -235,8 +236,9 @@ public class FilterPredicateResolver {
                             float16Probes(p.column(), p.values()),
                             isIeee754TotalOrder(cs.columnIndex(), columnOrders));
                 }
-                yield new ResolvedPredicate.BinaryInPredicate(cs.columnIndex(), p.values(),
-                        byteComparison(cs));
+                Comparison comparison = byteComparison(cs);
+                yield new ResolvedPredicate.BinaryInPredicate(cs.columnIndex(),
+                        comparedBytes(p.column(), p.values(), comparison, cs), comparison);
             }
             case DoubleInPredicate p -> {
                 ColumnSchema cs = resolveColumn(p.column(), schema);
@@ -445,6 +447,40 @@ public class FilterPredicateResolver {
         return columnSchema.logicalType() instanceof LogicalType.IntType intType && !intType.isSigned();
     }
 
+    /// The bytes a binary literal compares as on this column.
+    ///
+    /// A fixed-width `DECIMAL` stores each number in one encoding, its unscaled value
+    /// sign-extended to the column width, and the dictionary and Bloom filter probes test for
+    /// exactly those bytes. A literal of another length stands for the same number under
+    /// [BinaryComparator#compareSigned], so it is brought to that encoding and every path of the
+    /// read compares the same bytes. An empty literal is zero, as `compareSigned` reads it. Every
+    /// other comparison takes the literal as given.
+    ///
+    /// @throws ArithmeticException if the literal's value needs more bytes than the column holds
+    private static byte[] comparedBytes(String columnName, byte[] literal, Comparison comparison,
+            ColumnSchema columnSchema) {
+        if (comparison != Comparison.FIXED_DECIMAL) {
+            return literal;
+        }
+        BigInteger unscaled = literal.length == 0 ? BigInteger.ZERO : new BigInteger(literal);
+        return toFixedLenDecimalBytes(columnName, unscaled,
+                FixedWidthValidator.requireWidth(null, columnSchema));
+    }
+
+    /// [#comparedBytes(String, byte[], Comparison, ColumnSchema)] for each probe of a membership
+    /// test.
+    private static byte[][] comparedBytes(String columnName, byte[][] probes, Comparison comparison,
+            ColumnSchema columnSchema) {
+        if (comparison != Comparison.FIXED_DECIMAL) {
+            return probes;
+        }
+        byte[][] resolved = new byte[probes.length][];
+        for (int i = 0; i < probes.length; i++) {
+            resolved[i] = comparedBytes(columnName, probes[i], comparison, columnSchema);
+        }
+        return resolved;
+    }
+
     /// The order a binary literal compares in on this column.
     ///
     /// Either binary physical type reaches here whatever it is annotated, since [#validateType]
@@ -581,14 +617,17 @@ public class FilterPredicateResolver {
     /// Converts an unscaled [BigInteger] to a fixed-length big-endian two's complement byte array,
     /// matching the Parquet `FIXED_LEN_BYTE_ARRAY` encoding for decimals. The output is
     /// sign-extended (0x00 for positive, 0xFF for negative) to fill the fixed length.
-    static byte[] toFixedLenDecimalBytes(BigInteger unscaled, int typeLength) {
+    ///
+    /// @param columnName the column the literal filters, for the message
+    /// @throws ArithmeticException if the value needs more than `typeLength` bytes
+    static byte[] toFixedLenDecimalBytes(String columnName, BigInteger unscaled, int typeLength) {
         byte[] minimal = unscaled.toByteArray();
         if (minimal.length == typeLength) {
             return minimal;
         }
         if (minimal.length > typeLength) {
-            throw new ArithmeticException(
-                    "Decimal value requires " + minimal.length + " bytes but column has typeLength " + typeLength);
+            throw new ArithmeticException("Column '" + columnName + "' is a FIXED_LEN_BYTE_ARRAY("
+                    + typeLength + ") DECIMAL; the literal needs " + minimal.length + " bytes");
         }
         byte[] padded = new byte[typeLength];
         byte fill = (byte) (unscaled.signum() < 0 ? 0xFF : 0x00);

--- a/core/src/main/java/dev/hardwood/internal/predicate/FilterPredicateResolver.java
+++ b/core/src/main/java/dev/hardwood/internal/predicate/FilterPredicateResolver.java
@@ -195,14 +195,6 @@ public class FilterPredicateResolver {
                 yield new ResolvedPredicate.BinaryPredicate(cs.columnIndex(), p.op(),
                         comparedBytes(p.column(), p.value(), comparison, cs), comparison);
             }
-            case FilterPredicate.SignedBinaryColumnPredicate p -> {
-                ColumnSchema cs = resolveColumn(p.column(), schema);
-                rejectRepeated(p.column(), cs);
-                validateType(p.column(), PhysicalType.FIXED_LEN_BYTE_ARRAY, cs);
-                validateLogicalType(p.column(), LogicalType.DecimalType.class, cs);
-                yield new ResolvedPredicate.BinaryPredicate(cs.columnIndex(), p.op(),
-                        comparedBytes(p.column(), p.value(), Comparison.FIXED_DECIMAL, cs), Comparison.FIXED_DECIMAL);
-            }
             case FilterPredicate.UUIDColumnPredicate p -> {
                 ColumnSchema cs = resolveColumn(p.column(), schema);
                 rejectRepeated(p.column(), cs);

--- a/core/src/main/java/dev/hardwood/reader/FilterPredicate.java
+++ b/core/src/main/java/dev/hardwood/reader/FilterPredicate.java
@@ -90,7 +90,6 @@ public sealed interface FilterPredicate
                 FilterPredicate.DoubleColumnPredicate,
                 FilterPredicate.BooleanColumnPredicate,
                 FilterPredicate.BinaryColumnPredicate,
-                FilterPredicate.SignedBinaryColumnPredicate,
                 FilterPredicate.UUIDColumnPredicate,
                 FilterPredicate.IntInPredicate,
                 FilterPredicate.LongInPredicate,
@@ -543,27 +542,6 @@ public sealed interface FilterPredicate
         public boolean equals(Object o) {
             if (this == o) return true;
             if (!(o instanceof BinaryColumnPredicate that)) return false;
-            return column.equals(that.column) && op == that.op && Arrays.equals(value, that.value);
-        }
-
-        @Override
-        public int hashCode() {
-            int result = column.hashCode();
-            result = 31 * result + op.hashCode();
-            result = 31 * result + Arrays.hashCode(value);
-            return result;
-        }
-    }
-
-    /// Predicate for decimal columns stored as `FIXED_LEN_BYTE_ARRAY`, which require signed
-    /// (two's complement) comparison. The column must carry a `DECIMAL` logical type and the
-    /// value must be padded to the column's fixed length.
-    record SignedBinaryColumnPredicate(String column, Operator op, byte[] value) implements FilterPredicate {
-
-        @Override
-        public boolean equals(Object o) {
-            if (this == o) return true;
-            if (!(o instanceof SignedBinaryColumnPredicate that)) return false;
             return column.equals(that.column) && op == that.op && Arrays.equals(value, that.value);
         }
 

--- a/core/src/test/java/dev/hardwood/DifferentialColumnOrderTest.java
+++ b/core/src/test/java/dev/hardwood/DifferentialColumnOrderTest.java
@@ -135,7 +135,17 @@ class DifferentialColumnOrderTest {
                 new Case("dec in bytes of -1.25, 2.50",
                         bytesIn("dec", decimal("-1.25"), decimal("2.50")), "dec IN (-1.25, 2.50)"),
                 new Case("not dec in bytes of -1.25",
-                        FilterPredicate.not(bytesIn("dec", decimal("-1.25"))), "dec NOT IN (-1.25)"));
+                        FilterPredicate.not(bytesIn("dec", decimal("-1.25"))), "dec NOT IN (-1.25)"),
+                // A literal of any width stands for its value; the dictionary layout probes exact bytes.
+                new Case("dec == bytes of 1.25", bytes("dec", Operator.EQ, decimal("1.25")), "dec = 1.25"),
+                new Case("dec == minimal bytes of 1.25", bytes("dec", Operator.EQ, minimalDecimal("1.25")), "dec = 1.25"),
+                new Case("dec == minimal bytes of -1.25", bytes("dec", Operator.EQ, minimalDecimal("-1.25")), "dec = -1.25"),
+                new Case("dec == wide bytes of 1.25", bytes("dec", Operator.EQ, wideDecimal("1.25")), "dec = 1.25"),
+                new Case("dec > minimal bytes of 1.25", bytes("dec", Operator.GT, minimalDecimal("1.25")), "dec > 1.25"),
+                new Case("dec in minimal bytes of -1.25, 2.50",
+                        bytesIn("dec", minimalDecimal("-1.25"), minimalDecimal("2.50")), "dec IN (-1.25, 2.50)"),
+                new Case("not dec in minimal bytes of -1.25",
+                        FilterPredicate.not(bytesIn("dec", minimalDecimal("-1.25"))), "dec NOT IN (-1.25)"));
     }
 
     static Stream<Arguments> fixtureCases() {
@@ -206,6 +216,21 @@ class DifferentialColumnOrderTest {
         Arrays.fill(padded, 0, DECIMAL_WIDTH - minimal.length, unscaled.signum() < 0 ? (byte) 0xFF : 0);
         System.arraycopy(minimal, 0, padded, DECIMAL_WIDTH - minimal.length, minimal.length);
         return padded;
+    }
+
+    /// The fewest big-endian two's complement bytes that hold `value`'s unscaled form — narrower
+    /// than `dec` for every value in the corpus.
+    private static byte[] minimalDecimal(String value) {
+        return new BigDecimal(value).setScale(2).unscaledValue().toByteArray();
+    }
+
+    /// `value` as `dec` stores it, behind one more sign-extension byte — wider than the column.
+    private static byte[] wideDecimal(String value) {
+        byte[] padded = decimal(value);
+        byte[] wide = new byte[DECIMAL_WIDTH + 1];
+        wide[0] = padded[0] < 0 ? (byte) 0xFF : 0;
+        System.arraycopy(padded, 0, wide, 1, DECIMAL_WIDTH);
+        return wide;
     }
 
     private static FilterPredicate bytes(String column, Operator op, byte[] value) {

--- a/core/src/test/java/dev/hardwood/internal/predicate/FilterPredicateResolverTest.java
+++ b/core/src/test/java/dev/hardwood/internal/predicate/FilterPredicateResolverTest.java
@@ -236,7 +236,7 @@ class FilterPredicateResolverTest {
         ResolvedPredicate.BinaryPredicate bp = (ResolvedPredicate.BinaryPredicate) resolved;
         assertThat(bp.signed()).isTrue();
         // 1.00 with scale 2 → unscaled 100 → padded to 16 bytes
-        byte[] expected = FilterPredicateResolver.toFixedLenDecimalBytes(
+        byte[] expected = FilterPredicateResolver.toFixedLenDecimalBytes("amount",
                 new BigDecimal("1.00").setScale(2).unscaledValue(), 16);
         assertThat(bp.value()).isEqualTo(expected);
     }
@@ -294,11 +294,98 @@ class FilterPredicateResolverTest {
         ResolvedPredicate.BinaryPredicate bp = (ResolvedPredicate.BinaryPredicate) resolved;
         assertThat(bp.signed()).isTrue();
         // -1.50 with scale 2 → unscaled -150 → sign-extended to 8 bytes
-        byte[] expected = FilterPredicateResolver.toFixedLenDecimalBytes(
+        byte[] expected = FilterPredicateResolver.toFixedLenDecimalBytes("amount",
                 new BigDecimal("-1.50").setScale(2).unscaledValue(), 8);
         assertThat(bp.value()).isEqualTo(expected);
         // First byte should be 0xFF (negative sign extension)
         assertThat(bp.value()[0]).isEqualTo((byte) 0xFF);
+    }
+
+    @Test
+    void resolveDecimalTooWideForFixedLenColumnThrows() {
+        FileSchema schema = schemaWithLogicalType("amount", PhysicalType.FIXED_LEN_BYTE_ARRAY, 4,
+                LogicalType.decimal(9, 2));
+        // 30000000.00 is unscaled 3_000_000_000, which needs five bytes in two's complement
+        assertThatThrownBy(() -> FilterPredicateResolver.resolve(
+                FilterPredicate.eq("amount", new BigDecimal("30000000.00")), schema))
+                .isInstanceOf(ArithmeticException.class)
+                .hasMessage("Column 'amount' is a FIXED_LEN_BYTE_ARRAY(4) DECIMAL; the literal needs 5 bytes");
+    }
+
+    // ==================== Byte literal on a fixed-width DECIMAL ====================
+
+    /// A fixed-width `DECIMAL` holds each number in one encoding, sign-extended to the column
+    /// width, and the byte-exact shortcuts probe for exactly that encoding. A byte literal of any
+    /// length resolves to it.
+    @Test
+    void resolveNarrowByteLiteralOnFixedLenDecimalSignExtendsToWidth() {
+        assertThat(resolveFixedDecimalLiteral(0x7D)).containsExactly(0x00, 0x00, 0x00, 0x7D);
+        assertThat(resolveFixedDecimalLiteral(0x83)).containsExactly(0xFF, 0xFF, 0xFF, 0x83);
+    }
+
+    @Test
+    void resolveWideByteLiteralOnFixedLenDecimalDropsSignExtension() {
+        assertThat(resolveFixedDecimalLiteral(0x00, 0x00, 0x00, 0x00, 0x7D)).containsExactly(0x00, 0x00, 0x00, 0x7D);
+        assertThat(resolveFixedDecimalLiteral(0xFF, 0xFF, 0xFF, 0xFF, 0x83)).containsExactly(0xFF, 0xFF, 0xFF, 0x83);
+    }
+
+    /// `BinaryComparator.compareSigned` reads an empty array as zero.
+    @Test
+    void resolveEmptyByteLiteralOnFixedLenDecimalAsZero() {
+        assertThat(resolveFixedDecimalLiteral()).containsExactly(0x00, 0x00, 0x00, 0x00);
+    }
+
+    @Test
+    void resolveByteLiteralTooWideForFixedLenDecimalThrows() {
+        assertThatThrownBy(() -> resolveFixedDecimalLiteral(0x01, 0x00, 0x00, 0x00, 0x00))
+                .isInstanceOf(ArithmeticException.class)
+                .hasMessage("Column 'amount' is a FIXED_LEN_BYTE_ARRAY(4) DECIMAL; the literal needs 5 bytes");
+    }
+
+    @Test
+    void resolveByteLiteralProbesOnFixedLenDecimalSignExtendToWidth() {
+        FileSchema schema = schemaWithLogicalType("amount", PhysicalType.FIXED_LEN_BYTE_ARRAY, 4,
+                LogicalType.decimal(9, 2));
+        ResolvedPredicate resolved = FilterPredicateResolver.resolve(
+                new FilterPredicate.BinaryInPredicate("amount", new byte[][]{ byteLiteral(0x7D), byteLiteral(0x83) }),
+                schema);
+        assertThat(resolved).isInstanceOfSatisfying(ResolvedPredicate.BinaryInPredicate.class, p -> {
+            assertThat(p.byteExact()).isTrue();
+            assertThat(p.values()[0]).containsExactly(0x00, 0x00, 0x00, 0x7D);
+            assertThat(p.values()[1]).containsExactly(0xFF, 0xFF, 0xFF, 0x83);
+        });
+    }
+
+    /// An unannotated fixed-width column compares its bytes as a byte string, where a shorter
+    /// literal is a different value, not a padded one; it resolves as given.
+    @Test
+    void resolveByteLiteralOnUnannotatedFixedLenColumnAsGiven() {
+        FileSchema schema = schemaWithLogicalType("code", PhysicalType.FIXED_LEN_BYTE_ARRAY, 4, null);
+        ResolvedPredicate resolved = FilterPredicateResolver.resolve(FilterPredicate.eq("code", "aa"), schema);
+        assertThat(resolved).isInstanceOfSatisfying(ResolvedPredicate.BinaryPredicate.class,
+                p -> assertThat(p.value()).containsExactly('a', 'a'));
+    }
+
+    /// Resolves `eq` for `literal` against a `DECIMAL(9, 2)` in a `FIXED_LEN_BYTE_ARRAY(4)` and
+    /// returns the bytes the predicate compares.
+    private static byte[] resolveFixedDecimalLiteral(int... literal) {
+        FileSchema schema = schemaWithLogicalType("amount", PhysicalType.FIXED_LEN_BYTE_ARRAY, 4,
+                LogicalType.decimal(9, 2));
+        ResolvedPredicate resolved = FilterPredicateResolver.resolve(
+                new FilterPredicate.BinaryColumnPredicate("amount", FilterPredicate.Operator.EQ, byteLiteral(literal)),
+                schema);
+        assertThat(resolved).isInstanceOf(ResolvedPredicate.BinaryPredicate.class);
+        ResolvedPredicate.BinaryPredicate predicate = (ResolvedPredicate.BinaryPredicate) resolved;
+        assertThat(predicate.byteExact()).isTrue();
+        return predicate.value();
+    }
+
+    private static byte[] byteLiteral(int... values) {
+        byte[] bytes = new byte[values.length];
+        for (int i = 0; i < values.length; i++) {
+            bytes[i] = (byte) values[i];
+        }
+        return bytes;
     }
 
     // ==================== UUID ====================
@@ -882,7 +969,7 @@ class FilterPredicateResolverTest {
 
     @Test
     void toFixedLenDecimalBytes_zeroSignumPadding() {
-        byte[] bytes = FilterPredicateResolver.toFixedLenDecimalBytes(BigInteger.ZERO, 4);
+        byte[] bytes = FilterPredicateResolver.toFixedLenDecimalBytes("c", BigInteger.ZERO, 4);
         assertThat(bytes).containsExactly(0, 0, 0, 0);
     }
 

--- a/core/src/test/java/dev/hardwood/internal/predicate/FilterPredicateResolverTest.java
+++ b/core/src/test/java/dev/hardwood/internal/predicate/FilterPredicateResolverTest.java
@@ -262,26 +262,15 @@ class FilterPredicateResolverTest {
     }
 
     @Test
-    void resolveSignedBinaryOnDecimalColumn() {
+    void resolveByteLiteralOnFixedLenDecimalComparesSigned() {
         FileSchema schema = schemaWithLogicalType("amount", PhysicalType.FIXED_LEN_BYTE_ARRAY, 8,
                 LogicalType.decimal(18, 2));
         byte[] value = new byte[8];
         ResolvedPredicate resolved = FilterPredicateResolver.resolve(
-                new FilterPredicate.SignedBinaryColumnPredicate("amount", FilterPredicate.Operator.GT, value),
+                new FilterPredicate.BinaryColumnPredicate("amount", FilterPredicate.Operator.GT, value),
                 schema);
         assertThat(resolved).isInstanceOf(ResolvedPredicate.BinaryPredicate.class);
         assertThat(((ResolvedPredicate.BinaryPredicate) resolved).signed()).isTrue();
-    }
-
-    @Test
-    void resolveSignedBinaryOnNonDecimalColumnThrows() {
-        FileSchema schema = schemaWithLogicalType("data", PhysicalType.FIXED_LEN_BYTE_ARRAY, 8, null);
-        byte[] value = new byte[8];
-        assertThatThrownBy(() -> FilterPredicateResolver.resolve(
-                new FilterPredicate.SignedBinaryColumnPredicate("data", FilterPredicate.Operator.EQ, value),
-                schema))
-                .isInstanceOf(IllegalArgumentException.class)
-                .hasMessage("Column 'data' is not a DecimalType column (logical type: null)");
     }
 
     @Test
@@ -882,7 +871,6 @@ class FilterPredicateResolverTest {
                 FilterPredicate.eq("rep", LocalTime.NOON),
                 FilterPredicate.eq("rep", BigDecimal.ONE),
                 FilterPredicate.eq("rep", UUID.randomUUID()),
-                new FilterPredicate.SignedBinaryColumnPredicate("rep", FilterPredicate.Operator.EQ, new byte[8]),
                 FilterPredicate.in("rep", 1, 2),
                 FilterPredicate.in("rep", 1L, 2L),
                 FilterPredicate.in("rep", 1.0, 2.0),
@@ -951,13 +939,6 @@ class FilterPredicateResolverTest {
         assertThatThrownBy(() -> FilterPredicateResolver.resolve(FilterPredicate.eq("c", LocalTime.NOON), timeMicrosWrong))
                 .isInstanceOf(IllegalArgumentException.class)
                 .hasMessage(incompatible("INT32", "INT64"));
-
-        FileSchema signedBinaryWrong = schemaWithLogicalType("c", PhysicalType.INT32,
-                LogicalType.decimal(18, 2));
-        assertThatThrownBy(() -> FilterPredicateResolver.resolve(
-                new FilterPredicate.SignedBinaryColumnPredicate("c", FilterPredicate.Operator.EQ, new byte[8]), signedBinaryWrong))
-                .isInstanceOf(IllegalArgumentException.class)
-                .hasMessage(incompatible("INT32", "FIXED_LEN_BYTE_ARRAY"));
 
         FileSchema uuidWrong = schemaWithLogicalType("c", PhysicalType.INT32,
                 new LogicalType.UuidType());

--- a/docs/content/reference/query-controls.md
+++ b/docs/content/reference/query-controls.md
@@ -91,7 +91,10 @@ value as it is stored: an `int` against a `DATE` column tests the epoch day dire
 their bytes stand for rather than by the bytes themselves, and their statistics are written in
 that order, so a `String` literal against either compares as the column does — a `DECIMAL` by its
 unscaled value, a `FLOAT16` by the number its two little-endian bytes encode — rather than as a
-byte string. A `FLOAT16` literal must be exactly two bytes.
+byte string. A `FLOAT16` literal must be exactly two bytes. On a `FIXED_LEN_BYTE_ARRAY` `DECIMAL`,
+a literal of any length stands for the value it encodes and is brought to the column width:
+sign-extended when it is shorter, its leading sign-extension bytes dropped when it is longer. One
+whose value needs more bytes than the column holds throws `ArithmeticException`.
 
 `inStrings` compares each probe the same way, so on a `DECIMAL` a padded encoding of a probe is
 still a member, and on a `FLOAT16` each probe — exactly two bytes — is compared as the half it

--- a/docs/content/release-notes.md
+++ b/docs/content/release-notes.md
@@ -56,6 +56,8 @@ See [GitHub Releases](https://github.com/hardwood-hq/hardwood/releases) for down
 
 **Breaking Changes:**
 
+- `FilterPredicate.SignedBinaryColumnPredicate` is removed; a `DECIMAL` column is filtered with the `BigDecimal` factories ([#1190](https://github.com/hardwood-hq/hardwood/issues/1190)).
+
 - The reader's exception model separates what the transport got wrong from what the file did, so a failure says whether trying again can help ([#1104](https://github.com/hardwood-hq/hardwood/issues/1104)).
     - `IOException` now means the transport — a read that failed, a connection reset — and is declared where the reader reaches the file: `RowReader.hasNext`/`next`/`close` and `ColumnReader.nextBatch`/`close`, as `ParquetFileWriter` has always declared it. **The canonical idiom is unaffected**, because `ParquetFileReader.open(...)` already declared `IOException` and so the enclosing method already handles it:
 

--- a/docs/content/release-notes.md
+++ b/docs/content/release-notes.md
@@ -15,6 +15,8 @@ See [GitHub Releases](https://github.com/hardwood-hq/hardwood/releases) for down
 
 ## 1.1.0-SNAPSHOT
 
+- A `String`, `inStrings` or parquet-java `binaryColumn` literal on a `FIXED_LEN_BYTE_ARRAY` `DECIMAL` column that is narrower or wider than the column no longer drops row groups holding matching rows, and one whose value does not fit the column throws `ArithmeticException` ([#1190](https://github.com/hardwood-hq/hardwood/issues/1190)).
+
 - Row groups and pages are no longer pruned against `min` / `max` in a sort order the reader cannot read — a column annotated `INTERVAL`, `GEOMETRY`, `GEOGRAPHY`, `VARIANT`, `UNKNOWN`, `LIST` or `MAP`, or one whose file declares an unrecognized `ColumnOrder` ([#1179](https://github.com/hardwood-hq/hardwood/issues/1179)).
 
 - `isNull` and `isNotNull` accept the name of a group — a struct, a `LIST` or a `MAP` — testing whether the group itself is present rather than one of its fields ([#977](https://github.com/hardwood-hq/hardwood/issues/977)).


### PR DESCRIPTION
Fixes #1190.

A byte literal on a `FIXED_LEN_BYTE_ARRAY` `DECIMAL` column resolves to `FIXED_DECIMAL`, which declares the column byte-exact, but the literal was kept at the width the caller gave. Per-record evaluation, statistics and the page index sign-extend it through `compareSigned`; the dictionary and Bloom filter test its exact bytes. A literal narrower or wider than the column therefore dropped row groups holding matching rows — `eq("dec", "}")` on a `DECIMAL(9, 2)` in `FIXED_LEN_BYTE_ARRAY(4)` returned nothing for the `1.25` the file holds.

`FilterPredicateResolver` now brings the literal, and each probe of an `IN`, to the column width, as the `BigDecimal` path already does: sign-extended when narrower, sign-extension bytes dropped when wider, an empty literal read as zero, and `ArithmeticException` when the value does not fit. Every other comparison takes the literal as given. The evaluator is unchanged.

The second commit removes `FilterPredicate.SignedBinaryColumnPredicate`, which had no factory, no documentation and no caller outside the resolver's tests, and is redundant with `BinaryColumnPredicate` on the same column.

Tests: resolver unit tests for narrow, negative, wide, empty, too-wide and `IN` literals, plus an unannotated fixed-width control; seven `dec` cases in `DifferentialColumnOrderTest` against DuckDB across the single, multi-row-group and dictionary layouts. Without the fix the narrow and wide `eq` / `in` cases fail in the dictionary layout.

## Authorship

Hardwood is built with AI, not by AI. LLM assistance is welcome; submitting raw LLM output without understanding is not.
Neither are unattended agents opening pull requests.
See the [contribution guide](https://github.com/hardwood-hq/hardwood/blob/main/CONTRIBUTING.md) for more details.
Check this box to confirm:

- [ ] This change is coming from a human who understands what it does and why, and can discuss it in review

## Checklist

- [x] Build via `./mvnw clean verify` passes (ran `./mvnw verify` with the integration tests)
- [x] The commit message is prefixed with the issue key ("#123 Adding support for...")
- [x] Code changes are covered by tests
- [x] If this PR adds or changes user-facing behaviour, `docs/` has been updated
