### PR TITLE
#1139 Drop TIME, INT and DECIMAL annotations their carrier cannot hold

### DIFF
--- a/core/src/main/java/dev/hardwood/internal/conversion/LogicalTypeConverter.java
+++ b/core/src/main/java/dev/hardwood/internal/conversion/LogicalTypeConverter.java
@@ -20,6 +20,7 @@ import java.time.ZoneOffset;
 import java.time.temporal.Temporal;
 import java.util.UUID;
 
+import dev.hardwood.internal.schema.LogicalTypeValidator;
 import dev.hardwood.metadata.LogicalType;
 import dev.hardwood.metadata.PhysicalType;
 import dev.hardwood.row.PqInterval;
@@ -48,10 +49,12 @@ public final class LogicalTypeConverter {
     /// answers for. Nothing consults it per value, and by the time a conversion below runs
     /// the column has either a sound annotation or none.
     ///
-    /// This mirrors what the conversions accept and nothing more. [LogicalTypeValidator]
-    /// states the *writer's* rule, which is stricter — it pins `TIME(MILLIS)` to `INT32`
-    /// where reading accepts either width — and applying it here would refuse files that
-    /// read today.
+    /// An annotation is faulted where the format rules it out for the column's physical type
+    /// or width: `TIME(MILLIS)` anywhere but an `INT32`, `INT(64)` anywhere but an `INT64`, a
+    /// `DECIMAL` with more digits than its carrier holds. [LogicalTypeValidator] refuses the
+    /// same pairings to the writer. The two differ only where a file on disk leaves nothing to
+    /// prove wrong: a `FIXED_LEN_BYTE_ARRAY` without a usable width, which `FixedWidthValidator`
+    /// refuses by name, an opaque `GEOMETRY` or `GEOGRAPHY` payload, and `NULL`.
     ///
     /// @param physicalType the column's physical type
     /// @param typeLength its `FIXED_LEN_BYTE_ARRAY` byte length, `null` for any other type
@@ -69,13 +72,11 @@ public final class LogicalTypeConverter {
             case LogicalType.BsonType ignored -> requires(physicalType, "BSON", PhysicalType.BYTE_ARRAY);
             case LogicalType.DateType ignored -> requires(physicalType, "DATE", PhysicalType.INT32);
             case LogicalType.TimestampType ignored -> requires(physicalType, "TIMESTAMP", PhysicalType.INT64);
-            case LogicalType.TimeType ignored -> requires(physicalType, "TIME",
-                    PhysicalType.INT32, PhysicalType.INT64);
-            case LogicalType.IntType ignored -> requires(physicalType, "INT",
-                    PhysicalType.INT32, PhysicalType.INT64);
-            case LogicalType.DecimalType ignored -> requires(physicalType, "DECIMAL",
-                    PhysicalType.INT32, PhysicalType.INT64, PhysicalType.BYTE_ARRAY,
-                    PhysicalType.FIXED_LEN_BYTE_ARRAY);
+            case LogicalType.TimeType time -> requires(physicalType, "TIME(" + time.unit() + ")",
+                    time.unit() == LogicalType.TimeUnit.MILLIS ? PhysicalType.INT32 : PhysicalType.INT64);
+            case LogicalType.IntType integer -> requires(physicalType, "INT(" + integer.bitWidth() + ")",
+                    integer.bitWidth() == 64 ? PhysicalType.INT64 : PhysicalType.INT32);
+            case LogicalType.DecimalType decimal -> decimalFault(physicalType, typeLength, decimal);
             case LogicalType.UuidType ignored -> requiresFixed(physicalType, typeLength, "UUID", 16);
             case LogicalType.IntervalType ignored -> requiresFixed(physicalType, typeLength, "INTERVAL", 12);
             case LogicalType.Float16Type ignored -> requiresFixed(physicalType, typeLength, "FLOAT16", 2);
@@ -108,6 +109,30 @@ public final class LogicalTypeConverter {
             sb.append(i == 0 ? "" : i == allowed.length - 1 ? " or " : ", ").append(allowed[i]);
         }
         return annotation + " is read from " + sb + ", but the column is " + actual;
+    }
+
+    /// A `DECIMAL` is stored in one of four physical types, and its precision must fit the
+    /// digits that type holds.
+    private static String decimalFault(PhysicalType actual, Integer typeLength,
+                                       LogicalType.DecimalType decimal) {
+        String wrongType = requires(actual, "DECIMAL", PhysicalType.INT32, PhysicalType.INT64,
+                PhysicalType.BYTE_ARRAY, PhysicalType.FIXED_LEN_BYTE_ARRAY);
+        if (wrongType != null) {
+            return wrongType;
+        }
+        boolean fixed = actual == PhysicalType.FIXED_LEN_BYTE_ARRAY;
+        // A width that is absent or not positive is FixedWidthValidator's to refuse, and it has
+        // no digits to count. requiresFixed keeps only the absent case, because a declared
+        // width it can still compare against the one its annotation fixes.
+        if (fixed && (typeLength == null || typeLength <= 0)) {
+            return null;
+        }
+        long maxPrecision = LogicalTypeValidator.maxDecimalPrecision(actual, typeLength);
+        if (decimal.precision() <= maxPrecision) {
+            return null;
+        }
+        return decimal + " has " + decimal.precision() + " digits, but "
+                + (fixed ? actual + "(" + typeLength + ")" : actual) + " holds at most " + maxPrecision;
     }
 
     private static String requiresFixed(PhysicalType actual, Integer typeLength, String annotation,

--- a/core/src/main/java/dev/hardwood/internal/schema/LogicalTypeValidator.java
+++ b/core/src/main/java/dev/hardwood/internal/schema/LogicalTypeValidator.java
@@ -7,7 +7,7 @@
  */
 package dev.hardwood.internal.schema;
 
-import java.math.BigInteger;
+import java.math.BigDecimal;
 
 import dev.hardwood.metadata.LogicalType;
 import dev.hardwood.metadata.PhysicalType;
@@ -20,9 +20,16 @@ import dev.hardwood.metadata.RepetitionType;
 /// An illegal pairing produces a file whose annotation no reader can honour, so the writer
 /// rejects it where the schema is declared rather than emitting it.
 ///
-/// Only the writer validates. The reader stays lenient, because a file that already exists on
-/// disk has to be readable whatever a foreign writer put in its footer.
+/// Only the writer refuses. A file that already exists on disk has to be readable whatever a
+/// foreign writer put in its footer, so the reader drops an annotation that fails the same
+/// pairings and reads the column as its physical type: see
+/// [dev.hardwood.internal.conversion.LogicalTypeConverter#conversionFault].
 public class LogicalTypeValidator {
+
+    /// `log10(2)` to forty places, which makes [#maxFixedPrecision] exact for every width an
+    /// `i32` can declare: `(8 * length - 1) * log10(2)` never comes within `1e-11` of an
+    /// integer there, and this constant's error at the widest width is below `2e-30`.
+    private static final BigDecimal LOG10_2 = new BigDecimal("0.3010299956639811952137388947244930267681");
 
     /// Validates a primitive column's annotation.
     ///
@@ -74,16 +81,12 @@ public class LogicalTypeValidator {
         }
     }
 
-    /// A `DECIMAL`'s precision must fit the digits its physical representation can hold: 9 for
-    /// an `INT32`, 18 for an `INT64`, and for a `FIXED_LEN_BYTE_ARRAY` whatever the two's
-    /// complement of that byte length spans. A `BYTE_ARRAY` is unbounded.
+    /// A `DECIMAL`'s precision must fit the digits its physical representation can hold, as
+    /// [#maxDecimalPrecision] counts them.
     private static void validateDecimal(String columnName, PhysicalType type, Integer typeLength,
                                         LogicalType.DecimalType decimal) {
-        int maxPrecision = switch (type) {
-            case INT32 -> 9;
-            case INT64 -> 18;
-            case BYTE_ARRAY -> Integer.MAX_VALUE;
-            case FIXED_LEN_BYTE_ARRAY -> maxFixedPrecision(typeLength);
+        long maxPrecision = switch (type) {
+            case INT32, INT64, BYTE_ARRAY, FIXED_LEN_BYTE_ARRAY -> maxDecimalPrecision(type, typeLength);
             default -> throw new IllegalArgumentException("DECIMAL is not valid on physical type " + type
                     + " (column " + columnName + "); use INT32, INT64, BYTE_ARRAY or FIXED_LEN_BYTE_ARRAY");
         };
@@ -94,11 +97,35 @@ public class LogicalTypeValidator {
         }
     }
 
+    /// The most digits a `DECIMAL` stored in `type` can have: 9 for an `INT32`, 18 for an
+    /// `INT64`, and for a `FIXED_LEN_BYTE_ARRAY` whatever the two's complement of its width
+    /// spans. A `BYTE_ARRAY` is unbounded.
+    ///
+    /// @param type the physical type the `DECIMAL` is stored in
+    /// @param typeLength the `FIXED_LEN_BYTE_ARRAY` byte length; ignored for any other type
+    /// @return the largest precision `type` holds; `Long.MAX_VALUE` for a `BYTE_ARRAY`
+    /// @throws IllegalArgumentException if `type` does not store a `DECIMAL`, or is a
+    ///         `FIXED_LEN_BYTE_ARRAY` without a positive width
+    public static long maxDecimalPrecision(PhysicalType type, Integer typeLength) {
+        return switch (type) {
+            case INT32 -> 9;
+            case INT64 -> 18;
+            case BYTE_ARRAY -> Long.MAX_VALUE;
+            case FIXED_LEN_BYTE_ARRAY -> maxFixedPrecision(typeLength);
+            default -> throw new IllegalArgumentException("DECIMAL is not stored in " + type);
+        };
+    }
+
     /// The largest precision a two's-complement value of `length` bytes represents:
-    /// `floor(log10(2^(8 * length - 1) - 1))`, computed exactly rather than through a
-    /// floating-point logarithm.
-    private static int maxFixedPrecision(int length) {
-        return BigInteger.ONE.shiftLeft(8 * length - 1).subtract(BigInteger.ONE).toString().length() - 1;
+    /// `floor(log10(2^(8 * length - 1) - 1))`. No power of two is a power of ten, so that is
+    /// `floor((8 * length - 1) * log10(2))`, which [#LOG10_2] computes without building the
+    /// power, whose size a footer's `type_length` would otherwise set.
+    private static long maxFixedPrecision(Integer length) {
+        if (length == null || length <= 0) {
+            throw new IllegalArgumentException(
+                    "A FIXED_LEN_BYTE_ARRAY DECIMAL needs a positive width, not " + length);
+        }
+        return new BigDecimal(8L * length - 1).multiply(LOG10_2).longValue();
     }
 
     private static void require(String columnName, LogicalType logicalType, PhysicalType actual,

--- a/core/src/main/java/dev/hardwood/internal/thrift/LogicalTypeReader.java
+++ b/core/src/main/java/dev/hardwood/internal/thrift/LogicalTypeReader.java
@@ -246,7 +246,7 @@ public class LogicalTypeReader {
     }
 
     private static LogicalType.IntType readIntTypeInternal(ThriftCompactReader reader) {
-        int bitWidth = 8;
+        int bitWidth = -1;
         boolean isSigned = true;
 
         while (true) {
@@ -268,6 +268,13 @@ public class LogicalTypeReader {
                     reader.skipField(ThriftCompactReader.fieldType(header));
                     break;
             }
+        }
+
+        // Validate the required field was read, and that it names one of the four widths the
+        // annotation defines: the record rejects any other as a caller error, which a file
+        // carrying one is not.
+        if (bitWidth != 8 && bitWidth != 16 && bitWidth != 32 && bitWidth != 64) {
+            throw new ParquetReadException("Invalid IntType: bitWidth=" + bitWidth);
         }
 
         return LogicalType.intType(bitWidth, isSigned);

--- a/core/src/test/java/dev/hardwood/internal/conversion/ConversionFaultTest.java
+++ b/core/src/test/java/dev/hardwood/internal/conversion/ConversionFaultTest.java
@@ -16,10 +16,10 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 /// Which annotations a column can carry, as [LogicalTypeConverter#conversionFault] answers it.
 ///
-/// The answer must match what the conversions themselves accept: too lenient and a column
-/// reaches a conversion that cannot decode it, too strict and a file that reads today stops
-/// opening. `LogicalTypeValidator` states the writer's rule, which is deliberately stricter,
-/// and the cases below pin the two apart where they differ.
+/// An annotation is faulted where the format rules it out for the column's physical type or
+/// width. `LogicalTypeValidator` applies the same rule to the writer; the two differ only where
+/// a file on disk leaves nothing to prove wrong — an undeclared width, an opaque payload,
+/// `NULL` — and the cases below pin those.
 class ConversionFaultTest {
 
     @Test
@@ -69,14 +69,52 @@ class ConversionFaultTest {
                 .isEqualTo("UUID is read from FIXED_LEN_BYTE_ARRAY, but the column is BYTE_ARRAY");
     }
 
-    /// Reading accepts either width for `TIME` and `INT` whatever the unit or bit width,
-    /// where the writer pins `TIME(MILLIS)` to `INT32`. Applying the writer's rule here
-    /// would refuse files that read today.
+    /// `TIME(MILLIS)` is stored in an `INT32` and `TIME(MICROS / NANOS)` in an `INT64`, so
+    /// each unit is faulted on the other width.
     @Test
-    void readingIsLenientWhereWritingIsStrict() {
-        assertThat(fault(PhysicalType.INT64, null,
-                LogicalType.time(true, LogicalType.TimeUnit.MILLIS))).isNull();
-        assertThat(fault(PhysicalType.INT64, null, LogicalType.intType(8, true))).isNull();
+    void aTimeUnitOnTheOtherWidthIsFaulted() {
+        assertThat(fault(PhysicalType.INT32, null, time(LogicalType.TimeUnit.MILLIS))).isNull();
+        assertThat(fault(PhysicalType.INT64, null, time(LogicalType.TimeUnit.MICROS))).isNull();
+        assertThat(fault(PhysicalType.INT64, null, time(LogicalType.TimeUnit.NANOS))).isNull();
+        assertThat(fault(PhysicalType.INT64, null, time(LogicalType.TimeUnit.MILLIS)))
+                .isEqualTo("TIME(MILLIS) is read from INT32, but the column is INT64");
+        assertThat(fault(PhysicalType.INT32, null, time(LogicalType.TimeUnit.MICROS)))
+                .isEqualTo("TIME(MICROS) is read from INT64, but the column is INT32");
+        assertThat(fault(PhysicalType.INT32, null, time(LogicalType.TimeUnit.NANOS)))
+                .isEqualTo("TIME(NANOS) is read from INT64, but the column is INT32");
+    }
+
+    /// `INT(8)`, `INT(16)` and `INT(32)` are stored in an `INT32` and `INT(64)` in an
+    /// `INT64`, signed or not, so each bit width is faulted on the other width.
+    @Test
+    void anIntBitWidthOnTheOtherWidthIsFaulted() {
+        assertThat(fault(PhysicalType.INT32, null, LogicalType.intType(8, true))).isNull();
+        assertThat(fault(PhysicalType.INT32, null, LogicalType.intType(32, false))).isNull();
+        assertThat(fault(PhysicalType.INT64, null, LogicalType.intType(64, false))).isNull();
+        assertThat(fault(PhysicalType.INT64, null, LogicalType.intType(8, true)))
+                .isEqualTo("INT(8) is read from INT32, but the column is INT64");
+        assertThat(fault(PhysicalType.INT64, null, LogicalType.intType(32, false)))
+                .isEqualTo("INT(32) is read from INT32, but the column is INT64");
+        assertThat(fault(PhysicalType.INT32, null, LogicalType.intType(64, true)))
+                .isEqualTo("INT(64) is read from INT64, but the column is INT32");
+    }
+
+    /// A `DECIMAL`'s precision must fit the digits its carrier holds: nine for an `INT32`,
+    /// eighteen for an `INT64`, and for a `FIXED_LEN_BYTE_ARRAY` what the two's complement of
+    /// its width spans. A `BYTE_ARRAY` holds any number.
+    @Test
+    void aDecimalBeyondItsCarriersDigitsIsFaulted() {
+        assertThat(fault(PhysicalType.INT32, null, LogicalType.decimal(9, 2))).isNull();
+        assertThat(fault(PhysicalType.INT64, null, LogicalType.decimal(18, 0))).isNull();
+        assertThat(fault(PhysicalType.BYTE_ARRAY, null, LogicalType.decimal(1000, 0))).isNull();
+        assertThat(fault(PhysicalType.INT32, null, LogicalType.decimal(12, 2)))
+                .isEqualTo("DECIMAL(12, 2) has 12 digits, but INT32 holds at most 9");
+        assertThat(fault(PhysicalType.INT64, null, LogicalType.decimal(19, 0)))
+                .isEqualTo("DECIMAL(19, 0) has 19 digits, but INT64 holds at most 18");
+        assertThat(fault(PhysicalType.FIXED_LEN_BYTE_ARRAY, 3, LogicalType.decimal(7, 2)))
+                .isEqualTo("DECIMAL(7, 2) has 7 digits, but FIXED_LEN_BYTE_ARRAY(3) holds at most 6");
+        assertThat(fault(PhysicalType.FIXED_LEN_BYTE_ARRAY, 16, LogicalType.decimal(39, 0)))
+                .isEqualTo("DECIMAL(39, 0) has 39 digits, but FIXED_LEN_BYTE_ARRAY(16) holds at most 38");
     }
 
     /// Geometry and geography payloads are carried through untouched, so no physical type
@@ -114,12 +152,12 @@ class ConversionFaultTest {
                         + " FIXED_LEN_BYTE_ARRAY, but the column is BOOLEAN");
     }
 
-    /// A `DECIMAL` on a `FIXED_LEN_BYTE_ARRAY` imposes no particular width: the precision
-    /// decides how many bytes the unscaled value needs, and the conversion reads whatever
-    /// the column declares.
+    /// A `DECIMAL` on a `FIXED_LEN_BYTE_ARRAY` takes any width that holds its digits, however
+    /// much wider than it needs: three bytes span six digits, sixteen span thirty-eight.
     @Test
-    void aFixedLenDecimalImposesNoWidth() {
-        assertThat(fault(PhysicalType.FIXED_LEN_BYTE_ARRAY, 3, decimal())).isNull();
+    void aFixedLenDecimalTakesAnyWidthThatHoldsItsDigits() {
+        assertThat(fault(PhysicalType.FIXED_LEN_BYTE_ARRAY, 3, LogicalType.decimal(6, 2))).isNull();
+        assertThat(fault(PhysicalType.FIXED_LEN_BYTE_ARRAY, 16, LogicalType.decimal(38, 2))).isNull();
         assertThat(fault(PhysicalType.FIXED_LEN_BYTE_ARRAY, 32, decimal())).isNull();
     }
 
@@ -147,11 +185,14 @@ class ConversionFaultTest {
     /// A footer that omits `type_length` states no width for the annotation to contradict,
     /// so nothing here is provably wrong and the annotation is kept. Such a column cannot be
     /// decoded at all, and `FixedWidthValidator` refuses it by name — reporting it as a bad
-    /// annotation would drop a sound one and describe the wrong defect.
+    /// annotation would drop a sound one and describe the wrong defect. A `DECIMAL` has no
+    /// digits to count in a width that is absent or not positive, so neither is its fault.
     @Test
     void anUndeclaredWidthIsNotTheAnnotationsFault() {
         assertThat(fault(PhysicalType.FIXED_LEN_BYTE_ARRAY, null, LogicalType.float16()))
                 .isNull();
+        assertThat(fault(PhysicalType.FIXED_LEN_BYTE_ARRAY, null, decimal())).isNull();
+        assertThat(fault(PhysicalType.FIXED_LEN_BYTE_ARRAY, 0, decimal())).isNull();
     }
 
     private static String fault(PhysicalType type, Integer typeLength, LogicalType logicalType) {
@@ -159,7 +200,11 @@ class ConversionFaultTest {
     }
 
     private static LogicalType.DecimalType decimal() {
-        return LogicalType.decimal(10, 4);
+        return LogicalType.decimal(9, 4);
+    }
+
+    private static LogicalType.TimeType time(LogicalType.TimeUnit unit) {
+        return LogicalType.time(true, unit);
     }
 
     private static LogicalType.TimestampType timestamp() {

--- a/core/src/test/java/dev/hardwood/internal/predicate/FilterPredicateResolverTest.java
+++ b/core/src/test/java/dev/hardwood/internal/predicate/FilterPredicateResolverTest.java
@@ -165,6 +165,34 @@ class FilterPredicateResolverTest {
                 .hasMessage("Column 'col' does not have a TIME logical type");
     }
 
+    /// `TIME(MILLIS)` is stored in an `INT32`, so on an `INT64` column the annotation is
+    /// dropped and the column filters as the `INT64` it is: by `long`, not by `LocalTime`.
+    @Test
+    void resolveTimeOnATimeMillisAnnotationOverInt64Throws() {
+        FileSchema schema = schemaWithLogicalType("t", PhysicalType.INT64,
+                LogicalType.time(true, LogicalType.TimeUnit.MILLIS));
+        assertThatThrownBy(() -> FilterPredicateResolver.resolve(
+                FilterPredicate.eq("t", LocalTime.NOON), schema))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("Column 't' does not have a TIME logical type");
+        assertThat(FilterPredicateResolver.resolve(FilterPredicate.eq("t", 7L), schema))
+                .isInstanceOf(ResolvedPredicate.LongPredicate.class);
+    }
+
+    /// An `INT32` holds nine digits, so a `DECIMAL(12, 2)` annotation on one is dropped and
+    /// the column filters as a plain `INT32`.
+    @Test
+    void resolveDecimalOnADecimalAnnotationBeyondItsCarrierThrows() {
+        FileSchema schema = schemaWithLogicalType("amount", PhysicalType.INT32,
+                LogicalType.decimal(12, 2));
+        assertThatThrownBy(() -> FilterPredicateResolver.resolve(
+                FilterPredicate.eq("amount", new BigDecimal("1.50")), schema))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("Column 'amount' does not have a DECIMAL logical type");
+        assertThat(FilterPredicateResolver.resolve(FilterPredicate.eq("amount", 150), schema))
+                .isInstanceOf(ResolvedPredicate.IntPredicate.class);
+    }
+
     // ==================== Decimal ====================
 
     /// A literal is rescaled to the column's scale, so a column holding more scale than the
@@ -919,9 +947,9 @@ class FilterPredicateResolverTest {
                 .isInstanceOf(IllegalArgumentException.class)
                 .hasMessage(incompatible("INT64", "INT32"));
 
-        // A TIMESTAMP annotation on an INT32 column is dropped from the schema, so the column
-        // arrives with no logical type and the unit lookup rejects it before the physical type is
-        // compared. A TIME annotation survives, so that case still reports the type mismatch.
+        // A TIMESTAMP annotation on an INT32 column, and a TIME annotation on the width its unit
+        // is not stored in, are dropped from the schema, so the column arrives with no logical
+        // type and the unit lookup rejects it before the physical type is compared.
         FileSchema tsSchemaWrong = schemaWithLogicalType("c", PhysicalType.INT32,
                 new LogicalType.TimestampType(false, LogicalType.TimeUnit.MILLIS));
         assertThatThrownBy(() -> FilterPredicateResolver.resolve(FilterPredicate.eq("c", Instant.EPOCH), tsSchemaWrong))
@@ -932,13 +960,13 @@ class FilterPredicateResolverTest {
                 new LogicalType.TimeType(false, LogicalType.TimeUnit.MILLIS));
         assertThatThrownBy(() -> FilterPredicateResolver.resolve(FilterPredicate.eq("c", LocalTime.NOON), timeMillisWrong))
                 .isInstanceOf(IllegalArgumentException.class)
-                .hasMessage(incompatible("INT64", "INT32"));
+                .hasMessage("Column 'c' does not have a TIME logical type");
 
         FileSchema timeMicrosWrong = schemaWithLogicalType("c", PhysicalType.INT32,
                 new LogicalType.TimeType(false, LogicalType.TimeUnit.MICROS));
         assertThatThrownBy(() -> FilterPredicateResolver.resolve(FilterPredicate.eq("c", LocalTime.NOON), timeMicrosWrong))
                 .isInstanceOf(IllegalArgumentException.class)
-                .hasMessage(incompatible("INT32", "INT64"));
+                .hasMessage("Column 'c' does not have a TIME logical type");
 
         FileSchema uuidWrong = schemaWithLogicalType("c", PhysicalType.INT32,
                 new LogicalType.UuidType());

--- a/core/src/test/java/dev/hardwood/internal/schema/LogicalTypeValidatorTest.java
+++ b/core/src/test/java/dev/hardwood/internal/schema/LogicalTypeValidatorTest.java
@@ -1,0 +1,67 @@
+/*
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Copyright The original authors
+ *
+ *  Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package dev.hardwood.internal.schema;
+
+import java.math.BigInteger;
+
+import org.junit.jupiter.api.Test;
+
+import dev.hardwood.metadata.PhysicalType;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/// The digits a `DECIMAL` carrier holds, as [LogicalTypeValidator#maxDecimalPrecision] counts
+/// them for both the writer and the reader.
+class LogicalTypeValidatorTest {
+
+    @Test
+    void theIntegerCarriersHoldNineAndEighteenDigits() {
+        assertThat(LogicalTypeValidator.maxDecimalPrecision(PhysicalType.INT32, null)).isEqualTo(9);
+        assertThat(LogicalTypeValidator.maxDecimalPrecision(PhysicalType.INT64, null)).isEqualTo(18);
+        assertThat(LogicalTypeValidator.maxDecimalPrecision(PhysicalType.BYTE_ARRAY, null))
+                .isEqualTo(Long.MAX_VALUE);
+    }
+
+    /// Counted against the digits of the largest value each width holds, `2^(8n - 1) - 1`.
+    @Test
+    void aFixedWidthHoldsTheDigitsOfItsLargestValue() {
+        for (int width = 1; width <= 1024; width++) {
+            int exact = BigInteger.ONE.shiftLeft(8 * width - 1).subtract(BigInteger.ONE)
+                    .toString().length() - 1;
+            assertThat(LogicalTypeValidator.maxDecimalPrecision(PhysicalType.FIXED_LEN_BYTE_ARRAY, width))
+                    .as("width %d", width)
+                    .isEqualTo(exact);
+        }
+    }
+
+    /// The widest width an `i32` can declare holds more digits than an `int` counts.
+    @Test
+    void theWidestWidthIsCountedWithoutOverflow() {
+        assertThat(LogicalTypeValidator.maxDecimalPrecision(PhysicalType.FIXED_LEN_BYTE_ARRAY,
+                Integer.MAX_VALUE)).isEqualTo(5_171_655_943L);
+    }
+
+    @Test
+    void aTypeThatStoresNoDecimalIsRefused() {
+        assertThatThrownBy(() -> LogicalTypeValidator.maxDecimalPrecision(PhysicalType.BOOLEAN, null))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("DECIMAL is not stored in BOOLEAN");
+    }
+
+    /// A width that is absent or not positive has no digits to count.
+    @Test
+    void aFixedWidthThatIsNotPositiveIsRefused() {
+        assertThatThrownBy(() -> LogicalTypeValidator.maxDecimalPrecision(PhysicalType.FIXED_LEN_BYTE_ARRAY, 0))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("A FIXED_LEN_BYTE_ARRAY DECIMAL needs a positive width, not 0");
+        assertThatThrownBy(() -> LogicalTypeValidator.maxDecimalPrecision(PhysicalType.FIXED_LEN_BYTE_ARRAY, null))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("A FIXED_LEN_BYTE_ARRAY DECIMAL needs a positive width, not null");
+    }
+}

--- a/core/src/test/java/dev/hardwood/internal/thrift/LogicalTypeReaderTest.java
+++ b/core/src/test/java/dev/hardwood/internal/thrift/LogicalTypeReaderTest.java
@@ -13,8 +13,10 @@ import org.junit.jupiter.api.Test;
 
 import dev.hardwood.internal.thrift.ThriftCompactConstants.FieldType;
 import dev.hardwood.metadata.LogicalType;
+import dev.hardwood.reader.ParquetReadException;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 /// Unit tests for [LogicalTypeReader], focused on a logical-type union member
 /// the reader does not recognize. A future or bespoke logical type must decode
@@ -60,6 +62,56 @@ class LogicalTypeReaderTest {
         int sentinel = reader.readFieldHeader();
         assertThat(ThriftCompactReader.fieldId(sentinel)).isEqualTo((short) 1);
         assertThat(reader.readI32()).isEqualTo(7);
+    }
+
+    /// `INT` names one of four bit widths. A footer naming any other describes an annotation
+    /// the format does not define, which is the file's fault and not the caller's, so it is
+    /// reported as a read failure rather than as the record's `IllegalArgumentException`.
+    @Test
+    void anUndefinedBitWidthIsAReadFailure() throws Exception {
+        assertThatThrownBy(() -> read(intType((byte) 7, true)))
+                .isInstanceOf(ParquetReadException.class)
+                .hasMessage("Invalid IntType: bitWidth=7");
+    }
+
+    /// `bitWidth` is a required field, so a member struct that omits it states no width at
+    /// all. Defaulting it would read the column as an `INT(8)` the footer never declared.
+    @Test
+    void anAbsentBitWidthIsAReadFailure() throws Exception {
+        ThriftCompactWriter writer = new ThriftCompactWriter();
+        writer.writeFieldBegin(10, FieldType.STRUCT);
+        short savedMember = writer.pushFieldIdContext();
+        writer.writeBool(2, false);
+        writer.writeFieldStop(); // member struct STOP
+        writer.popFieldIdContext(savedMember);
+        writer.writeFieldStop(); // union STOP
+
+        assertThatThrownBy(() -> read(writer))
+                .isInstanceOf(ParquetReadException.class)
+                .hasMessage("Invalid IntType: bitWidth=-1");
+    }
+
+    @Test
+    void everyDefinedBitWidthDecodes() throws Exception {
+        for (byte bitWidth : new byte[] { 8, 16, 32, 64 }) {
+            assertThat(read(intType(bitWidth, false)))
+                    .isEqualTo(LogicalType.intType(bitWidth, false));
+        }
+    }
+
+    /// The `INT` union member, as a footer carries it: field id 10 holding an `IntType`
+    /// struct of an i8 `bitWidth` and a bool `isSigned`.
+    private static ThriftCompactWriter intType(byte bitWidth, boolean isSigned) {
+        ThriftCompactWriter writer = new ThriftCompactWriter();
+        writer.writeFieldBegin(10, FieldType.STRUCT);
+        short savedMember = writer.pushFieldIdContext();
+        writer.writeFieldBegin(1, FieldType.BYTE);
+        writer.writeByte(bitWidth);
+        writer.writeBool(2, isSigned);
+        writer.writeFieldStop(); // member struct STOP
+        writer.popFieldIdContext(savedMember);
+        writer.writeFieldStop(); // union STOP
+        return writer;
     }
 
     private static LogicalType read(ThriftCompactWriter writer) throws Exception {

--- a/core/src/test/java/dev/hardwood/schema/FileSchemaConvertedTypeTest.java
+++ b/core/src/test/java/dev/hardwood/schema/FileSchemaConvertedTypeTest.java
@@ -30,8 +30,6 @@ class FileSchemaConvertedTypeTest {
     private static final String ROOT = "schema";
     private static final String COLUMN = "col";
 
-    /// Build a one-column schema whose single leaf carries only the given
-    /// `convertedType` (no modern logical type), and return the resolved column.
     /// A legacy `converted_type` is promoted to its modern annotation first, so the same
     /// rule drops it when the column's physical type cannot carry it — a writer that put
     /// `UTF8` on an `INT32` produced a file no version of the format defines, whichever of
@@ -42,6 +40,18 @@ class FileSchemaConvertedTypeTest {
         assertThat(resolveColumn(PhysicalType.BYTE_ARRAY, ConvertedType.DATE).logicalType()).isNull();
     }
 
+    /// The same holds where the converted type names a width or a digit count the physical
+    /// type does not have: `TIME_MILLIS` and `INT_8` are 32-bit, and an `INT32` holds nine
+    /// digits, not twelve.
+    @Test
+    void aPromotedConvertedTypeItsCarrierCannotHoldIsDropped() {
+        assertThat(resolveColumn(PhysicalType.INT64, ConvertedType.TIME_MILLIS).logicalType()).isNull();
+        assertThat(resolveColumn(PhysicalType.INT64, ConvertedType.INT_8).logicalType()).isNull();
+        assertThat(resolveColumn(PhysicalType.INT32, ConvertedType.DECIMAL, 2, 12).logicalType()).isNull();
+    }
+
+    /// Build a one-column schema whose single leaf carries only the given
+    /// `convertedType` (no modern logical type), and return the resolved column.
     private static ColumnSchema resolveColumn(PhysicalType type, ConvertedType convertedType) {
         return resolveColumn(type, convertedType, null, null);
     }

--- a/docs/content/reference/accessors.md
+++ b/docs/content/reference/accessors.md
@@ -66,10 +66,11 @@ normal control flow. If the column type isn't known statically, check it up fron
 `logicalType()` — see [Inspect File Metadata](../how-to/metadata.md).
 
 A column whose annotation its physical type cannot carry is not an error. `FLOAT16` is defined as
-a two-byte payload, so a `FLOAT16` column that declares three bytes is invalid. The format tells
-readers to ignore such an annotation rather than reject the file, so Hardwood drops it — and drops
-one it does not recognize at all — logging a warning in each case. The column is then reported and
-read as its physical type.
+a two-byte payload, so a `FLOAT16` column that declares three bytes is invalid. So are a
+`TIME(MILLIS)` or an `INT(8)` on an `INT64`, and a `DECIMAL(12, 2)` on an `INT32`, which holds at
+most nine digits. The format tells readers to ignore such an annotation rather than reject the
+file, so Hardwood drops it — and drops one it does not recognize at all — logging a warning in each
+case. The column is then reported and read as its physical type.
 
 `getFileSchema()` reports no logical type for it, `getValue` returns the physical value, and the
 physical accessors work. A logical accessor fails as it would on any unannotated column of that

--- a/docs/content/reference/query-controls.md
+++ b/docs/content/reference/query-controls.md
@@ -47,12 +47,12 @@ literal a column does not take throws `IllegalArgumentException` at reader creat
 | `FLOAT` | | `float` | numeric |
 | `DOUBLE` | | `double` | numeric |
 | `BYTE_ARRAY`, `FIXED_LEN_BYTE_ARRAY(n)` | | `String` | unsigned lexicographic |
-| `INT32`, `INT64` | `INT(8/16/32/64, isSigned = true)` | `int` / `long` | signed |
-| `INT32`, `INT64` | `INT(8/16/32/64, isSigned = false)` | `int` / `long` | unsigned magnitude |
+| `INT32` 8/16/32-bit, `INT64` 64-bit | `INT(8/16/32/64, isSigned = true)` | `int` / `long` | signed |
+| `INT32` 8/16/32-bit, `INT64` 64-bit | `INT(8/16/32/64, isSigned = false)` | `int` / `long` | unsigned magnitude |
 | `INT32` | `DATE` | `LocalDate` | days since the Unix epoch |
 | `INT32` millis, `INT64` micros / nanos | `TIME` | `LocalTime` | the column's time unit |
 | `INT64` | `TIMESTAMP` | `Instant` | the column's time unit |
-| `INT32`, `INT64`, `BYTE_ARRAY`, `FIXED_LEN_BYTE_ARRAY` | `DECIMAL` | `BigDecimal`, `String` | the represented value, under all four physical types |
+| `INT32` up to 9 digits, `INT64` up to 18, `FIXED_LEN_BYTE_ARRAY(n)` up to what `n` bytes hold, `BYTE_ARRAY` any | `DECIMAL` | `BigDecimal`, `String` | the represented value, under all four physical types |
 | `BYTE_ARRAY` | `STRING`, `ENUM`, `JSON`, `BSON` | `String` | unsigned lexicographic |
 | `BYTE_ARRAY` | `GEOMETRY`, `GEOGRAPHY` | four `double` bounds | bounding-box overlap |
 | `FIXED_LEN_BYTE_ARRAY(16)` | `UUID` | `UUID`, `String` | the 16 bytes, unsigned |

--- a/docs/content/release-notes.md
+++ b/docs/content/release-notes.md
@@ -15,6 +15,10 @@ See [GitHub Releases](https://github.com/hardwood-hq/hardwood/releases) for down
 
 ## 1.1.0-SNAPSHOT
 
+- A `TIME`, `INT` or `DECIMAL` annotation stored in a physical type that cannot hold it is dropped, and the column is read as its physical type: `TIME(MILLIS)` on `INT64`, `TIME(MICROS)` or `TIME(NANOS)` on `INT32`, `INT(8)`, `INT(16)` or `INT(32)` on `INT64`, `INT(64)` on `INT32`, and a `DECIMAL` with more digits than its `INT32`, `INT64` or `FIXED_LEN_BYTE_ARRAY` holds ([#1139](https://github.com/hardwood-hq/hardwood/issues/1139)).
+
+- An `INT` annotation whose footer names a bit width other than 8, 16, 32 or 64, or names none at all, raises `ParquetReadException` instead of `IllegalArgumentException` ([#1139](https://github.com/hardwood-hq/hardwood/issues/1139)).
+
 - A `ColumnReader` filter on a `FLOAT16` column no longer throws `ClassCastException`, and one on a struct leaf no longer reads a leaf that is null under a present struct as a value ([#1197](https://github.com/hardwood-hq/hardwood/issues/1197)).
 
 - A `String`, `inStrings` or parquet-java `binaryColumn` literal on a `FIXED_LEN_BYTE_ARRAY` `DECIMAL` column that is narrower or wider than the column no longer drops row groups holding matching rows, and one whose value does not fit the column throws `ArithmeticException` ([#1190](https://github.com/hardwood-hq/hardwood/issues/1190)).


### PR DESCRIPTION
Closes #1139

`FileSchema` drops an annotation the column's physical type cannot carry, but it judged `TIME`, `INT` and `DECIMAL` only by the physical types they may appear on at all. `TIME(MILLIS)` on an `INT64`, `INT(8)` on an `INT64` and `DECIMAL(12, 2)` on an `INT32` were kept, although the format stores each time unit and bit width in one width only and bounds a `DECIMAL`'s precision by the digits its carrier holds. On a kept `TIME(MILLIS)` over `INT64`, a `LocalTime` predicate failed with "Column 'c' has physical type INT64; given filter predicate type INT32 is incompatible".

`conversionFault` now applies the pairings `LogicalTypeValidator` enforces on the writer, so a file on disk and a declared schema are judged alike, and the two share one digit count. The rule covers the comparable pairings the issue's list did not name: `INT(64)` on an `INT32`, and a `DECIMAL` beyond what a `FIXED_LEN_BYTE_ARRAY`'s width holds.

That digit count takes its width from an untrusted footer, so it multiplies by a forty-place `log10(2)` instead of building `2^(8n - 1)`, whose size a crafted `type_length` would otherwise set. The constant is exact for every width an `i32` can declare, and a test checks it against the exact digit count for widths 1 to 1024. This also fixes an `int` overflow in the previous writer-side count at widths of 2^28 bytes and above.

Only files that violate the format are affected. A valid file reads exactly as it did, and such a column is now reported and read as its physical type, so a logical accessor or predicate on it fails as on any unannotated column.
