### PR TITLE
#1197 Read FLOAT16 and nullable struct leaves in the ColumnReader filter

### DIFF
--- a/core/src/main/java/dev/hardwood/internal/reader/NestedBatch.java
+++ b/core/src/main/java/dev/hardwood/internal/reader/NestedBatch.java
@@ -55,9 +55,11 @@ public final class NestedBatch {
     /// otherwise re-derive the same fact.
     public boolean allPresent;
 
-    // Pre-computed index (computed by drain before publish). Validity bit set
-    // iff present. Null means "all items at that layer are present in this
-    // batch."
+    // Pre-computed index. Validity bit set iff present. Null means "all items
+    // at that layer are present in this batch." The drain computes both before
+    // publish, except on the exact-filtered ColumnReader path: there it leaves
+    // both null, and the SelectionEngine derives elementValidity for its
+    // predicate columns.
     public long[] elementValidity;
     public int[][] multiLevelOffsets;
 

--- a/core/src/main/java/dev/hardwood/internal/reader/NestedBatchDataView.java
+++ b/core/src/main/java/dev/hardwood/internal/reader/NestedBatchDataView.java
@@ -82,8 +82,10 @@ public final class NestedBatchDataView {
         }
     }
 
-    /// Install batch data from [NestedBatch] objects whose index fields
-    /// have been pre-computed by the drain thread.
+    /// Install batch data from [NestedBatch] objects whose index fields are
+    /// already computed: by the drain thread before publish, or, for the
+    /// predicate columns of an exact-filtered `ColumnReader`, by the
+    /// `SelectionEngine`.
     public void setBatchData(NestedBatch[] batches, ColumnSchema[] columnSchemas, String fileName) {
         this.batchIndex = NestedBatchIndex.buildFromBatches(
                 batches, columnSchemas, schema, projectedSchema, fieldMap);

--- a/core/src/main/java/dev/hardwood/internal/reader/NestedColumnWorker.java
+++ b/core/src/main/java/dev/hardwood/internal/reader/NestedColumnWorker.java
@@ -564,7 +564,8 @@ public class NestedColumnWorker extends ColumnWorker<NestedBatch> {
             // Exact-filtered ColumnReader: applySelection compacts the batch from the
             // raw levels (kept above) before the consumer reads it, then the consumer
             // rebuilds the view lazily. Nothing is derived on the drain here; the
-            // all-items index the ColumnReader never reads is skipped.
+            // all-items index is skipped, and the SelectionEngine derives the element
+            // validity of the predicate columns itself.
             batch.elementValidity = null;
             batch.multiLevelOffsets = null;
             return;

--- a/core/src/main/java/dev/hardwood/reader/SelectionEngine.java
+++ b/core/src/main/java/dev/hardwood/reader/SelectionEngine.java
@@ -31,6 +31,7 @@ import dev.hardwood.internal.reader.BatchMatchMerger;
 import dev.hardwood.internal.reader.BinaryBatchValues;
 import dev.hardwood.internal.reader.NestedBatch;
 import dev.hardwood.internal.reader.NestedBatchDataView;
+import dev.hardwood.internal.reader.NestedLevelComputer;
 import dev.hardwood.internal.schema.ProjectedSchema;
 import dev.hardwood.row.PqInterval;
 import dev.hardwood.row.PqList;
@@ -295,13 +296,21 @@ final class SelectionEngine {
         /// array + validity for the current batch. Called once per batch before
         /// per-record evaluation, so the per-record accessors avoid repeated
         /// lookups and `getXxx()` dispatch.
+        ///
+        /// The filtered read path publishes nested batches without the leaf
+        /// validity the view reads nulls from, so it is derived here from the
+        /// definition levels. Without it, a leaf that is null under a present
+        /// struct reads as a value.
         void refresh() {
             for (FlatField field : flatByName.values()) {
                 field.refresh();
             }
             if (nestedView != null) {
                 for (int j = 0; j < nestedReaders.length; j++) {
-                    nestedBatches[j] = nestedReaders[j].currentNestedBatch();
+                    NestedBatch batch = nestedReaders[j].currentNestedBatch();
+                    batch.elementValidity = NestedLevelComputer.computeElementValidity(
+                            batch.definitionLevels, batch.valueCount, nestedColumnSchemas[j].maxDefinitionLevel());
+                    nestedBatches[j] = batch;
                 }
                 nestedView.setBatchData(nestedBatches, nestedColumnSchemas, nestedBatches[0].fileName);
             }
@@ -339,7 +348,11 @@ final class SelectionEngine {
         }
 
         @Override public float getFloat(String name) {
-            return ((float[]) flat(name).values)[record];
+            Object values = flat(name).values;
+            // A FLOAT16 column is held as two-byte binary values, read as the half they encode.
+            return values instanceof float[] floats
+                    ? floats[record]
+                    : ((BinaryBatchValues) values).float16At(record);
         }
 
         @Override public double getDouble(String name) {

--- a/core/src/test/java/dev/hardwood/ColumnReaderExactFilterTest.java
+++ b/core/src/test/java/dev/hardwood/ColumnReaderExactFilterTest.java
@@ -446,4 +446,105 @@ class ColumnReaderExactFilterTest {
         assertThat(distinctValueSum).isEqualTo(oracleValueSum);
         assertThat(groupedValueSum).isEqualTo(oracleValueSum);
     }
+
+    // ==================== Leaves read by the record-matcher view ====================
+
+    private static final Path FLOAT16_FILE = Paths.get("src/test/resources/float16_logical_type_test.parquet");
+    private static final Path DICT_FLOAT16_FILE = Paths.get("src/test/resources/dict_float16_pushdown.parquet");
+    private static final Path OPTIONAL_LEAF_FILE = Paths.get("src/test/resources/optional_struct_optional_leaf_test.parquet");
+
+    /// `half` over ids 1..7 holds 0.0, 1.0, -1.5, 65504.0, +Inf, NaN and null; a FLOAT16
+    /// column is held as two-byte binary values, which the record view decodes to a half.
+    static Stream<Arguments> float16Filters() {
+        return Stream.of(
+                Arguments.of(FilterPredicate.eq("half", 1.0f), List.of(2)),
+                Arguments.of(FilterPredicate.notEq("half", 1.0f), List.of(1, 3, 4, 5, 6)),
+                Arguments.of(FilterPredicate.lt("half", 1.0f), List.of(1, 3)),
+                Arguments.of(FilterPredicate.ltEq("half", 0.0f), List.of(1, 3)),
+                Arguments.of(FilterPredicate.gt("half", 1.0f), List.of(4, 5, 6)),
+                Arguments.of(FilterPredicate.gtEq("half", 65504.0f), List.of(4, 5, 6)),
+                Arguments.of(FilterPredicate.in("half", 1.0, -1.5), List.of(2, 3)),
+                Arguments.of(FilterPredicate.not(FilterPredicate.in("half", 1.0, -1.5)), List.of(1, 4, 5, 6)));
+    }
+
+    @ParameterizedTest(name = "{0}")
+    @MethodSource("float16Filters")
+    void float16LeafAgreesWithRowReader(FilterPredicate filter, List<Integer> expectedIds) throws Exception {
+        assertIdsAgreeWithRowReader(FLOAT16_FILE, filter, expectedIds);
+    }
+
+    @Test
+    void dictionaryEncodedFloat16LeafIsExact() throws Exception {
+        // `half` cycles 1.0, 2.0, 4.0, 8.0 over 4096 rows, so each value is 1024 rows.
+        try (ParquetFileReader reader = ParquetFileReader.open(InputFile.of(DICT_FLOAT16_FILE));
+             ColumnReader half = reader.buildColumnReader("half")
+                     .filter(FilterPredicate.in("half", 2.0, 8.0)).build()) {
+            int count = 0;
+            while (half.nextBatch()) {
+                count += half.getRecordCount();
+            }
+            assertThat(count).isEqualTo(2048);
+        }
+    }
+
+    /// `point` is an optional struct over the optional leaf `x`: null in id 1, present with
+    /// `x` null in id 2, and present with `x = 42` in id 3.
+    static Stream<Arguments> optionalStructLeafFilters() {
+        return Stream.of(
+                Arguments.of(FilterPredicate.isNull("point.x"), List.of(1, 2)),
+                Arguments.of(FilterPredicate.isNotNull("point.x"), List.of(3)),
+                Arguments.of(FilterPredicate.lt("point.x", 100), List.of(3)),
+                Arguments.of(FilterPredicate.notEq("point.x", 42), List.of()),
+                Arguments.of(FilterPredicate.and(FilterPredicate.isNotNull("point"), FilterPredicate.isNull("point.x")),
+                        List.of(2)),
+                Arguments.of(FilterPredicate.isNull("point"), List.of(1)));
+    }
+
+    @ParameterizedTest(name = "{0}")
+    @MethodSource("optionalStructLeafFilters")
+    void nullLeafUnderPresentStructAgreesWithRowReader(FilterPredicate filter, List<Integer> expectedIds)
+            throws Exception {
+        assertIdsAgreeWithRowReader(OPTIONAL_LEAF_FILE, filter, expectedIds);
+    }
+
+    /// Reads the `INT32` column `id` of `file` under `filter` through the row reader, a single
+    /// column reader and a column-reader group, and asserts that each yields `expectedIds`.
+    private static void assertIdsAgreeWithRowReader(Path file, FilterPredicate filter, List<Integer> expectedIds)
+            throws Exception {
+        List<Integer> rowIds = new ArrayList<>();
+        try (ParquetFileReader reader = ParquetFileReader.open(InputFile.of(file));
+             RowReader rows = reader.buildRowReader().filter(filter).build()) {
+            while (rows.hasNext()) {
+                rows.next();
+                rowIds.add(rows.getInt("id"));
+            }
+        }
+
+        List<Integer> singleIds = new ArrayList<>();
+        try (ParquetFileReader reader = ParquetFileReader.open(InputFile.of(file));
+             ColumnReader idReader = reader.buildColumnReader("id").filter(filter).build()) {
+            while (idReader.nextBatch()) {
+                int[] ids = idReader.getInts();
+                for (int i = 0; i < idReader.getRecordCount(); i++) {
+                    singleIds.add(ids[i]);
+                }
+            }
+        }
+
+        List<Integer> groupedIds = new ArrayList<>();
+        try (ParquetFileReader reader = ParquetFileReader.open(InputFile.of(file));
+             ColumnReaders columns = reader.buildColumnReaders(ColumnProjection.columns("id"))
+                     .filter(filter).build()) {
+            while (columns.nextBatch()) {
+                int[] ids = columns.getColumnReader("id").getInts();
+                for (int i = 0; i < columns.getRecordCount(); i++) {
+                    groupedIds.add(ids[i]);
+                }
+            }
+        }
+
+        assertThat(rowIds).isEqualTo(expectedIds);
+        assertThat(singleIds).isEqualTo(expectedIds);
+        assertThat(groupedIds).isEqualTo(expectedIds);
+    }
 }

--- a/docs/content/release-notes.md
+++ b/docs/content/release-notes.md
@@ -15,6 +15,8 @@ See [GitHub Releases](https://github.com/hardwood-hq/hardwood/releases) for down
 
 ## 1.1.0-SNAPSHOT
 
+- A `ColumnReader` filter on a `FLOAT16` column no longer throws `ClassCastException`, and one on a struct leaf no longer reads a leaf that is null under a present struct as a value ([#1197](https://github.com/hardwood-hq/hardwood/issues/1197)).
+
 - A `String`, `inStrings` or parquet-java `binaryColumn` literal on a `FIXED_LEN_BYTE_ARRAY` `DECIMAL` column that is narrower or wider than the column no longer drops row groups holding matching rows, and one whose value does not fit the column throws `ArithmeticException` ([#1190](https://github.com/hardwood-hq/hardwood/issues/1190)).
 
 - Row groups and pages are no longer pruned against `min` / `max` in a sort order the reader cannot read — a column annotated `INTERVAL`, `GEOMETRY`, `GEOGRAPHY`, `VARIANT`, `UNKNOWN`, `LIST` or `MAP`, or one whose file declares an unrecognized `ColumnOrder` ([#1179](https://github.com/hardwood-hq/hardwood/issues/1179)).


### PR DESCRIPTION
Closes #1197

When the drain-side matchers cannot take a predicate, a `ColumnReader` filter evaluates each record through `SelectionEngine`'s batch-backed row view. That view read two kinds of leaf differently from the `RowReader`:

- **FLOAT16:** `getFloat` cast every float leaf's batch to `float[]`, but a `FLOAT16` column is held as two-byte binary values, so every `FLOAT16` predicate threw `ClassCastException`. The view now reads the half the two bytes encode, as the `RowReader` does.
- **Null leaf under a present struct:** the filtered read path (`REAL_VIEW_KEEP_LEVELS`) publishes nested batches without the leaf validity the nested view reads nulls from, so such a leaf was taken for a value by `isNull`, `isNotNull` and every comparison. The view now derives the leaf validity of its nested predicate columns from their definition levels once per batch; payload columns keep the lean drain path.

`ColumnReaderExactFilterTest` checks the row reader, a single column reader and a column-reader group against pinned ids on existing fixtures: `float16_logical_type_test.parquet` (every operator, the set form and its negation), `dict_float16_pushdown.parquet`, and `optional_struct_optional_leaf_test.parquet`.