### PR TITLE
#1181 Take a binary column's literal as byte[], and a String only where getString reads

### DIFF
--- a/_designs/PREDICATE_LITERALS.md
+++ b/_designs/PREDICATE_LITERALS.md
@@ -267,7 +267,7 @@ express get the same answer; the differences are listed below.
 | Part | Issue |
 |---|---|
 | Fixed-width `DECIMAL` byte literal resolved to the column width | [#1190](https://github.com/hardwood-hq/hardwood/issues/1190) (done) |
-| `byte[]` literals and factories; `String` only where `getString` reads; `String` records; null literals and malformed `String`s rejected when built | [#1181](https://github.com/hardwood-hq/hardwood/issues/1181) |
+| `byte[]` literals and factories; `String` only where `getString` reads; `String` records; null literals and malformed `String`s rejected when built | [#1181](https://github.com/hardwood-hq/hardwood/issues/1181) (done) |
 | Ordered operators exactly on ordered types: `BOOLEAN` gains them, with record-level and batch matchers; `INTERVAL`, `GEOMETRY`, `GEOGRAPHY` and `NULL` lose them. `PqInterval` literal; leaves below a `VARIANT` group take null tests only; `not` over `intersects` rejected | [#1183](https://github.com/hardwood-hq/hardwood/issues/1183) |
 | `INT96` literals | [#1192](https://github.com/hardwood-hq/hardwood/issues/1192) |
 | Literals the column cannot hold; the constant predicates | [#1193](https://github.com/hardwood-hq/hardwood/issues/1193) (done) |

--- a/core/src/main/java/dev/hardwood/internal/predicate/FilterPredicateResolver.java
+++ b/core/src/main/java/dev/hardwood/internal/predicate/FilterPredicateResolver.java
@@ -10,6 +10,7 @@ package dev.hardwood.internal.predicate;
 import java.math.BigDecimal;
 import java.math.BigInteger;
 import java.math.RoundingMode;
+import java.nio.charset.StandardCharsets;
 import java.time.Instant;
 import java.util.HexFormat;
 import java.util.List;
@@ -236,6 +237,26 @@ public class FilterPredicateResolver {
                 }
                 rejectUnholdableWidth(p.column(), cs, p.op(), p.value());
                 yield new ResolvedPredicate.BinaryPredicate(cs.columnIndex(), p.op(), p.value(), comparison);
+            }
+            case FilterPredicate.StringColumnPredicate p -> {
+                ColumnSchema cs = resolveColumn(p.column(), schema);
+                rejectRepeated(p.column(), cs);
+                validateType(p.column(), PhysicalType.BYTE_ARRAY, cs);
+                requireTextColumn(p.column(), cs);
+                yield new ResolvedPredicate.BinaryPredicate(cs.columnIndex(), p.op(),
+                        p.value().getBytes(StandardCharsets.UTF_8), Comparison.BYTE_STRING);
+            }
+            case FilterPredicate.StringInPredicate p -> {
+                ColumnSchema cs = resolveColumn(p.column(), schema);
+                rejectRepeated(p.column(), cs);
+                validateType(p.column(), PhysicalType.BYTE_ARRAY, cs);
+                requireTextColumn(p.column(), cs);
+                byte[][] probes = new byte[p.values().length][];
+                for (int i = 0; i < probes.length; i++) {
+                    probes[i] = p.values()[i].getBytes(StandardCharsets.UTF_8);
+                }
+                yield new ResolvedPredicate.BinaryInPredicate(cs.columnIndex(), probes,
+                        Comparison.BYTE_STRING);
             }
             case FilterPredicate.UUIDColumnPredicate p -> {
                 ColumnSchema cs = resolveColumn(p.column(), schema);
@@ -550,6 +571,64 @@ public class FilterPredicateResolver {
             case LogicalType.TimeType ignored -> Comparison.BYTE_STRING;
             case LogicalType.TimestampType ignored -> Comparison.BYTE_STRING;
         };
+    }
+
+    /// Refuses a `String` literal on a column that does not hold text.
+    ///
+    /// A `String` is the literal exactly where `getString` reads the column: a `STRING`, an
+    /// `ENUM`, a `JSON` and an unannotated `BYTE_ARRAY`, whose stored bytes are the literal's
+    /// UTF-8 encoding. Every other binary column stores bytes its annotation reads as something
+    /// else, which a caller writes as a `byte[]` or as the annotation's own literal type.
+    ///
+    /// The switch is exhaustive rather than a list of exceptions, the shape [#byteComparison]
+    /// has, so an annotation added later has to state whether a `String` reads it.
+    private static void requireTextColumn(String columnName, ColumnSchema columnSchema) {
+        LogicalType logicalType = columnSchema.logicalType();
+        if (logicalType == null) {
+            if (columnSchema.type() == PhysicalType.BYTE_ARRAY) {
+                return;
+            }
+            throw notTextColumn(columnName, "an unannotated " + columnSchema.type(), "byte[]");
+        }
+        String literals = nonTextLiterals(logicalType);
+        if (literals != null) {
+            throw notTextColumn(columnName, "annotated " + logicalType, literals);
+        }
+    }
+
+    /// The literals a binary column takes in place of a `String`, or `null` where a `String`
+    /// reads the column.
+    ///
+    /// The annotations that reach an arm returning `byte[]` alone read the stored bytes as an
+    /// opaque payload, or annotate a physical type no binary column has —
+    /// [dev.hardwood.schema.FileSchema] drops the latter before a predicate sees it.
+    private static String nonTextLiterals(LogicalType logicalType) {
+        return switch (logicalType) {
+            case LogicalType.StringType ignored -> null;
+            case LogicalType.EnumType ignored -> null;
+            case LogicalType.JsonType ignored -> null;
+            case LogicalType.DecimalType ignored -> "BigDecimal and byte[]";
+            case LogicalType.Float16Type ignored -> "float and byte[]";
+            case LogicalType.UuidType ignored -> "UUID and byte[]";
+            case LogicalType.BsonType ignored -> "byte[]";
+            case LogicalType.IntervalType ignored -> "byte[]";
+            case LogicalType.GeometryType ignored -> "byte[]";
+            case LogicalType.GeographyType ignored -> "byte[]";
+            case LogicalType.NullType ignored -> "byte[]";
+            case LogicalType.VariantType ignored -> "byte[]";
+            case LogicalType.ListType ignored -> "byte[]";
+            case LogicalType.MapType ignored -> "byte[]";
+            case LogicalType.IntType ignored -> "byte[]";
+            case LogicalType.DateType ignored -> "byte[]";
+            case LogicalType.TimeType ignored -> "byte[]";
+            case LogicalType.TimestampType ignored -> "byte[]";
+        };
+    }
+
+    private static IllegalArgumentException notTextColumn(String columnName, String description,
+            String literals) {
+        return new IllegalArgumentException("Column '" + columnName + "' is " + description
+                + ", which takes " + literals + " literals, not a String");
     }
 
     /// The two bytes of a `FLOAT16` literal, as the value they encode.

--- a/core/src/main/java/dev/hardwood/reader/FilterPredicate.java
+++ b/core/src/main/java/dev/hardwood/reader/FilterPredicate.java
@@ -15,6 +15,7 @@ import java.time.LocalDate;
 import java.time.LocalTime;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Objects;
 import java.util.UUID;
 
 /// A predicate for filtering row groups based on column statistics.
@@ -91,11 +92,13 @@ public sealed interface FilterPredicate
                 FilterPredicate.DoubleColumnPredicate,
                 FilterPredicate.BooleanColumnPredicate,
                 FilterPredicate.BinaryColumnPredicate,
+                FilterPredicate.StringColumnPredicate,
                 FilterPredicate.UUIDColumnPredicate,
                 FilterPredicate.IntInPredicate,
                 FilterPredicate.LongInPredicate,
                 FilterPredicate.DoubleInPredicate,
                 FilterPredicate.BinaryInPredicate,
+                FilterPredicate.StringInPredicate,
                 FilterPredicate.DateColumnPredicate,
                 FilterPredicate.InstantColumnPredicate,
                 FilterPredicate.TimeColumnPredicate,
@@ -243,62 +246,110 @@ public sealed interface FilterPredicate
         return new BooleanColumnPredicate(column, Operator.NOT_EQ, value);
     }
 
-    // ==================== STRING (BYTE_ARRAY) Predicates ====================
+    // ==================== String Predicates ====================
 
+    /// Creates an equals predicate for a text column, one of `STRING`, `ENUM`, `JSON` and an
+    /// unannotated `BYTE_ARRAY`. The value compares as its UTF-8 bytes, which is what such a
+    /// column stores. Any other column rejects a `String` with `IllegalArgumentException` at
+    /// reader creation.
     static FilterPredicate eq(String column, String value) {
-        return new BinaryColumnPredicate(column, Operator.EQ, value.getBytes(StandardCharsets.UTF_8));
+        return new StringColumnPredicate(column, Operator.EQ, value);
     }
 
+    /// Creates a not-equals predicate for a text column. See [#eq(String,String)].
     static FilterPredicate notEq(String column, String value) {
-        return new BinaryColumnPredicate(column, Operator.NOT_EQ, value.getBytes(StandardCharsets.UTF_8));
+        return new StringColumnPredicate(column, Operator.NOT_EQ, value);
     }
 
+    /// Creates a less-than predicate for a text column. See [#eq(String,String)].
     static FilterPredicate lt(String column, String value) {
-        return new BinaryColumnPredicate(column, Operator.LT, value.getBytes(StandardCharsets.UTF_8));
+        return new StringColumnPredicate(column, Operator.LT, value);
     }
 
+    /// Creates a less-than-or-equal predicate for a text column. See [#eq(String,String)].
     static FilterPredicate ltEq(String column, String value) {
-        return new BinaryColumnPredicate(column, Operator.LT_EQ, value.getBytes(StandardCharsets.UTF_8));
+        return new StringColumnPredicate(column, Operator.LT_EQ, value);
     }
 
+    /// Creates a greater-than predicate for a text column. See [#eq(String,String)].
     static FilterPredicate gt(String column, String value) {
-        return new BinaryColumnPredicate(column, Operator.GT, value.getBytes(StandardCharsets.UTF_8));
+        return new StringColumnPredicate(column, Operator.GT, value);
     }
 
+    /// Creates a greater-than-or-equal predicate for a text column. See [#eq(String,String)].
     static FilterPredicate gtEq(String column, String value) {
-        return new BinaryColumnPredicate(column, Operator.GT_EQ, value.getBytes(StandardCharsets.UTF_8));
+        return new StringColumnPredicate(column, Operator.GT_EQ, value);
+    }
+
+    // ==================== Binary (BYTE_ARRAY, FIXED_LEN_BYTE_ARRAY) Predicates ====================
+
+    /// Creates an equals predicate for a binary column, whose literal is the stored bytes —
+    /// the value [RowReader#getBinary] returns for it.
+    ///
+    /// The column's annotation decides what the bytes stand for and how they compare: a
+    /// `DECIMAL` reads them as the number they encode, a `FLOAT16` as the half its two bytes
+    /// encode, and every other binary column compares them unsigned lexicographically. A
+    /// fixed-width column takes an equality literal of its own width only, and a fixed-width
+    /// `DECIMAL` any length whose value fits that width.
+    ///
+    /// The array is copied, so a caller reusing it does not change the predicate.
+    static FilterPredicate eq(String column, byte[] value) {
+        return new BinaryColumnPredicate(column, Operator.EQ, value);
+    }
+
+    /// Creates a not-equals predicate for a binary column. See [#eq(String,byte[])].
+    static FilterPredicate notEq(String column, byte[] value) {
+        return new BinaryColumnPredicate(column, Operator.NOT_EQ, value);
+    }
+
+    /// Creates a less-than predicate for a binary column. See [#eq(String,byte[])].
+    static FilterPredicate lt(String column, byte[] value) {
+        return new BinaryColumnPredicate(column, Operator.LT, value);
+    }
+
+    /// Creates a less-than-or-equal predicate for a binary column. See [#eq(String,byte[])].
+    static FilterPredicate ltEq(String column, byte[] value) {
+        return new BinaryColumnPredicate(column, Operator.LT_EQ, value);
+    }
+
+    /// Creates a greater-than predicate for a binary column. See [#eq(String,byte[])].
+    static FilterPredicate gt(String column, byte[] value) {
+        return new BinaryColumnPredicate(column, Operator.GT, value);
+    }
+
+    /// Creates a greater-than-or-equal predicate for a binary column. See [#eq(String,byte[])].
+    static FilterPredicate gtEq(String column, byte[] value) {
+        return new BinaryColumnPredicate(column, Operator.GT_EQ, value);
+    }
+
+    /// Creates a set-membership predicate for a binary column, matching a row whose value is any
+    /// of `values`. Each probe is an equality literal and compares as [#eq(String,byte[])]
+    /// describes. The arrays are copied.
+    static FilterPredicate in(String column, byte[]... values) {
+        requireValues(Objects.requireNonNull(values, "values").length);
+        return new BinaryInPredicate(column, values);
     }
 
     static FilterPredicate in(String column, int... values) {
-        if (values.length == 0) {
-            throw new IllegalArgumentException("IN predicate requires at least one value");
-        }
+        requireValues(Objects.requireNonNull(values, "values").length);
         return new IntInPredicate(column, values);
     }
 
     static FilterPredicate in(String column, long... values) {
-        if (values.length == 0) {
-            throw new IllegalArgumentException("IN predicate requires at least one value");
-        }
+        requireValues(Objects.requireNonNull(values, "values").length);
         return new LongInPredicate(column, values);
     }
 
     static FilterPredicate in(String column, double... values) {
-        if (values.length == 0) {
-            throw new IllegalArgumentException("IN predicate requires at least one value");
-        }
+        requireValues(Objects.requireNonNull(values, "values").length);
         return new DoubleInPredicate(column, values);
     }
 
+    /// Creates a set-membership predicate for a text column, matching a row whose value is any of
+    /// `values`. Each probe compares as [#eq(String,String)] describes.
     static FilterPredicate inStrings(String column, String... values) {
-        if (values.length == 0) {
-            throw new IllegalArgumentException("IN predicate requires at least one value");
-        }
-        byte[][] encoded = new byte[values.length][];
-        for (int i = 0; i < values.length; i++) {
-            encoded[i] = values[i].getBytes(StandardCharsets.UTF_8);
-        }
-        return new BinaryInPredicate(column, encoded);
+        requireValues(Objects.requireNonNull(values, "values").length);
+        return new StringInPredicate(column, values);
     }
 
     // ==================== LocalDate (DATE) Predicates ====================
@@ -471,7 +522,29 @@ public sealed interface FilterPredicate
 
     // ==================== Conversion Helpers ====================
 
+    /// Rejects a set form with no probe to test against.
+    private static void requireValues(int count) {
+        if (count == 0) {
+            throw new IllegalArgumentException("IN predicate requires at least one value");
+        }
+    }
+
+    /// Rejects a `String` literal that is not well-formed UTF-16, which is one holding an
+    /// unpaired surrogate. Such a literal has no UTF-8 encoding: encoding it replaces the
+    /// surrogate with `?`, and the predicate would silently be one on a different value.
+    ///
+    /// `argument` names the offending literal the way the message reads it back, so a set form
+    /// says which probe is at fault.
+    private static void requireWellFormed(String column, String value, String argument) {
+        if (!StandardCharsets.UTF_8.newEncoder().canEncode(value)) {
+            throw new IllegalArgumentException("Column '" + column
+                    + "' compares a String literal as its UTF-8 bytes; " + argument + " is not"
+                    + " well-formed UTF-16 and has no UTF-8 encoding");
+        }
+    }
+
     private static byte[] uuidToBytes(UUID value) {
+        Objects.requireNonNull(value, "value");
         ByteBuffer buffer = ByteBuffer.allocate(16);
         buffer.putLong(value.getMostSignificantBits());
         buffer.putLong(value.getLeastSignificantBits());
@@ -537,7 +610,15 @@ public sealed interface FilterPredicate
     record BooleanColumnPredicate(String column, Operator op, boolean value) implements FilterPredicate {
     }
 
+    /// Predicate for a binary column, comparing the stored bytes as the column's annotation reads
+    /// them. Built by the `byte[]` factories and by `parquet-java-compat`'s filter conversion.
     record BinaryColumnPredicate(String column, Operator op, byte[] value) implements FilterPredicate {
+
+        public BinaryColumnPredicate(String column, Operator op, byte[] value) {
+            this.column = column;
+            this.op = op;
+            this.value = Objects.requireNonNull(value, "value").clone();
+        }
 
         @Override
         public boolean equals(Object o) {
@@ -552,6 +633,16 @@ public sealed interface FilterPredicate
             result = 31 * result + op.hashCode();
             result = 31 * result + Arrays.hashCode(value);
             return result;
+        }
+    }
+
+    /// Predicate for a text column, comparing the literal's UTF-8 bytes. The value is held as
+    /// given and encoded at reader creation, where the column is also checked to be one a
+    /// `String` reads.
+    record StringColumnPredicate(String column, Operator op, String value) implements FilterPredicate {
+
+        public StringColumnPredicate {
+            requireWellFormed(column, Objects.requireNonNull(value, "value"), "the literal");
         }
     }
 
@@ -576,7 +667,7 @@ public sealed interface FilterPredicate
 
         public IntInPredicate(String column, int[] values) {
             this.column = column;
-            this.values = values.clone();
+            this.values = Objects.requireNonNull(values, "values").clone();
         }
 
         @Override
@@ -596,7 +687,7 @@ public sealed interface FilterPredicate
 
         public LongInPredicate(String column, long[] values) {
             this.column = column;
-            this.values = values.clone();
+            this.values = Objects.requireNonNull(values, "values").clone();
         }
 
         @Override
@@ -616,7 +707,7 @@ public sealed interface FilterPredicate
 
         public DoubleInPredicate(String column, double[] values) {
             this.column = column;
-            this.values = values.clone();
+            this.values = Objects.requireNonNull(values, "values").clone();
         }
 
         @Override
@@ -632,11 +723,16 @@ public sealed interface FilterPredicate
         }
     }
 
+    /// Set-membership predicate for a binary column. Each probe compares as a
+    /// [BinaryColumnPredicate] literal does.
     record BinaryInPredicate(String column, byte[][] values) implements FilterPredicate {
 
         public BinaryInPredicate(String column, byte[][] values) {
             this.column = column;
-            this.values = values.clone();
+            this.values = new byte[Objects.requireNonNull(values, "values").length][];
+            for (int i = 0; i < values.length; i++) {
+                this.values[i] = Objects.requireNonNull(values[i], "values[" + i + "]").clone();
+            }
         }
 
         @Override
@@ -652,25 +748,67 @@ public sealed interface FilterPredicate
         }
     }
 
+    /// Set-membership predicate for a text column. Each probe compares as a
+    /// [StringColumnPredicate] literal does.
+    record StringInPredicate(String column, String[] values) implements FilterPredicate {
+
+        public StringInPredicate(String column, String[] values) {
+            this.column = column;
+            this.values = Objects.requireNonNull(values, "values").clone();
+            for (int i = 0; i < this.values.length; i++) {
+                String argument = "values[" + i + "]";
+                requireWellFormed(column, Objects.requireNonNull(this.values[i], argument), argument);
+            }
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) return true;
+            if (!(o instanceof StringInPredicate that)) return false;
+            return column.equals(that.column) && Arrays.equals(values, that.values);
+        }
+
+        @Override
+        public int hashCode() {
+            return 31 * column.hashCode() + Arrays.hashCode(values);
+        }
+    }
+
     // ==================== Logical-Type Predicate Records ====================
 
     /// Predicate for DATE columns. The [LocalDate] value is converted to epoch days at reader creation.
     record DateColumnPredicate(String column, Operator op, LocalDate value) implements FilterPredicate {
+
+        public DateColumnPredicate {
+            Objects.requireNonNull(value, "value");
+        }
     }
 
     /// Predicate for TIMESTAMP columns. The [Instant] value is converted to the column's time unit
     /// (MILLIS, MICROS, or NANOS) at reader creation using the schema's `TimestampType`.
     record InstantColumnPredicate(String column, Operator op, Instant value) implements FilterPredicate {
+
+        public InstantColumnPredicate {
+            Objects.requireNonNull(value, "value");
+        }
     }
 
     /// Predicate for TIME columns. The [LocalTime] value is converted to the column's time unit
     /// at reader creation using the schema's `TimeType`.
     record TimeColumnPredicate(String column, Operator op, LocalTime value) implements FilterPredicate {
+
+        public TimeColumnPredicate {
+            Objects.requireNonNull(value, "value");
+        }
     }
 
     /// Predicate for DECIMAL columns. The [BigDecimal] value is converted to the column's physical
     /// representation at reader creation using the schema's `DecimalType`.
     record DecimalColumnPredicate(String column, Operator op, BigDecimal value) implements FilterPredicate {
+
+        public DecimalColumnPredicate {
+            Objects.requireNonNull(value, "value");
+        }
     }
 
     // ==================== NULL Predicate Records ====================

--- a/core/src/test/java/dev/hardwood/DifferentialColumnOrderTest.java
+++ b/core/src/test/java/dev/hardwood/DifferentialColumnOrderTest.java
@@ -49,9 +49,8 @@ import static org.assertj.core.api.Assertions.assertThat;
 /// dictionary read in the wrong order shows up as a missing or extra row.
 ///
 /// An unsigned literal is the stored bit pattern, the form the accessors return. Binary literals
-/// go through the public [FilterPredicate.BinaryColumnPredicate] and
-/// [FilterPredicate.BinaryInPredicate] records, the form a filter converted from parquet-java
-/// takes.
+/// go through the `byte[]` factories, which take the stored bytes as a filter converted from
+/// parquet-java does.
 @Tag("differential")
 class DifferentialColumnOrderTest {
 
@@ -234,10 +233,17 @@ class DifferentialColumnOrderTest {
     }
 
     private static FilterPredicate bytes(String column, Operator op, byte[] value) {
-        return new FilterPredicate.BinaryColumnPredicate(column, op, value);
+        return switch (op) {
+            case EQ -> FilterPredicate.eq(column, value);
+            case NOT_EQ -> FilterPredicate.notEq(column, value);
+            case LT -> FilterPredicate.lt(column, value);
+            case LT_EQ -> FilterPredicate.ltEq(column, value);
+            case GT -> FilterPredicate.gt(column, value);
+            case GT_EQ -> FilterPredicate.gtEq(column, value);
+        };
     }
 
     private static FilterPredicate bytesIn(String column, byte[]... values) {
-        return new FilterPredicate.BinaryInPredicate(column, values);
+        return FilterPredicate.in(column, values);
     }
 }

--- a/core/src/test/java/dev/hardwood/FilterPredicateTest.java
+++ b/core/src/test/java/dev/hardwood/FilterPredicateTest.java
@@ -101,7 +101,17 @@ class FilterPredicateTest {
     @Test
     void testStringPredicateCreation() {
         FilterPredicate p = FilterPredicate.eq("name", "hello");
-        assertThat(p).isInstanceOf(FilterPredicate.BinaryColumnPredicate.class);
+        assertThat(p).isInstanceOf(FilterPredicate.StringColumnPredicate.class);
+    }
+
+    @Test
+    void testBinaryPredicateCreation() {
+        FilterPredicate p = FilterPredicate.eq("code", new byte[] { 0x01, (byte) 0xC8 });
+        assertThat(p).isInstanceOfSatisfying(FilterPredicate.BinaryColumnPredicate.class, binary -> {
+            assertThat(binary.column()).isEqualTo("code");
+            assertThat(binary.op()).isEqualTo(FilterPredicate.Operator.EQ);
+            assertThat(binary.value()).containsExactly(0x01, 0xC8);
+        });
     }
 
     @Test
@@ -418,7 +428,124 @@ class FilterPredicateTest {
     @Test
     void testStringInPredicateCreation() {
         FilterPredicate p = FilterPredicate.inStrings("city", "NYC", "LA");
-        assertThat(p).isInstanceOf(FilterPredicate.BinaryInPredicate.class);
+        assertThat(p).isInstanceOf(FilterPredicate.StringInPredicate.class);
+    }
+
+    @Test
+    void testBinaryInPredicateCreation() {
+        FilterPredicate p = FilterPredicate.in("code", new byte[] { 0x01 }, new byte[] { 0x02 });
+        assertThat(p).isInstanceOfSatisfying(FilterPredicate.BinaryInPredicate.class, in -> {
+            assertThat(in.column()).isEqualTo("code");
+            assertThat(in.values()).hasDimensions(2, 1);
+            assertThat(in.values()[0]).containsExactly(0x01);
+            assertThat(in.values()[1]).containsExactly(0x02);
+        });
+    }
+
+    /// A caller reusing its array to build a second predicate must not change the first.
+    @Test
+    void byteLiteralsAreCopiedWhenThePredicateIsBuilt() {
+        byte[] literal = { 0x01, 0x02 };
+        FilterPredicate.BinaryColumnPredicate scalar =
+                (FilterPredicate.BinaryColumnPredicate) FilterPredicate.eq("code", literal);
+        FilterPredicate.BinaryInPredicate set =
+                (FilterPredicate.BinaryInPredicate) FilterPredicate.in("code", literal);
+
+        literal[1] = 0x03;
+
+        assertThat(scalar.value()).containsExactly(0x01, 0x02);
+        assertThat(set.values()[0]).containsExactly(0x01, 0x02);
+    }
+
+    /// Two predicates on the same bytes are the same predicate, whichever arrays they were
+    /// built from.
+    @Test
+    void byteLiteralsCompareByContent() {
+        assertThat(FilterPredicate.eq("code", new byte[] { 0x01, 0x02 }))
+                .isEqualTo(FilterPredicate.eq("code", new byte[] { 0x01, 0x02 }))
+                .hasSameHashCodeAs(FilterPredicate.eq("code", new byte[] { 0x01, 0x02 }))
+                .isNotEqualTo(FilterPredicate.eq("code", new byte[] { 0x01, 0x03 }));
+        assertThat(FilterPredicate.in("code", new byte[] { 0x01 }, new byte[] { 0x02 }))
+                .isEqualTo(FilterPredicate.in("code", new byte[] { 0x01 }, new byte[] { 0x02 }))
+                .hasSameHashCodeAs(FilterPredicate.in("code", new byte[] { 0x01 }, new byte[] { 0x02 }))
+                .isNotEqualTo(FilterPredicate.in("code", new byte[] { 0x01 }));
+    }
+
+    /// A `String` literal is compared as its UTF-8 bytes, and an unpaired surrogate has no UTF-8
+    /// encoding: encoding it would silently substitute `?` and filter on a different value.
+    @Test
+    void aStringLiteralThatIsNotWellFormedUtf16IsRejected() {
+        assertThatThrownBy(() -> FilterPredicate.eq("name", "\uD800"))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("Column 'name' compares a String literal as its UTF-8 bytes;"
+                        + " the literal is not well-formed UTF-16 and has no UTF-8 encoding");
+        assertThatThrownBy(() -> FilterPredicate.inStrings("name", "ok", "\uDC00"))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("Column 'name' compares a String literal as its UTF-8 bytes;"
+                        + " values[1] is not well-formed UTF-16 and has no UTF-8 encoding");
+    }
+
+    /// Two predicates on the same text are the same predicate, which the set form spells out
+    /// itself because an array does not compare by content.
+    @Test
+    void stringLiteralsCompareByContent() {
+        assertThat(FilterPredicate.eq("city", "NYC"))
+                .isEqualTo(FilterPredicate.eq("city", "NYC"))
+                .hasSameHashCodeAs(FilterPredicate.eq("city", "NYC"))
+                .isNotEqualTo(FilterPredicate.eq("city", "LA"))
+                .isNotEqualTo(FilterPredicate.notEq("city", "NYC"));
+        assertThat(FilterPredicate.inStrings("city", "NYC", "LA"))
+                .isEqualTo(FilterPredicate.inStrings("city", "NYC", "LA"))
+                .hasSameHashCodeAs(FilterPredicate.inStrings("city", "NYC", "LA"))
+                .isNotEqualTo(FilterPredicate.inStrings("city", "NYC"))
+                .isNotEqualTo(FilterPredicate.inStrings("town", "NYC", "LA"));
+    }
+
+    /// Every set form needs a value to test against: an empty one would be a predicate matching
+    /// nothing, which `not(isNull(...))` already says.
+    @Test
+    void everySetFormRejectsAnEmptyList() {
+        assertThatThrownBy(() -> FilterPredicate.in("c", new int[0]))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("IN predicate requires at least one value");
+        assertThatThrownBy(() -> FilterPredicate.in("c", new long[0]))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("IN predicate requires at least one value");
+        assertThatThrownBy(() -> FilterPredicate.in("c", new double[0]))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("IN predicate requires at least one value");
+        assertThatThrownBy(() -> FilterPredicate.in("c", new byte[0][]))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("IN predicate requires at least one value");
+        assertThatThrownBy(() -> FilterPredicate.inStrings("c"))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("IN predicate requires at least one value");
+    }
+
+    /// A null literal is a mistake at the call site, and it is caught there rather than at
+    /// reader creation or, worse, in a comparison.
+    @Test
+    void everyFactoryRejectsANullLiteral() {
+        assertThatThrownBy(() -> FilterPredicate.eq("c", (String) null))
+                .isInstanceOf(NullPointerException.class).hasMessage("value");
+        assertThatThrownBy(() -> FilterPredicate.gt("c", (byte[]) null))
+                .isInstanceOf(NullPointerException.class).hasMessage("value");
+        assertThatThrownBy(() -> FilterPredicate.lt("c", (LocalDate) null))
+                .isInstanceOf(NullPointerException.class).hasMessage("value");
+        assertThatThrownBy(() -> FilterPredicate.ltEq("c", (Instant) null))
+                .isInstanceOf(NullPointerException.class).hasMessage("value");
+        assertThatThrownBy(() -> FilterPredicate.gtEq("c", (LocalTime) null))
+                .isInstanceOf(NullPointerException.class).hasMessage("value");
+        assertThatThrownBy(() -> FilterPredicate.notEq("c", (BigDecimal) null))
+                .isInstanceOf(NullPointerException.class).hasMessage("value");
+        assertThatThrownBy(() -> FilterPredicate.eq("c", (UUID) null))
+                .isInstanceOf(NullPointerException.class).hasMessage("value");
+        assertThatThrownBy(() -> FilterPredicate.in("c", (byte[][]) null))
+                .isInstanceOf(NullPointerException.class).hasMessage("values");
+        assertThatThrownBy(() -> FilterPredicate.in("c", new byte[] { 0x01 }, null))
+                .isInstanceOf(NullPointerException.class).hasMessage("values[1]");
+        assertThatThrownBy(() -> FilterPredicate.inStrings("c", "a", null))
+                .isInstanceOf(NullPointerException.class).hasMessage("values[1]");
     }
 
     @Test

--- a/core/src/test/java/dev/hardwood/PredicatePathAgreementTest.java
+++ b/core/src/test/java/dev/hardwood/PredicatePathAgreementTest.java
@@ -76,8 +76,7 @@ class PredicatePathAgreementTest {
 
     /// A comparison no batch matcher takes, on a required column whose every value is `z`, so it
     /// matches no row and pushes the filter it is `or`-ed into onto the record-level path.
-    private static final FilterPredicate NEVER =
-            new FilterPredicate.BinaryColumnPredicate("zz", Operator.LT, new byte[0]);
+    private static final FilterPredicate NEVER = FilterPredicate.lt("zz", new byte[0]);
 
     private static final ReaderConfig METADATA_FILTERING_OFF = ReaderConfig.builder()
             .option("hardwood.metadata-filtering", "false")
@@ -316,8 +315,47 @@ class PredicatePathAgreementTest {
                 new Rejected("Column 'f16' has physical type FIXED_LEN_BYTE_ARRAY; "
                         + "given filter predicate type DOUBLE/FLOAT is incompatible")));
 
+        stringLiteralsOnlyWhereGetStringReads(cases);
         literalsTheColumnCannotHold(cases);
         return cases;
+    }
+
+    /// A `String` is the literal where `getString` reads the column, and a `byte[]` is the
+    /// literal of every binary column. On a column whose annotation reads the stored bytes as
+    /// something other than text, a `String` says nothing about the values: it would be taken as
+    /// the bytes it encodes rather than as the text a caller wrote.
+    private static void stringLiteralsOnlyWhereGetStringReads(List<Case> cases) {
+        cases.add(new Case("str", "eq(the bytes of k0200)",
+                binary("str", Operator.EQ, "k0200".getBytes(StandardCharsets.UTF_8)),
+                matching(eqPhysical("k0200".getBytes(StandardCharsets.UTF_8)))));
+        cases.add(new Case("enum", "gt(the bytes of E3)",
+                binary("enum", Operator.GT, "E3".getBytes(StandardCharsets.UTF_8)),
+                matching(cmpPhysical(Operator.GT, "E3".getBytes(StandardCharsets.UTF_8)))));
+
+        cases.add(new Case("dec_flba", "eq(\"1.25\"), a String on a DECIMAL column",
+                FilterPredicate.eq("dec_flba", "1.25"),
+                new Rejected("Column 'dec_flba' is annotated DECIMAL(20, 2), "
+                        + "which takes BigDecimal and byte[] literals, not a String")));
+        cases.add(new Case("f16", "lt(\"6.25\"), a String on a FLOAT16 column",
+                FilterPredicate.lt("f16", "6.25"),
+                new Rejected("Column 'f16' is annotated FLOAT16, "
+                        + "which takes float and byte[] literals, not a String")));
+        cases.add(new Case("uuid", "eq(a String on a UUID column)",
+                FilterPredicate.eq("uuid", "0123456789abcdef"),
+                new Rejected("Column 'uuid' is annotated UUID, "
+                        + "which takes UUID and byte[] literals, not a String")));
+        cases.add(new Case("flba5", "eq(a String on an unannotated FIXED_LEN_BYTE_ARRAY)",
+                FilterPredicate.eq("flba5", "abcde"),
+                new Rejected("Column 'flba5' is an unannotated FIXED_LEN_BYTE_ARRAY, "
+                        + "which takes byte[] literals, not a String")));
+        cases.add(new Case("bson", "inStrings(a String on a BSON column)",
+                FilterPredicate.inStrings("bson", "abc"),
+                new Rejected("Column 'bson' is annotated BSON, "
+                        + "which takes byte[] literals, not a String")));
+        cases.add(new Case("iv", "eq(a String on an INTERVAL column)",
+                FilterPredicate.eq("iv", "months days ms"),
+                new Rejected("Column 'iv' is annotated INTERVAL, "
+                        + "which takes byte[] literals, not a String")));
     }
 
     /// A literal of the column's literal type that the column cannot hold: finer than its time
@@ -538,11 +576,10 @@ class PredicatePathAgreementTest {
                 matching(cmpPhysical(Operator.LT, literal))));
         cases.add(new Case(column, "gtEq(" + shown + ")", binary(column, Operator.GT_EQ, literal),
                 matching(cmpPhysical(Operator.GT_EQ, literal))));
-        cases.add(new Case(column, "in(" + shown + ")",
-                new FilterPredicate.BinaryInPredicate(column, new byte[][] { literal }),
+        cases.add(new Case(column, "in(" + shown + ")", FilterPredicate.in(column, literal),
                 matching(eqPhysical(literal))));
         cases.add(new Case(column, "not(in(" + shown + "))",
-                FilterPredicate.not(new FilterPredicate.BinaryInPredicate(column, new byte[][] { literal })),
+                FilterPredicate.not(FilterPredicate.in(column, literal)),
                 matching(notEqPhysical(literal))));
     }
 
@@ -553,11 +590,10 @@ class PredicatePathAgreementTest {
                 matching(eqPhysical(literal))));
         cases.add(new Case(column, "notEq(" + shown + ")", binary(column, Operator.NOT_EQ, literal),
                 matching(notEqPhysical(literal))));
-        cases.add(new Case(column, "in(" + shown + ")",
-                new FilterPredicate.BinaryInPredicate(column, new byte[][] { literal }),
+        cases.add(new Case(column, "in(" + shown + ")", FilterPredicate.in(column, literal),
                 matching(eqPhysical(literal))));
         cases.add(new Case(column, "not(in(" + shown + "))",
-                FilterPredicate.not(new FilterPredicate.BinaryInPredicate(column, new byte[][] { literal })),
+                FilterPredicate.not(FilterPredicate.in(column, literal)),
                 matching(notEqPhysical(literal))));
     }
 
@@ -867,7 +903,14 @@ class PredicatePathAgreementTest {
     private static final HexFormat HEX = HexFormat.of();
 
     private static FilterPredicate binary(String column, Operator op, byte[] value) {
-        return new FilterPredicate.BinaryColumnPredicate(column, op, value);
+        return switch (op) {
+            case EQ -> FilterPredicate.eq(column, value);
+            case NOT_EQ -> FilterPredicate.notEq(column, value);
+            case LT -> FilterPredicate.lt(column, value);
+            case LT_EQ -> FilterPredicate.ltEq(column, value);
+            case GT -> FilterPredicate.gt(column, value);
+            case GT_EQ -> FilterPredicate.gtEq(column, value);
+        };
     }
 
     /// The two little-endian bytes a `FLOAT16` column stores for `value`.

--- a/core/src/test/java/dev/hardwood/internal/predicate/BinaryDecimalFilterTest.java
+++ b/core/src/test/java/dev/hardwood/internal/predicate/BinaryDecimalFilterTest.java
@@ -185,14 +185,14 @@ class BinaryDecimalFilterTest {
         }
     }
 
-    /// The bytes of `1.27` are in the file, and a byte-string `eq` for exactly those bytes came
+    /// The bytes of `1.27` are in the file, and a byte `eq` for exactly those bytes came
     /// back empty: the row group's statistics are written in the column's signed order
     /// (`min = FF 00`, `max = 01 2C`) and pruning them unsigned sorts the literal `7F` below the
     /// minimum. The literal now takes the column's own comparison, which is the one those bounds
     /// were written in, so the row is found.
     @Test
     void aByteStringPredicateComparesAsTheColumnDoes() throws Exception {
-        assertThat(filtered(FilterPredicate.eq("amount", "\u007F")))
+        assertThat(filtered(FilterPredicate.eq("amount", new byte[] { 0x7F })))
                 .containsExactly(new BigDecimal("1.27"));
     }
 
@@ -200,7 +200,7 @@ class BinaryDecimalFilterTest {
     /// number, so the ordering is visible in the rows that come back.
     @Test
     void aByteStringRangePredicateOrdersByValue() throws Exception {
-        assertThat(filtered(FilterPredicate.gt("amount", "\u007F")))
+        assertThat(filtered(FilterPredicate.gt("amount", new byte[] { 0x7F })))
                 .containsExactly(new BigDecimal("1.28"), new BigDecimal("3.00"));
     }
 
@@ -213,7 +213,7 @@ class BinaryDecimalFilterTest {
         byte[] file = writeRawBinaryDecimals(paddedRows());
         try (ParquetFileReader reader = ParquetFileReader.open(InputFile.of(ByteBuffer.wrap(file)));
                 RowReader rows = reader.buildRowReader()
-                        .filter(FilterPredicate.inStrings("amount", "\u007F"))
+                        .filter(FilterPredicate.in("amount", new byte[] { 0x7F }))
                         .build()) {
             assertThat(collect(rows)).hasSize(PADDED_ROWS / 2)
                     .allMatch(value -> value.compareTo(new BigDecimal("1.27")) == 0);
@@ -221,7 +221,7 @@ class BinaryDecimalFilterTest {
     }
 
     /// A `BYTE_ARRAY` column that is not a `DECIMAL` orders as its bytes, so the same predicates
-    /// stay available on it.
+    /// stay available on it, a `String` literal among them.
     @Test
     void aByteStringPredicateStaysAvailableOnAPlainBinaryColumn() {
         FileSchema plain = FileSchema.builder("schema")

--- a/core/src/test/java/dev/hardwood/internal/predicate/ByteStringOrderFilterTest.java
+++ b/core/src/test/java/dev/hardwood/internal/predicate/ByteStringOrderFilterTest.java
@@ -10,6 +10,7 @@ package dev.hardwood.internal.predicate;
 import java.math.BigDecimal;
 import java.nio.ByteBuffer;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 
 import org.junit.jupiter.api.Test;
@@ -46,7 +47,7 @@ class ByteStringOrderFilterTest {
     @Test
     void aFloat16ColumnComparesABinaryLiteralNumerically() {
         assertThat(FilterPredicateResolver.resolve(
-                FilterPredicate.lt("h", asString(half(1.5f))), float16Schema()))
+                FilterPredicate.lt("h", half(1.5f)), float16Schema()))
                 .isInstanceOfSatisfying(ResolvedPredicate.Float16Predicate.class,
                         p -> assertThat(p.value()).isEqualTo(1.5f));
     }
@@ -58,14 +59,14 @@ class ByteStringOrderFilterTest {
         byte[] oneAndABit = { 0x01, 0x3C };
         byte[] file = writeFloat16(new byte[][] { half(1.0f), oneAndABit, half(1.5f) });
 
-        assertThat(filteredFloat16(file, FilterPredicate.eq("h", asString(oneAndABit))))
+        assertThat(filteredFloat16(file, FilterPredicate.eq("h", oneAndABit)))
                 .containsExactly(oneAndABit);
     }
 
     @Test
     void aFloat16LiteralOfTheWrongWidthIsRejected() {
         assertThatThrownBy(() -> FilterPredicateResolver.resolve(
-                FilterPredicate.eq("h", "abc"), float16Schema()))
+                FilterPredicate.eq("h", new byte[] { 0x01, 0x02, 0x03 }), float16Schema()))
                 .isInstanceOf(IllegalArgumentException.class)
                 .hasMessage("Column 'h' is a FLOAT16, whose literal is 2 bytes, not 3");
     }
@@ -76,7 +77,7 @@ class ByteStringOrderFilterTest {
     @Test
     void aByteArrayDecimalComparesABinaryLiteralAsItsValue() {
         assertThat(FilterPredicateResolver.resolve(
-                FilterPredicate.gt("amount", asString(new byte[] { 0x7F })), decimalSchema()))
+                FilterPredicate.gt("amount", new byte[] { 0x7F }), decimalSchema()))
                 .isInstanceOfSatisfying(ResolvedPredicate.BinaryPredicate.class,
                         p -> assertThat(p.comparison()).isEqualTo(Comparison.VARIABLE_DECIMAL));
     }
@@ -89,7 +90,7 @@ class ByteStringOrderFilterTest {
                 .build();
 
         assertThat(FilterPredicateResolver.resolve(
-                FilterPredicate.gt("amount", asString(new byte[] { 0x7F })), fixed))
+                FilterPredicate.gt("amount", new byte[] { 0x7F }), fixed))
                 .isInstanceOfSatisfying(ResolvedPredicate.BinaryPredicate.class,
                         p -> assertThat(p.comparison()).isEqualTo(Comparison.FIXED_DECIMAL));
     }
@@ -101,7 +102,7 @@ class ByteStringOrderFilterTest {
         byte[] file = writeDecimals(new BigDecimal[] {
                 new BigDecimal("1.27"), new BigDecimal("3.00"), new BigDecimal("-1.00") });
 
-        assertThat(filteredDecimals(file, FilterPredicate.gt("amount", asString(new byte[] { 0x7F }))))
+        assertThat(filteredDecimals(file, FilterPredicate.gt("amount", new byte[] { 0x7F })))
                 .containsExactly(new BigDecimal("3.00"));
     }
 
@@ -112,7 +113,7 @@ class ByteStringOrderFilterTest {
     @Test
     void aDecimalSetTakesTheColumnsComparison() {
         assertThat(FilterPredicateResolver.resolve(
-                FilterPredicate.inStrings("amount", "a"), decimalSchema()))
+                FilterPredicate.in("amount", new byte[] { 0x61 }), decimalSchema()))
                 .isInstanceOfSatisfying(ResolvedPredicate.BinaryInPredicate.class, p -> {
                     assertThat(p.comparison()).isEqualTo(Comparison.VARIABLE_DECIMAL);
                     assertThat(p.byteExact()).isFalse();
@@ -122,7 +123,7 @@ class ByteStringOrderFilterTest {
                 .addColumn("amount", PhysicalType.FIXED_LEN_BYTE_ARRAY, RepetitionType.REQUIRED, 4,
                         LogicalType.decimal(9, 2))
                 .build();
-        assertThat(FilterPredicateResolver.resolve(FilterPredicate.inStrings("amount", "a"), fixed))
+        assertThat(FilterPredicateResolver.resolve(FilterPredicate.in("amount", new byte[] { 0x61 }), fixed))
                 .isInstanceOfSatisfying(ResolvedPredicate.BinaryInPredicate.class, p -> {
                     assertThat(p.comparison()).isEqualTo(Comparison.FIXED_DECIMAL);
                     assertThat(p.byteExact()).isTrue();
@@ -152,10 +153,10 @@ class ByteStringOrderFilterTest {
         byte[] oneAndABit = { 0x01, 0x3C };
         byte[] file = writeFloat16(new byte[][] { half(1.0f), oneAndABit, half(1.5f) });
 
-        assertThat(filteredFloat16(file, FilterPredicate.inStrings("h", asString(oneAndABit))))
+        assertThat(filteredFloat16(file, FilterPredicate.in("h", oneAndABit)))
                 .containsExactly(oneAndABit);
         assertThat(filteredFloat16(file, FilterPredicate.not(
-                FilterPredicate.inStrings("h", asString(oneAndABit)))))
+                FilterPredicate.in("h", oneAndABit))))
                 .containsExactly(half(1.0f), half(1.5f));
     }
 
@@ -176,7 +177,7 @@ class ByteStringOrderFilterTest {
     @Test
     void aFloat16SetProbeOfTheWrongWidthIsRejected() {
         assertThatThrownBy(() -> FilterPredicateResolver.resolve(
-                FilterPredicate.inStrings("h", "abc"), float16Schema()))
+                FilterPredicate.in("h", new byte[] { 0x01, 0x02, 0x03 }), float16Schema()))
                 .isInstanceOf(IllegalArgumentException.class)
                 .hasMessage("Column 'h' is a FLOAT16, whose literal is 2 bytes, not 3");
     }
@@ -186,7 +187,7 @@ class ByteStringOrderFilterTest {
     @Test
     void aFloat16SetPrunesInTheColumnsOrder() {
         ResolvedPredicate leaf = FilterPredicateResolver.resolve(
-                FilterPredicate.inStrings("h", asString(new byte[] { 0x01, 0x3C })), float16Schema());
+                FilterPredicate.in("h", new byte[] { 0x01, 0x3C }), float16Schema());
         Statistics stats = new Statistics(half(1.0f), half(1.5f), 0L, null, false);
 
         assertThat(MinMaxStats.of(stats, leaf, BoundsReadability.ALL).canDrop(leaf)).isFalse();
@@ -214,12 +215,13 @@ class ByteStringOrderFilterTest {
     /// only byte strings of that width and refuses an equality literal of any other.
     private static void assertByteString(FileSchema schema) {
         Integer width = schema.getColumn("c").typeLength();
-        String literal = "a".repeat(width == null ? 1 : width);
+        byte[] literal = new byte[width == null ? 1 : width];
+        Arrays.fill(literal, (byte) 0x61);
 
         assertThat(FilterPredicateResolver.resolve(FilterPredicate.eq("c", literal), schema))
                 .isInstanceOfSatisfying(ResolvedPredicate.BinaryPredicate.class,
                         p -> assertThat(p.comparison()).isEqualTo(Comparison.BYTE_STRING));
-        assertThat(FilterPredicateResolver.resolve(FilterPredicate.inStrings("c", literal), schema))
+        assertThat(FilterPredicateResolver.resolve(FilterPredicate.in("c", literal), schema))
                 .isInstanceOfSatisfying(ResolvedPredicate.BinaryInPredicate.class,
                         p -> assertThat(p.comparison()).isEqualTo(Comparison.BYTE_STRING));
     }
@@ -227,16 +229,6 @@ class ByteStringOrderFilterTest {
     private static byte[] half(float value) {
         short bits = Float.floatToFloat16(value);
         return new byte[] { (byte) bits, (byte) (bits >>> 8) };
-    }
-
-    /// The literal as the byte-string factories take it. Every byte here is below `0x80`, which
-    /// is what UTF-8 round-trips one-for-one.
-    private static String asString(byte[] bytes) {
-        char[] chars = new char[bytes.length];
-        for (int i = 0; i < bytes.length; i++) {
-            chars[i] = (char) (bytes[i] & 0xFF);
-        }
-        return new String(chars);
     }
 
     private static FileSchema float16Schema() {

--- a/core/src/test/java/dev/hardwood/internal/predicate/DictionaryFixedLenByteArrayPushDownTest.java
+++ b/core/src/test/java/dev/hardwood/internal/predicate/DictionaryFixedLenByteArrayPushDownTest.java
@@ -8,6 +8,7 @@
 package dev.hardwood.internal.predicate;
 
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 
@@ -73,17 +74,22 @@ class DictionaryFixedLenByteArrayPushDownTest {
 
     @Test
     void absentCodeIsDroppedOnlyByTheDictionary() throws IOException {
-        FilterPredicate absent = FilterPredicate.eq("code", "aa05");
+        FilterPredicate absent = FilterPredicate.eq("code", code("aa05"));
 
         assertThat(statisticsDrop(absent)).as("aa05 sorts within [aa00, aa09]").isFalse();
         assertThat(dictionaryDrop(absent)).isTrue();
-        assertThat(dictionaryDrop(FilterPredicate.eq("code", "aa06"))).isFalse();
+        assertThat(dictionaryDrop(FilterPredicate.eq("code", code("aa06")))).isFalse();
     }
 
     @Test
     void codeInListDropsOnlyWhenEveryValueIsAbsent() throws IOException {
-        assertThat(dictionaryDrop(FilterPredicate.inStrings("code", "aa05", "aa07"))).isTrue();
-        assertThat(dictionaryDrop(FilterPredicate.inStrings("code", "aa05", "aa06"))).isFalse();
+        assertThat(dictionaryDrop(FilterPredicate.in("code", code("aa05"), code("aa07")))).isTrue();
+        assertThat(dictionaryDrop(FilterPredicate.in("code", code("aa05"), code("aa06")))).isFalse();
+    }
+
+    /// A `code` literal, which the column stores as the four bytes of its ASCII spelling.
+    private static byte[] code(String value) {
+        return value.getBytes(StandardCharsets.US_ASCII);
     }
 
     private static RowGroupDictionaryFilterSource dictionaries() {

--- a/core/src/test/java/dev/hardwood/internal/predicate/FilterPredicateResolverTest.java
+++ b/core/src/test/java/dev/hardwood/internal/predicate/FilterPredicateResolverTest.java
@@ -21,6 +21,7 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 
+import dev.hardwood.internal.predicate.ResolvedPredicate.BinaryPredicate.Comparison;
 import dev.hardwood.metadata.ColumnOrder;
 import dev.hardwood.metadata.ConvertedType;
 import dev.hardwood.metadata.LogicalType;
@@ -438,7 +439,7 @@ class FilterPredicateResolverTest {
         FileSchema schema = schemaWithLogicalType("code", PhysicalType.FIXED_LEN_BYTE_ARRAY, 4, null);
 
         assertThatThrownBy(() -> FilterPredicateResolver.resolve(
-                FilterPredicate.inStrings("code", "aaaa", "aa"), schema))
+                FilterPredicate.in("code", byteLiteral(0x61, 0x61, 0x61, 0x61), byteLiteral(0x61, 0x61)), schema))
                 .isInstanceOf(IllegalArgumentException.class)
                 .hasMessage("Column 'code' holds a byte string of 4 bytes; "
                         + "the equality literal 6161 (2 bytes) is not a value it can hold");
@@ -451,12 +452,12 @@ class FilterPredicateResolverTest {
     void resolveByteLiteralOfAnotherWidthOnUnannotatedFixedLenColumn() {
         FileSchema schema = schemaWithLogicalType("code", PhysicalType.FIXED_LEN_BYTE_ARRAY, 4, null);
 
-        assertThatThrownBy(() -> FilterPredicateResolver.resolve(FilterPredicate.eq("code", "aa"), schema))
+        assertThatThrownBy(() -> FilterPredicateResolver.resolve(FilterPredicate.eq("code", byteLiteral(0x61, 0x61)), schema))
                 .isInstanceOf(IllegalArgumentException.class)
                 .hasMessage("Column 'code' holds a byte string of 4 bytes; "
                         + "the equality literal 6161 (2 bytes) is not a value it can hold");
 
-        assertThat(FilterPredicateResolver.resolve(FilterPredicate.lt("code", "aa"), schema))
+        assertThat(FilterPredicateResolver.resolve(FilterPredicate.lt("code", byteLiteral(0x61, 0x61)), schema))
                 .isInstanceOfSatisfying(ResolvedPredicate.BinaryPredicate.class,
                         p -> assertThat(p.value()).containsExactly('a', 'a'));
     }
@@ -1060,7 +1061,111 @@ class FilterPredicateResolverTest {
         assertThat(bytes).containsExactly(0, 0, 0, 0);
     }
 
+    // ==================== String literals ====================
+
+    /// A `String` is the literal where `getString` reads the column, and it compares as its
+    /// UTF-8 bytes, which is what such a column stores.
+    @ParameterizedTest(name = "{0}")
+    @MethodSource
+    void aStringLiteralResolvesOnATextColumn(String name, FileSchema schema) {
+        assertThat(FilterPredicateResolver.resolve(FilterPredicate.eq("c", "hé"), schema))
+                .isInstanceOfSatisfying(ResolvedPredicate.BinaryPredicate.class, p -> {
+                    assertThat(p.comparison()).isEqualTo(Comparison.BYTE_STRING);
+                    assertThat(p.value()).containsExactly(0x68, 0xC3, 0xA9);
+                });
+        assertThat(FilterPredicateResolver.resolve(FilterPredicate.inStrings("c", "hé"), schema))
+                .isInstanceOfSatisfying(ResolvedPredicate.BinaryInPredicate.class, p -> {
+                    assertThat(p.comparison()).isEqualTo(Comparison.BYTE_STRING);
+                    assertThat(p.values()[0]).containsExactly(0x68, 0xC3, 0xA9);
+                });
+    }
+
+    static Stream<Arguments> aStringLiteralResolvesOnATextColumn() {
+        return Stream.of(
+                Arguments.of("STRING", schemaWithLogicalType("c", PhysicalType.BYTE_ARRAY,
+                        LogicalType.string())),
+                Arguments.of("ENUM", schemaWithLogicalType("c", PhysicalType.BYTE_ARRAY,
+                        LogicalType.enumType())),
+                Arguments.of("JSON", schemaWithLogicalType("c", PhysicalType.BYTE_ARRAY,
+                        LogicalType.json())),
+                Arguments.of("unannotated BYTE_ARRAY", schemaWithLogicalType("c",
+                        PhysicalType.BYTE_ARRAY, null)));
+    }
+
+    /// Every other binary column stores bytes its annotation reads as something else, and a
+    /// `String` on one would be taken as the bytes it encodes rather than as the text that was
+    /// written. It is refused, naming the literals the column does take.
+    @ParameterizedTest(name = "{0}")
+    @MethodSource
+    void aStringLiteralIsRefusedOnAColumnThatDoesNotHoldText(String name, FileSchema schema,
+            String message) {
+        assertThatThrownBy(() -> FilterPredicateResolver.resolve(FilterPredicate.eq("c", "a"), schema))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage(message);
+        assertThatThrownBy(() -> FilterPredicateResolver.resolve(
+                FilterPredicate.inStrings("c", "a"), schema))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage(message);
+    }
+
+    static Stream<Arguments> aStringLiteralIsRefusedOnAColumnThatDoesNotHoldText() {
+        return Stream.of(
+                Arguments.of("DECIMAL over BYTE_ARRAY",
+                        schemaWithLogicalType("c", PhysicalType.BYTE_ARRAY, LogicalType.decimal(9, 2)),
+                        notText("annotated DECIMAL(9, 2)", "BigDecimal and byte[]")),
+                Arguments.of("DECIMAL over FIXED_LEN_BYTE_ARRAY",
+                        schemaWithLogicalType("c", PhysicalType.FIXED_LEN_BYTE_ARRAY, 4,
+                                LogicalType.decimal(9, 2)),
+                        notText("annotated DECIMAL(9, 2)", "BigDecimal and byte[]")),
+                Arguments.of("FLOAT16",
+                        schemaWithLogicalType("c", PhysicalType.FIXED_LEN_BYTE_ARRAY, 2,
+                                LogicalType.float16()),
+                        notText("annotated FLOAT16", "float and byte[]")),
+                Arguments.of("UUID",
+                        schemaWithLogicalType("c", PhysicalType.FIXED_LEN_BYTE_ARRAY, 16,
+                                LogicalType.uuid()),
+                        notText("annotated UUID", "UUID and byte[]")),
+                Arguments.of("INTERVAL",
+                        schemaWithLogicalType("c", PhysicalType.FIXED_LEN_BYTE_ARRAY, 12,
+                                new LogicalType.IntervalType()),
+                        notText("annotated INTERVAL", "byte[]")),
+                Arguments.of("BSON",
+                        schemaWithLogicalType("c", PhysicalType.BYTE_ARRAY, LogicalType.bson()),
+                        notText("annotated BSON", "byte[]")),
+                Arguments.of("GEOMETRY",
+                        schemaWithLogicalType("c", PhysicalType.BYTE_ARRAY,
+                                new LogicalType.GeometryType(null)),
+                        notText("annotated GEOMETRY", "byte[]")),
+                Arguments.of("GEOGRAPHY",
+                        schemaWithLogicalType("c", PhysicalType.BYTE_ARRAY,
+                                new LogicalType.GeographyType(null, null)),
+                        notText("annotated GEOGRAPHY", "byte[]")),
+                Arguments.of("NULL",
+                        schemaWithLogicalType("c", PhysicalType.BYTE_ARRAY, new LogicalType.NullType()),
+                        notText("annotated NULL", "byte[]")),
+                Arguments.of("unannotated FIXED_LEN_BYTE_ARRAY",
+                        schemaWithLogicalType("c", PhysicalType.FIXED_LEN_BYTE_ARRAY, 4, null),
+                        notText("an unannotated FIXED_LEN_BYTE_ARRAY", "byte[]")));
+    }
+
+    /// The same column takes the bytes themselves, which is what its accessor returns for it.
+    @Test
+    void aByteLiteralResolvesOnAColumnThatDoesNotHoldText() {
+        FileSchema schema = schemaWithLogicalType("c", PhysicalType.FIXED_LEN_BYTE_ARRAY, 4, null);
+
+        assertThat(FilterPredicateResolver.resolve(
+                FilterPredicate.eq("c", byteLiteral(0x61, 0x61, 0x61, 0x61)), schema))
+                .isInstanceOfSatisfying(ResolvedPredicate.BinaryPredicate.class,
+                        p -> assertThat(p.value()).containsExactly(0x61, 0x61, 0x61, 0x61));
+    }
+
     // ==================== Helpers ====================
+
+    /// The message a `String` literal raises on a column that does not hold text.
+    private static String notText(String description, String literals) {
+        return "Column 'c' is " + description + ", which takes " + literals
+                + " literals, not a String";
+    }
 
     /// The message `validateType` raises when a column's physical type does not admit the
     /// predicate's value type.

--- a/core/src/test/java/dev/hardwood/internal/predicate/UnreadableSortOrderTest.java
+++ b/core/src/test/java/dev/hardwood/internal/predicate/UnreadableSortOrderTest.java
@@ -61,7 +61,7 @@ class UnreadableSortOrderTest {
     void boundsOnAnUnorderedAnnotationDoNotPrune() {
         FileSchema geometry = geometrySchema();
         ResolvedPredicate leaf = FilterPredicateResolver.resolve(
-                FilterPredicate.eq("g", "M"), geometry);
+                FilterPredicate.eq("g", bytes("M")), geometry);
         Statistics foreign = new Statistics(bytes("N"), bytes("Z"), 0L, null, false);
 
         MinMaxStats stats = MinMaxStats.of(foreign, leaf, readability(geometry));
@@ -79,7 +79,7 @@ class UnreadableSortOrderTest {
     void anUnorderedAnnotationWithoutBoundsReportsNothing() {
         FileSchema geometry = geometrySchema();
         ResolvedPredicate leaf = FilterPredicateResolver.resolve(
-                FilterPredicate.eq("g", "M"), geometry);
+                FilterPredicate.eq("g", bytes("M")), geometry);
         Statistics boundless = new Statistics(null, null, 0L, null, false);
 
         MinMaxStats stats = MinMaxStats.of(boundless, leaf, readability(geometry));
@@ -187,7 +187,7 @@ class UnreadableSortOrderTest {
     void eachFileOfAMultiFileReadIsJudgedInItsOwnOrdinals() throws Exception {
         try (ParquetFileReader reader = ParquetFileReader.openAll(List.of(
                 InputFile.of(geometryThenValue()), InputFile.of(valueThenGeometry())));
-                RowReader rows = reader.buildRowReader().filter(FilterPredicate.eq("g", "M")).build()) {
+                RowReader rows = reader.buildRowReader().filter(FilterPredicate.eq("g", bytes("M"))).build()) {
             assertThat(values(rows)).containsExactly(1, 2);
         }
     }

--- a/docs/content/how-to/query-controls.md
+++ b/docs/content/how-to/query-controls.md
@@ -41,6 +41,9 @@ FilterPredicate filter = FilterPredicate.in("department_id", 1, 3, 7);
 FilterPredicate filter = FilterPredicate.in("temperature", 20.5, 21.0, 22.5);
 FilterPredicate filter = FilterPredicate.inStrings("city", "NYC", "LA", "Chicago");
 
+// Binary filter, on the bytes the column stores
+FilterPredicate filter = FilterPredicate.eq("checksum", new byte[] { 0x00, (byte) 0xC8 });
+
 // NULL checks
 FilterPredicate filter = FilterPredicate.isNull("middle_name");
 FilterPredicate filter = FilterPredicate.isNotNull("email");
@@ -135,7 +138,15 @@ FilterPredicate filter = FilterPredicate.gtEq("amount", new BigDecimal("99.99"))
 // UUID columns — column must carry the UUID logical type
 FilterPredicate filter = FilterPredicate.eq("request_id",
     UUID.fromString("550e8400-e29b-41d4-a716-446655440000"));
+
+// Binary columns — the literal is the stored bytes, whatever the annotation reads them as
+FilterPredicate filter = FilterPredicate.gt("amount_bytes", new byte[] { 0x01, 0x2C });
 ```
+
+A `String` literal filters a text column: a `STRING`, an `ENUM`, a `JSON` or an unannotated
+`BYTE_ARRAY`, where its UTF-8 encoding is the stored bytes. On any other binary column — a
+`DECIMAL`, a `FLOAT16`, a `UUID`, an `INTERVAL`, a `BSON`, a `GEOMETRY`, a `GEOGRAPHY`, a `NULL`
+or an unannotated `FIXED_LEN_BYTE_ARRAY` — pass the annotation's literal type or a `byte[]`.
 
 A column takes the literal type its annotation names — a `DECIMAL` column a `BigDecimal`, a `UUID` column a `UUID` — and rejects a literal belonging to a different annotation with `IllegalArgumentException` at reader creation. It also takes the literal for its own physical type, for filtering on the stored value directly. For what each column takes and the order it compares in, see [Predicate literals by column type](../reference/query-controls.md#predicate-literals-by-column-type).
 
@@ -155,7 +166,7 @@ Filters work with all reader types: `RowReader`, `ColumnReader`, `AvroRowReader`
   decided from the null count alone.
 - **Two equality probes cannot use either.** `eq(NaN)`, or an `in` list holding one, is not
   Bloom-pruned: raw-bit hashing distinguishes NaN payloads that `Double.compare` treats as equal,
-  so a miss cannot prove a NaN absent. An `eq` or `inStrings` on a `DECIMAL` stored as
+  so a miss cannot prove a NaN absent. An `eq` or `in` on a `DECIMAL` stored as
   `BYTE_ARRAY` is pruned by neither, since such a column may hold the same number under more than
   one byte string, so a miss on a probe's own bytes does not prove the value absent.
 

--- a/docs/content/reference/accessors.md
+++ b/docs/content/reference/accessors.md
@@ -32,7 +32,7 @@ All accessors are available in two forms — name-based (`getInt("column_name")`
 | `getLong` | INT64 | | `long` |
 | `getFloat` | FLOAT, or FIXED_LEN_BYTE_ARRAY(2) | FLOAT16 (optional) | `float` |
 | `getDouble` | DOUBLE | | `double` |
-| `getBinary` | BYTE_ARRAY | BSON (optional) | `byte[]` |
+| `getBinary` | BYTE_ARRAY or FIXED_LEN_BYTE_ARRAY | BSON (optional) | `byte[]` |
 | `getString` | BYTE_ARRAY | STRING, ENUM, or JSON | `String` |
 | `getDate` | INT32 | DATE | `LocalDate` |
 | `getTime` | INT32 or INT64 | TIME | `LocalTime` |

--- a/docs/content/reference/query-controls.md
+++ b/docs/content/reference/query-controls.md
@@ -20,7 +20,7 @@ behavior of each control — predicate pushdown, projection, row limits, splits,
 | Category | Supported |
 |---|---|
 | Comparison operators | `eq`, `notEq`, `lt`, `ltEq`, `gt`, `gtEq` |
-| Set operators | `in` (int, long, double), `inStrings` |
+| Set operators | `in` (int, long, double, `byte[]`), `inStrings` |
 | Null operators | `isNull`, `isNotNull` (any type) |
 | Spatial operators | `intersects`, on a `GEOMETRY` or `GEOGRAPHY` column |
 | Combinators | `and`, `or`, `not` (`and` / `or` accept varargs for three or more conditions) |
@@ -33,11 +33,14 @@ skipping. Filters work with all reader types — `RowReader`, `ColumnReader`,
 ## Predicate literals by column type
 
 A column takes the literal types listed for its physical type, and — where it carries an
-annotation — those listed for that annotation as well. Where both rows apply, the annotation
-names the order: a `UINT_32` column matches the `INT32` row and the `INT(32, isSigned = false)`
-row, and compares by unsigned magnitude. Set membership follows the same mapping: `in` on the
-`INT32`, `INT64`, `FLOAT`, `DOUBLE` and `FLOAT16` columns, `inStrings` on those taking a `String`. A
-literal a column does not take throws `IllegalArgumentException` at reader creation.
+annotation — those listed for that annotation as well. A `String` is the one literal that does
+not compose this way: it filters a `STRING`, an `ENUM`, a `JSON` and an unannotated `BYTE_ARRAY`,
+and no other binary column. Where both rows apply, the annotation names the order: a `UINT_32`
+column matches the `INT32` row and the `INT(32, isSigned = false)` row, and compares by unsigned
+magnitude. Set membership follows the same mapping: `in` on the
+`INT32`, `INT64`, `FLOAT`, `DOUBLE` and `FLOAT16` columns and on every binary column, `inStrings`
+on those taking a `String`. A literal a column does not take throws `IllegalArgumentException` at
+reader creation.
 
 | Physical type | Logical type | Literal | Compared as |
 |---|---|---|---|
@@ -46,18 +49,21 @@ literal a column does not take throws `IllegalArgumentException` at reader creat
 | `INT64` | | `long` | signed |
 | `FLOAT` | | `float` | numeric |
 | `DOUBLE` | | `double` | numeric |
-| `BYTE_ARRAY`, `FIXED_LEN_BYTE_ARRAY(n)` | | `String` | unsigned lexicographic |
+| `BYTE_ARRAY` | | `byte[]`; `String` where the column carries no annotation | unsigned lexicographic |
+| `FIXED_LEN_BYTE_ARRAY(n)` | | `byte[]` of `n` bytes | unsigned lexicographic |
 | `INT32` 8/16/32-bit, `INT64` 64-bit | `INT(8/16/32/64, isSigned = true)` | `int` / `long` | signed |
 | `INT32` 8/16/32-bit, `INT64` 64-bit | `INT(8/16/32/64, isSigned = false)` | `int` / `long` | unsigned magnitude |
 | `INT32` | `DATE` | `LocalDate` | days since the Unix epoch |
 | `INT32` millis, `INT64` micros / nanos | `TIME` | `LocalTime` | the column's time unit |
 | `INT64` | `TIMESTAMP` | `Instant` | the column's time unit |
-| `INT32` up to 9 digits, `INT64` up to 18, `FIXED_LEN_BYTE_ARRAY(n)` up to what `n` bytes hold, `BYTE_ARRAY` any | `DECIMAL` | `BigDecimal`, `String` | the represented value, under all four physical types |
-| `BYTE_ARRAY` | `STRING`, `ENUM`, `JSON`, `BSON` | `String` | unsigned lexicographic |
+| `INT32` up to 9 digits, `INT64` up to 18 | `DECIMAL` | `BigDecimal`; `int` / `long` unscaled | the represented value |
+| `FIXED_LEN_BYTE_ARRAY(n)` up to what `n` bytes hold, `BYTE_ARRAY` any | `DECIMAL` | `BigDecimal`, `byte[]` | the represented value |
+| `BYTE_ARRAY` | `STRING`, `ENUM`, `JSON` | `String`, `byte[]` | unsigned lexicographic |
+| `BYTE_ARRAY` | `BSON` | `byte[]` | unsigned lexicographic |
 | `BYTE_ARRAY` | `GEOMETRY`, `GEOGRAPHY` | four `double` bounds | bounding-box overlap |
-| `FIXED_LEN_BYTE_ARRAY(16)` | `UUID` | `UUID`, `String` | the 16 bytes, unsigned |
-| `FIXED_LEN_BYTE_ARRAY(2)` | `FLOAT16` | `float`, `String` | numeric, widened to `float` |
-| `FIXED_LEN_BYTE_ARRAY(12)` | `INTERVAL` | `String`, `inStrings` | the 12 bytes, unsigned; the format defines no order for `INTERVAL`, so only equality is meaningful |
+| `FIXED_LEN_BYTE_ARRAY(16)` | `UUID` | `UUID`, `byte[]` of 16 bytes | the 16 bytes, unsigned |
+| `FIXED_LEN_BYTE_ARRAY(2)` | `FLOAT16` | `float`, `byte[]` of 2 bytes | numeric, widened to `float` |
+| `FIXED_LEN_BYTE_ARRAY(12)` | `INTERVAL` | `byte[]` of 12 bytes | the 12 bytes, unsigned; the format defines no order for `INTERVAL`, so only equality is meaningful |
 | any | `NULL` | the literal for the physical type | nothing — every value is null, so no comparison matches |
 | group of two `BYTE_ARRAY` | `VARIANT` | `isNull`, `isNotNull` | whether the group is present |
 
@@ -87,22 +93,38 @@ zero.
 A column that carries an annotation also takes the literal for its physical type, comparing the
 value as it is stored: an `int` against a `DATE` column tests the epoch day directly.
 
+### Binary columns
+
+The literal of a `BYTE_ARRAY` or `FIXED_LEN_BYTE_ARRAY` column is a `byte[]`, the stored bytes
+that [`getBinary`](accessors.md) returns. The factories copy the array, so a caller reusing it
+does not change a predicate already built.
+
+```java
+FilterPredicate filter = FilterPredicate.eq("code", new byte[] { 0x00, (byte) 0xC8 });
+FilterPredicate members = FilterPredicate.in("code",
+        new byte[] { 0x00, (byte) 0xC8 }, new byte[] { 0x00, (byte) 0xC9 });
+```
+
 `DECIMAL` and `FLOAT16` are the exceptions to *how* the bytes compare. Both order by the value
 their bytes stand for rather than by the bytes themselves, and their statistics are written in
-that order, so a `String` literal against either compares as the column does — a `DECIMAL` by its
+that order, so a `byte[]` literal against either compares as the column does — a `DECIMAL` by its
 unscaled value, a `FLOAT16` by the number its two little-endian bytes encode — rather than as a
 byte string. A `FLOAT16` literal must be exactly two bytes. On a `FIXED_LEN_BYTE_ARRAY` `DECIMAL`,
 a literal of any length stands for the value it encodes and is brought to the column width:
 sign-extended when it is shorter, its leading sign-extension bytes dropped when it is longer.
 
-`inStrings` compares each probe the same way, so on a `DECIMAL` a padded encoding of a probe is
-still a member, and on a `FLOAT16` each probe — exactly two bytes — is compared as the half it
+`in(byte[]...)` compares each probe the same way, so on a `DECIMAL` a padded encoding of a probe
+is still a member, and on a `FLOAT16` each probe — exactly two bytes — is compared as the half it
 encodes. `in(double...)` on a `FLOAT16` compares against the decoded half as it does against a
 `FLOAT`'s widened value, so a probe no half represents, such as `0.1`, matches nothing.
 
-Note that a `String` literal is encoded as UTF-8, which reproduces a byte one-for-one only below
-`0x80`. A `DECIMAL`'s unscaled value sets the high bit for every negative number, so those are
-not expressible this way; reach for the `BigDecimal` factory instead.
+A `String` literal is the literal of a text column — `STRING`, `ENUM`, `JSON` and an unannotated
+`BYTE_ARRAY` — where its UTF-8 encoding is exactly the stored bytes. On any other binary column
+it throws `IllegalArgumentException` at reader creation, naming the literals the column does
+take. A `String` that is not well-formed UTF-16, such as one holding an unpaired surrogate, has
+no UTF-8 encoding and throws `IllegalArgumentException` when the predicate is built.
+
+Every factory rejects a null literal with a `NullPointerException` naming the argument.
 
 ## Literals the column cannot hold
 

--- a/docs/content/release-notes.md
+++ b/docs/content/release-notes.md
@@ -15,6 +15,14 @@ See [GitHub Releases](https://github.com/hardwood-hq/hardwood/releases) for down
 
 ## 1.1.0-SNAPSHOT
 
+- `FilterPredicate` takes a `byte[]` literal on any binary column, through `eq`, `notEq`, `lt`, `ltEq`, `gt`, `gtEq` and `in` ([#1181](https://github.com/hardwood-hq/hardwood/issues/1181)).
+
+- A `String` literal filters a column that holds text — a `STRING`, an `ENUM`, a `JSON` or an unannotated `BYTE_ARRAY` — and throws `IllegalArgumentException` on every other binary column, where a `byte[]` or the annotation's own literal type filters instead ([#1181](https://github.com/hardwood-hq/hardwood/issues/1181)).
+
+- A `String` literal that is not well-formed UTF-16 throws `IllegalArgumentException` when the predicate is built ([#1181](https://github.com/hardwood-hq/hardwood/issues/1181)).
+
+- Every `FilterPredicate` factory rejects a null literal with a `NullPointerException` naming the argument ([#1181](https://github.com/hardwood-hq/hardwood/issues/1181)).
+
 - An equality literal a column cannot hold throws `IllegalArgumentException`: an `Instant` or `LocalTime` finer than the column's time unit, a `BigDecimal` past its scale, a byte literal of a width a fixed-width column does not have, a `float` no IEEE half represents, and any literal outside the range of the `INT32` or `INT64` behind the column ([#1193](https://github.com/hardwood-hq/hardwood/issues/1193)).
 
 - An ordered predicate whose literal the column cannot hold is answered exactly, where several such literals used to throw `ArithmeticException` ([#1193](https://github.com/hardwood-hq/hardwood/issues/1193)).


### PR DESCRIPTION
Closes #1181. Step 5 of #1198.

A binary column's only literal was a `String`, encoded as UTF-8. That spells a byte one-for-one below `0x80` alone, so a literal with a high byte silently became a different value and matched nothing, and on a column whose annotation makes the bytes a typed value a caller's text was read as the stored bytes — `eq("dec", "1.25")` tested the unscaled value 825,111,093 rather than the number 1.25.

Every binary column now takes the `byte[]` its accessor returns for it, through `eq`, `notEq`, `lt`, `ltEq`, `gt`, `gtEq` and `in`. A literal resolves as a byte literal always did: a `DECIMAL` compares by the number the bytes encode, a `FLOAT16` by the half its two bytes encode, every other binary column unsigned lexicographically. The factories copy the caller's array.

A `String` is the literal exactly where `getString` reads the column: `STRING`, `ENUM`, `JSON` and an unannotated `BYTE_ARRAY`. On any other binary column it now throws `IllegalArgumentException` at reader creation, naming the column, its annotation and the literals it does take. `requireTextColumn` is an exhaustive switch over `LogicalType`, the shape `byteComparison` has, so an annotation added later has to state whether a `String` reads it.

Two failures move to where the predicate is built: a `String` that is not well-formed UTF-16 has no UTF-8 encoding to compare by and throws `IllegalArgumentException`, and every factory rejects a null literal with a `NullPointerException` naming the argument, which used to fail at reader creation or inside a conversion instead.

`String` and `byte[]` literals now have records of their own — `StringColumnPredicate` / `StringInPredicate` hold the text as given, `BinaryColumnPredicate` / `BinaryInPredicate` carry bytes only. `parquet-java-compat`'s `FilterConverter` is unchanged; the tests that used a `String` to spell bytes move onto the `byte[]` factories, `DifferentialColumnOrderTest` among them.

`PredicatePathAgreementTest` gains 16 cells for the rule, run through all five read paths (3,345 cells, up from 3,220); with the text-column check disabled they fail on every path. `FilterPredicateResolverTest` covers the accept/reject table with full messages, and `FilterPredicateTest` the copying, content equality, the malformed `String` and the null literals. Full `./mvnw verify` is green.

The living matrix on #1198 moves from correct 57 / wrong 17 / no factory 5 to correct 62 / wrong 13 / no factory 4, with no row left owning #1181.