### PR TITLE
#1194 Take a LocalDateTime literal on a local timestamp column

### DIFF
--- a/_designs/PREDICATE_LITERALS.md
+++ b/_designs/PREDICATE_LITERALS.md
@@ -273,7 +273,7 @@ express get the same answer; the differences are listed below.
 | Ordered operators exactly on ordered types: `BOOLEAN` gains them; `INTERVAL`, `GEOMETRY`, `GEOGRAPHY` and `NULL` lose them. `PqInterval` literal; leaves below a `VARIANT` group take null tests only; `not` over `intersects` rejected | [#1183](https://github.com/hardwood-hq/hardwood/issues/1183) (done) |
 | `INT96` literals | [#1192](https://github.com/hardwood-hq/hardwood/issues/1192) |
 | Literals the column cannot hold; the constant predicates | [#1193](https://github.com/hardwood-hq/hardwood/issues/1193) (done) |
-| `LocalDateTime` literal; `Instant` on UTC timestamps only | [#1194](https://github.com/hardwood-hq/hardwood/issues/1194) |
+| `LocalDateTime` literal; `Instant` on UTC timestamps only | [#1194](https://github.com/hardwood-hq/hardwood/issues/1194) (done) |
 | Set forms for every literal type; `in(double...)` on `DOUBLE` only; `in(String, String...)` | [#1195](https://github.com/hardwood-hq/hardwood/issues/1195), [#1178](https://github.com/hardwood-hq/hardwood/issues/1178) |
 | `getString` reads text columns only | [#1196](https://github.com/hardwood-hq/hardwood/issues/1196) (done) |
 | `TIMESTAMP` over `FIXED_LEN_BYTE_ARRAY(12)` | [#921](https://github.com/hardwood-hq/hardwood/issues/921) |

--- a/core/src/main/java/dev/hardwood/internal/predicate/FilterPredicateResolver.java
+++ b/core/src/main/java/dev/hardwood/internal/predicate/FilterPredicateResolver.java
@@ -14,10 +14,13 @@ import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
 import java.nio.charset.StandardCharsets;
 import java.time.Instant;
+import java.time.LocalDateTime;
+import java.time.ZoneOffset;
 import java.util.HexFormat;
 import java.util.List;
 
 import dev.hardwood.internal.predicate.ResolvedPredicate.BinaryPredicate.Comparison;
+import dev.hardwood.internal.reader.TimestampAccessorKind;
 import dev.hardwood.internal.schema.FixedWidthValidator;
 import dev.hardwood.internal.schema.SchemaPathResolver;
 import dev.hardwood.internal.schema.TextColumns;
@@ -39,6 +42,7 @@ import dev.hardwood.reader.FilterPredicate.IntColumnPredicate;
 import dev.hardwood.reader.FilterPredicate.IntInPredicate;
 import dev.hardwood.reader.FilterPredicate.IntersectsPredicate;
 import dev.hardwood.reader.FilterPredicate.IntervalColumnPredicate;
+import dev.hardwood.reader.FilterPredicate.LocalDateTimeColumnPredicate;
 import dev.hardwood.reader.FilterPredicate.LongColumnPredicate;
 import dev.hardwood.reader.FilterPredicate.LongInPredicate;
 import dev.hardwood.reader.FilterPredicate.Not;
@@ -120,14 +124,17 @@ public class FilterPredicateResolver {
             }
             case InstantColumnPredicate p -> {
                 ColumnSchema cs = leafColumn(p.column(), schema, p.op());
-                LogicalType.TimeUnit unit = getTimestampUnit(p.column(), cs);
+                LogicalType.TimeUnit unit = getTimestampUnit(p.column(), cs, true);
                 validateType(p.column(), PhysicalType.INT64, cs);
-                yield carried(p.column(), cs.columnIndex(), p.op(),
-                        inUnit(nanosSinceEpoch(p.value()), unit, INT64_MIN, INT64_MAX),
-                        "a whole number of " + unitName(unit) + " within the INT64 range",
-                        p.value().toString(),
-                        (op, value) -> new ResolvedPredicate.LongPredicate(cs.columnIndex(), op,
-                                value.longValueExact()));
+                yield timestamp(p.column(), cs, p.op(), unit, nanosSinceEpoch(p.value()), p.value().toString());
+            }
+            case LocalDateTimeColumnPredicate p -> {
+                ColumnSchema cs = leafColumn(p.column(), schema, p.op());
+                LogicalType.TimeUnit unit = getTimestampUnit(p.column(), cs, false);
+                validateType(p.column(), PhysicalType.INT64, cs);
+                // A local timestamp stores its wall clock as though it were a UTC instant.
+                yield timestamp(p.column(), cs, p.op(), unit,
+                        nanosSinceEpoch(p.value().toInstant(ZoneOffset.UTC)), p.value().toString());
             }
             case TimeColumnPredicate p -> {
                 ColumnSchema cs = leafColumn(p.column(), schema, p.op());
@@ -757,12 +764,21 @@ public class FilterPredicateResolver {
 
     // ==================== Value conversion helpers ====================
 
-    private static LogicalType.TimeUnit getTimestampUnit(String columnName, ColumnSchema columnSchema) {
-        if (columnSchema.logicalType() instanceof LogicalType.TimestampType timestampType) {
-            return timestampType.unit();
+    /// The unit of a `TIMESTAMP` column of the kind the literal denotes: an [Instant] a
+    /// UTC-adjusted one, a [LocalDateTime] a local wall clock.
+    private static LogicalType.TimeUnit getTimestampUnit(String columnName, ColumnSchema columnSchema,
+            boolean literalIsInstant) {
+        if (!(columnSchema.logicalType() instanceof LogicalType.TimestampType timestampType)) {
+            throw new IllegalArgumentException(
+                    "Column '" + columnName + "' does not have a TIMESTAMP logical type");
         }
-        throw new IllegalArgumentException(
-                "Column '" + columnName + "' does not have a TIMESTAMP logical type");
+        if (timestampType.isAdjustedToUTC() != literalIsInstant) {
+            throw new IllegalArgumentException("Column '" + columnName + "' is "
+                    + TimestampAccessorKind.describe(timestampType.isAdjustedToUTC()) + ", which takes "
+                    + (literalIsInstant ? "LocalDateTime and long literals, not an Instant"
+                            : "Instant and long literals, not a LocalDateTime"));
+        }
+        return timestampType.unit();
     }
 
     private static LogicalType.TimeUnit getTimeUnit(String columnName, ColumnSchema columnSchema) {
@@ -892,6 +908,15 @@ public class FilterPredicateResolver {
     /// sits in the column's order.
     private static boolean isEquality(FilterPredicate.Operator op) {
         return op == FilterPredicate.Operator.EQ || op == FilterPredicate.Operator.NOT_EQ;
+    }
+
+    /// A timestamp literal, `nanos` since the epoch, on an `INT64` column counting `unit`.
+    private static ResolvedPredicate timestamp(String columnName, ColumnSchema cs, Operator op,
+            LogicalType.TimeUnit unit, BigInteger nanos, String shown) {
+        return carried(columnName, cs.columnIndex(), op, inUnit(nanos, unit, INT64_MIN, INT64_MAX),
+                "a whole number of " + unitName(unit) + " within the INT64 range", shown,
+                (resolvedOp, value) -> new ResolvedPredicate.LongPredicate(cs.columnIndex(), resolvedOp,
+                        value.longValueExact()));
     }
 
     /// `nanos` measured in `unit`, narrowed to `[min, max]`.

--- a/core/src/main/java/dev/hardwood/internal/reader/TimestampAccessorKind.java
+++ b/core/src/main/java/dev/hardwood/internal/reader/TimestampAccessorKind.java
@@ -19,7 +19,7 @@ import dev.hardwood.schema.SchemaNode;
 /// requires local. Each impl funnels through [#require] so the rejection
 /// message is identical everywhere and the INT96 fallthrough is handled in
 /// one place.
-final class TimestampAccessorKind {
+public final class TimestampAccessorKind {
 
     private TimestampAccessorKind() {
     }
@@ -56,6 +56,11 @@ final class TimestampAccessorKind {
         if (lt == null) {
             return "a legacy INT96 TIMESTAMP (no isAdjustedToUTC field)";
         }
+        return describe(utcAdjusted);
+    }
+
+    /// The kind of a column annotated TIMESTAMP, as a rejection names it.
+    public static String describe(boolean utcAdjusted) {
         return utcAdjusted
                 ? "a UTC-adjusted TIMESTAMP (isAdjustedToUTC=true)"
                 : "a local-wall-clock TIMESTAMP (isAdjustedToUTC=false)";

--- a/core/src/main/java/dev/hardwood/reader/FilterPredicate.java
+++ b/core/src/main/java/dev/hardwood/reader/FilterPredicate.java
@@ -12,6 +12,7 @@ import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
 import java.time.Instant;
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.time.LocalTime;
 import java.util.Arrays;
 import java.util.List;
@@ -103,6 +104,7 @@ public sealed interface FilterPredicate
                 FilterPredicate.StringInPredicate,
                 FilterPredicate.DateColumnPredicate,
                 FilterPredicate.InstantColumnPredicate,
+                FilterPredicate.LocalDateTimeColumnPredicate,
                 FilterPredicate.TimeColumnPredicate,
                 FilterPredicate.DecimalColumnPredicate,
                 FilterPredicate.IntervalColumnPredicate,
@@ -414,8 +416,9 @@ public sealed interface FilterPredicate
 
     // ==================== Instant (TIMESTAMP) Predicates ====================
 
-    /// Creates an equals predicate for an [Instant] column (Parquet TIMESTAMP logical type).
-    /// The column's time unit is determined from the schema at reader creation.
+    /// Creates an equals predicate for an [Instant] column (Parquet TIMESTAMP logical type with
+    /// `isAdjustedToUTC = true`). The column's time unit is determined from the schema at reader
+    /// creation.
     static FilterPredicate eq(String column, Instant value) {
         return new InstantColumnPredicate(column, Operator.EQ, value);
     }
@@ -443,6 +446,40 @@ public sealed interface FilterPredicate
     /// Creates a greater-than-or-equal predicate for an [Instant] column.
     static FilterPredicate gtEq(String column, Instant value) {
         return new InstantColumnPredicate(column, Operator.GT_EQ, value);
+    }
+
+    // ==================== LocalDateTime (local TIMESTAMP) Predicates ====================
+
+    /// Creates an equals predicate for a [LocalDateTime] column (Parquet TIMESTAMP logical type
+    /// with `isAdjustedToUTC = false`). The column's time unit is determined from the schema at
+    /// reader creation.
+    static FilterPredicate eq(String column, LocalDateTime value) {
+        return new LocalDateTimeColumnPredicate(column, Operator.EQ, value);
+    }
+
+    /// Creates a not-equals predicate for a [LocalDateTime] column.
+    static FilterPredicate notEq(String column, LocalDateTime value) {
+        return new LocalDateTimeColumnPredicate(column, Operator.NOT_EQ, value);
+    }
+
+    /// Creates a less-than predicate for a [LocalDateTime] column.
+    static FilterPredicate lt(String column, LocalDateTime value) {
+        return new LocalDateTimeColumnPredicate(column, Operator.LT, value);
+    }
+
+    /// Creates a less-than-or-equal predicate for a [LocalDateTime] column.
+    static FilterPredicate ltEq(String column, LocalDateTime value) {
+        return new LocalDateTimeColumnPredicate(column, Operator.LT_EQ, value);
+    }
+
+    /// Creates a greater-than predicate for a [LocalDateTime] column.
+    static FilterPredicate gt(String column, LocalDateTime value) {
+        return new LocalDateTimeColumnPredicate(column, Operator.GT, value);
+    }
+
+    /// Creates a greater-than-or-equal predicate for a [LocalDateTime] column.
+    static FilterPredicate gtEq(String column, LocalDateTime value) {
+        return new LocalDateTimeColumnPredicate(column, Operator.GT_EQ, value);
     }
 
     // ==================== LocalTime (TIME) Predicates ====================
@@ -834,11 +871,22 @@ public sealed interface FilterPredicate
         }
     }
 
-    /// Predicate for TIMESTAMP columns. The [Instant] value is converted to the column's time unit
-    /// (MILLIS, MICROS, or NANOS) at reader creation using the schema's `TimestampType`.
+    /// Predicate for TIMESTAMP columns with `isAdjustedToUTC = true`. The [Instant] value is
+    /// converted to the column's time unit (MILLIS, MICROS, or NANOS) at reader creation using the
+    /// schema's `TimestampType`.
     record InstantColumnPredicate(String column, Operator op, Instant value) implements FilterPredicate {
 
         public InstantColumnPredicate {
+            Objects.requireNonNull(value, "value");
+        }
+    }
+
+    /// Predicate for TIMESTAMP columns with `isAdjustedToUTC = false`. The [LocalDateTime] value
+    /// is converted to the column's time unit at reader creation, reading the wall clock as UTC.
+    record LocalDateTimeColumnPredicate(String column, Operator op, LocalDateTime value)
+            implements FilterPredicate {
+
+        public LocalDateTimeColumnPredicate {
             Objects.requireNonNull(value, "value");
         }
     }

--- a/core/src/test/java/dev/hardwood/FilterPredicateTest.java
+++ b/core/src/test/java/dev/hardwood/FilterPredicateTest.java
@@ -13,6 +13,7 @@ import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
 import java.time.Instant;
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.time.LocalTime;
 import java.util.List;
 import java.util.Map;
@@ -535,6 +536,8 @@ class FilterPredicateTest {
                 .isInstanceOf(NullPointerException.class).hasMessage("value");
         assertThatThrownBy(() -> FilterPredicate.ltEq("c", (Instant) null))
                 .isInstanceOf(NullPointerException.class).hasMessage("value");
+        assertThatThrownBy(() -> FilterPredicate.gt("c", (LocalDateTime) null))
+                .isInstanceOf(NullPointerException.class).hasMessage("value");
         assertThatThrownBy(() -> FilterPredicate.gtEq("c", (LocalTime) null))
                 .isInstanceOf(NullPointerException.class).hasMessage("value");
         assertThatThrownBy(() -> FilterPredicate.notEq("c", (BigDecimal) null))
@@ -789,6 +792,25 @@ class FilterPredicateTest {
         assertThat(((FilterPredicate.InstantColumnPredicate) FilterPredicate.ltEq("ts", instant)).op()).isEqualTo(FilterPredicate.Operator.LT_EQ);
         assertThat(((FilterPredicate.InstantColumnPredicate) FilterPredicate.gt("ts", instant)).op()).isEqualTo(FilterPredicate.Operator.GT);
         assertThat(((FilterPredicate.InstantColumnPredicate) FilterPredicate.gtEq("ts", instant)).op()).isEqualTo(FilterPredicate.Operator.GT_EQ);
+    }
+
+    // ==================== LocalDateTime Factory Tests ====================
+
+    @Test
+    void testLocalDateTimeAllOperators() {
+        LocalDateTime wallClock = LocalDateTime.of(2024, 6, 15, 12, 30);
+        assertThat(FilterPredicate.eq("ts", wallClock))
+                .isEqualTo(new FilterPredicate.LocalDateTimeColumnPredicate("ts", FilterPredicate.Operator.EQ, wallClock));
+        assertThat(FilterPredicate.notEq("ts", wallClock))
+                .isEqualTo(new FilterPredicate.LocalDateTimeColumnPredicate("ts", FilterPredicate.Operator.NOT_EQ, wallClock));
+        assertThat(FilterPredicate.lt("ts", wallClock))
+                .isEqualTo(new FilterPredicate.LocalDateTimeColumnPredicate("ts", FilterPredicate.Operator.LT, wallClock));
+        assertThat(FilterPredicate.ltEq("ts", wallClock))
+                .isEqualTo(new FilterPredicate.LocalDateTimeColumnPredicate("ts", FilterPredicate.Operator.LT_EQ, wallClock));
+        assertThat(FilterPredicate.gt("ts", wallClock))
+                .isEqualTo(new FilterPredicate.LocalDateTimeColumnPredicate("ts", FilterPredicate.Operator.GT, wallClock));
+        assertThat(FilterPredicate.gtEq("ts", wallClock))
+                .isEqualTo(new FilterPredicate.LocalDateTimeColumnPredicate("ts", FilterPredicate.Operator.GT_EQ, wallClock));
     }
 
     // ==================== LocalTime Factory Tests ====================

--- a/core/src/test/java/dev/hardwood/PredicatePathAgreementTest.java
+++ b/core/src/test/java/dev/hardwood/PredicatePathAgreementTest.java
@@ -17,7 +17,9 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.time.Instant;
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.time.LocalTime;
+import java.time.ZoneOffset;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
@@ -265,6 +267,17 @@ class PredicatePathAgreementTest {
         instantCases(cases, "ts_ms_utc", Instant.ofEpochMilli(1_700_000_000_000L));
         instantCases(cases, "ts_us_utc", Instant.ofEpochSecond(1_700_000_000L, 200_000L));
         instantCases(cases, "ts_ns_utc", Instant.ofEpochSecond(1_700_000_000L, 200L));
+        localDateTimeCases(cases, "ts_us_local", LocalDateTime.ofEpochSecond(1_700_000_000L, 200_000, ZoneOffset.UTC));
+        cases.add(new Case("ts_us_local", "eq(an Instant), a local timestamp",
+                FilterPredicate.eq("ts_us_local", Instant.ofEpochSecond(1_700_000_000L, 200_000L)),
+                new Rejected("Column 'ts_us_local' is a local-wall-clock TIMESTAMP (isAdjustedToUTC=false),"
+                        + " which takes LocalDateTime and long literals, not an Instant")));
+        cases.add(new Case("ts_us_utc", "eq(a LocalDateTime), a UTC timestamp",
+                FilterPredicate.eq("ts_us_utc", LocalDateTime.ofEpochSecond(1_700_000_000L, 200_000, ZoneOffset.UTC)),
+                new Rejected("Column 'ts_us_utc' is a UTC-adjusted TIMESTAMP (isAdjustedToUTC=true),"
+                        + " which takes Instant and long literals, not a LocalDateTime")));
+        cases.add(new Case("ts_us_local", "eq(stored microseconds as long)",
+                FilterPredicate.eq("ts_us_local", 1_700_000_000_000_200L), matching(eqPhysical(1_700_000_000_000_200L))));
 
         // --- DECIMAL over INT32, INT64 and FIXED_LEN_BYTE_ARRAY ---
         decimalCases(cases, "dec_i32", new BigDecimal("0.00"));
@@ -378,6 +391,17 @@ class PredicatePathAgreementTest {
                 FilterPredicate.lt("ts_us_utc", subMicrosecond), matching(cmp(Operator.LT, subMicrosecond))));
         cases.add(new Case("ts_us_utc", "gt(a sub-microsecond instant)",
                 FilterPredicate.gt("ts_us_utc", subMicrosecond), matching(cmp(Operator.GT, subMicrosecond))));
+        LocalDateTime subMicrosecondWallClock = LocalDateTime.ofEpochSecond(1_700_000_000L, 200_500, ZoneOffset.UTC);
+        cases.add(new Case("ts_us_local", "eq(a sub-microsecond wall clock)",
+                FilterPredicate.eq("ts_us_local", subMicrosecondWallClock),
+                new Rejected("Column 'ts_us_local' holds a whole number of microseconds within the INT64 range; "
+                        + "the equality literal " + subMicrosecondWallClock + " is not a value it can hold")));
+        cases.add(new Case("ts_us_local", "lt(a sub-microsecond wall clock)",
+                FilterPredicate.lt("ts_us_local", subMicrosecondWallClock),
+                matching(cmp(Operator.LT, subMicrosecondWallClock))));
+        cases.add(new Case("ts_us_local", "gt(a sub-microsecond wall clock)",
+                FilterPredicate.gt("ts_us_local", subMicrosecondWallClock),
+                matching(cmp(Operator.GT, subMicrosecondWallClock))));
 
         LocalTime subMillisecond = LocalTime.ofNanoOfDay(3_600_000_000_000L + 200 * 60_000_000_000L + 1);
         cases.add(new Case("time_ms", "eq(a sub-millisecond time)",
@@ -539,6 +563,22 @@ class PredicatePathAgreementTest {
         cases.add(new Case(column, "eq(" + literal + ")", FilterPredicate.eq(column, literal), matching(eq(literal))));
         cases.add(new Case(column, "lt(" + literal + ")", FilterPredicate.lt(column, literal),
                 matching(cmp(Operator.LT, literal))));
+        cases.add(new Case(column, "gtEq(" + literal + ")", FilterPredicate.gtEq(column, literal),
+                matching(cmp(Operator.GT_EQ, literal))));
+        cases.add(new Case(column, "not(lt(" + literal + "))",
+                FilterPredicate.not(FilterPredicate.lt(column, literal)), matching(cmp(Operator.GT_EQ, literal))));
+    }
+
+    private static void localDateTimeCases(List<Case> cases, String column, LocalDateTime literal) {
+        cases.add(new Case(column, "eq(" + literal + ")", FilterPredicate.eq(column, literal), matching(eq(literal))));
+        cases.add(new Case(column, "notEq(" + literal + ")", FilterPredicate.notEq(column, literal),
+                matching(notEq(literal))));
+        cases.add(new Case(column, "lt(" + literal + ")", FilterPredicate.lt(column, literal),
+                matching(cmp(Operator.LT, literal))));
+        cases.add(new Case(column, "ltEq(" + literal + ")", FilterPredicate.ltEq(column, literal),
+                matching(cmp(Operator.LT_EQ, literal))));
+        cases.add(new Case(column, "gt(" + literal + ")", FilterPredicate.gt(column, literal),
+                matching(cmp(Operator.GT, literal))));
         cases.add(new Case(column, "gtEq(" + literal + ")", FilterPredicate.gtEq(column, literal),
                 matching(cmp(Operator.GT_EQ, literal))));
         cases.add(new Case(column, "not(lt(" + literal + "))",
@@ -884,6 +924,7 @@ class PredicatePathAgreementTest {
             case byte[] l -> compareBytes(column, (byte[]) value, l);
             case LocalDate l -> ((LocalDate) value).compareTo(l);
             case Instant l -> ((Instant) value).compareTo(l);
+            case LocalDateTime l -> ((LocalDateTime) value).compareTo(l);
             case LocalTime l -> ((LocalTime) value).compareTo(l);
             case BigDecimal l -> ((BigDecimal) value).compareTo(l);
             case UUID l -> Arrays.compareUnsigned(uuidBytes((UUID) value), uuidBytes(l));

--- a/core/src/test/java/dev/hardwood/internal/predicate/FilterPredicateResolverTest.java
+++ b/core/src/test/java/dev/hardwood/internal/predicate/FilterPredicateResolverTest.java
@@ -11,7 +11,9 @@ import java.math.BigDecimal;
 import java.math.BigInteger;
 import java.time.Instant;
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.time.LocalTime;
+import java.time.ZoneOffset;
 import java.util.List;
 import java.util.UUID;
 import java.util.stream.Stream;
@@ -19,6 +21,7 @@ import java.util.stream.Stream;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.EnumSource;
 import org.junit.jupiter.params.provider.MethodSource;
 
 import dev.hardwood.internal.predicate.ResolvedPredicate.BinaryPredicate.Comparison;
@@ -130,6 +133,95 @@ class FilterPredicateResolverTest {
                 FilterPredicate.eq("col", Instant.now()), schema))
                 .isInstanceOf(IllegalArgumentException.class)
                 .hasMessage("Column 'col' does not have a TIMESTAMP logical type");
+    }
+
+    @Test
+    void resolveInstantOnLocalTimestampColumnThrows() {
+        FileSchema schema = schemaWithLogicalType("ts", PhysicalType.INT64,
+                LogicalType.timestamp(false, LogicalType.TimeUnit.MICROS));
+        assertThatThrownBy(() -> FilterPredicateResolver.resolve(
+                FilterPredicate.gt("ts", Instant.EPOCH), schema))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("Column 'ts' is a local-wall-clock TIMESTAMP (isAdjustedToUTC=false),"
+                        + " which takes LocalDateTime and long literals, not an Instant");
+    }
+
+    @ParameterizedTest
+    @EnumSource(value = ConvertedType.class, names = { "TIMESTAMP_MILLIS", "TIMESTAMP_MICROS" })
+    void resolveInstantOnLegacyTimestampColumn(ConvertedType convertedType) {
+        FileSchema schema = schemaWithConvertedType("ts", PhysicalType.INT64, convertedType);
+        Instant instant = Instant.parse("2024-06-15T12:30:00.123Z");
+        ResolvedPredicate resolved = FilterPredicateResolver.resolve(FilterPredicate.eq("ts", instant), schema);
+
+        long expected = convertedType == ConvertedType.TIMESTAMP_MILLIS
+                ? instant.toEpochMilli()
+                : Math.multiplyExact(instant.toEpochMilli(), 1_000L);
+        assertThat(((ResolvedPredicate.LongPredicate) resolved).value()).isEqualTo(expected);
+        assertThatThrownBy(() -> FilterPredicateResolver.resolve(
+                FilterPredicate.eq("ts", LocalDateTime.ofInstant(instant, ZoneOffset.UTC)), schema))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("Column 'ts' is a UTC-adjusted TIMESTAMP (isAdjustedToUTC=true),"
+                        + " which takes Instant and long literals, not a LocalDateTime");
+    }
+
+    // ==================== LocalDateTime ====================
+
+    static Stream<Arguments> localDateTimeUnits() {
+        LocalDateTime wallClock = LocalDateTime.parse("2024-06-15T12:30:00.123456789");
+        long epochSecond = wallClock.toEpochSecond(ZoneOffset.UTC);
+        return Stream.of(
+                Arguments.of(LogicalType.TimeUnit.MILLIS, LocalDateTime.parse("2024-06-15T12:30:00.123"),
+                        epochSecond * 1_000L + 123L),
+                Arguments.of(LogicalType.TimeUnit.MICROS, LocalDateTime.parse("2024-06-15T12:30:00.123456"),
+                        epochSecond * 1_000_000L + 123_456L),
+                Arguments.of(LogicalType.TimeUnit.NANOS, wallClock, epochSecond * 1_000_000_000L + 123_456_789L),
+                Arguments.of(LogicalType.TimeUnit.MICROS, LocalDateTime.parse("1969-12-31T23:59:59.999999"), -1L));
+    }
+
+    @ParameterizedTest
+    @MethodSource("localDateTimeUnits")
+    void resolveLocalDateTimeToWallClockInColumnUnit(LogicalType.TimeUnit unit, LocalDateTime wallClock,
+            long expected) {
+        FileSchema schema = schemaWithLogicalType("ts", PhysicalType.INT64, LogicalType.timestamp(false, unit));
+        ResolvedPredicate resolved = FilterPredicateResolver.resolve(
+                FilterPredicate.ltEq("ts", wallClock), schema);
+
+        assertThat(resolved).isEqualTo(new ResolvedPredicate.LongPredicate(0, FilterPredicate.Operator.LT_EQ,
+                expected));
+    }
+
+    @Test
+    void resolveLocalDateTimeOnUtcTimestampColumnThrows() {
+        FileSchema schema = schemaWithLogicalType("ts", PhysicalType.INT64,
+                LogicalType.timestamp(true, LogicalType.TimeUnit.MILLIS));
+        assertThatThrownBy(() -> FilterPredicateResolver.resolve(
+                FilterPredicate.eq("ts", LocalDateTime.of(2024, 6, 15, 12, 30)), schema))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("Column 'ts' is a UTC-adjusted TIMESTAMP (isAdjustedToUTC=true),"
+                        + " which takes Instant and long literals, not a LocalDateTime");
+    }
+
+    @Test
+    void resolveLocalDateTimeOnNonTimestampColumnThrows() {
+        FileSchema schema = schemaWithLogicalType("col", PhysicalType.INT64, null);
+        assertThatThrownBy(() -> FilterPredicateResolver.resolve(
+                FilterPredicate.eq("col", LocalDateTime.of(2024, 6, 15, 12, 30)), schema))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("Column 'col' does not have a TIMESTAMP logical type");
+    }
+
+    @Test
+    void resolveSubUnitLocalDateTime() {
+        FileSchema schema = schemaWithLogicalType("ts", PhysicalType.INT64,
+                LogicalType.timestamp(false, LogicalType.TimeUnit.MILLIS));
+        LocalDateTime subMilli = LocalDateTime.parse("1970-01-01T00:00:00.0015");
+
+        assertThatThrownBy(() -> FilterPredicateResolver.resolve(FilterPredicate.eq("ts", subMilli), schema))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("Column 'ts' holds a whole number of milliseconds within the INT64 range;"
+                        + " the equality literal 1970-01-01T00:00:00.001500 is not a value it can hold");
+        assertThat(FilterPredicateResolver.resolve(FilterPredicate.lt("ts", subMilli), schema))
+                .isEqualTo(new ResolvedPredicate.LongPredicate(0, FilterPredicate.Operator.LT_EQ, 1L));
     }
 
     // ==================== LocalTime ====================
@@ -1437,6 +1529,14 @@ class FilterPredicateResolverTest {
         SchemaElement root = SchemaElement.root("root", 1);
         SchemaElement col = new SchemaElement(columnName, type, typeLength, RepetitionType.REQUIRED,
                 null, null, null, null, null, logicalType);
+        return FileSchema.fromSchemaElements(List.of(root, col));
+    }
+
+    private static FileSchema schemaWithConvertedType(String columnName, PhysicalType type,
+            ConvertedType convertedType) {
+        SchemaElement root = SchemaElement.root("root", 1);
+        SchemaElement col = new SchemaElement(columnName, type, null, RepetitionType.REQUIRED,
+                null, convertedType, null, null, null, null);
         return FileSchema.fromSchemaElements(List.of(root, col));
     }
 

--- a/docs/content/concepts/timestamps.md
+++ b/docs/content/concepts/timestamps.md
@@ -41,6 +41,11 @@ requires, the exception thrown) lives in [Typed Accessors](../reference/accessor
 column's kind isn't known statically, branching on the flag — or the generic `getValue` accessor,
 which returns `Instant` or `LocalDateTime` per the flag — recovers the right type without a guess.
 
+Filter predicates follow the same split. A `FilterPredicate` literal on a UTC-adjusted column is an
+`Instant` and on a local one a `LocalDateTime`, so a predicate compares the same kind of value the
+column's accessor returns; the other kind is rejected when the reader is built, for the same reason
+the other accessor throws (see [Predicate literals by column type](../reference/query-controls.md#predicate-literals-by-column-type)).
+
 ## TIME's informational flag
 
 The TIME logical type carries the same `isAdjustedToUTC` flag, but the situation is different:

--- a/docs/content/how-to/query-controls.md
+++ b/docs/content/how-to/query-controls.md
@@ -119,6 +119,7 @@ encoding automatically:
 import java.math.BigDecimal;
 import java.time.Instant;
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.time.LocalTime;
 import java.util.UUID;
 
@@ -130,6 +131,10 @@ FilterPredicate filter = FilterPredicate.gt("birth_date", LocalDate.of(2000, 1, 
 // TIMESTAMP columns — time unit is resolved from the column schema
 FilterPredicate filter = FilterPredicate.gtEq("created_at",
     Instant.parse("2025-01-01T00:00:00Z"));
+
+// TIMESTAMP columns with isAdjustedToUTC = false hold a wall clock, and take a LocalDateTime
+FilterPredicate filter = FilterPredicate.lt("pickup_time",
+    LocalDateTime.of(2025, 1, 1, 8, 30));
 
 // TIME columns
 FilterPredicate filter = FilterPredicate.lt("start_time", LocalTime.of(9, 0));
@@ -153,7 +158,7 @@ A `String` literal filters a text column: a `STRING`, an `ENUM`, a `JSON` or an 
 `DECIMAL`, a `FLOAT16`, a `UUID`, an `INTERVAL`, a `BSON`, a `GEOMETRY`, a `GEOGRAPHY`, a `NULL`
 or an unannotated `FIXED_LEN_BYTE_ARRAY` — pass the annotation's literal type or a `byte[]`.
 
-A column takes the literal type its annotation names — a `DECIMAL` column a `BigDecimal`, a `UUID` column a `UUID` — and rejects a literal belonging to a different annotation with `IllegalArgumentException` at reader creation. It also takes the literal for its own physical type, for filtering on the stored value directly. For what each column takes and the order it compares in, see [Predicate literals by column type](../reference/query-controls.md#predicate-literals-by-column-type).
+A column takes the literal type its annotation names — a `DECIMAL` column a `BigDecimal`, a `UUID` column a `UUID`, a `TIMESTAMP` column an `Instant` or, where `isAdjustedToUTC = false`, a `LocalDateTime` — and rejects a literal belonging to a different annotation with `IllegalArgumentException` at reader creation. It also takes the literal for its own physical type, for filtering on the stored value directly. For what each column takes and the order it compares in, see [Predicate literals by column type](../reference/query-controls.md#predicate-literals-by-column-type).
 
 `lt`, `ltEq`, `gt` and `gtEq` need a column whose type defines an order. An `INTERVAL`, a `GEOMETRY`, a `GEOGRAPHY` and a `NULL` column define none, and take `eq`, `notEq` and the set form only. A `BOOLEAN` column orders `false` before `true` and takes every operator but the set form, which `eq`, `notEq` and `isNotNull` already express.
 

--- a/docs/content/reference/query-controls.md
+++ b/docs/content/reference/query-controls.md
@@ -61,7 +61,8 @@ express every set of two values.
 | `INT32` 8/16/32-bit, `INT64` 64-bit | `INT(8/16/32/64, isSigned = false)` | `int` / `long` | unsigned magnitude |
 | `INT32` | `DATE` | `LocalDate` | days since the Unix epoch |
 | `INT32` millis, `INT64` micros / nanos | `TIME` | `LocalTime` | the column's time unit |
-| `INT64` | `TIMESTAMP` | `Instant` | the column's time unit |
+| `INT64` | `TIMESTAMP(isAdjustedToUTC = true)`, and the legacy `TIMESTAMP_MILLIS` / `TIMESTAMP_MICROS` | `Instant` | the column's time unit |
+| `INT64` | `TIMESTAMP(isAdjustedToUTC = false)` | `LocalDateTime` | the wall clock, in the column's time unit |
 | `INT32` up to 9 digits, `INT64` up to 18 | `DECIMAL` | `BigDecimal`; `int` / `long` unscaled | the represented value |
 | `FIXED_LEN_BYTE_ARRAY(n)` up to what `n` bytes hold, `BYTE_ARRAY` any | `DECIMAL` | `BigDecimal`, `byte[]` | the represented value |
 | `BYTE_ARRAY` | `STRING`, `ENUM`, `JSON` | `String`, `byte[]` | unsigned lexicographic |

--- a/docs/content/release-notes.md
+++ b/docs/content/release-notes.md
@@ -33,6 +33,10 @@ See [GitHub Releases](https://github.com/hardwood-hq/hardwood/releases) for down
 
 - `FilterPredicate.eq` and `notEq` take a `PqInterval` literal on an `INTERVAL` column ([#1183](https://github.com/hardwood-hq/hardwood/issues/1183)).
 
+- `FilterPredicate` takes a `LocalDateTime` literal on a `TIMESTAMP` column with `isAdjustedToUTC = false`, through `eq`, `notEq`, `lt`, `ltEq`, `gt` and `gtEq` ([#1194](https://github.com/hardwood-hq/hardwood/issues/1194)).
+
+- An `Instant` literal on a `TIMESTAMP` column with `isAdjustedToUTC = false` throws `IllegalArgumentException`, where it used to compare the instant against the stored wall clock as though that were UTC ([#1194](https://github.com/hardwood-hq/hardwood/issues/1194)).
+
 - `getString` and `ColumnReader.getStrings` throw `IllegalArgumentException` on a column that does not hold text, where they used to decode its stored bytes as characters ([#1196](https://github.com/hardwood-hq/hardwood/issues/1196)).
 
 - An equality literal a column cannot hold throws `IllegalArgumentException`: an `Instant` or `LocalTime` finer than the column's time unit, a `BigDecimal` past its scale, a byte literal of a width a fixed-width column does not have, a `float` no IEEE half represents, and any literal outside the range of the `INT32` or `INT64` behind the column ([#1193](https://github.com/hardwood-hq/hardwood/issues/1193)).


### PR DESCRIPTION
Closes #1194

A `TIMESTAMP` column with `isAdjustedToUTC = false` holds a wall clock, and its accessor returns a `LocalDateTime`. The filter side had no such literal and accepted an `Instant` instead, comparing its epoch units against the stored wall clock as though that were UTC — the coercion `getTimestamp` refuses on such a column.

`eq`, `notEq`, `lt`, `ltEq`, `gt` and `gtEq` take a `LocalDateTime` on a local timestamp column, converted to the column's unit with the wall clock read as UTC. An `Instant` on a local column, or a `LocalDateTime` on a UTC one, throws `IllegalArgumentException` at reader creation with the description the accessors use. The legacy `TIMESTAMP_MILLIS` / `TIMESTAMP_MICROS` converted types are promoted to UTC timestamps by `FileSchema` and keep taking an `Instant`. A `LocalDateTime` finer than the column's unit follows #1193.

`PredicatePathAgreementTest` gains cases on the existing `ts_us_local` fixture column (3,470 → 3,665 cells). The refused-`Instant` case failed on all 15 layout × path cells before the change.

Part of epic #1198.
